### PR TITLE
feat: inference page with prediction and ground truth support (Phase 7)

### DIFF
--- a/frontend/src/api/inference.ts
+++ b/frontend/src/api/inference.ts
@@ -1,0 +1,120 @@
+/**
+ * Inference API client (H-0003).
+ */
+
+import { apiFetch } from "./client";
+
+export interface InferenceRecord {
+  inf_id: string;
+  job_id: string;
+  data_ref: {
+    source_type: "path" | "upload";
+    path: string;
+    filename: string;
+    fingerprint: string;
+    shape: [number, number];
+  };
+  has_ground_truth: boolean;
+  created_at: string;
+  row_count: number;
+  warnings: string[];
+}
+
+export interface PredictionsPage {
+  columns: string[];
+  data: Record<string, unknown>[];
+  total_rows: number;
+}
+
+export function runInference(
+  jobId: string,
+  dataPath: string,
+  returnShap: boolean = false,
+): Promise<{ inf_id: string; job_id: string }> {
+  return apiFetch("/inference/run", {
+    method: "POST",
+    body: JSON.stringify({
+      job_id: jobId,
+      data_path: dataPath,
+      return_shap: returnShap,
+    }),
+  });
+}
+
+export async function uploadAndRunInference(
+  file: File,
+  jobId: string,
+  returnShap: boolean = false,
+): Promise<{ inf_id: string; job_id: string }> {
+  const form = new FormData();
+  form.append("file", file);
+  form.append("job_id", jobId);
+  form.append("return_shap", String(returnShap));
+  const res = await fetch("/api/inference/upload", {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`API ${res.status}: ${body}`);
+  }
+  return res.json();
+}
+
+export function fetchInferenceHistory(
+  jobId: string,
+): Promise<InferenceRecord[]> {
+  return apiFetch(`/inference/history?job_id=${jobId}`);
+}
+
+export function fetchInference(
+  infId: string,
+  jobId: string,
+): Promise<InferenceRecord> {
+  return apiFetch(`/inference/${infId}?job_id=${jobId}`);
+}
+
+export function fetchInferencePredictions(
+  infId: string,
+  jobId: string,
+  rows: number = 50,
+  offset: number = 0,
+): Promise<PredictionsPage> {
+  return apiFetch(
+    `/inference/${infId}/predictions?job_id=${jobId}&rows=${rows}&offset=${offset}`,
+  );
+}
+
+export function fetchInferenceMetrics(
+  infId: string,
+  jobId: string,
+): Promise<Record<string, unknown>> {
+  return apiFetch(`/inference/${infId}/metrics?job_id=${jobId}`);
+}
+
+export function fetchInferencePlot(
+  infId: string,
+  jobId: string,
+  plotType: string,
+): Promise<{ plotly_json: string }> {
+  return apiFetch(
+    `/inference/${infId}/plot/${plotType}?job_id=${jobId}`,
+  );
+}
+
+export function inferenceDownloadUrl(
+  infId: string,
+  jobId: string,
+): string {
+  return `/api/inference/${infId}/download?job_id=${jobId}`;
+}
+
+export function fetchInferenceComparison(
+  infId: string,
+  otherInfId: string,
+  jobId: string,
+): Promise<Record<string, unknown>> {
+  return apiFetch(
+    `/inference/${infId}/comparison/${otherInfId}?job_id=${jobId}`,
+  );
+}

--- a/frontend/src/pages/InferencePage.tsx
+++ b/frontend/src/pages/InferencePage.tsx
@@ -1,10 +1,614 @@
-import { Title, Text, Stack } from "@mantine/core";
+import { useState, useCallback, useMemo } from "react";
+import {
+  Accordion,
+  Alert,
+  Badge,
+  Box,
+  Button,
+  Checkbox,
+  Group,
+  Loader,
+  Pagination,
+  Paper,
+  ScrollArea,
+  Select,
+  Stack,
+  Table,
+  Text,
+  TextInput,
+  Title,
+  UnstyledButton,
+} from "@mantine/core";
+import { Dropzone } from "@mantine/dropzone";
+import { notifications } from "@mantine/notifications";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  IconCheck,
+  IconDownload,
+  IconUpload,
+  IconPlayerPlay,
+} from "@tabler/icons-react";
+
+import { type JobSummary, fetchJobs, fetchJobPlots } from "../api/jobs";
+import {
+  type InferenceRecord,
+  runInference,
+  uploadAndRunInference,
+  fetchInferenceHistory,
+  fetchInferencePredictions,
+  fetchInferenceMetrics,
+  fetchInferencePlot,
+  inferenceDownloadUrl,
+  fetchInferenceComparison,
+} from "../api/inference";
+import { PlotlyChart } from "../components/PlotlyChart";
 
 export function InferencePage() {
+  const queryClient = useQueryClient();
+
+  // Setup state
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
+  const [dataPath, setDataPath] = useState("");
+  const [returnShap, setReturnShap] = useState(false);
+  const [running, setRunning] = useState(false);
+
+  // Selected inference result
+  const [selectedInfId, setSelectedInfId] = useState<string | null>(null);
+
+  // Fetch completed jobs for selector
+  const jobsQuery = useQuery({
+    queryKey: ["jobs", "completed"],
+    queryFn: () => fetchJobs("completed"),
+  });
+
+  const completedJobs = jobsQuery.data ?? [];
+
+  // Fetch inference history for selected job
+  const historyQuery = useQuery({
+    queryKey: ["inference-history", selectedJobId],
+    queryFn: () => fetchInferenceHistory(selectedJobId!),
+    enabled: !!selectedJobId,
+  });
+
+  const history = useMemo(
+    () => historyQuery.data ?? [],
+    [historyQuery.data],
+  );
+
+  // Auto-select latest inference
+  const effectiveInfId = useMemo(() => {
+    if (selectedInfId && history.some((h) => h.inf_id === selectedInfId)) {
+      return selectedInfId;
+    }
+    return history.length > 0 ? history[0].inf_id : null;
+  }, [selectedInfId, history]);
+
+  // Run inference from path
+  const onRunPath = useCallback(async () => {
+    if (!selectedJobId || !dataPath) return;
+    setRunning(true);
+    try {
+      const res = await runInference(selectedJobId, dataPath, returnShap);
+      setSelectedInfId(res.inf_id);
+      queryClient.invalidateQueries({
+        queryKey: ["inference-history", selectedJobId],
+      });
+      notifications.show({
+        title: "Inference complete",
+        message: `${res.inf_id}`,
+        color: "green",
+      });
+    } catch (e) {
+      notifications.show({
+        title: "Inference failed",
+        message: String(e),
+        color: "red",
+      });
+    } finally {
+      setRunning(false);
+    }
+  }, [selectedJobId, dataPath, returnShap, queryClient]);
+
+  // Run inference from upload
+  const onDropFiles = useCallback(
+    async (files: File[]) => {
+      const file = files[0];
+      if (!file || !selectedJobId) return;
+      setRunning(true);
+      try {
+        const res = await uploadAndRunInference(file, selectedJobId, returnShap);
+        setSelectedInfId(res.inf_id);
+        queryClient.invalidateQueries({
+          queryKey: ["inference-history", selectedJobId],
+        });
+        notifications.show({
+          title: "Inference complete",
+          message: `${res.inf_id}`,
+          color: "green",
+        });
+      } catch (e) {
+        notifications.show({
+          title: "Inference failed",
+          message: String(e),
+          color: "red",
+        });
+      } finally {
+        setRunning(false);
+      }
+    },
+    [selectedJobId, returnShap, queryClient],
+  );
+
+  // Job select data
+  const jobSelectData = completedJobs.map((j: JobSummary) => ({
+    value: j.job_id,
+    label: `${j.job_id} (${j.job_type})`,
+  }));
+
   return (
-    <Stack>
-      <Title order={3}>Inference</Title>
-      <Text c="dimmed">Run predictions with trained models. Full implementation in Phase 7.</Text>
+    <Box style={{ display: "flex", gap: 16, height: "calc(100vh - 80px)" }}>
+      {/* Left Panel — Setup + History */}
+      <Paper
+        withBorder
+        p="sm"
+        style={{
+          width: 360,
+          flexShrink: 0,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <Stack gap="sm" mb="sm">
+          <Title order={4}>Inference</Title>
+
+          {/* Model select */}
+          <Select
+            label="Model (Job)"
+            placeholder="Select a completed job"
+            data={jobSelectData}
+            value={selectedJobId}
+            onChange={setSelectedJobId}
+            size="xs"
+            searchable
+          />
+
+          {/* Data source — path */}
+          <TextInput
+            label="Data Path"
+            placeholder="/path/to/data.csv"
+            value={dataPath}
+            onChange={(e) => setDataPath(e.currentTarget.value)}
+            size="xs"
+          />
+
+          {/* Data source — upload */}
+          <Dropzone
+            onDrop={onDropFiles}
+            accept={{
+              "text/csv": [".csv"],
+              "application/octet-stream": [".parquet"],
+            }}
+            maxSize={100 * 1024 * 1024}
+            disabled={!selectedJobId || running}
+            p="xs"
+          >
+            <Group justify="center" gap="xs">
+              <IconUpload size={16} />
+              <Text size="xs" c="dimmed">
+                Drop CSV/Parquet or click
+              </Text>
+            </Group>
+          </Dropzone>
+
+          {/* Options */}
+          <Checkbox
+            label="Return SHAP values"
+            checked={returnShap}
+            onChange={(e) => setReturnShap(e.currentTarget.checked)}
+            size="xs"
+          />
+
+          {/* Run button */}
+          <Button
+            leftSection={<IconPlayerPlay size={14} />}
+            onClick={onRunPath}
+            loading={running}
+            disabled={!selectedJobId || !dataPath}
+            fullWidth
+          >
+            Run
+          </Button>
+        </Stack>
+
+        {/* Inference History */}
+        {history.length > 0 && (
+          <>
+            <Text fw={600} size="sm" mb={4}>
+              History
+            </Text>
+            <ScrollArea style={{ flex: 1 }}>
+              <Stack gap={4}>
+                {history.map((rec) => (
+                  <HistoryRow
+                    key={rec.inf_id}
+                    record={rec}
+                    selected={rec.inf_id === effectiveInfId}
+                    onClick={() => setSelectedInfId(rec.inf_id)}
+                  />
+                ))}
+              </Stack>
+            </ScrollArea>
+          </>
+        )}
+      </Paper>
+
+      {/* Right Panel — Results */}
+      <Paper withBorder p="md" style={{ flex: 1, overflow: "auto" }}>
+        {effectiveInfId && selectedJobId ? (
+          <InferenceResults
+            infId={effectiveInfId}
+            jobId={selectedJobId}
+            history={history}
+          />
+        ) : (
+          <Stack align="center" justify="center" h="100%">
+            <Text c="dimmed">
+              Select a model and run inference to see results
+            </Text>
+          </Stack>
+        )}
+      </Paper>
+    </Box>
+  );
+}
+
+// --- History Row ---
+
+function HistoryRow({
+  record,
+  selected,
+  onClick,
+}: {
+  record: InferenceRecord;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <UnstyledButton
+      onClick={onClick}
+      p="xs"
+      style={{
+        borderRadius: 6,
+        border: selected
+          ? "1px solid var(--mantine-color-blue-4)"
+          : "1px solid transparent",
+        backgroundColor: selected
+          ? "var(--mantine-color-blue-0)"
+          : undefined,
+      }}
+    >
+      <Group gap="xs" wrap="nowrap">
+        <Text size="xs" fw={500} truncate style={{ flex: 1 }}>
+          {record.inf_id}
+        </Text>
+        <Badge size="xs" variant="light">
+          {record.row_count} rows
+        </Badge>
+        {record.has_ground_truth && (
+          <Badge size="xs" variant="light" color="green">
+            GT
+          </Badge>
+        )}
+      </Group>
+    </UnstyledButton>
+  );
+}
+
+// --- Inference Results ---
+
+function InferenceResults({
+  infId,
+  jobId,
+  history,
+}: {
+  infId: string;
+  jobId: string;
+  history: InferenceRecord[];
+}) {
+  const record = history.find((h) => h.inf_id === infId);
+  const hasGT = record?.has_ground_truth ?? false;
+
+  return (
+    <Stack gap="md">
+      {/* Header */}
+      <Group gap="xs">
+        <Title order={4}>{infId}</Title>
+        <Badge variant="light">{jobId}</Badge>
+        <Badge variant="light">{record?.row_count ?? "?"} rows</Badge>
+        {hasGT ? (
+          <Badge color="green" leftSection={<IconCheck size={12} />}>
+            Ground Truth
+          </Badge>
+        ) : (
+          <Badge color="gray">Prediction Only</Badge>
+        )}
+      </Group>
+
+      {/* Warnings */}
+      {record && record.warnings.length > 0 && (
+        <Alert color="yellow" title="Warnings">
+          {record.warnings.map((w, i) => (
+            <Text key={i} size="xs">
+              {w}
+            </Text>
+          ))}
+        </Alert>
+      )}
+
+      {/* Metrics (ground truth only) */}
+      {hasGT && <InferenceMetricsSection infId={infId} jobId={jobId} />}
+
+      {/* Plots */}
+      <InferencePlotSection infId={infId} jobId={jobId} />
+
+      {/* Predictions table */}
+      <Accordion defaultValue="predictions">
+        <Accordion.Item value="predictions">
+          <Accordion.Control>Predictions</Accordion.Control>
+          <Accordion.Panel>
+            <PredictionsTable infId={infId} jobId={jobId} />
+          </Accordion.Panel>
+        </Accordion.Item>
+
+        {/* Comparison (no GT only) */}
+        {!hasGT && history.length > 1 && (
+          <Accordion.Item value="comparison">
+            <Accordion.Control>Comparison</Accordion.Control>
+            <Accordion.Panel>
+              <ComparisonSection
+                infId={infId}
+                jobId={jobId}
+                history={history}
+              />
+            </Accordion.Panel>
+          </Accordion.Item>
+        )}
+      </Accordion>
+
+      {/* Download */}
+      <Button
+        size="xs"
+        variant="light"
+        leftSection={<IconDownload size={14} />}
+        component="a"
+        href={inferenceDownloadUrl(infId, jobId)}
+        download={`inference_${infId}_${jobId}.csv`}
+      >
+        Download CSV
+      </Button>
     </Stack>
   );
+}
+
+// --- Sub-components ---
+
+function InferenceMetricsSection({
+  infId,
+  jobId,
+}: {
+  infId: string;
+  jobId: string;
+}) {
+  const metricsQuery = useQuery({
+    queryKey: ["inference-metrics", infId, jobId],
+    queryFn: () => fetchInferenceMetrics(infId, jobId),
+  });
+
+  const metrics = metricsQuery.data;
+  if (!metrics || "error" in metrics) return null;
+
+  const entries = Object.entries(metrics);
+  if (entries.length === 0) return null;
+
+  return (
+    <Stack gap="xs">
+      <Text fw={600} size="sm">
+        Inference Metrics
+      </Text>
+      <Table fz="xs" withTableBorder striped>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Metric</Table.Th>
+            <Table.Th>Value</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {entries.map(([key, val]) => (
+            <Table.Tr key={key}>
+              <Table.Td>{key}</Table.Td>
+              <Table.Td>
+                {typeof val === "number" ? val.toFixed(4) : String(val)}
+              </Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+    </Stack>
+  );
+}
+
+function InferencePlotSection({
+  infId,
+  jobId,
+}: {
+  infId: string;
+  jobId: string;
+}) {
+  const [plotType, setPlotType] = useState<string | null>(null);
+
+  // Use the model's available plots (from the job)
+  const plotsQuery = useQuery({
+    queryKey: ["job-plots-for-inf", jobId],
+    queryFn: () => fetchJobPlots(jobId),
+  });
+
+  const plotQuery = useQuery({
+    queryKey: ["inference-plot", infId, jobId, plotType],
+    queryFn: () => fetchInferencePlot(infId, jobId, plotType!),
+    enabled: !!plotType,
+  });
+
+  const availablePlots = plotsQuery.data ?? [];
+  if (availablePlots.length === 0) return null;
+
+  return (
+    <Stack gap="xs">
+      <Group>
+        <Text fw={600} size="sm">
+          Plots
+        </Text>
+        <Select
+          size="xs"
+          data={availablePlots}
+          value={plotType}
+          onChange={setPlotType}
+          placeholder="Select plot"
+          w={200}
+        />
+      </Group>
+      {plotQuery.data && <PlotlyChart json={plotQuery.data.plotly_json} />}
+    </Stack>
+  );
+}
+
+function PredictionsTable({
+  infId,
+  jobId,
+}: {
+  infId: string;
+  jobId: string;
+}) {
+  const [page, setPage] = useState(1);
+  const rows = 50;
+  const offset = (page - 1) * rows;
+
+  const predQuery = useQuery({
+    queryKey: ["inference-predictions", infId, jobId, page],
+    queryFn: () => fetchInferencePredictions(infId, jobId, rows, offset),
+  });
+
+  if (predQuery.isLoading) return <Loader size="sm" />;
+  if (!predQuery.data) return null;
+
+  const { columns, data, total_rows } = predQuery.data;
+  const totalPages = Math.ceil(total_rows / rows);
+
+  return (
+    <Stack gap="xs">
+      <Table fz="xs" withTableBorder striped>
+        <Table.Thead>
+          <Table.Tr>
+            {columns.map((c) => (
+              <Table.Th key={c}>{c}</Table.Th>
+            ))}
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {data.map((row, i) => (
+            <Table.Tr key={i}>
+              {columns.map((c) => (
+                <Table.Td key={c}>{formatCell(row[c])}</Table.Td>
+              ))}
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+      {totalPages > 1 && (
+        <Group justify="center">
+          <Pagination
+            size="xs"
+            total={totalPages}
+            value={page}
+            onChange={setPage}
+          />
+          <Text size="xs" c="dimmed">
+            {total_rows} total rows
+          </Text>
+        </Group>
+      )}
+    </Stack>
+  );
+}
+
+function ComparisonSection({
+  infId,
+  jobId,
+  history,
+}: {
+  infId: string;
+  jobId: string;
+  history: InferenceRecord[];
+}) {
+  const others = history.filter((h) => h.inf_id !== infId);
+  const [otherInfId, setOtherInfId] = useState<string | null>(
+    others.length > 0 ? others[0].inf_id : null,
+  );
+
+  const compQuery = useQuery({
+    queryKey: ["inference-comparison", infId, otherInfId, jobId],
+    queryFn: () => fetchInferenceComparison(infId, otherInfId!, jobId),
+    enabled: !!otherInfId,
+  });
+
+  if (others.length === 0)
+    return <Text size="sm" c="dimmed">No other inferences to compare.</Text>;
+
+  const compData = compQuery.data as
+    | {
+        current?: Record<string, number>;
+        other?: Record<string, number>;
+      }
+    | undefined;
+
+  return (
+    <Stack gap="xs">
+      <Select
+        size="xs"
+        label="Compare with"
+        data={others.map((h) => ({
+          value: h.inf_id,
+          label: `${h.inf_id} (${h.row_count} rows)`,
+        }))}
+        value={otherInfId}
+        onChange={setOtherInfId}
+        w={250}
+      />
+      {compData?.current && compData?.other && (
+        <Table fz="xs" withTableBorder>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Stat</Table.Th>
+              <Table.Th>Current</Table.Th>
+              <Table.Th>Other</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {Object.keys(compData.current).map((key) => (
+              <Table.Tr key={key}>
+                <Table.Td>{key}</Table.Td>
+                <Table.Td>{compData.current![key].toFixed(4)}</Table.Td>
+                <Table.Td>{compData.other![key].toFixed(4)}</Table.Td>
+              </Table.Tr>
+            ))}
+          </Table.Tbody>
+        </Table>
+      )}
+    </Stack>
+  );
+}
+
+function formatCell(val: unknown): string {
+  if (val === null || val === undefined || val === "") return "";
+  if (typeof val === "number") return Number.isInteger(val) ? String(val) : val.toFixed(4);
+  return String(val);
 }

--- a/src/lizystudio/api/inference.py
+++ b/src/lizystudio/api/inference.py
@@ -1,7 +1,239 @@
-"""Inference API router — stubs for Phase 7."""
+"""Inference API router (BLUEPRINT §5.4, H-0003).
+
+Covers: run, upload-and-run, history, get, predictions, metrics, plot,
+download, comparison.
+"""
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+import tempfile
+from dataclasses import asdict
+from io import StringIO
+from typing import Any
+
+from fastapi import APIRouter, Depends, UploadFile
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from lizystudio.api.errors import (
+    BackendError,
+    JobNotCompletedError,
+    JobNotFoundError,
+    StudioError,
+)
+from lizystudio.services.inference import (
+    InferenceStore,
+    get_comparison_stats,
+    run_inference,
+)
+from lizystudio.services.jobs import JobStore, get_job_store
+from lizystudio.services.workspace import WorkspaceState, get_workspace
 
 router = APIRouter()
+
+
+# --- Helpers ---
+
+
+class InferenceNotFoundError(StudioError):
+    def __init__(self, inf_id: str) -> None:
+        super().__init__("INFERENCE_NOT_FOUND", f"Inference not found: {inf_id}", 404)
+
+
+def _get_inf_store(job_store: JobStore) -> InferenceStore:
+    return InferenceStore(job_store.jobs_dir)
+
+
+def _get_job_or_404(job_id: str, job_store: JobStore) -> Any:
+    from lizystudio.services.jobs import Job
+
+    job: Job | None = job_store.get(job_id)
+    if job is None:
+        raise JobNotFoundError(job_id)
+    if job.status != "completed":
+        raise JobNotCompletedError(job_id)
+    return job
+
+
+# --- Run ---
+
+
+class RunRequest(BaseModel):
+    job_id: str
+    data_path: str
+    return_shap: bool = False
+
+
+@router.post("/run")
+def inference_run(
+    body: RunRequest,
+    job_store: JobStore = Depends(get_job_store),
+    ws: WorkspaceState = Depends(get_workspace),
+) -> dict[str, str]:
+    """Run inference with a path to data."""
+    job = _get_job_or_404(body.job_id, job_store)
+    try:
+        record = run_inference(
+            job=job,
+            job_store=job_store,
+            backend=ws.backend,
+            data_path=body.data_path,
+            return_shap=body.return_shap,
+        )
+        return {"inf_id": record.inf_id, "job_id": record.job_id}
+    except Exception as exc:
+        raise BackendError(exc) from exc
+
+
+@router.post("/upload")
+async def inference_upload(
+    file: UploadFile,
+    job_id: str,
+    return_shap: bool = False,
+    job_store: JobStore = Depends(get_job_store),
+    ws: WorkspaceState = Depends(get_workspace),
+) -> dict[str, str]:
+    """Upload data and run inference in one step."""
+    job = _get_job_or_404(job_id, job_store)
+    # Save upload to temp file
+    suffix = ".csv"
+    if file.filename and file.filename.endswith(".parquet"):
+        suffix = ".parquet"
+    content = await file.read()
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp.write(content)
+        tmp_path = tmp.name
+    try:
+        record = run_inference(
+            job=job,
+            job_store=job_store,
+            backend=ws.backend,
+            data_path=tmp_path,
+            return_shap=return_shap,
+        )
+        return {"inf_id": record.inf_id, "job_id": record.job_id}
+    except Exception as exc:
+        raise BackendError(exc) from exc
+
+
+# --- Query ---
+
+
+@router.get("/history")
+def inference_history(
+    job_id: str,
+    job_store: JobStore = Depends(get_job_store),
+) -> list[dict[str, Any]]:
+    """List inference records for a job."""
+    store = _get_inf_store(job_store)
+    records = store.list(job_id)
+    return [asdict(r) for r in records]
+
+
+@router.get("/{inf_id}")
+def inference_get(
+    inf_id: str,
+    job_id: str,
+    job_store: JobStore = Depends(get_job_store),
+) -> dict[str, Any]:
+    """Get inference record metadata."""
+    store = _get_inf_store(job_store)
+    record = store.get(job_id, inf_id)
+    if record is None:
+        raise InferenceNotFoundError(inf_id)
+    return asdict(record)
+
+
+@router.get("/{inf_id}/predictions")
+def inference_predictions(
+    inf_id: str,
+    job_id: str,
+    rows: int = 50,
+    offset: int = 0,
+    job_store: JobStore = Depends(get_job_store),
+) -> dict[str, Any]:
+    """Get paginated predictions table."""
+    store = _get_inf_store(job_store)
+    record = store.get(job_id, inf_id)
+    if record is None:
+        raise InferenceNotFoundError(inf_id)
+    return store.get_predictions(job_id, inf_id, rows=rows, offset=offset)
+
+
+@router.get("/{inf_id}/metrics")
+def inference_metrics(
+    inf_id: str,
+    job_id: str,
+    job_store: JobStore = Depends(get_job_store),
+) -> dict[str, Any]:
+    """Get inference metrics (requires ground truth)."""
+    store = _get_inf_store(job_store)
+    record = store.get(job_id, inf_id)
+    if record is None:
+        raise InferenceNotFoundError(inf_id)
+    metrics = store.get_metrics(job_id, inf_id)
+    if metrics is None:
+        return {"error": "no ground truth available"}
+    return metrics
+
+
+@router.get("/{inf_id}/plot/{plot_type}")
+def inference_plot(
+    inf_id: str,
+    plot_type: str,
+    job_id: str,
+    job_store: JobStore = Depends(get_job_store),
+    ws: WorkspaceState = Depends(get_workspace),
+) -> dict[str, str]:
+    """Get a plot from the model used for inference."""
+    store = _get_inf_store(job_store)
+    record = store.get(job_id, inf_id)
+    if record is None:
+        raise InferenceNotFoundError(inf_id)
+    # Load model from the job and generate plot
+    job = job_store.get(job_id)
+    if job is None or job.model_path is None:
+        raise JobNotFoundError(job_id)
+    try:
+        model = ws.backend.load_model(job.model_path)
+        plot_data = ws.backend.plot(model, plot_type)
+        return {"plotly_json": plot_data.plotly_json}
+    except Exception as exc:
+        raise BackendError(exc) from exc
+
+
+@router.get("/{inf_id}/download")
+def inference_download(
+    inf_id: str,
+    job_id: str,
+    job_store: JobStore = Depends(get_job_store),
+) -> StreamingResponse:
+    """Download predictions as CSV."""
+    store = _get_inf_store(job_store)
+    record = store.get(job_id, inf_id)
+    if record is None:
+        raise InferenceNotFoundError(inf_id)
+    df = store.get_predictions_df(job_id, inf_id)
+    if df is None:
+        raise InferenceNotFoundError(inf_id)
+    buf = StringIO()
+    df.to_csv(buf, index=False)
+    buf.seek(0)
+    filename = f"inference_{inf_id}_{job_id}.csv"
+    return StreamingResponse(
+        iter([buf.getvalue()]),
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.get("/{inf_id}/comparison/{other_inf_id}")
+def inference_comparison(
+    inf_id: str,
+    other_inf_id: str,
+    job_id: str,
+    job_store: JobStore = Depends(get_job_store),
+) -> dict[str, Any]:
+    """Compare two inference runs."""
+    store = _get_inf_store(job_store)
+    return get_comparison_stats(store, job_id, inf_id, other_inf_id)

--- a/src/lizystudio/services/export.py
+++ b/src/lizystudio/services/export.py
@@ -63,7 +63,9 @@ def export_report(
     if out.is_dir() or not out.suffix:
         out = out / f"report_{job.job_id}.html"
 
-    html = _build_report_html(job=job, info=info, metrics=metrics, plot_jsons=plot_jsons)
+    html = _build_report_html(
+        job=job, info=info, metrics=metrics, plot_jsons=plot_jsons
+    )
     out.write_text(html, encoding="utf-8")
     return str(out)
 
@@ -94,7 +96,9 @@ def _build_report_html(
                 f"<td>{html.escape(str(row.get(c, '')))}</td>" for c in cols
             )
             rows_html += f"<tr>{cells}</tr>"
-        metric_rows = f"<table border='1' cellpadding='4'><tr>{header}</tr>{rows_html}</table>"
+        metric_rows = (
+            f"<table border='1' cellpadding='4'><tr>{header}</tr>{rows_html}</table>"
+        )
 
     # Plotly divs
     plot_divs = ""
@@ -102,8 +106,8 @@ def _build_report_html(
         plot_divs += f"""
         <div id="plot-{i}" style="width:100%;height:500px;margin-bottom:20px;"></div>
         <script>
-            Plotly.newPlot('plot-{i}', {json.dumps(json.loads(pj).get('data', []))},
-                           {json.dumps(json.loads(pj).get('layout', {{}}))});
+            Plotly.newPlot('plot-{i}', {json.dumps(json.loads(pj).get("data", []))},
+                           {json.dumps(json.loads(pj).get("layout", {{}}))});
         </script>
         """
 
@@ -114,7 +118,9 @@ def _build_report_html(
     <title>{title}</title>
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
     <style>
-        body {{ font-family: system-ui, sans-serif; max-width: 1000px; margin: 0 auto; padding: 20px; }}
+        body {{ font-family: system-ui, sans-serif;
+               max-width: 1000px; margin: 0 auto;
+               padding: 20px; }}
         table {{ border-collapse: collapse; margin: 10px 0; }}
         th {{ background: #f0f0f0; }}
         td, th {{ padding: 6px 12px; text-align: left; }}

--- a/src/lizystudio/services/inference.py
+++ b/src/lizystudio/services/inference.py
@@ -1,0 +1,281 @@
+"""Inference service — run predictions and manage inference records (H-0003).
+
+Persistence layout::
+
+    {jobs_dir}/{job_id}/inferences/{inf_id}/
+    ├── meta.json
+    ├── predictions.parquet
+    └── metrics.json          (ground truth only)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pandas as pd
+
+from lizystudio.backends.base import BackendAdapter
+from lizystudio.backends.types import DataRef
+from lizystudio.services.data import load_dataframe, make_data_ref
+from lizystudio.services.jobs import Job, JobStore
+
+
+@dataclass
+class InferenceRecord:
+    """Persisted inference metadata."""
+
+    inf_id: str
+    job_id: str
+    data_ref: DataRef
+    has_ground_truth: bool
+    created_at: str  # ISO-8601
+    row_count: int
+    warnings: list[str]
+
+
+class InferenceStore:
+    """Disk-backed inference record store."""
+
+    def __init__(self, jobs_dir: Path) -> None:
+        self.jobs_dir = jobs_dir
+
+    def _inf_dir(self, job_id: str, inf_id: str) -> Path:
+        return self.jobs_dir / job_id / "inferences" / inf_id
+
+    # --- CRUD ---
+
+    def save(
+        self,
+        record: InferenceRecord,
+        predictions: pd.DataFrame,
+        metrics: dict[str, Any] | None = None,
+    ) -> None:
+        """Persist an inference record with its predictions."""
+        d = self._inf_dir(record.job_id, record.inf_id)
+        d.mkdir(parents=True, exist_ok=True)
+
+        # meta.json
+        meta = asdict(record)
+        meta["data_ref"]["shape"] = list(meta["data_ref"]["shape"])
+        (d / "meta.json").write_text(
+            json.dumps(meta, ensure_ascii=False, default=str), encoding="utf-8"
+        )
+
+        # predictions.parquet
+        predictions.to_parquet(d / "predictions.parquet", index=False)
+
+        # metrics.json (ground truth only)
+        if metrics is not None:
+            (d / "metrics.json").write_text(
+                json.dumps(metrics, ensure_ascii=False, default=str), encoding="utf-8"
+            )
+
+    def get(self, job_id: str, inf_id: str) -> InferenceRecord | None:
+        """Load an inference record by ID."""
+        meta_path = self._inf_dir(job_id, inf_id) / "meta.json"
+        if not meta_path.exists():
+            return None
+        return self._load_record(meta_path)
+
+    def list(self, job_id: str) -> list[InferenceRecord]:
+        """List all inferences for a job, newest first."""
+        inf_base = self.jobs_dir / job_id / "inferences"
+        if not inf_base.exists():
+            return []
+        records: list[InferenceRecord] = []
+        for d in inf_base.iterdir():
+            mp = d / "meta.json"
+            if d.is_dir() and mp.exists():
+                records.append(self._load_record(mp))
+        records.sort(key=lambda r: r.created_at, reverse=True)
+        return records
+
+    def get_predictions(
+        self, job_id: str, inf_id: str, *, rows: int = 50, offset: int = 0
+    ) -> dict[str, Any]:
+        """Return paginated predictions."""
+        pq = self._inf_dir(job_id, inf_id) / "predictions.parquet"
+        if not pq.exists():
+            return {"columns": [], "data": [], "total_rows": 0}
+        df = pd.read_parquet(pq)
+        total = len(df)
+        page = df.iloc[offset : offset + rows]
+        return {
+            "columns": list(page.columns),
+            "data": page.fillna("").to_dict("records"),
+            "total_rows": total,
+        }
+
+    def get_metrics(self, job_id: str, inf_id: str) -> dict[str, Any] | None:
+        """Return inference metrics (None if no ground truth)."""
+        mp = self._inf_dir(job_id, inf_id) / "metrics.json"
+        if not mp.exists():
+            return None
+        return json.loads(mp.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
+
+    def get_predictions_df(self, job_id: str, inf_id: str) -> pd.DataFrame | None:
+        """Return full predictions DataFrame."""
+        pq = self._inf_dir(job_id, inf_id) / "predictions.parquet"
+        if not pq.exists():
+            return None
+        return pd.read_parquet(pq)
+
+    # --- Internal ---
+
+    @staticmethod
+    def _load_record(meta_path: Path) -> InferenceRecord:
+        raw = json.loads(meta_path.read_text(encoding="utf-8"))
+        dr = raw["data_ref"]
+        dr["shape"] = tuple(dr["shape"])
+        return InferenceRecord(
+            inf_id=raw["inf_id"],
+            job_id=raw["job_id"],
+            data_ref=DataRef(**dr),
+            has_ground_truth=raw["has_ground_truth"],
+            created_at=raw["created_at"],
+            row_count=raw["row_count"],
+            warnings=raw.get("warnings", []),
+        )
+
+
+# --- Run inference ---
+
+
+def run_inference(
+    *,
+    job: Job,
+    job_store: JobStore,
+    backend: BackendAdapter,
+    data_path: str,
+    return_shap: bool = False,
+) -> InferenceRecord:
+    """Run prediction on new data using a completed job's model.
+
+    Detects ground truth automatically when the training target column
+    exists in the inference data.
+    """
+    # Load model
+    if job.model_path is None:
+        msg = f"Job {job.job_id} has no saved model"
+        raise ValueError(msg)
+    model = backend.load_model(job.model_path)
+
+    # Load inference data
+    df = load_dataframe(data_path)
+    data_ref = make_data_ref(
+        df, source_type="path", path=data_path, filename=Path(data_path).name
+    )
+
+    # Detect ground truth — check if training target column is in inference data
+    model_info = backend.model_info(model)
+    target_col: str | None = model_info.get("target")
+    # LizyML stores target in config
+    if target_col is None and job.config:
+        target_col = job.config.get("target")
+
+    has_ground_truth = target_col is not None and target_col in df.columns
+
+    # Run prediction
+    pred_result = backend.predict(model, df, return_shap=return_shap)
+    pred_df = pred_result.predictions
+
+    # Add actual column if ground truth available
+    if has_ground_truth and target_col is not None:
+        pred_df["actual"] = df[target_col].values
+
+    # Compute inference metrics if ground truth
+    metrics: dict[str, Any] | None = None
+    if has_ground_truth:
+        metrics = _compute_inference_metrics(pred_df, model_info)
+
+    # Create record
+    inf_id = f"inf_{uuid4().hex[:8]}"
+    record = InferenceRecord(
+        inf_id=inf_id,
+        job_id=job.job_id,
+        data_ref=data_ref,
+        has_ground_truth=has_ground_truth,
+        created_at=datetime.now(timezone.utc).isoformat(),
+        row_count=len(df),
+        warnings=pred_result.warnings,
+    )
+
+    # Persist
+    inf_store = InferenceStore(job_store.jobs_dir)
+    inf_store.save(record, pred_df, metrics)
+
+    return record
+
+
+def _compute_inference_metrics(
+    pred_df: pd.DataFrame, model_info: dict[str, Any]
+) -> dict[str, Any]:
+    """Compute basic metrics from predictions vs actuals."""
+    actual = pred_df["actual"]
+    pred = pred_df["pred"]
+    task = model_info.get("task", "regression")
+
+    metrics: dict[str, Any] = {}
+
+    if task == "regression":
+        residuals = actual - pred
+        metrics["mae"] = float(residuals.abs().mean())
+        metrics["mse"] = float((residuals**2).mean())
+        metrics["rmse"] = float((residuals**2).mean() ** 0.5)
+        ss_res = float((residuals**2).sum())
+        ss_tot = float(((actual - actual.mean()) ** 2).sum())
+        metrics["r2"] = 1.0 - ss_res / ss_tot if ss_tot > 0 else 0.0
+    else:
+        # Classification
+        pred_labels = pred
+        metrics["accuracy"] = float((pred_labels == actual).mean())
+        if "proba" in pred_df.columns:
+            try:
+                from sklearn.metrics import log_loss, roc_auc_score  # type: ignore[import-untyped]
+
+                proba = pred_df["proba"]
+                metrics["auc"] = float(roc_auc_score(actual, proba))
+                metrics["logloss"] = float(log_loss(actual, proba))
+            except Exception:  # noqa: BLE001
+                pass
+
+    return metrics
+
+
+def get_comparison_stats(
+    inf_store: InferenceStore,
+    job_id: str,
+    inf_id: str,
+    other_inf_id: str,
+) -> dict[str, Any]:
+    """Compare two inference runs on the same job."""
+    df1 = inf_store.get_predictions_df(job_id, inf_id)
+    df2 = inf_store.get_predictions_df(job_id, other_inf_id)
+    if df1 is None or df2 is None:
+        return {"error": "predictions not found"}
+
+    def _stats(s: "pd.Series[Any]") -> dict[str, float]:
+        return {
+            "mean": float(s.mean()),
+            "std": float(s.std()),
+            "min": float(s.min()),
+            "max": float(s.max()),
+            "count": int(len(s)),
+        }
+
+    result: dict[str, Any] = {
+        "current": _stats(df1["pred"]),
+        "other": _stats(df2["pred"]),
+    }
+
+    # Add proba stats if available
+    if "proba" in df1.columns and "proba" in df2.columns:
+        result["current_proba"] = _stats(df1["proba"])
+        result["other_proba"] = _stats(df2["proba"])
+
+    return result


### PR DESCRIPTION
## Summary
- **Inference service**: `InferenceStore` with disk persistence (`{jobs_dir}/{job_id}/inferences/{inf_id}/`), ground truth auto-detection, metrics computation (MAE/MSE/R2 for regression, accuracy/AUC/logloss for classification)
- **API endpoints** (H-0003): `POST /run`, `POST /upload`, `GET /history`, `GET /{inf_id}`, `GET /{inf_id}/predictions` (paginated), `GET /{inf_id}/metrics`, `GET /{inf_id}/plot/{plot_type}`, `GET /{inf_id}/download` (CSV), `GET /{inf_id}/comparison/{other_inf_id}`
- **Inference page**: Two-panel layout — left 360px setup panel (job selector, data path/upload via Dropzone, SHAP checkbox, Run button, inference history list) + right results panel
- **Results display**: Ground truth mode (metrics table + plots + predictions) vs prediction-only mode (predictions + comparison section), paginated predictions table (50 rows/page), CSV download
- **Comparison**: Select past inference for distribution stats comparison

## Test plan
- [x] 32 backend tests pass
- [x] mypy strict clean (23 source files)
- [x] Ruff lint/format clean
- [x] ESLint clean
- [x] Frontend builds successfully
- [ ] Manual: Select completed job, provide data path, run inference
- [ ] Manual: Upload CSV via dropzone, inference runs
- [ ] Manual: Ground truth detected when target column present
- [ ] Manual: Predictions paginated correctly
- [ ] Manual: CSV download works
- [ ] Manual: Comparison between two inferences shows stats