### PR TITLE
feat: jobs page with export support (Phase 6)

### DIFF
--- a/frontend/src/api/jobs.ts
+++ b/frontend/src/api/jobs.ts
@@ -76,6 +76,23 @@ export function deleteJob(jobId: string): Promise<{ status: string }> {
   return apiFetch(`/jobs/${jobId}`, { method: "DELETE" });
 }
 
+export function fetchJobConfig(
+  jobId: string,
+): Promise<Record<string, unknown>> {
+  return apiFetch(`/jobs/${jobId}/config`);
+}
+
+export function exportJob(
+  jobId: string,
+  exportType: "model" | "report",
+  outputPath: string,
+): Promise<{ exported_path: string; export_type: string }> {
+  return apiFetch(`/jobs/${jobId}/export`, {
+    method: "POST",
+    body: JSON.stringify({ export_type: exportType, output_path: outputPath }),
+  });
+}
+
 export function runFit(): Promise<{ job_id: string }> {
   return apiFetch("/workspace/fit", { method: "POST" });
 }

--- a/frontend/src/components/ExportDialog.tsx
+++ b/frontend/src/components/ExportDialog.tsx
@@ -1,0 +1,93 @@
+import { useState, useCallback } from "react";
+import {
+  Button,
+  Group,
+  Modal,
+  SegmentedControl,
+  Stack,
+  Text,
+  TextInput,
+} from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+
+import { exportJob } from "../api/jobs";
+
+interface ExportDialogProps {
+  opened: boolean;
+  onClose: () => void;
+  jobId: string;
+}
+
+export function ExportDialog({ opened, onClose, jobId }: ExportDialogProps) {
+  const [exportType, setExportType] = useState<"model" | "report">("model");
+  const [outputPath, setOutputPath] = useState(
+    `./exports/${jobId}_${exportType}`,
+  );
+  const [loading, setLoading] = useState(false);
+
+  const onExportTypeChange = useCallback(
+    (val: string) => {
+      const t = val as "model" | "report";
+      setExportType(t);
+      setOutputPath(`./exports/${jobId}_${t}`);
+    },
+    [jobId],
+  );
+
+  const onExport = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await exportJob(jobId, exportType, outputPath);
+      notifications.show({
+        title: "Export complete",
+        message: `Exported to ${res.exported_path}`,
+        color: "green",
+      });
+      onClose();
+    } catch (e) {
+      notifications.show({
+        title: "Export failed",
+        message: String(e),
+        color: "red",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [jobId, exportType, outputPath, onClose]);
+
+  return (
+    <Modal opened={opened} onClose={onClose} title="Export Job" centered>
+      <Stack gap="md">
+        <SegmentedControl
+          value={exportType}
+          onChange={onExportTypeChange}
+          data={[
+            { label: "Model", value: "model" },
+            { label: "Report", value: "report" },
+          ]}
+          fullWidth
+        />
+        <Text size="xs" c="dimmed">
+          {exportType === "model"
+            ? "Includes: pkl + metadata JSON"
+            : "HTML — metrics/plots"}
+        </Text>
+
+        <TextInput
+          label="Output Path"
+          value={outputPath}
+          onChange={(e) => setOutputPath(e.currentTarget.value)}
+        />
+
+        <Group justify="flex-end">
+          <Button variant="default" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={onExport} loading={loading}>
+            Export
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/frontend/src/components/ResultsPanel.tsx
+++ b/frontend/src/components/ResultsPanel.tsx
@@ -213,9 +213,9 @@ export function ResultsPanel({ jobId, onJobCreated }: ResultsPanelProps) {
   );
 }
 
-// --- Sub-components ---
+// --- Sub-components (exported for reuse in JobDetail) ---
 
-function MetricsTable({ fitResult }: { fitResult: FitResult }) {
+export function MetricsTable({ fitResult }: { fitResult: FitResult }) {
   const metrics = fitResult.metrics;
   if (!metrics || typeof metrics !== "object") return null;
   const rows = Object.entries(metrics);
@@ -246,7 +246,7 @@ function MetricsTable({ fitResult }: { fitResult: FitResult }) {
   );
 }
 
-function TuneResultSection({ tuneResult }: { tuneResult: TuneResult }) {
+export function TuneResultSection({ tuneResult }: { tuneResult: TuneResult }) {
   return (
     <Stack gap="xs">
       <Alert icon={<IconInfoCircle size={16} />} variant="light" color="blue">
@@ -275,7 +275,7 @@ function TuneResultSection({ tuneResult }: { tuneResult: TuneResult }) {
   );
 }
 
-function PlotViewer({ jobId }: { jobId: string }) {
+export function PlotViewer({ jobId }: { jobId: string }) {
   const [plotType, setPlotType] = useState<string | null>(null);
 
   const plotsQuery = useQuery({
@@ -311,7 +311,7 @@ function PlotViewer({ jobId }: { jobId: string }) {
   );
 }
 
-function ParamsTable({ params }: { params: Array<Record<string, unknown>> }) {
+export function ParamsTable({ params }: { params: Array<Record<string, unknown>> }) {
   if (params.length === 0) return <Text size="sm" c="dimmed">No parameters</Text>;
   const keys = Object.keys(params[0]);
   return (
@@ -336,7 +336,7 @@ function ParamsTable({ params }: { params: Array<Record<string, unknown>> }) {
   );
 }
 
-function TrialsTable({
+export function TrialsTable({
   trials,
   bestScore,
 }: {

--- a/frontend/src/pages/JobsPage.tsx
+++ b/frontend/src/pages/JobsPage.tsx
@@ -1,10 +1,474 @@
-import { Title, Text, Stack } from "@mantine/core";
+import { useState, useCallback, useMemo } from "react";
+import {
+  Accordion,
+  Alert,
+  Badge,
+  Box,
+  Button,
+  Code,
+  Group,
+  Loader,
+  Paper,
+  ScrollArea,
+  SegmentedControl,
+  Select,
+  Stack,
+  Text,
+  Title,
+  Tooltip,
+  UnstyledButton,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { notifications } from "@mantine/notifications";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  IconCheck,
+  IconX,
+  IconPlayerPlay,
+  IconTrash,
+  IconDownload,
+  IconArrowRight,
+} from "@tabler/icons-react";
+import { useNavigate } from "react-router-dom";
+
+import {
+  type JobSummary,
+  fetchJobs,
+  fetchJob,
+  fetchJobConfig,
+  deleteJob,
+} from "../api/jobs";
+import {
+  MetricsTable,
+  TuneResultSection,
+  PlotViewer,
+  ParamsTable,
+  TrialsTable,
+} from "../components/ResultsPanel";
+import { ExportDialog } from "../components/ExportDialog";
 
 export function JobsPage() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  // Filters
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [typeFilter, setTypeFilter] = useState<string | null>("all");
+
+  // Selected job
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
+
+  // Export dialog
+  const [exportOpened, { open: openExport, close: closeExport }] =
+    useDisclosure(false);
+
+  // Fetch jobs list
+  const jobsQuery = useQuery({
+    queryKey: ["jobs", statusFilter],
+    queryFn: () =>
+      fetchJobs(statusFilter === "all" ? undefined : statusFilter),
+    refetchInterval: 5000,
+  });
+
+  // Apply type filter client-side
+  const filteredJobs = (jobsQuery.data ?? []).filter(
+    (j) => typeFilter === "all" || j.job_type === typeFilter,
+  );
+
+  // Auto-select latest job if none selected
+  const effectiveJobId = useMemo(() => {
+    if (selectedJobId && filteredJobs.some((j) => j.job_id === selectedJobId)) {
+      return selectedJobId;
+    }
+    return filteredJobs.length > 0 ? filteredJobs[0].job_id : null;
+  }, [selectedJobId, filteredJobs]);
+
+  const onDelete = useCallback(
+    async (jobId: string) => {
+      if (!confirm(`Delete job ${jobId}? This cannot be undone.`)) return;
+      try {
+        await deleteJob(jobId);
+        queryClient.invalidateQueries({ queryKey: ["jobs"] });
+        if (effectiveJobId === jobId) setSelectedJobId(null);
+        notifications.show({
+          title: "Job deleted",
+          message: jobId,
+          color: "green",
+        });
+      } catch (e) {
+        notifications.show({
+          title: "Delete failed",
+          message: String(e),
+          color: "red",
+        });
+      }
+    },
+    [queryClient, effectiveJobId],
+  );
+
+  return (
+    <Box style={{ display: "flex", gap: 16, height: "calc(100vh - 80px)" }}>
+      {/* Left Panel — Job List */}
+      <Paper
+        withBorder
+        p="sm"
+        style={{ width: 360, flexShrink: 0, display: "flex", flexDirection: "column" }}
+      >
+        <Stack gap="xs" mb="sm">
+          <Title order={4}>Jobs</Title>
+          <SegmentedControl
+            size="xs"
+            value={statusFilter}
+            onChange={setStatusFilter}
+            data={[
+              { label: "All", value: "all" },
+              { label: "Done", value: "completed" },
+              { label: "Run", value: "running" },
+              { label: "Fail", value: "failed" },
+            ]}
+            fullWidth
+          />
+          <Select
+            size="xs"
+            data={[
+              { label: "All Types", value: "all" },
+              { label: "Fit", value: "fit" },
+              { label: "Tune", value: "tune" },
+            ]}
+            value={typeFilter}
+            onChange={setTypeFilter}
+          />
+        </Stack>
+        <ScrollArea style={{ flex: 1 }}>
+          <Stack gap={4}>
+            {filteredJobs.length === 0 && (
+              <Text size="sm" c="dimmed" ta="center" py="xl">
+                No jobs yet. Run Fit or Tune from the Workspace.
+              </Text>
+            )}
+            {filteredJobs.map((job) => (
+              <JobRow
+                key={job.job_id}
+                job={job}
+                selected={job.job_id === effectiveJobId}
+                onClick={() => setSelectedJobId(job.job_id)}
+              />
+            ))}
+          </Stack>
+        </ScrollArea>
+      </Paper>
+
+      {/* Right Panel — Job Detail */}
+      <Paper
+        withBorder
+        p="md"
+        style={{ flex: 1, overflow: "auto" }}
+      >
+        {effectiveJobId ? (
+          <JobDetailPanel
+            jobId={effectiveJobId}
+            onDelete={onDelete}
+            onExport={openExport}
+            onNavigateWorkspace={() => navigate("/")}
+            onNavigateInference={() => navigate("/inference")}
+          />
+        ) : (
+          <Stack align="center" justify="center" h="100%">
+            <Text c="dimmed">Select a job to view details</Text>
+          </Stack>
+        )}
+      </Paper>
+
+      {/* Export Dialog */}
+      {effectiveJobId && (
+        <ExportDialog
+          opened={exportOpened}
+          onClose={closeExport}
+          jobId={effectiveJobId}
+        />
+      )}
+    </Box>
+  );
+}
+
+// --- Job Row ---
+
+function JobRow({
+  job,
+  selected,
+  onClick,
+}: {
+  job: JobSummary;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  const statusIcon =
+    job.status === "completed" ? (
+      <IconCheck size={14} color="var(--mantine-color-green-6)" />
+    ) : job.status === "running" || job.status === "pending" ? (
+      <IconPlayerPlay size={14} color="var(--mantine-color-blue-6)" />
+    ) : (
+      <IconX size={14} color="var(--mantine-color-red-6)" />
+    );
+
+  const timeStr = job.completed_at ?? job.created_at;
+
+  return (
+    <Tooltip label={timeStr} position="right" withArrow>
+      <UnstyledButton
+        onClick={onClick}
+        p="xs"
+        style={{
+          borderRadius: 6,
+          border: selected
+            ? "1px solid var(--mantine-color-blue-4)"
+            : "1px solid transparent",
+          backgroundColor: selected
+            ? "var(--mantine-color-blue-0)"
+            : undefined,
+        }}
+      >
+        <Group gap="xs" wrap="nowrap">
+          {statusIcon}
+          <Text size="xs" fw={500} truncate style={{ flex: 1 }}>
+            {job.job_id}
+          </Text>
+          <Badge size="xs" variant="light">
+            {job.job_type}
+          </Badge>
+        </Group>
+      </UnstyledButton>
+    </Tooltip>
+  );
+}
+
+// --- Job Detail Panel ---
+
+function JobDetailPanel({
+  jobId,
+  onDelete,
+  onExport,
+  onNavigateWorkspace,
+  onNavigateInference,
+}: {
+  jobId: string;
+  onDelete: (jobId: string) => void;
+  onExport: () => void;
+  onNavigateWorkspace: () => void;
+  onNavigateInference: () => void;
+}) {
+  const jobQuery = useQuery({
+    queryKey: ["job", jobId],
+    queryFn: () => fetchJob(jobId),
+    refetchInterval: (query) => {
+      const s = query.state.data?.status;
+      return s === "running" || s === "pending" ? 2000 : false;
+    },
+  });
+
+  const configQuery = useQuery({
+    queryKey: ["job-config", jobId],
+    queryFn: () => fetchJobConfig(jobId),
+  });
+
+  if (jobQuery.isLoading) {
+    return (
+      <Stack align="center" py="xl">
+        <Loader />
+      </Stack>
+    );
+  }
+
+  if (jobQuery.error || !jobQuery.data) {
+    return (
+      <Alert color="red">Failed to load job details.</Alert>
+    );
+  }
+
+  const job = jobQuery.data;
+  const config = configQuery.data;
+
+  // Header
+  const header = (
+    <Group justify="space-between" mb="md">
+      <Group gap="xs">
+        <Title order={4}>
+          {job.job_type === "fit" ? "Fit" : "Tune"} — {job.job_id}
+        </Title>
+        <StatusBadge status={job.status} />
+      </Group>
+    </Group>
+  );
+
+  // Running state
+  if (job.status === "running" || job.status === "pending") {
+    return (
+      <Stack>
+        {header}
+        <Stack align="center" gap="md" py="xl">
+          <Loader />
+          <Text size="sm" c="dimmed">
+            Processing...
+          </Text>
+        </Stack>
+        {config && <ConfigAccordion config={config} />}
+      </Stack>
+    );
+  }
+
+  // Failed state
+  if (job.status === "failed") {
+    return (
+      <Stack>
+        {header}
+        <Alert color="red" icon={<IconX size={16} />}>
+          {job.error ?? "Unknown error"}
+        </Alert>
+        {config && <ConfigAccordion config={config} />}
+        <Group mt="md">
+          <Button
+            size="xs"
+            variant="light"
+            leftSection={<IconArrowRight size={14} />}
+            onClick={onNavigateWorkspace}
+          >
+            Re-fit
+          </Button>
+          <Button
+            size="xs"
+            variant="light"
+            color="red"
+            leftSection={<IconTrash size={14} />}
+            onClick={() => onDelete(jobId)}
+          >
+            Delete
+          </Button>
+        </Group>
+      </Stack>
+    );
+  }
+
+  // Completed state
   return (
     <Stack>
-      <Title order={3}>Jobs</Title>
-      <Text c="dimmed">Manage fit and tune jobs. Full implementation in Phase 6.</Text>
+      {header}
+
+      {/* Tune-specific */}
+      {job.tune_result && <TuneResultSection tuneResult={job.tune_result} />}
+
+      {/* Score */}
+      {job.fit_result && <MetricsTable fitResult={job.fit_result} />}
+
+      {/* Plots */}
+      <PlotViewer jobId={job.job_id} />
+
+      {/* Accordion details */}
+      <Accordion>
+        {job.fit_result && job.fit_result.fold_count > 1 && (
+          <Accordion.Item value="fold-details">
+            <Accordion.Control>Fold Details</Accordion.Control>
+            <Accordion.Panel>
+              <Text size="sm" c="dimmed">
+                {job.fit_result.fold_count} folds
+              </Text>
+            </Accordion.Panel>
+          </Accordion.Item>
+        )}
+        {job.fit_result && (
+          <Accordion.Item value="params">
+            <Accordion.Control>Parameters</Accordion.Control>
+            <Accordion.Panel>
+              <ParamsTable params={job.fit_result.params} />
+            </Accordion.Panel>
+          </Accordion.Item>
+        )}
+        {job.tune_result && (
+          <Accordion.Item value="trials">
+            <Accordion.Control>Trial Results</Accordion.Control>
+            <Accordion.Panel>
+              <TrialsTable
+                trials={job.tune_result.trials}
+                bestScore={job.tune_result.best_score}
+              />
+            </Accordion.Panel>
+          </Accordion.Item>
+        )}
+        {config && (
+          <Accordion.Item value="config">
+            <Accordion.Control>Config</Accordion.Control>
+            <Accordion.Panel>
+              <Code block>{JSON.stringify(config, null, 2)}</Code>
+            </Accordion.Panel>
+          </Accordion.Item>
+        )}
+      </Accordion>
+
+      {/* Action buttons */}
+      <Group mt="md">
+        <Button
+          size="xs"
+          leftSection={<IconArrowRight size={14} />}
+          onClick={onNavigateInference}
+        >
+          Inference
+        </Button>
+        <Button
+          size="xs"
+          variant="light"
+          leftSection={<IconDownload size={14} />}
+          onClick={onExport}
+        >
+          Export
+        </Button>
+        <Button
+          size="xs"
+          variant="light"
+          leftSection={<IconArrowRight size={14} />}
+          onClick={onNavigateWorkspace}
+        >
+          Re-fit
+        </Button>
+        <Button
+          size="xs"
+          variant="light"
+          color="red"
+          leftSection={<IconTrash size={14} />}
+          onClick={() => onDelete(jobId)}
+        >
+          Delete
+        </Button>
+      </Group>
     </Stack>
+  );
+}
+
+// --- Helpers ---
+
+function StatusBadge({ status }: { status: string }) {
+  if (status === "completed")
+    return (
+      <Badge color="green" leftSection={<IconCheck size={12} />}>
+        Completed
+      </Badge>
+    );
+  if (status === "running" || status === "pending")
+    return <Badge color="blue">Running</Badge>;
+  return (
+    <Badge color="red" leftSection={<IconX size={12} />}>
+      Failed
+    </Badge>
+  );
+}
+
+function ConfigAccordion({ config }: { config: Record<string, unknown> }) {
+  return (
+    <Accordion>
+      <Accordion.Item value="config">
+        <Accordion.Control>Config</Accordion.Control>
+        <Accordion.Panel>
+          <Code block>{JSON.stringify(config, null, 2)}</Code>
+        </Accordion.Panel>
+      </Accordion.Item>
+    </Accordion>
   );
 }

--- a/src/lizystudio/api/jobs.py
+++ b/src/lizystudio/api/jobs.py
@@ -1,7 +1,7 @@
 """Jobs API router (BLUEPRINT §5.3).
 
-Covers: list, get, config, metrics, split-summary, importance, plot, plots, delete.
-Export endpoint added in Phase 6.
+Covers: list, get, config, metrics, split-summary, importance, plot, plots,
+export, delete.
 """
 
 from __future__ import annotations
@@ -10,12 +10,14 @@ from dataclasses import asdict
 from typing import Any
 
 from fastapi import APIRouter, Depends
+from pydantic import BaseModel
 
 from lizystudio.api.errors import (
     BackendError,
     JobNotCompletedError,
     JobNotFoundError,
 )
+from lizystudio.services.export import export_model, export_report
 from lizystudio.services.jobs import Job, JobStore, get_job_store
 from lizystudio.services.workspace import WorkspaceState, get_workspace
 
@@ -187,5 +189,37 @@ def get_job_available_plots(
     try:
         model = _load_model(job, ws)
         return ws.backend.available_plots(model)
+    except Exception as exc:
+        raise BackendError(exc) from exc
+
+
+# --- Export ---
+
+
+class ExportRequest(BaseModel):
+    export_type: str  # "model" or "report"
+    output_path: str
+
+
+@router.post("/{job_id}/export")
+def export_job(
+    job_id: str,
+    body: ExportRequest,
+    job_store: JobStore = Depends(get_job_store),
+    ws: WorkspaceState = Depends(get_workspace),
+) -> dict[str, str]:
+    """Export model or report to the given path (H-0005)."""
+    job = _get_job_or_404(job_id, job_store)
+    _require_completed(job)
+    try:
+        if body.export_type == "report":
+            path = export_report(
+                job=job, backend=ws.backend, output_path=body.output_path
+            )
+        else:
+            path = export_model(
+                job=job, backend=ws.backend, output_path=body.output_path
+            )
+        return {"exported_path": path, "export_type": body.export_type}
     except Exception as exc:
         raise BackendError(exc) from exc

--- a/src/lizystudio/services/export.py
+++ b/src/lizystudio/services/export.py
@@ -1,0 +1,132 @@
+"""Export service — model and report export (H-0005)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from lizystudio.backends.base import BackendAdapter
+from lizystudio.services.jobs import Job
+
+
+def export_model(
+    *,
+    job: Job,
+    backend: BackendAdapter,
+    output_path: str,
+) -> str:
+    """Export a trained model to the given path.
+
+    Loads the model from the job's saved model_path and re-exports it to
+    a user-specified location.
+    """
+    if job.model_path is None:
+        msg = f"Job {job.job_id} has no saved model"
+        raise ValueError(msg)
+
+    model: Any = backend.load_model(job.model_path)
+    resolved = backend.export_model(model, output_path)
+    return resolved
+
+
+def export_report(
+    *,
+    job: Job,
+    backend: BackendAdapter,
+    output_path: str,
+) -> str:
+    """Export an HTML report with metrics and plots.
+
+    Generates a self-contained HTML file summarizing the job results.
+    """
+    if job.model_path is None:
+        msg = f"Job {job.job_id} has no saved model"
+        raise ValueError(msg)
+
+    model: Any = backend.load_model(job.model_path)
+
+    # Collect report data
+    metrics = backend.evaluate_table(model)
+    info = backend.model_info(model)
+    plots = backend.available_plots(model)
+    plot_jsons: list[str] = []
+    for pt in plots[:5]:  # Limit to first 5 plots
+        try:
+            pd = backend.plot(model, pt)
+            plot_jsons.append(pd.plotly_json)
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Build HTML
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    if out.is_dir() or not out.suffix:
+        out = out / f"report_{job.job_id}.html"
+
+    html = _build_report_html(job=job, info=info, metrics=metrics, plot_jsons=plot_jsons)
+    out.write_text(html, encoding="utf-8")
+    return str(out)
+
+
+def _build_report_html(
+    *,
+    job: Job,
+    info: dict[str, Any],
+    metrics: list[dict[str, Any]],
+    plot_jsons: list[str],
+) -> str:
+    """Build a minimal self-contained HTML report."""
+    import html
+    import json
+
+    title = html.escape(f"Job {job.job_id} — {job.job_type.title()} Report")
+    task = html.escape(str(info.get("task", "")))
+    model_name = html.escape(str(info.get("model_name", "")))
+
+    # Metrics table rows
+    metric_rows = ""
+    if metrics:
+        cols = list(metrics[0].keys())
+        header = "".join(f"<th>{html.escape(str(c))}</th>" for c in cols)
+        rows_html = ""
+        for row in metrics:
+            cells = "".join(
+                f"<td>{html.escape(str(row.get(c, '')))}</td>" for c in cols
+            )
+            rows_html += f"<tr>{cells}</tr>"
+        metric_rows = f"<table border='1' cellpadding='4'><tr>{header}</tr>{rows_html}</table>"
+
+    # Plotly divs
+    plot_divs = ""
+    for i, pj in enumerate(plot_jsons):
+        plot_divs += f"""
+        <div id="plot-{i}" style="width:100%;height:500px;margin-bottom:20px;"></div>
+        <script>
+            Plotly.newPlot('plot-{i}', {json.dumps(json.loads(pj).get('data', []))},
+                           {json.dumps(json.loads(pj).get('layout', {{}}))});
+        </script>
+        """
+
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{title}</title>
+    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+    <style>
+        body {{ font-family: system-ui, sans-serif; max-width: 1000px; margin: 0 auto; padding: 20px; }}
+        table {{ border-collapse: collapse; margin: 10px 0; }}
+        th {{ background: #f0f0f0; }}
+        td, th {{ padding: 6px 12px; text-align: left; }}
+    </style>
+</head>
+<body>
+    <h1>{title}</h1>
+    <p><strong>Task:</strong> {task} | <strong>Model:</strong> {model_name}</p>
+    <p><strong>Created:</strong> {html.escape(job.created_at)}</p>
+    <h2>Metrics</h2>
+    {metric_rows if metric_rows else "<p>No metrics available.</p>"}
+    <h2>Plots</h2>
+    {plot_divs if plot_divs else "<p>No plots available.</p>"}
+</body>
+</html>"""


### PR DESCRIPTION
## Summary
- **Export service**: `export_model` (re-exports pkl to user path) and `export_report` (self-contained HTML with Plotly CDN)
- **Export endpoint**: `POST /api/jobs/{job_id}/export` with model/report type selector (H-0005)
- **Jobs page**: Two-panel layout — left 360px panel with SegmentedControl status filter + Select type filter + job list, right panel with full job details
- **Job detail**: Conditional rendering for running/failed/completed states, reuses MetricsTable/TuneResultSection/PlotViewer/ParamsTable/TrialsTable from ResultsPanel
- **ExportDialog**: Modal with model/report toggle, output path input
- **Action buttons**: Inference, Export, Re-fit, Delete with navigation

## Test plan
- [x] 32 backend tests pass
- [x] mypy strict clean (22 source files)
- [x] Ruff lint/format clean
- [x] ESLint clean
- [x] Frontend builds successfully
- [ ] Manual: Jobs page lists existing jobs with correct status/type badges
- [ ] Manual: Filters narrow the job list correctly
- [ ] Manual: Selecting a job shows details in right panel
- [ ] Manual: Export dialog opens and submits model/report export
- [ ] Manual: Delete removes job with confirmation