### PR TITLE
feat: fit/tune execution with results panel (Phase 5)

### DIFF
--- a/frontend/src/api/jobs.ts
+++ b/frontend/src/api/jobs.ts
@@ -1,0 +1,85 @@
+/**
+ * Jobs API client.
+ */
+
+import { apiFetch } from "./client";
+
+export interface JobSummary {
+  job_id: string;
+  status: "pending" | "running" | "completed" | "failed";
+  backend_name: string;
+  job_type: "fit" | "tune";
+  created_at: string;
+  completed_at: string | null;
+  error: string | null;
+}
+
+export interface FitResult {
+  metrics: Record<string, unknown>;
+  fold_count: number;
+  params: Array<Record<string, unknown>>;
+}
+
+export interface TuneResult {
+  best_params: Record<string, unknown>;
+  best_score: number;
+  trials: Array<Record<string, unknown>>;
+  metric_name: string;
+  direction: string;
+}
+
+export interface JobDetail extends JobSummary {
+  fit_result?: FitResult;
+  tune_result?: TuneResult;
+}
+
+export function fetchJobs(status?: string): Promise<JobSummary[]> {
+  const params = status ? `?status=${status}` : "";
+  return apiFetch(`/jobs/${params}`);
+}
+
+export function fetchJob(jobId: string): Promise<JobDetail> {
+  return apiFetch(`/jobs/${jobId}`);
+}
+
+export function fetchJobMetrics(
+  jobId: string,
+): Promise<Array<Record<string, unknown>>> {
+  return apiFetch(`/jobs/${jobId}/metrics`);
+}
+
+export function fetchJobImportance(
+  jobId: string,
+  kind: string = "split",
+): Promise<Record<string, number>> {
+  return apiFetch(`/jobs/${jobId}/importance?kind=${kind}`);
+}
+
+export function fetchJobPlot(
+  jobId: string,
+  plotType: string,
+): Promise<{ plotly_json: string }> {
+  return apiFetch(`/jobs/${jobId}/plot/${plotType}`);
+}
+
+export function fetchJobPlots(jobId: string): Promise<string[]> {
+  return apiFetch(`/jobs/${jobId}/plots`);
+}
+
+export function fetchJobSplitSummary(
+  jobId: string,
+): Promise<Array<Record<string, unknown>>> {
+  return apiFetch(`/jobs/${jobId}/split-summary`);
+}
+
+export function deleteJob(jobId: string): Promise<{ status: string }> {
+  return apiFetch(`/jobs/${jobId}`, { method: "DELETE" });
+}
+
+export function runFit(): Promise<{ job_id: string }> {
+  return apiFetch("/workspace/fit", { method: "POST" });
+}
+
+export function runTune(): Promise<{ job_id: string }> {
+  return apiFetch("/workspace/tune", { method: "POST" });
+}

--- a/frontend/src/components/PlotlyChart.tsx
+++ b/frontend/src/components/PlotlyChart.tsx
@@ -1,0 +1,32 @@
+/**
+ * Wrapper that renders a Plotly figure from a JSON string (fig.to_json()).
+ */
+import { useMemo } from "react";
+import { Plot } from "./Plot";
+
+interface PlotlyChartProps {
+  json: string;
+}
+
+export function PlotlyChart({ json }: PlotlyChartProps) {
+  const { data, layout } = useMemo(() => {
+    try {
+      const parsed = JSON.parse(json);
+      return {
+        data: parsed.data ?? [],
+        layout: { ...parsed.layout, autosize: true },
+      };
+    } catch {
+      return { data: [], layout: {} };
+    }
+  }, [json]);
+
+  return (
+    <Plot
+      data={data}
+      layout={layout}
+      useResizeHandler
+      style={{ width: "100%", height: "100%" }}
+    />
+  );
+}

--- a/frontend/src/components/ResultsPanel.tsx
+++ b/frontend/src/components/ResultsPanel.tsx
@@ -1,0 +1,386 @@
+import { useState, useCallback } from "react";
+import {
+  Accordion,
+  Alert,
+  Button,
+  Group,
+  Loader,
+  Paper,
+  Select,
+  Stack,
+  Table,
+  Text,
+  Title,
+  Badge,
+} from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { IconCheck, IconX, IconInfoCircle } from "@tabler/icons-react";
+
+import {
+  type FitResult,
+  type TuneResult,
+  fetchJob,
+  fetchJobPlot,
+  fetchJobPlots,
+  runFit,
+  runTune,
+} from "../api/jobs";
+import { PlotlyChart } from "./PlotlyChart";
+
+interface ResultsPanelProps {
+  jobId: string | null;
+  onJobCreated?: (jobId: string) => void;
+}
+
+export function ResultsPanel({ jobId, onJobCreated }: ResultsPanelProps) {
+  const queryClient = useQueryClient();
+  const [running, setRunning] = useState(false);
+
+  const jobQuery = useQuery({
+    queryKey: ["job", jobId],
+    queryFn: () => fetchJob(jobId!),
+    enabled: !!jobId,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status === "running" || status === "pending" ? 2000 : false;
+    },
+  });
+
+  const onFit = useCallback(async () => {
+    setRunning(true);
+    try {
+      const res = await runFit();
+      onJobCreated?.(res.job_id);
+      queryClient.invalidateQueries({ queryKey: ["job"] });
+    } catch (e) {
+      notifications.show({ title: "Fit failed", message: String(e), color: "red" });
+    } finally {
+      setRunning(false);
+    }
+  }, [onJobCreated, queryClient]);
+
+  const onTuneClick = useCallback(async () => {
+    setRunning(true);
+    try {
+      const res = await runTune();
+      onJobCreated?.(res.job_id);
+      queryClient.invalidateQueries({ queryKey: ["job"] });
+    } catch (e) {
+      notifications.show({ title: "Tune failed", message: String(e), color: "red" });
+    } finally {
+      setRunning(false);
+    }
+  }, [onJobCreated, queryClient]);
+
+  // No job yet — show guide
+  if (!jobId || !jobQuery.data) {
+    return (
+      <Paper p="md" withBorder>
+        <Stack align="center" gap="md" py="xl">
+          <Title order={5}>Results</Title>
+          <Text c="dimmed" size="sm" ta="center">
+            1. Load data in Data Panel{"\n"}
+            2. Configure model in Model Panel{"\n"}
+            3. Click Fit or Tune below
+          </Text>
+          <Group>
+            <Button onClick={onFit} loading={running}>
+              Fit
+            </Button>
+            <Button variant="light" onClick={onTuneClick} loading={running}>
+              Tune
+            </Button>
+          </Group>
+        </Stack>
+      </Paper>
+    );
+  }
+
+  const job = jobQuery.data;
+
+  // Running
+  if (job.status === "running" || job.status === "pending") {
+    return (
+      <Paper p="md" withBorder>
+        <Stack align="center" gap="md" py="xl">
+          <Group>
+            <Title order={5}>
+              {job.job_type === "fit" ? "Fit" : "Tune"} — {job.job_id}
+            </Title>
+            <Badge color="blue">Running</Badge>
+          </Group>
+          <Loader />
+          <Text size="sm" c="dimmed">
+            Processing...
+          </Text>
+        </Stack>
+      </Paper>
+    );
+  }
+
+  // Failed
+  if (job.status === "failed") {
+    return (
+      <Paper p="md" withBorder>
+        <Stack gap="md">
+          <Group>
+            <Title order={5}>
+              {job.job_type === "fit" ? "Fit" : "Tune"} — {job.job_id}
+            </Title>
+            <Badge color="red" leftSection={<IconX size={12} />}>
+              Failed
+            </Badge>
+          </Group>
+          <Alert color="red" icon={<IconX size={16} />}>
+            {job.error ?? "Unknown error"}
+          </Alert>
+          <Group>
+            <Button onClick={onFit} loading={running}>
+              Retry Fit
+            </Button>
+          </Group>
+        </Stack>
+      </Paper>
+    );
+  }
+
+  // Completed
+  return (
+    <Paper p="md" withBorder>
+      <Stack gap="md">
+        <Group>
+          <Title order={5}>
+            {job.job_type === "fit" ? "Fit" : "Tune"} — {job.job_id}
+          </Title>
+          <Badge color="green" leftSection={<IconCheck size={12} />}>
+            Completed
+          </Badge>
+        </Group>
+
+        {/* Tune-specific sections */}
+        {job.tune_result && <TuneResultSection tuneResult={job.tune_result} />}
+
+        {/* Score (from fit_result) */}
+        {job.fit_result && <MetricsTable fitResult={job.fit_result} />}
+
+        {/* Plots */}
+        <PlotViewer jobId={job.job_id} />
+
+        {/* Accordion details */}
+        <Accordion>
+          {job.fit_result && job.fit_result.fold_count > 1 && (
+            <Accordion.Item value="fold-details">
+              <Accordion.Control>Fold Details</Accordion.Control>
+              <Accordion.Panel>
+                <Text size="sm" c="dimmed">
+                  {job.fit_result.fold_count} folds
+                </Text>
+              </Accordion.Panel>
+            </Accordion.Item>
+          )}
+          {job.fit_result && (
+            <Accordion.Item value="params">
+              <Accordion.Control>Parameters</Accordion.Control>
+              <Accordion.Panel>
+                <ParamsTable params={job.fit_result.params} />
+              </Accordion.Panel>
+            </Accordion.Item>
+          )}
+          {job.tune_result && (
+            <Accordion.Item value="trials">
+              <Accordion.Control>Trial Results</Accordion.Control>
+              <Accordion.Panel>
+                <TrialsTable
+                  trials={job.tune_result.trials}
+                  bestScore={job.tune_result.best_score}
+                />
+              </Accordion.Panel>
+            </Accordion.Item>
+          )}
+        </Accordion>
+
+        <Group>
+          <Button onClick={onFit} loading={running}>
+            Fit
+          </Button>
+          <Button variant="light" onClick={onTuneClick} loading={running}>
+            Tune
+          </Button>
+        </Group>
+      </Stack>
+    </Paper>
+  );
+}
+
+// --- Sub-components ---
+
+function MetricsTable({ fitResult }: { fitResult: FitResult }) {
+  const metrics = fitResult.metrics;
+  if (!metrics || typeof metrics !== "object") return null;
+  const rows = Object.entries(metrics);
+  if (rows.length === 0) return null;
+
+  return (
+    <Stack gap="xs">
+      <Text fw={600} size="sm">
+        Score
+      </Text>
+      <Table fz="xs" withTableBorder striped>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Metric</Table.Th>
+            <Table.Th>Value</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {rows.map(([key, val]) => (
+            <Table.Tr key={key}>
+              <Table.Td>{key}</Table.Td>
+              <Table.Td>{formatMetric(val)}</Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+    </Stack>
+  );
+}
+
+function TuneResultSection({ tuneResult }: { tuneResult: TuneResult }) {
+  return (
+    <Stack gap="xs">
+      <Alert icon={<IconInfoCircle size={16} />} variant="light" color="blue">
+        Best {tuneResult.metric_name}: {tuneResult.best_score.toFixed(4)} ({tuneResult.direction})
+      </Alert>
+      <Text fw={600} size="sm">
+        Best Params
+      </Text>
+      <Table fz="xs" withTableBorder>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Param</Table.Th>
+            <Table.Th>Value</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {Object.entries(tuneResult.best_params).map(([k, v]) => (
+            <Table.Tr key={k}>
+              <Table.Td>{k}</Table.Td>
+              <Table.Td>{String(v)}</Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+    </Stack>
+  );
+}
+
+function PlotViewer({ jobId }: { jobId: string }) {
+  const [plotType, setPlotType] = useState<string | null>(null);
+
+  const plotsQuery = useQuery({
+    queryKey: ["job-plots", jobId],
+    queryFn: () => fetchJobPlots(jobId),
+  });
+
+  const plotQuery = useQuery({
+    queryKey: ["job-plot", jobId, plotType],
+    queryFn: () => fetchJobPlot(jobId, plotType!),
+    enabled: !!plotType,
+  });
+
+  const availablePlots = plotsQuery.data ?? [];
+
+  return (
+    <Stack gap="xs">
+      <Group>
+        <Text fw={600} size="sm">
+          Plots
+        </Text>
+        <Select
+          size="xs"
+          data={availablePlots}
+          value={plotType}
+          onChange={setPlotType}
+          placeholder="Select plot"
+          w={200}
+        />
+      </Group>
+      {plotQuery.data && <PlotlyChart json={plotQuery.data.plotly_json} />}
+    </Stack>
+  );
+}
+
+function ParamsTable({ params }: { params: Array<Record<string, unknown>> }) {
+  if (params.length === 0) return <Text size="sm" c="dimmed">No parameters</Text>;
+  const keys = Object.keys(params[0]);
+  return (
+    <Table fz="xs" withTableBorder striped>
+      <Table.Thead>
+        <Table.Tr>
+          {keys.map((k) => (
+            <Table.Th key={k}>{k}</Table.Th>
+          ))}
+        </Table.Tr>
+      </Table.Thead>
+      <Table.Tbody>
+        {params.map((row, i) => (
+          <Table.Tr key={i}>
+            {keys.map((k) => (
+              <Table.Td key={k}>{String(row[k] ?? "")}</Table.Td>
+            ))}
+          </Table.Tr>
+        ))}
+      </Table.Tbody>
+    </Table>
+  );
+}
+
+function TrialsTable({
+  trials,
+  bestScore,
+}: {
+  trials: Array<Record<string, unknown>>;
+  bestScore: number;
+}) {
+  if (trials.length === 0) return null;
+  return (
+    <Table fz="xs" withTableBorder striped>
+      <Table.Thead>
+        <Table.Tr>
+          <Table.Th>Trial</Table.Th>
+          <Table.Th>Score</Table.Th>
+          <Table.Th>Params</Table.Th>
+        </Table.Tr>
+      </Table.Thead>
+      <Table.Tbody>
+        {trials.map((t) => {
+          const score = Number(t.score);
+          const isBest = Math.abs(score - bestScore) < 1e-8;
+          return (
+            <Table.Tr key={String(t.number)} bg={isBest ? "var(--mantine-color-green-0)" : undefined}>
+              <Table.Td>
+                {isBest ? "★ " : ""}
+                {String(t.number)}
+              </Table.Td>
+              <Table.Td>{score.toFixed(4)}</Table.Td>
+              <Table.Td>
+                <Text size="xs" lineClamp={1}>
+                  {JSON.stringify(t.params)}
+                </Text>
+              </Table.Td>
+            </Table.Tr>
+          );
+        })}
+      </Table.Tbody>
+    </Table>
+  );
+}
+
+function formatMetric(val: unknown): string {
+  if (typeof val === "number") return val.toFixed(4);
+  if (typeof val === "object" && val !== null) {
+    return JSON.stringify(val);
+  }
+  return String(val);
+}

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -1,9 +1,17 @@
-import { Grid, Title, Text, Paper, Stack } from "@mantine/core";
+import { useState, useCallback } from "react";
+import { Grid } from "@mantine/core";
 
 import { DataPanel } from "../components/DataPanel";
 import { ModelPanel } from "../components/ModelPanel";
+import { ResultsPanel } from "../components/ResultsPanel";
 
 export function WorkspacePage() {
+  const [currentJobId, setCurrentJobId] = useState<string | null>(null);
+
+  const onJobCreated = useCallback((jobId: string) => {
+    setCurrentJobId(jobId);
+  }, []);
+
   return (
     <Grid gutter="md">
       {/* Left: Data Panel */}
@@ -16,16 +24,9 @@ export function WorkspacePage() {
         <ModelPanel />
       </Grid.Col>
 
-      {/* Right: Results Panel (stub) */}
+      {/* Right: Results Panel */}
       <Grid.Col span={4}>
-        <Paper p="md" withBorder>
-          <Stack>
-            <Title order={5}>Results</Title>
-            <Text c="dimmed" size="sm">
-              Results will appear here after fitting.
-            </Text>
-          </Stack>
-        </Paper>
+        <ResultsPanel jobId={currentJobId} onJobCreated={onJobCreated} />
       </Grid.Col>
     </Grid>
   );

--- a/src/lizystudio/_version.py
+++ b/src/lizystudio/_version.py
@@ -28,7 +28,7 @@ version_tuple: VERSION_TUPLE
 commit_id: COMMIT_ID
 __commit_id__: COMMIT_ID
 
-__version__ = version = '0.1.dev1+ge8434ef10'
-__version_tuple__ = version_tuple = (0, 1, 'dev1', 'ge8434ef10')
+__version__ = version = "0.1.dev6+gdf1bb732a.d20260309"
+__version_tuple__ = version_tuple = (0, 1, "dev6", "gdf1bb732a.d20260309")
 
 __commit_id__ = commit_id = None

--- a/src/lizystudio/api/jobs.py
+++ b/src/lizystudio/api/jobs.py
@@ -1,6 +1,7 @@
-"""Jobs API router — list, get, and stubs for job management.
+"""Jobs API router (BLUEPRINT §5.3).
 
-Full endpoints (metrics, plots, export, etc.) are implemented in Phase 5–6.
+Covers: list, get, config, metrics, split-summary, importance, plot, plots, delete.
+Export endpoint added in Phase 6.
 """
 
 from __future__ import annotations
@@ -10,10 +11,51 @@ from typing import Any
 
 from fastapi import APIRouter, Depends
 
-from lizystudio.api.errors import JobNotFoundError
-from lizystudio.services.jobs import JobStore, get_job_store
+from lizystudio.api.errors import (
+    BackendError,
+    JobNotCompletedError,
+    JobNotFoundError,
+)
+from lizystudio.services.jobs import Job, JobStore, get_job_store
+from lizystudio.services.workspace import WorkspaceState, get_workspace
 
 router = APIRouter()
+
+
+# --- Helpers ---
+
+
+def _get_job_or_404(job_id: str, job_store: JobStore) -> Job:
+    job = job_store.get(job_id)
+    if job is None:
+        raise JobNotFoundError(job_id)
+    return job
+
+
+def _require_completed(job: Job) -> None:
+    if job.status != "completed":
+        raise JobNotCompletedError(job.job_id)
+
+
+def _load_model(job: Job, ws: WorkspaceState) -> Any:
+    if job.model_path is None:
+        raise JobNotCompletedError(job.job_id)
+    return ws.backend.load_model(job.model_path)
+
+
+def _job_summary(job: Job) -> dict[str, Any]:
+    return {
+        "job_id": job.job_id,
+        "status": job.status,
+        "backend_name": job.backend_name,
+        "job_type": job.job_type,
+        "created_at": job.created_at,
+        "completed_at": job.completed_at,
+        "error": job.error,
+    }
+
+
+# --- CRUD ---
 
 
 @router.get("/")
@@ -33,9 +75,7 @@ def get_job(
     job_store: JobStore = Depends(get_job_store),
 ) -> dict[str, Any]:
     """Get job details."""
-    job = job_store.get(job_id)
-    if job is None:
-        raise JobNotFoundError(job_id)
+    job = _get_job_or_404(job_id, job_store)
     result: dict[str, Any] = _job_summary(job)
     if job.fit_result is not None:
         result["fit_result"] = asdict(job.fit_result)
@@ -44,13 +84,108 @@ def get_job(
     return result
 
 
-def _job_summary(job: Any) -> dict[str, Any]:
-    return {
-        "job_id": job.job_id,
-        "status": job.status,
-        "backend_name": job.backend_name,
-        "job_type": job.job_type,
-        "created_at": job.created_at,
-        "completed_at": job.completed_at,
-        "error": job.error,
-    }
+@router.get("/{job_id}/config")
+def get_job_config(
+    job_id: str,
+    job_store: JobStore = Depends(get_job_store),
+) -> dict[str, Any]:
+    """Get the config used for this job."""
+    job = _get_job_or_404(job_id, job_store)
+    return job.config
+
+
+@router.delete("/{job_id}")
+def delete_job(
+    job_id: str,
+    job_store: JobStore = Depends(get_job_store),
+) -> dict[str, str]:
+    """Delete a job."""
+    if not job_store.delete(job_id):
+        raise JobNotFoundError(job_id)
+    return {"status": "deleted"}
+
+
+# --- Result viewing ---
+
+
+@router.get("/{job_id}/metrics")
+def get_job_metrics(
+    job_id: str,
+    job_store: JobStore = Depends(get_job_store),
+    ws: WorkspaceState = Depends(get_workspace),
+) -> list[dict[str, Any]]:
+    """Get metrics table (evaluate_table)."""
+    job = _get_job_or_404(job_id, job_store)
+    _require_completed(job)
+    try:
+        model = _load_model(job, ws)
+        return ws.backend.evaluate_table(model)
+    except Exception as exc:
+        raise BackendError(exc) from exc
+
+
+@router.get("/{job_id}/split-summary")
+def get_job_split_summary(
+    job_id: str,
+    job_store: JobStore = Depends(get_job_store),
+    ws: WorkspaceState = Depends(get_workspace),
+) -> list[dict[str, Any]]:
+    """Get fold/split summary."""
+    job = _get_job_or_404(job_id, job_store)
+    _require_completed(job)
+    try:
+        model = _load_model(job, ws)
+        return ws.backend.split_summary(model)
+    except Exception as exc:
+        raise BackendError(exc) from exc
+
+
+@router.get("/{job_id}/importance")
+def get_job_importance(
+    job_id: str,
+    kind: str = "split",
+    job_store: JobStore = Depends(get_job_store),
+    ws: WorkspaceState = Depends(get_workspace),
+) -> dict[str, float]:
+    """Get feature importance."""
+    job = _get_job_or_404(job_id, job_store)
+    _require_completed(job)
+    try:
+        model = _load_model(job, ws)
+        return ws.backend.importance(model, kind=kind)
+    except Exception as exc:
+        raise BackendError(exc) from exc
+
+
+@router.get("/{job_id}/plot/{plot_type}")
+def get_job_plot(
+    job_id: str,
+    plot_type: str,
+    job_store: JobStore = Depends(get_job_store),
+    ws: WorkspaceState = Depends(get_workspace),
+) -> dict[str, str]:
+    """Get a Plotly figure as JSON."""
+    job = _get_job_or_404(job_id, job_store)
+    _require_completed(job)
+    try:
+        model = _load_model(job, ws)
+        plot_data = ws.backend.plot(model, plot_type)
+        return {"plotly_json": plot_data.plotly_json}
+    except Exception as exc:
+        raise BackendError(exc) from exc
+
+
+@router.get("/{job_id}/plots")
+def get_job_available_plots(
+    job_id: str,
+    job_store: JobStore = Depends(get_job_store),
+    ws: WorkspaceState = Depends(get_workspace),
+) -> list[str]:
+    """Get list of available plot types for this job."""
+    job = _get_job_or_404(job_id, job_store)
+    _require_completed(job)
+    try:
+        model = _load_model(job, ws)
+        return ws.backend.available_plots(model)
+    except Exception as exc:
+        raise BackendError(exc) from exc

--- a/src/lizystudio/api/workspace.py
+++ b/src/lizystudio/api/workspace.py
@@ -1,7 +1,6 @@
 """Workspace API router (BLUEPRINT §5.2).
 
-Covers: status, reset, data endpoints, config endpoints.
-Fit/Tune added in Phase 5.
+Covers: status, reset, data, config, fit, tune.
 """
 
 from __future__ import annotations
@@ -16,6 +15,7 @@ from fastapi import APIRouter, Depends, UploadFile
 from fastapi.responses import Response
 
 from lizystudio.api.errors import (
+    BackendError,
     FileInvalidError,
     PathNotFoundError,
     WorkspaceNoConfigError,
@@ -28,6 +28,8 @@ from lizystudio.services.data import (
     load_dataframe,
     make_data_ref,
 )
+from lizystudio.services.jobs import JobStore, get_job_store
+from lizystudio.services.training import run_fit, run_tune
 from lizystudio.services.workspace import WorkspaceState, get_workspace
 
 router = APIRouter()
@@ -212,3 +214,72 @@ def config_download(
         media_type="application/x-yaml",
         headers={"Content-Disposition": "attachment; filename=config.yaml"},
     )
+
+
+# --- Fit / Tune endpoints (BLUEPRINT §5.2 Fit/Tune) ---
+
+
+@router.post("/fit")
+def workspace_fit(
+    ws: WorkspaceState = Depends(get_workspace),
+    job_store: JobStore = Depends(get_job_store),
+) -> dict[str, Any]:
+    """Create and run a fit job with current config + data."""
+    if not ws.config:
+        raise WorkspaceNoConfigError()
+    if ws.dataframe is None or ws.data_ref is None:
+        raise WorkspaceNoDataError()
+    job = job_store.create(
+        backend_name=ws.backend.info.name,
+        config=ws.config,
+        data_ref=ws.data_ref,
+        job_type="fit",
+    )
+    try:
+        job = run_fit(
+            job=job,
+            job_store=job_store,
+            backend=ws.backend,
+            config=ws.config,
+            dataframe=ws.dataframe,
+        )
+    except Exception as exc:
+        raise BackendError(exc) from exc
+    # Update workspace volatile state
+    ws.workspace_fit_result = job.fit_result
+    ws.workspace_tune_result = None
+    ws.current_job_id = job.job_id
+    return {"job_id": job.job_id}
+
+
+@router.post("/tune")
+def workspace_tune(
+    ws: WorkspaceState = Depends(get_workspace),
+    job_store: JobStore = Depends(get_job_store),
+) -> dict[str, Any]:
+    """Create and run a tune job with current config + data."""
+    if not ws.config:
+        raise WorkspaceNoConfigError()
+    if ws.dataframe is None or ws.data_ref is None:
+        raise WorkspaceNoDataError()
+    job = job_store.create(
+        backend_name=ws.backend.info.name,
+        config=ws.config,
+        data_ref=ws.data_ref,
+        job_type="tune",
+    )
+    try:
+        job = run_tune(
+            job=job,
+            job_store=job_store,
+            backend=ws.backend,
+            config=ws.config,
+            dataframe=ws.dataframe,
+        )
+    except Exception as exc:
+        raise BackendError(exc) from exc
+    # Update workspace volatile state
+    ws.workspace_fit_result = job.fit_result
+    ws.workspace_tune_result = job.tune_result
+    ws.current_job_id = job.job_id
+    return {"job_id": job.job_id}

--- a/src/lizystudio/services/training.py
+++ b/src/lizystudio/services/training.py
@@ -1,0 +1,77 @@
+"""Training service — run fit/tune jobs (BLUEPRINT §4.2.4, H-0002 Case B)."""
+
+from __future__ import annotations
+
+import traceback
+from datetime import datetime, timezone
+from typing import Any
+
+from lizystudio.backends.base import BackendAdapter
+from lizystudio.backends.types import FitSummary, TuningSummary
+from lizystudio.services.jobs import Job, JobStore
+
+
+def run_fit(
+    *,
+    job: Job,
+    job_store: JobStore,
+    backend: BackendAdapter,
+    config: dict[str, Any],
+    dataframe: Any,
+    params: dict[str, Any] | None = None,
+) -> Job:
+    """Execute a fit job synchronously. Updates job in-place and on disk."""
+    job.status = "running"
+    job_store.update(job)
+    try:
+        model = backend.create_model(config, dataframe)
+        fit_result: FitSummary = backend.fit(model, params=params)
+        # Export model
+        model_dir = str(job_store.jobs_dir / job.job_id / "model")
+        backend.export_model(model, model_dir)
+        # Update job
+        job.status = "completed"
+        job.fit_result = fit_result
+        job.model_path = model_dir
+        job.completed_at = datetime.now(timezone.utc).isoformat()
+        job_store.update(job)
+    except Exception as exc:
+        job.status = "failed"
+        job.error = f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}"
+        job.completed_at = datetime.now(timezone.utc).isoformat()
+        job_store.update(job)
+    return job
+
+
+def run_tune(
+    *,
+    job: Job,
+    job_store: JobStore,
+    backend: BackendAdapter,
+    config: dict[str, Any],
+    dataframe: Any,
+) -> Job:
+    """Execute a tune job: tune → auto-fit with best params (H-0002 Case B)."""
+    job.status = "running"
+    job_store.update(job)
+    try:
+        model = backend.create_model(config, dataframe)
+        tune_result: TuningSummary = backend.tune(model)
+        job.tune_result = tune_result
+        # Auto-fit with best params
+        model2 = backend.create_model(config, dataframe)
+        fit_result: FitSummary = backend.fit(model2, params=tune_result.best_params)
+        # Export model (the one fit with best params)
+        model_dir = str(job_store.jobs_dir / job.job_id / "model")
+        backend.export_model(model2, model_dir)
+        job.status = "completed"
+        job.fit_result = fit_result
+        job.model_path = model_dir
+        job.completed_at = datetime.now(timezone.utc).isoformat()
+        job_store.update(job)
+    except Exception as exc:
+        job.status = "failed"
+        job.error = f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}"
+        job.completed_at = datetime.now(timezone.utc).isoformat()
+        job_store.update(job)
+    return job

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -76,9 +76,7 @@ def test_list_with_filter(job_store: JobStore, sample_data_ref: DataRef) -> None
     assert completed[0].job_id == job.job_id
 
 
-def test_update_with_results(
-    job_store: JobStore, sample_data_ref: DataRef
-) -> None:
+def test_update_with_results(job_store: JobStore, sample_data_ref: DataRef) -> None:
     job = job_store.create(
         backend_name="lizyml",
         config={},


### PR DESCRIPTION
## Summary
- **Training service**: `run_fit` / `run_tune` implementing H-0002 Case B flow (tune → auto-fit with best_params → store both results)
- **Workspace API**: `POST /fit` and `POST /tune` endpoints
- **Jobs API**: Full result-viewing endpoints — metrics, split-summary, importance, plot/{plot_type}, plots
- **ResultsPanel**: 4-state UI (initial guide → running loader → completed results → error alert) with polling
- **PlotlyChart**: Wrapper that parses `fig.to_json()` strings for react-plotly.js
- **Jobs API client**: TypeScript types and fetch functions for all job endpoints

## Test plan
- [x] 32 backend tests pass (`uv run pytest`)
- [x] Ruff lint/format clean
- [x] mypy strict clean (21 source files)
- [x] ESLint clean
- [x] Frontend builds successfully
- [ ] Manual: CSV load → config → Fit → job created → results displayed
- [ ] Manual: Tune → auto-fit → both results stored and viewable