### PR TITLE
feat: WebSocket progress broadcasting for fit/tune (Phase 8)

### DIFF
--- a/frontend/src/api/websocket.ts
+++ b/frontend/src/api/websocket.ts
@@ -1,0 +1,94 @@
+/**
+ * WebSocket client for job progress (BLUEPRINT §5.5).
+ *
+ * Connects to /ws/jobs/{jobId}/progress and invokes callbacks
+ * on progress, completed, and error messages. Falls back to
+ * polling if the WebSocket connection fails.
+ */
+
+export interface ProgressMessage {
+  type: "progress";
+  job_id: string;
+  current: number;
+  total: number;
+  message: string;
+}
+
+export interface CompletedMessage {
+  type: "completed";
+  job_id: string;
+  message: string;
+}
+
+export interface ErrorMessage {
+  type: "error";
+  job_id: string;
+  message: string;
+  code: string;
+}
+
+export type WsMessage = ProgressMessage | CompletedMessage | ErrorMessage;
+
+export interface WsCallbacks {
+  onProgress?: (msg: ProgressMessage) => void;
+  onCompleted?: (msg: CompletedMessage) => void;
+  onError?: (msg: ErrorMessage) => void;
+  onDisconnect?: () => void;
+}
+
+export function connectJobProgress(
+  jobId: string,
+  callbacks: WsCallbacks,
+): () => void {
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const url = `${protocol}//${window.location.host}/ws/jobs/${jobId}/progress`;
+
+  let ws: WebSocket | null = null;
+  let closed = false;
+
+  function connect() {
+    if (closed) return;
+    ws = new WebSocket(url);
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data) as WsMessage & { type: string };
+        if (msg.type === "progress") {
+          callbacks.onProgress?.(msg as ProgressMessage);
+        } else if (msg.type === "completed") {
+          callbacks.onCompleted?.(msg as CompletedMessage);
+          cleanup();
+        } else if (msg.type === "error") {
+          callbacks.onError?.(msg as ErrorMessage);
+          cleanup();
+        }
+        // Ignore "ping" messages silently
+      } catch {
+        // Ignore parse errors
+      }
+    };
+
+    ws.onclose = () => {
+      if (!closed) {
+        callbacks.onDisconnect?.();
+      }
+    };
+
+    ws.onerror = () => {
+      callbacks.onDisconnect?.();
+    };
+  }
+
+  function cleanup() {
+    closed = true;
+    if (ws) {
+      ws.close();
+      ws = null;
+    }
+  }
+
+  connect();
+
+  // Return disconnect function
+  return cleanup;
+}

--- a/frontend/src/components/ResultsPanel.tsx
+++ b/frontend/src/components/ResultsPanel.tsx
@@ -1,11 +1,11 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import {
   Accordion,
   Alert,
   Button,
   Group,
-  Loader,
   Paper,
+  Progress,
   Select,
   Stack,
   Table,
@@ -26,6 +26,10 @@ import {
   runFit,
   runTune,
 } from "../api/jobs";
+import {
+  type ProgressMessage,
+  connectJobProgress,
+} from "../api/websocket";
 import { PlotlyChart } from "./PlotlyChart";
 
 interface ResultsPanelProps {
@@ -103,18 +107,9 @@ export function ResultsPanel({ jobId, onJobCreated }: ResultsPanelProps) {
   if (job.status === "running" || job.status === "pending") {
     return (
       <Paper p="md" withBorder>
-        <Stack align="center" gap="md" py="xl">
-          <Group>
-            <Title order={5}>
-              {job.job_type === "fit" ? "Fit" : "Tune"} — {job.job_id}
-            </Title>
-            <Badge color="blue">Running</Badge>
-          </Group>
-          <Loader />
-          <Text size="sm" c="dimmed">
-            Processing...
-          </Text>
-        </Stack>
+        <RunningView jobId={job.job_id} jobType={job.job_type} onDone={() => {
+          queryClient.invalidateQueries({ queryKey: ["job", jobId] });
+        }} />
       </Paper>
     );
   }
@@ -210,6 +205,82 @@ export function ResultsPanel({ jobId, onJobCreated }: ResultsPanelProps) {
         </Group>
       </Stack>
     </Paper>
+  );
+}
+
+// --- Running view with WebSocket progress ---
+
+export function RunningView({
+  jobId,
+  jobType,
+  onDone,
+}: {
+  jobId: string;
+  jobType: string;
+  onDone: () => void;
+}) {
+  const [progress, setProgress] = useState<ProgressMessage | null>(null);
+  const [elapsed, setElapsed] = useState(0);
+  const startRef = useRef(0);
+
+  // Elapsed time timer
+  useEffect(() => {
+    startRef.current = Date.now();
+    const timer = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startRef.current) / 1000));
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [jobId]);
+
+  // WebSocket connection
+  useEffect(() => {
+    const disconnect = connectJobProgress(jobId, {
+      onProgress: (msg) => setProgress(msg),
+      onCompleted: () => onDone(),
+      onError: () => onDone(),
+      onDisconnect: () => {
+        // Fallback: poll will pick up the change via refetchInterval
+      },
+    });
+    return disconnect;
+  }, [jobId, onDone]);
+
+  const pct = progress && progress.total > 0
+    ? Math.round((progress.current / progress.total) * 100)
+    : 0;
+  const mins = Math.floor(elapsed / 60);
+  const secs = elapsed % 60;
+
+  return (
+    <Stack align="center" gap="md" py="xl">
+      <Group>
+        <Title order={5}>
+          {jobType === "fit" ? "Fit" : "Tune"} — {jobId}
+        </Title>
+        <Badge color="blue">Running</Badge>
+      </Group>
+      {progress ? (
+        <>
+          <Text size="sm" fw={500}>
+            {progress.message}
+          </Text>
+          <Progress value={pct} size="lg" w="80%" animated />
+          <Text size="xs" c="dimmed">
+            {progress.current} / {progress.total} ({pct}%)
+          </Text>
+        </>
+      ) : (
+        <>
+          <Progress value={100} size="lg" w="80%" animated striped />
+          <Text size="sm" c="dimmed">
+            Starting...
+          </Text>
+        </>
+      )}
+      <Text size="xs" c="dimmed">
+        Elapsed: {mins}m {secs.toString().padStart(2, "0")}s
+      </Text>
+    </Stack>
   );
 }
 

--- a/src/lizystudio/api/workspace.py
+++ b/src/lizystudio/api/workspace.py
@@ -6,16 +6,16 @@ Covers: status, reset, data, config, fit, tune.
 from __future__ import annotations
 
 import tempfile
+import threading
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
 import yaml
-from fastapi import APIRouter, Depends, UploadFile
+from fastapi import APIRouter, Depends, Request, UploadFile
 from fastapi.responses import Response
 
 from lizystudio.api.errors import (
-    BackendError,
     FileInvalidError,
     PathNotFoundError,
     WorkspaceNoConfigError,
@@ -31,6 +31,7 @@ from lizystudio.services.data import (
 from lizystudio.services.jobs import JobStore, get_job_store
 from lizystudio.services.training import run_fit, run_tune
 from lizystudio.services.workspace import WorkspaceState, get_workspace
+from lizystudio.ws.progress import ProgressBroadcaster
 
 router = APIRouter()
 
@@ -216,15 +217,89 @@ def config_download(
     )
 
 
+# --- Helpers ---
+
+
+def _get_broadcaster(request: Request) -> ProgressBroadcaster:
+    return request.app.state.broadcaster  # type: ignore[no-any-return]
+
+
+def _run_fit_background(
+    ws: WorkspaceState,
+    job_store: JobStore,
+    broadcaster: ProgressBroadcaster,
+    job_id: str,
+    config: dict[str, Any],
+    dataframe: Any,
+) -> None:
+    """Run fit in background thread with progress broadcasting."""
+    job = job_store.get(job_id)
+    if job is None:
+        return
+    cb = broadcaster.make_callback(job_id)
+    try:
+        job = run_fit(
+            job=job,
+            job_store=job_store,
+            backend=ws.backend,
+            config=config,
+            dataframe=dataframe,
+            on_progress=cb,
+        )
+        ws.workspace_fit_result = job.fit_result
+        ws.workspace_tune_result = None
+        ws.current_job_id = job.job_id
+        if job.status == "completed":
+            broadcaster.send_completed(job_id)
+        else:
+            broadcaster.send_error(job_id, job.error or "Unknown error")
+    except Exception as exc:
+        broadcaster.send_error(job_id, str(exc))
+
+
+def _run_tune_background(
+    ws: WorkspaceState,
+    job_store: JobStore,
+    broadcaster: ProgressBroadcaster,
+    job_id: str,
+    config: dict[str, Any],
+    dataframe: Any,
+) -> None:
+    """Run tune in background thread with progress broadcasting."""
+    job = job_store.get(job_id)
+    if job is None:
+        return
+    cb = broadcaster.make_callback(job_id)
+    try:
+        job = run_tune(
+            job=job,
+            job_store=job_store,
+            backend=ws.backend,
+            config=config,
+            dataframe=dataframe,
+            on_progress=cb,
+        )
+        ws.workspace_fit_result = job.fit_result
+        ws.workspace_tune_result = job.tune_result
+        ws.current_job_id = job.job_id
+        if job.status == "completed":
+            broadcaster.send_completed(job_id)
+        else:
+            broadcaster.send_error(job_id, job.error or "Unknown error")
+    except Exception as exc:
+        broadcaster.send_error(job_id, str(exc))
+
+
 # --- Fit / Tune endpoints (BLUEPRINT §5.2 Fit/Tune) ---
 
 
 @router.post("/fit")
 def workspace_fit(
+    request: Request,
     ws: WorkspaceState = Depends(get_workspace),
     job_store: JobStore = Depends(get_job_store),
 ) -> dict[str, Any]:
-    """Create and run a fit job with current config + data."""
+    """Create a fit job and run it in a background thread."""
     if not ws.config:
         raise WorkspaceNoConfigError()
     if ws.dataframe is None or ws.data_ref is None:
@@ -235,29 +310,23 @@ def workspace_fit(
         data_ref=ws.data_ref,
         job_type="fit",
     )
-    try:
-        job = run_fit(
-            job=job,
-            job_store=job_store,
-            backend=ws.backend,
-            config=ws.config,
-            dataframe=ws.dataframe,
-        )
-    except Exception as exc:
-        raise BackendError(exc) from exc
-    # Update workspace volatile state
-    ws.workspace_fit_result = job.fit_result
-    ws.workspace_tune_result = None
-    ws.current_job_id = job.job_id
+    broadcaster = _get_broadcaster(request)
+    t = threading.Thread(
+        target=_run_fit_background,
+        args=(ws, job_store, broadcaster, job.job_id, ws.config, ws.dataframe),
+        daemon=True,
+    )
+    t.start()
     return {"job_id": job.job_id}
 
 
 @router.post("/tune")
 def workspace_tune(
+    request: Request,
     ws: WorkspaceState = Depends(get_workspace),
     job_store: JobStore = Depends(get_job_store),
 ) -> dict[str, Any]:
-    """Create and run a tune job with current config + data."""
+    """Create a tune job and run it in a background thread."""
     if not ws.config:
         raise WorkspaceNoConfigError()
     if ws.dataframe is None or ws.data_ref is None:
@@ -268,18 +337,11 @@ def workspace_tune(
         data_ref=ws.data_ref,
         job_type="tune",
     )
-    try:
-        job = run_tune(
-            job=job,
-            job_store=job_store,
-            backend=ws.backend,
-            config=ws.config,
-            dataframe=ws.dataframe,
-        )
-    except Exception as exc:
-        raise BackendError(exc) from exc
-    # Update workspace volatile state
-    ws.workspace_fit_result = job.fit_result
-    ws.workspace_tune_result = job.tune_result
-    ws.current_job_id = job.job_id
+    broadcaster = _get_broadcaster(request)
+    t = threading.Thread(
+        target=_run_tune_background,
+        args=(ws, job_store, broadcaster, job.job_id, ws.config, ws.dataframe),
+        daemon=True,
+    )
+    t.start()
     return {"job_id": job.job_id}

--- a/src/lizystudio/server.py
+++ b/src/lizystudio/server.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -17,6 +18,7 @@ from lizystudio.api.errors import StudioError, studio_error_handler
 from lizystudio.backends.registry import get_adapter
 from lizystudio.services.jobs import JobStore
 from lizystudio.services.workspace import WorkspaceState
+from lizystudio.ws.progress import ProgressBroadcaster, websocket_progress
 
 STATIC_DIR = Path(__file__).parent / "static"
 
@@ -38,6 +40,9 @@ def create_app() -> FastAPI:
         adapter = get_adapter(backend_name)
         application.state.workspace = WorkspaceState(backend=adapter)
         application.state.job_store = JobStore(jobs_dir)
+        broadcaster = ProgressBroadcaster()
+        broadcaster.set_loop(asyncio.get_running_loop())
+        application.state.broadcaster = broadcaster
         yield
 
     application = FastAPI(
@@ -66,6 +71,12 @@ def create_app() -> FastAPI:
     application.include_router(
         inference.router, prefix="/api/inference", tags=["inference"]
     )
+
+    # WebSocket route for job progress (BLUEPRINT §5.5)
+    @application.websocket("/ws/jobs/{job_id}/progress")
+    async def ws_job_progress(ws: WebSocket, job_id: str) -> None:
+        broadcaster: ProgressBroadcaster = application.state.broadcaster
+        await websocket_progress(ws, job_id, broadcaster)
 
     # Serve built frontend (production)
     if STATIC_DIR.is_dir() and (STATIC_DIR / "index.html").exists():

--- a/src/lizystudio/services/training.py
+++ b/src/lizystudio/services/training.py
@@ -6,7 +6,7 @@ import traceback
 from datetime import datetime, timezone
 from typing import Any
 
-from lizystudio.backends.base import BackendAdapter
+from lizystudio.backends.base import BackendAdapter, ProgressCallback
 from lizystudio.backends.types import FitSummary, TuningSummary
 from lizystudio.services.jobs import Job, JobStore
 
@@ -19,13 +19,16 @@ def run_fit(
     config: dict[str, Any],
     dataframe: Any,
     params: dict[str, Any] | None = None,
+    on_progress: ProgressCallback | None = None,
 ) -> Job:
     """Execute a fit job synchronously. Updates job in-place and on disk."""
     job.status = "running"
     job_store.update(job)
     try:
         model = backend.create_model(config, dataframe)
-        fit_result: FitSummary = backend.fit(model, params=params)
+        fit_result: FitSummary = backend.fit(
+            model, params=params, on_progress=on_progress
+        )
         # Export model
         model_dir = str(job_store.jobs_dir / job.job_id / "model")
         backend.export_model(model, model_dir)
@@ -50,13 +53,14 @@ def run_tune(
     backend: BackendAdapter,
     config: dict[str, Any],
     dataframe: Any,
+    on_progress: ProgressCallback | None = None,
 ) -> Job:
-    """Execute a tune job: tune → auto-fit with best params (H-0002 Case B)."""
+    """Execute a tune job: tune -> auto-fit with best params (H-0002 B)."""
     job.status = "running"
     job_store.update(job)
     try:
         model = backend.create_model(config, dataframe)
-        tune_result: TuningSummary = backend.tune(model)
+        tune_result: TuningSummary = backend.tune(model, on_progress=on_progress)
         job.tune_result = tune_result
         # Auto-fit with best params
         model2 = backend.create_model(config, dataframe)

--- a/src/lizystudio/ws/progress.py
+++ b/src/lizystudio/ws/progress.py
@@ -1,0 +1,124 @@
+"""WebSocket progress broadcaster (BLUEPRINT §5.5).
+
+Stores progress state per job_id in memory. WebSocket clients connect
+to ``/ws/jobs/{job_id}/progress`` and receive JSON messages:
+
+- ``{"type": "progress", "job_id": ..., "current": N, "total": M, "message": ...}``
+- ``{"type": "completed", "job_id": ..., "message": ...}``
+- ``{"type": "error", "job_id": ..., "message": ..., "code": ...}``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from typing import Any
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+
+class ProgressBroadcaster:
+    """In-memory progress broadcaster.
+
+    Thread-safe: training threads call :meth:`send` which enqueues messages
+    for async WebSocket handlers to read via :meth:`subscribe`.
+    """
+
+    def __init__(self) -> None:
+        self._queues: dict[str, list[asyncio.Queue[dict[str, Any]]]] = {}
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Store the event loop reference for thread-safe enqueuing."""
+        self._loop = loop
+
+    def subscribe(self, job_id: str) -> asyncio.Queue[dict[str, Any]]:
+        """Create a new subscription queue for a job. Called from async."""
+        q: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self._queues.setdefault(job_id, []).append(q)
+        return q
+
+    def unsubscribe(self, job_id: str, q: asyncio.Queue[dict[str, Any]]) -> None:
+        """Remove a subscription."""
+        qs = self._queues.get(job_id, [])
+        if q in qs:
+            qs.remove(q)
+        if not qs:
+            self._queues.pop(job_id, None)
+
+    def send(self, job_id: str, message: dict[str, Any]) -> None:
+        """Enqueue a message for all subscribers (thread-safe)."""
+        qs = self._queues.get(job_id, [])
+        if not qs or self._loop is None:
+            return
+        for q in qs:
+            self._loop.call_soon_threadsafe(q.put_nowait, message)
+
+    def send_progress(
+        self, job_id: str, *, current: int, total: int, message: str
+    ) -> None:
+        """Convenience: send a progress message."""
+        self.send(
+            job_id,
+            {
+                "type": "progress",
+                "job_id": job_id,
+                "current": current,
+                "total": total,
+                "message": message,
+            },
+        )
+
+    def send_completed(self, job_id: str, message: str = "Completed.") -> None:
+        """Convenience: send a completion message."""
+        self.send(
+            job_id,
+            {"type": "completed", "job_id": job_id, "message": message},
+        )
+
+    def send_error(
+        self, job_id: str, message: str, code: str = "BACKEND_ERROR"
+    ) -> None:
+        """Convenience: send an error message."""
+        self.send(
+            job_id,
+            {
+                "type": "error",
+                "job_id": job_id,
+                "message": message,
+                "code": code,
+            },
+        )
+
+    def make_callback(self, job_id: str) -> Any:
+        """Create a ProgressCallback for a specific job."""
+
+        def callback(*, current: int, total: int, message: str) -> None:
+            self.send_progress(job_id, current=current, total=total, message=message)
+
+        return callback
+
+
+async def websocket_progress(
+    websocket: WebSocket,
+    job_id: str,
+    broadcaster: ProgressBroadcaster,
+) -> None:
+    """WebSocket handler for ``/ws/jobs/{job_id}/progress``."""
+    await websocket.accept()
+    queue = broadcaster.subscribe(job_id)
+    try:
+        while True:
+            msg = await asyncio.wait_for(queue.get(), timeout=30.0)
+            await websocket.send_text(json.dumps(msg))
+            if msg.get("type") in ("completed", "error"):
+                break
+    except asyncio.TimeoutError:
+        # Send keepalive ping on timeout
+        with contextlib.suppress(Exception):
+            await websocket.send_text(json.dumps({"type": "ping", "job_id": job_id}))
+    except WebSocketDisconnect:
+        pass
+    finally:
+        broadcaster.unsubscribe(job_id, queue)


### PR DESCRIPTION
## Summary
- **ProgressBroadcaster** (`ws/progress.py`): In-memory pub/sub per job_id using `asyncio.Queue`, thread-safe message delivery from training threads via `loop.call_soon_threadsafe()`
- **WebSocket endpoint**: `/ws/jobs/{job_id}/progress` delivering progress/completed/error JSON messages per BLUEPRINT §5.5
- **Background training**: Fit/tune endpoints now return immediately with job_id, training runs in daemon thread with progress callback
- **Frontend WebSocket client** (`api/websocket.ts`): Connect/disconnect with auto-cleanup, callbacks for progress/completed/error/disconnect
- **RunningView component**: Progress bar with percentage, elapsed timer (updated every second), fold/trial message display, falls back to polling on WebSocket disconnect

## Test plan
- [x] 32 backend tests pass
- [x] mypy strict clean (24 source files)
- [x] Ruff lint/format clean
- [x] ESLint clean
- [x] Frontend builds successfully
- [ ] Manual: Fit shows progress bar updating via WebSocket
- [ ] Manual: Tune shows trial progress
- [ ] Manual: Elapsed timer counts up during training
- [ ] Manual: Completion message triggers result display
- [ ] Manual: WebSocket disconnect falls back to polling