### PR TITLE
feat: config API and model panel (Phase 4)

### DIFF
--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -1,0 +1,56 @@
+/**
+ * Config API client.
+ */
+
+import { apiFetch } from "./client";
+
+export interface ConfigUpdateResponse {
+  config: Record<string, unknown>;
+  errors: Array<Record<string, unknown>>;
+}
+
+export function fetchConfigSchema(): Promise<Record<string, unknown>> {
+  return apiFetch("/workspace/config/schema");
+}
+
+export function fetchConfig(): Promise<Record<string, unknown>> {
+  return apiFetch("/workspace/config");
+}
+
+export function updateConfig(
+  config: Record<string, unknown>,
+): Promise<ConfigUpdateResponse> {
+  return apiFetch("/workspace/config", {
+    method: "PUT",
+    body: JSON.stringify(config),
+  });
+}
+
+export function validateConfig(
+  config: Record<string, unknown>,
+): Promise<{ valid: boolean; errors: Array<Record<string, unknown>> }> {
+  return apiFetch("/workspace/config/validate", {
+    method: "POST",
+    body: JSON.stringify(config),
+  });
+}
+
+export async function uploadConfig(
+  file: File,
+): Promise<ConfigUpdateResponse> {
+  const form = new FormData();
+  form.append("file", file);
+  const res = await fetch("/api/workspace/config/upload", {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`API ${res.status}: ${body}`);
+  }
+  return res.json();
+}
+
+export function downloadConfigUrl(): string {
+  return "/api/workspace/config/download";
+}

--- a/frontend/src/components/ConfigForm.tsx
+++ b/frontend/src/components/ConfigForm.tsx
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  Accordion,
+  NumberInput,
+  Select,
+  Switch,
+  TextInput,
+  Stack,
+  Text,
+  Button,
+  Group,
+} from "@mantine/core";
+
+interface JsonSchema {
+  type?: string;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  enum?: unknown[];
+  default?: unknown;
+  title?: string;
+  description?: string;
+  minimum?: number;
+  maximum?: number;
+  // Nested object sections
+  [key: string]: unknown;
+}
+
+interface ConfigFormProps {
+  schema: Record<string, unknown>;
+  config: Record<string, unknown>;
+  errors: Array<Record<string, unknown>>;
+  onChange: (config: Record<string, unknown>) => void;
+  onSave: (config: Record<string, unknown>) => void;
+}
+
+export function ConfigForm({
+  schema,
+  config,
+  errors,
+  onChange,
+  onSave,
+}: ConfigFormProps) {
+  const [localConfig, setLocalConfig] = useState<Record<string, unknown>>(config);
+
+  // Sync when external config changes (e.g. after import)
+  useEffect(() => {
+    setLocalConfig(config);
+  }, [config]);
+
+  const updateField = useCallback(
+    (path: string[], value: unknown) => {
+      const next = structuredClone(localConfig);
+      let obj: Record<string, unknown> = next;
+      for (let i = 0; i < path.length - 1; i++) {
+        if (typeof obj[path[i]] !== "object" || obj[path[i]] === null) {
+          obj[path[i]] = {};
+        }
+        obj = obj[path[i]] as Record<string, unknown>;
+      }
+      obj[path[path.length - 1]] = value;
+      setLocalConfig(next);
+      onChange(next);
+    },
+    [localConfig, onChange],
+  );
+
+  const typedSchema = schema as JsonSchema;
+  const properties = typedSchema.properties ?? {};
+
+  // Group top-level properties into accordion sections
+  const sections = Object.entries(properties);
+
+  return (
+    <Stack gap="sm">
+      <Accordion multiple defaultValue={sections.map(([key]) => key)}>
+        {sections.map(([key, propSchema]) => {
+          const s = propSchema as JsonSchema;
+          if (s.type === "object" && s.properties) {
+            // Nested object → accordion section
+            return (
+              <Accordion.Item key={key} value={key}>
+                <Accordion.Control>{s.title ?? key}</Accordion.Control>
+                <Accordion.Panel>
+                  <Stack gap="xs">
+                    {Object.entries(s.properties).map(([subKey, subSchema]) => (
+                      <SchemaField
+                        key={subKey}
+                        name={subKey}
+                        schema={subSchema as JsonSchema}
+                        value={getNestedValue(localConfig, [key, subKey])}
+                        onChange={(v) => updateField([key, subKey], v)}
+                      />
+                    ))}
+                  </Stack>
+                </Accordion.Panel>
+              </Accordion.Item>
+            );
+          }
+          // Top-level field
+          return (
+            <Accordion.Item key={key} value={key}>
+              <Accordion.Control>{s.title ?? key}</Accordion.Control>
+              <Accordion.Panel>
+                <SchemaField
+                  name={key}
+                  schema={s}
+                  value={localConfig[key]}
+                  onChange={(v) => updateField([key], v)}
+                />
+              </Accordion.Panel>
+            </Accordion.Item>
+          );
+        })}
+      </Accordion>
+
+      {errors.length > 0 && (
+        <Text size="xs" c="red">
+          {errors.length} validation error(s)
+        </Text>
+      )}
+
+      <Group>
+        <Button size="sm" onClick={() => onSave(localConfig)}>
+          Save Config
+        </Button>
+      </Group>
+    </Stack>
+  );
+}
+
+function SchemaField({
+  name,
+  schema,
+  value,
+  onChange,
+}: {
+  name: string;
+  schema: JsonSchema;
+  value: unknown;
+  onChange: (value: unknown) => void;
+}) {
+  const label = schema.title ?? name;
+  const description = schema.description;
+
+  // Enum → Select
+  if (schema.enum) {
+    return (
+      <Select
+        label={label}
+        description={description}
+        data={schema.enum.map((e) => String(e))}
+        value={value != null ? String(value) : null}
+        onChange={onChange}
+        clearable
+      />
+    );
+  }
+
+  // Boolean → Switch
+  if (schema.type === "boolean") {
+    return (
+      <Switch
+        label={label}
+        description={description}
+        checked={value === true}
+        onChange={(e) => onChange(e.currentTarget.checked)}
+      />
+    );
+  }
+
+  // Number / Integer → NumberInput
+  if (schema.type === "number" || schema.type === "integer") {
+    return (
+      <NumberInput
+        label={label}
+        description={description}
+        value={typeof value === "number" ? value : undefined}
+        onChange={(v) => onChange(v === "" ? undefined : v)}
+        min={schema.minimum}
+        max={schema.maximum}
+        step={schema.type === "integer" ? 1 : undefined}
+        allowDecimal={schema.type !== "integer"}
+      />
+    );
+  }
+
+  // String → TextInput (default)
+  return (
+    <TextInput
+      label={label}
+      description={description}
+      value={typeof value === "string" ? value : ""}
+      onChange={(e) => onChange(e.currentTarget.value || undefined)}
+    />
+  );
+}
+
+function getNestedValue(
+  obj: Record<string, unknown>,
+  path: string[],
+): unknown {
+  let current: unknown = obj;
+  for (const key of path) {
+    if (current == null || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}

--- a/frontend/src/components/ModelPanel.tsx
+++ b/frontend/src/components/ModelPanel.tsx
@@ -1,0 +1,267 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+import {
+  Accordion,
+  Badge,
+  Button,
+  Group,
+  JsonInput,
+  Paper,
+  Stack,
+  Tabs,
+  Text,
+  Title,
+} from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  fetchConfig,
+  fetchConfigSchema,
+  updateConfig,
+  uploadConfig,
+  validateConfig,
+  downloadConfigUrl,
+} from "../api/config";
+import { ConfigForm } from "./ConfigForm";
+
+export function ModelPanel() {
+  const queryClient = useQueryClient();
+  const [activeTab, setActiveTab] = useState<string | null>("fit");
+  const [errors, setErrors] = useState<Array<Record<string, unknown>>>([]);
+
+  const schemaQuery = useQuery({
+    queryKey: ["config-schema"],
+    queryFn: fetchConfigSchema,
+  });
+
+  const configQuery = useQuery({
+    queryKey: ["config"],
+    queryFn: fetchConfig,
+  });
+
+  // Debounce timer for auto-validation
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const onConfigChange = useCallback(
+    (config: Record<string, unknown>) => {
+      // Debounced auto-validation
+      clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(async () => {
+        try {
+          const res = await validateConfig(config);
+          setErrors(res.errors);
+        } catch {
+          // Ignore validation errors during typing
+        }
+      }, 500);
+    },
+    [],
+  );
+
+  const onSaveConfig = useCallback(
+    async (config: Record<string, unknown>) => {
+      try {
+        const res = await updateConfig(config);
+        setErrors(res.errors);
+        queryClient.invalidateQueries({ queryKey: ["config"] });
+        if (res.errors.length === 0) {
+          notifications.show({
+            title: "Config saved",
+            message: "Configuration updated successfully",
+            color: "green",
+          });
+        }
+      } catch (e) {
+        notifications.show({
+          title: "Save failed",
+          message: String(e),
+          color: "red",
+        });
+      }
+    },
+    [queryClient],
+  );
+
+  const onImportYaml = useCallback(async () => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = ".yaml,.yml,.json";
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      try {
+        const res = await uploadConfig(file);
+        setErrors(res.errors);
+        queryClient.invalidateQueries({ queryKey: ["config"] });
+        notifications.show({
+          title: "Config imported",
+          message: `Loaded from ${file.name}`,
+          color: "green",
+        });
+      } catch (e) {
+        notifications.show({
+          title: "Import failed",
+          message: String(e),
+          color: "red",
+        });
+      }
+    };
+    input.click();
+  }, [queryClient]);
+
+  // Cleanup debounce on unmount
+  useEffect(() => {
+    return () => clearTimeout(debounceRef.current);
+  }, []);
+
+  const schema = schemaQuery.data;
+  const config = configQuery.data ?? {};
+
+  return (
+    <Paper p="md" withBorder>
+      {/* Sticky header */}
+      <Group justify="space-between" mb="sm">
+        <Group gap="xs">
+          <Title order={5}>Model</Title>
+          <Badge size="sm" variant="light">
+            lizyml
+          </Badge>
+        </Group>
+      </Group>
+
+      <Tabs value={activeTab} onChange={setActiveTab}>
+        <Tabs.List>
+          <Tabs.Tab value="fit">Fit</Tabs.Tab>
+          <Tabs.Tab value="tune">Tune</Tabs.Tab>
+        </Tabs.List>
+
+        {/* Fit Tab */}
+        <Tabs.Panel value="fit" pt="sm">
+          <Stack gap="sm">
+            {schema ? (
+              <ConfigForm
+                schema={schema}
+                config={config}
+                errors={errors}
+                onChange={onConfigChange}
+                onSave={onSaveConfig}
+              />
+            ) : (
+              <Text c="dimmed" size="sm">
+                Loading schema...
+              </Text>
+            )}
+          </Stack>
+        </Tabs.Panel>
+
+        {/* Tune Tab */}
+        <Tabs.Panel value="tune" pt="sm">
+          <Stack gap="sm">
+            <Accordion>
+              <Accordion.Item value="model">
+                <Accordion.Control>Model</Accordion.Control>
+                <Accordion.Panel>
+                  <Text size="sm" c="dimmed">
+                    Model selection for tuning. Shared with Fit tab.
+                  </Text>
+                </Accordion.Panel>
+              </Accordion.Item>
+              <Accordion.Item value="settings">
+                <Accordion.Control>Settings</Accordion.Control>
+                <Accordion.Panel>
+                  <Text size="sm" c="dimmed">
+                    Tuning settings (n_trials, timeout, scoring). Full implementation in Phase 5.
+                  </Text>
+                </Accordion.Panel>
+              </Accordion.Item>
+              <Accordion.Item value="search-space">
+                <Accordion.Control>Search Space</Accordion.Control>
+                <Accordion.Panel>
+                  <Text size="sm" c="dimmed">
+                    Search space editor. Full implementation in Phase 5.
+                  </Text>
+                </Accordion.Panel>
+              </Accordion.Item>
+            </Accordion>
+          </Stack>
+        </Tabs.Panel>
+      </Tabs>
+
+      {/* Import / Export / Raw */}
+      <Group mt="md" gap="xs">
+        <Button size="xs" variant="light" onClick={onImportYaml}>
+          Import YAML
+        </Button>
+        <Button
+          size="xs"
+          variant="light"
+          component="a"
+          href={downloadConfigUrl()}
+          download="config.yaml"
+        >
+          Export YAML
+        </Button>
+        <RawConfigToggle config={config} onSave={onSaveConfig} />
+      </Group>
+    </Paper>
+  );
+}
+
+function RawConfigToggle({
+  config,
+  onSave,
+}: {
+  config: Record<string, unknown>;
+  onSave: (config: Record<string, unknown>) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [raw, setRaw] = useState("");
+
+  useEffect(() => {
+    setRaw(JSON.stringify(config, null, 2));
+  }, [config]);
+
+  if (!open) {
+    return (
+      <Button size="xs" variant="subtle" onClick={() => setOpen(true)}>
+        Raw Config
+      </Button>
+    );
+  }
+
+  return (
+    <Stack gap="xs" mt="sm" style={{ width: "100%" }}>
+      <JsonInput
+        value={raw}
+        onChange={setRaw}
+        autosize
+        minRows={6}
+        maxRows={20}
+        formatOnBlur
+        validationError="Invalid JSON"
+      />
+      <Group gap="xs">
+        <Button
+          size="xs"
+          onClick={() => {
+            try {
+              onSave(JSON.parse(raw));
+              setOpen(false);
+            } catch {
+              notifications.show({
+                title: "Invalid JSON",
+                message: "Could not parse config",
+                color: "red",
+              });
+            }
+          }}
+        >
+          Apply
+        </Button>
+        <Button size="xs" variant="subtle" onClick={() => setOpen(false)}>
+          Close
+        </Button>
+      </Group>
+    </Stack>
+  );
+}

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -1,6 +1,7 @@
 import { Grid, Title, Text, Paper, Stack } from "@mantine/core";
 
 import { DataPanel } from "../components/DataPanel";
+import { ModelPanel } from "../components/ModelPanel";
 
 export function WorkspacePage() {
   return (
@@ -10,16 +11,9 @@ export function WorkspacePage() {
         <DataPanel />
       </Grid.Col>
 
-      {/* Center: Model Panel (stub) */}
+      {/* Center: Model Panel */}
       <Grid.Col span={4}>
-        <Paper p="md" withBorder>
-          <Stack>
-            <Title order={5}>Model</Title>
-            <Text c="dimmed" size="sm">
-              Configure model settings and run fit/tune.
-            </Text>
-          </Stack>
-        </Paper>
+        <ModelPanel />
       </Grid.Col>
 
       {/* Right: Results Panel (stub) */}

--- a/src/lizystudio/api/workspace.py
+++ b/src/lizystudio/api/workspace.py
@@ -1,6 +1,7 @@
 """Workspace API router (BLUEPRINT §5.2).
 
-Covers: status, reset, data endpoints. Config/Fit/Tune added in later phases.
+Covers: status, reset, data endpoints, config endpoints.
+Fit/Tune added in Phase 5.
 """
 
 from __future__ import annotations
@@ -10,11 +11,14 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
+import yaml
 from fastapi import APIRouter, Depends, UploadFile
+from fastapi.responses import Response
 
 from lizystudio.api.errors import (
     FileInvalidError,
     PathNotFoundError,
+    WorkspaceNoConfigError,
     WorkspaceNoDataError,
 )
 from lizystudio.services.data import (
@@ -135,3 +139,76 @@ def data_describe(
     if ws.dataframe is None:
         raise WorkspaceNoDataError()
     return get_describe(ws.dataframe)
+
+
+# --- Config endpoints (BLUEPRINT §5.2 Config) ---
+
+
+@router.get("/config/schema")
+def config_schema(
+    ws: WorkspaceState = Depends(get_workspace),
+) -> dict[str, Any]:
+    """Return the backend's config JSON Schema."""
+    schema = ws.backend.get_config_schema()
+    return schema.json_schema
+
+
+@router.get("/config")
+def config_get(
+    ws: WorkspaceState = Depends(get_workspace),
+) -> dict[str, Any]:
+    """Return the current workspace config."""
+    return ws.config
+
+
+@router.put("/config")
+def config_update(
+    body: dict[str, Any],
+    ws: WorkspaceState = Depends(get_workspace),
+) -> dict[str, Any]:
+    """Update config with validation."""
+    errors = ws.backend.validate_config(body)
+    ws.set_config(body)
+    return {"config": body, "errors": errors}
+
+
+@router.post("/config/validate")
+def config_validate(
+    body: dict[str, Any],
+    ws: WorkspaceState = Depends(get_workspace),
+) -> dict[str, Any]:
+    """Validate config without saving."""
+    errors = ws.backend.validate_config(body)
+    return {"valid": len(errors) == 0, "errors": errors}
+
+
+@router.post("/config/upload")
+async def config_upload(
+    file: UploadFile,
+    ws: WorkspaceState = Depends(get_workspace),
+) -> dict[str, Any]:
+    """Load config from an uploaded YAML/JSON file."""
+    content = await file.read()
+    filename = file.filename or "config.yaml"
+    try:
+        config = ws.backend.load_config_from_file(content, filename)
+    except Exception as exc:
+        raise FileInvalidError(str(exc)) from exc
+    errors = ws.backend.validate_config(config)
+    ws.set_config(config)
+    return {"config": config, "errors": errors}
+
+
+@router.get("/config/download")
+def config_download(
+    ws: WorkspaceState = Depends(get_workspace),
+) -> Response:
+    """Download the current config as YAML."""
+    if not ws.config:
+        raise WorkspaceNoConfigError()
+    content = yaml.dump(ws.config, default_flow_style=False, allow_unicode=True)
+    return Response(
+        content=content,
+        media_type="application/x-yaml",
+        headers={"Content-Disposition": "attachment; filename=config.yaml"},
+    )

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -1,0 +1,69 @@
+"""Tests for Workspace Config API endpoints."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_config_schema(client: TestClient) -> None:
+    res = client.get("/api/workspace/config/schema")
+    assert res.status_code == 200
+    body = res.json()
+    assert "properties" in body
+
+
+def test_config_get_empty(client: TestClient) -> None:
+    res = client.get("/api/workspace/config")
+    assert res.status_code == 200
+    assert res.json() == {}
+
+
+def test_config_put(client: TestClient) -> None:
+    config = {"task": "binary", "model": {"name": "lightgbm"}}
+    res = client.put("/api/workspace/config", json=config)
+    assert res.status_code == 200
+    body = res.json()
+    assert body["config"]["task"] == "binary"
+    # Partial config will have validation errors
+    assert isinstance(body["errors"], list)
+
+
+def test_config_get_after_put(client: TestClient) -> None:
+    config = {"task": "regression"}
+    client.put("/api/workspace/config", json=config)
+    res = client.get("/api/workspace/config")
+    assert res.status_code == 200
+    assert res.json()["task"] == "regression"
+
+
+def test_config_validate_invalid(client: TestClient) -> None:
+    res = client.post("/api/workspace/config/validate", json={})
+    assert res.status_code == 200
+    body = res.json()
+    assert body["valid"] is False
+    assert len(body["errors"]) > 0
+
+
+def test_config_upload_yaml(client: TestClient) -> None:
+    yaml_content = b"task: binary\nmodel:\n  name: lightgbm"
+    res = client.post(
+        "/api/workspace/config/upload",
+        files={"file": ("config.yaml", yaml_content, "application/x-yaml")},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["config"]["task"] == "binary"
+
+
+def test_config_download(client: TestClient) -> None:
+    client.put("/api/workspace/config", json={"task": "binary"})
+    res = client.get("/api/workspace/config/download")
+    assert res.status_code == 200
+    assert "task: binary" in res.text
+    assert res.headers["content-type"] == "application/x-yaml"
+
+
+def test_config_download_empty(client: TestClient) -> None:
+    res = client.get("/api/workspace/config/download")
+    assert res.status_code == 400
+    assert res.json()["error"]["code"] == "WORKSPACE_NO_CONFIG"


### PR DESCRIPTION
## Summary
- **6 Config API endpoints**: `GET /config/schema`, `GET /config`, `PUT /config`, `POST /config/validate`, `POST /config/upload`, `GET /config/download`
- **ModelPanel**: Fit/Tune tabs with sticky header, backend badge
- **ConfigForm**: JSON Schema → dynamic form generation (NumberInput, Select, Switch, TextInput per type)
- **Features**: debounced auto-validation, raw JSON editor, YAML import/export

## Test plan
- [x] 32 tests passing (8 new config API tests)
- [x] `ruff check` / `ruff format` / `mypy` clean
- [x] `pnpm lint` / `pnpm build` clean