### PR TITLE
fix: importance kind selector and dark mode implementation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -693,3 +693,25 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
 - **Compatibility:** 非破壊的（新フィールド追加のみ）
 - **Acceptance Criteria:** `GET /api/backends/ui-schema` が capabilities 等を含む
 - **Decision:** 2026-03-22 accepted — Widget 踏襲方針
+
+---
+
+### H-0033: Importance kind 選択機能の追加
+- **Status:** accepted
+- **Scope:** Adapter, API, Frontend
+- **Related:** BLUEPRINT.md §3.3 BackendAdapter Protocol
+- **Context:** Feature Importance が split のみ表示されている。LizyML は split / gain / shap の3種類をサポートするが、LizyStudio 側で kind を切り替える UI と API が不足。
+- **Proposal:**
+  1. `BackendAdapter` Protocol に `importance_kinds(model) -> list[str]` メソッド追加（デフォルト `["split"]`）
+  2. LizyML Adapter で `["split", "gain", "shap"]` を返す実装
+  3. API エンドポイント `GET /api/jobs/{job_id}/importance-kinds` 追加
+  4. フロントエンド FoldDetailsSection に kind セレクタ（SegmentGroup）追加
+  5. `fetchJobImportance(jobId, kind)` の kind パラメータを UI から制御
+- **Impact:** base.py（Protocol）、lizyml.py（Adapter）、api/jobs.py、FoldDetailsSection.tsx、ResultsPanel.tsx、api/jobs.ts
+- **Compatibility:** 非破壊的（Protocol にデフォルト実装付きメソッド追加、新 API エンドポイント追加のみ）
+- **Alternatives:** ハードコードで kind リストをフロントに持つ案 → バックエンド依存の種別なので動的取得が適切
+- **Acceptance Criteria:**
+  1. Importance セクションで split / gain / shap を切り替えられる
+  2. 選択した kind に応じてテーブルとプロットが更新される
+  3. 既存テストが全パス
+- **Decision:** 2026-03-28 accepted

--- a/frontend/src/api/jobs.test.ts
+++ b/frontend/src/api/jobs.test.ts
@@ -11,6 +11,7 @@ import {
   exportJob,
   fetchJob,
   fetchJobImportance,
+  fetchJobImportanceKinds,
   fetchJobLog,
   fetchJobPlot,
   fetchJobPlots,
@@ -68,6 +69,18 @@ describe("fetchJobImportance", () => {
     mockApiFetch.mockResolvedValue({});
     await fetchJobImportance("j1", "shap");
     expect(mockApiFetch).toHaveBeenCalledWith("/jobs/j1/importance?kind=shap");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchJobImportanceKinds
+// ---------------------------------------------------------------------------
+describe("fetchJobImportanceKinds", () => {
+  it("calls /jobs/:id/importance-kinds", async () => {
+    mockApiFetch.mockResolvedValue(["split", "gain", "shap"]);
+    const result = await fetchJobImportanceKinds("j1");
+    expect(mockApiFetch).toHaveBeenCalledWith("/jobs/j1/importance-kinds");
+    expect(result).toEqual(["split", "gain", "shap"]);
   });
 });
 

--- a/frontend/src/api/jobs.ts
+++ b/frontend/src/api/jobs.ts
@@ -23,6 +23,10 @@ export function fetchJobImportance(
   return apiFetch(`/jobs/${jobId}/importance?kind=${kind}`);
 }
 
+export function fetchJobImportanceKinds(jobId: string): Promise<string[]> {
+  return apiFetch(`/jobs/${jobId}/importance-kinds`);
+}
+
 export function fetchJobPlot(
   jobId: string,
   plotType: string,

--- a/frontend/src/components/jobs/JobList.tsx
+++ b/frontend/src/components/jobs/JobList.tsx
@@ -37,11 +37,17 @@ interface JobListProps {
 function getStatusIcon(status: string): { icon: string; className: string } {
   switch (status) {
     case "completed":
-      return { icon: "\u2713", className: "text-green-600" };
+      return {
+        icon: "\u2713",
+        className: "text-green-600 dark:text-green-400",
+      };
     case "running":
-      return { icon: "\u25CF", className: "text-blue-500 animate-pulse" };
+      return {
+        icon: "\u25CF",
+        className: "text-blue-500 dark:text-blue-400 animate-pulse",
+      };
     case "failed":
-      return { icon: "\u2717", className: "text-red-500" };
+      return { icon: "\u2717", className: "text-red-500 dark:text-red-400" };
     case "cancelled":
       return { icon: "\u2717", className: "text-muted-foreground" };
     default:

--- a/frontend/src/components/ui/design-tokens.css
+++ b/frontend/src/components/ui/design-tokens.css
@@ -72,6 +72,7 @@
   white-space: nowrap;
 }
 .lzs-segment__btn:hover { background: hsl(207, 60%, 95%); border-color: hsl(207, 60%, 80%); }
+.dark .lzs-segment__btn:hover { background: hsl(217, 33%, 22%); border-color: hsl(217, 33%, 30%); }
 .lzs-segment__btn--active {
   background: var(--lzs-accent);
   border-color: var(--lzs-accent);
@@ -174,6 +175,9 @@
   scrollbar-width: thin;
   scrollbar-color: hsl(0, 0%, 75%) hsl(0, 0%, 95%);
 }
+.dark .lzs-scrollable {
+  scrollbar-color: hsl(0, 0%, 40%) hsl(0, 0%, 15%);
+}
 .lzs-scrollable::-webkit-scrollbar { width: 8px; height: 8px; }
 .lzs-scrollable::-webkit-scrollbar-thumb {
   background: hsl(0, 0%, 75%);
@@ -182,4 +186,10 @@
 .lzs-scrollable::-webkit-scrollbar-track {
   background: hsl(0, 0%, 95%);
   border-radius: 4px;
+}
+.dark .lzs-scrollable::-webkit-scrollbar-thumb {
+  background: hsl(0, 0%, 40%);
+}
+.dark .lzs-scrollable::-webkit-scrollbar-track {
+  background: hsl(0, 0%, 15%);
 }

--- a/frontend/src/components/workspace/FoldDetailsSection.test.tsx
+++ b/frontend/src/components/workspace/FoldDetailsSection.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   FitResult,
@@ -21,6 +22,9 @@ interface FoldDetailsSectionProps {
   splitSummary: SplitSummaryRow[] | undefined;
   importance: ImportanceResponse | undefined;
   importancePlot: PlotResponse | undefined;
+  importanceKinds?: string[];
+  selectedKind?: string;
+  onKindChange?: (kind: string) => void;
 }
 
 function renderSection(props: FoldDetailsSectionProps) {
@@ -88,6 +92,50 @@ describe("FoldDetailsSection", () => {
       expect(cells[3]).toHaveTextContent("0.3000");
       expect(cells[4]).toHaveTextContent("feature_a");
       expect(cells[5]).toHaveTextContent("0.1000");
+    });
+
+    it("renders kind selector when importanceKinds has multiple options", () => {
+      renderSection({
+        fitResult: baseFitResult,
+        hasFolds: false,
+        splitSummary: undefined,
+        importance: { feature_a: 0.5 },
+        importancePlot: undefined,
+        importanceKinds: ["split", "gain", "shap"],
+        selectedKind: "split",
+        onKindChange: vi.fn(),
+      });
+      expect(screen.getByRole("radiogroup")).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "Split" })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "Gain" })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "SHAP" })).toBeInTheDocument();
+    });
+
+    it("calls onKindChange when a different kind is selected", async () => {
+      const onKindChange = vi.fn();
+      renderSection({
+        fitResult: baseFitResult,
+        hasFolds: false,
+        splitSummary: undefined,
+        importance: { feature_a: 0.5 },
+        importancePlot: undefined,
+        importanceKinds: ["split", "gain", "shap"],
+        selectedKind: "split",
+        onKindChange,
+      });
+      await userEvent.click(screen.getByRole("radio", { name: "Gain" }));
+      expect(onKindChange).toHaveBeenCalledWith("gain");
+    });
+
+    it("does not render kind selector when importanceKinds is undefined", () => {
+      renderSection({
+        fitResult: baseFitResult,
+        hasFolds: false,
+        splitSummary: undefined,
+        importance: { feature_a: 0.5 },
+        importancePlot: undefined,
+      });
+      expect(screen.queryByRole("radiogroup")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/workspace/FoldDetailsSection.tsx
+++ b/frontend/src/components/workspace/FoldDetailsSection.tsx
@@ -19,6 +19,13 @@ import {
 } from "@/components/ui/table";
 import { formatNum } from "@/lib/utils";
 import { PlotlyChart } from "./PlotlyChart";
+import { SegmentGroup } from "./SegmentGroup";
+
+const KIND_LABELS: Record<string, string> = {
+  split: "Split",
+  gain: "Gain",
+  shap: "SHAP",
+};
 
 interface FoldDetailsSectionProps {
   fitResult: FitResult;
@@ -26,6 +33,9 @@ interface FoldDetailsSectionProps {
   splitSummary: SplitSummaryRow[] | undefined;
   importance: ImportanceResponse | undefined;
   importancePlot: PlotResponse | undefined;
+  importanceKinds?: string[];
+  selectedKind?: string;
+  onKindChange?: (kind: string) => void;
 }
 
 /**
@@ -38,6 +48,9 @@ export function FoldDetailsSection({
   splitSummary,
   importance,
   importancePlot,
+  importanceKinds,
+  selectedKind,
+  onKindChange,
 }: FoldDetailsSectionProps) {
   return (
     <>
@@ -46,6 +59,19 @@ export function FoldDetailsSection({
         <AccordionItem value="importance">
           <AccordionTrigger>Feature Importance</AccordionTrigger>
           <AccordionContent>
+            {importanceKinds &&
+              importanceKinds.length > 1 &&
+              selectedKind &&
+              onKindChange && (
+                <div className="mb-3">
+                  <SegmentGroup
+                    options={importanceKinds}
+                    value={selectedKind}
+                    onChange={onKindChange}
+                    labels={KIND_LABELS}
+                  />
+                </div>
+              )}
             {importancePlot && (
               <div className="mb-4">
                 <PlotlyChart plotlyJson={importancePlot.plotly_json} />

--- a/frontend/src/components/workspace/PlotlyChart.test.tsx
+++ b/frontend/src/components/workspace/PlotlyChart.test.tsx
@@ -129,4 +129,36 @@ describe("PlotlyChart", () => {
     expect(layout.yaxis.title).toEqual({ text: "Y Label", standoff: 15 });
     expect(layout.yaxis2.title).toEqual({ text: "Y2 Label", standoff: 15 });
   });
+
+  it("applies transparent background in light mode", () => {
+    document.documentElement.classList.remove("dark");
+    const json = JSON.stringify({ data: [], layout: {} });
+    render(<PlotlyChart plotlyJson={json} />);
+    const { layout } = getPlotProps();
+    expect(layout.paper_bgcolor).toBe("transparent");
+    expect(layout.plot_bgcolor).toBe("transparent");
+  });
+
+  it("applies dark theme colors when dark class is present", () => {
+    document.documentElement.classList.add("dark");
+    const json = JSON.stringify({ data: [], layout: {} });
+    render(<PlotlyChart plotlyJson={json} />);
+    const { layout } = getPlotProps();
+    expect(layout.paper_bgcolor).toBe("transparent");
+    expect(layout.plot_bgcolor).toBe("transparent");
+    expect(layout.font.color).toContain("210");
+    document.documentElement.classList.remove("dark");
+  });
+
+  it("applies theme gridcolor to subplot axes", () => {
+    document.documentElement.classList.remove("dark");
+    const json = JSON.stringify({
+      data: [],
+      layout: { xaxis2: { anchor: "y2" }, yaxis2: { anchor: "x2" } },
+    });
+    render(<PlotlyChart plotlyJson={json} />);
+    const { layout } = getPlotProps();
+    expect(layout.xaxis2.gridcolor).toBeDefined();
+    expect(layout.yaxis2.gridcolor).toBeDefined();
+  });
 });

--- a/frontend/src/components/workspace/PlotlyChart.tsx
+++ b/frontend/src/components/workspace/PlotlyChart.tsx
@@ -1,5 +1,52 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Plot from "react-plotly.js";
+
+function useIsDark(): boolean {
+  const [isDark, setIsDark] = useState(() =>
+    document.documentElement.classList.contains("dark"),
+  );
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setIsDark(document.documentElement.classList.contains("dark"));
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return isDark;
+}
+
+const DARK_THEME = {
+  paper_bgcolor: "transparent",
+  plot_bgcolor: "transparent",
+  font: { color: "hsl(210, 40%, 88%)" },
+  xaxis: {
+    gridcolor: "hsl(217, 33%, 22%)",
+    zerolinecolor: "hsl(217, 33%, 25%)",
+  },
+  yaxis: {
+    gridcolor: "hsl(217, 33%, 22%)",
+    zerolinecolor: "hsl(217, 33%, 25%)",
+  },
+} as const;
+
+const LIGHT_THEME = {
+  paper_bgcolor: "transparent",
+  plot_bgcolor: "transparent",
+  font: { color: "hsl(222, 84%, 5%)" },
+  xaxis: {
+    gridcolor: "hsl(214, 32%, 91%)",
+    zerolinecolor: "hsl(214, 32%, 85%)",
+  },
+  yaxis: {
+    gridcolor: "hsl(214, 32%, 91%)",
+    zerolinecolor: "hsl(214, 32%, 85%)",
+  },
+} as const;
 
 interface PlotlyChartProps {
   plotlyJson: string;
@@ -13,6 +60,8 @@ export function PlotlyChart({
   className,
   height = 350,
 }: PlotlyChartProps) {
+  const isDark = useIsDark();
+
   const { data, layout } = useMemo(() => {
     try {
       const parsed: unknown = JSON.parse(plotlyJson);
@@ -45,14 +94,35 @@ export function PlotlyChart({
         }
       }
 
+      // Apply theme colors to all axes (including subplot axes like xaxis2, yaxis2)
+      const theme = isDark ? DARK_THEME : LIGHT_THEME;
+      for (const key of Object.keys(patched)) {
+        if (
+          (key.startsWith("xaxis") || key.startsWith("yaxis")) &&
+          typeof patched[key] === "object"
+        ) {
+          patched[key] = {
+            ...(patched[key] as object),
+            gridcolor: theme.xaxis.gridcolor,
+            zerolinecolor: theme.xaxis.zerolinecolor,
+          };
+        }
+      }
+
       return {
         data: rawData,
-        layout: { ...patched, autosize: true },
+        layout: {
+          ...patched,
+          autosize: true,
+          paper_bgcolor: theme.paper_bgcolor,
+          plot_bgcolor: theme.plot_bgcolor,
+          font: theme.font,
+        },
       };
     } catch {
       return { data: [], layout: { autosize: true } };
     }
-  }, [plotlyJson]);
+  }, [plotlyJson, isDark]);
 
   return (
     <div className={`overflow-hidden min-w-0 ${className ?? ""}`}>

--- a/frontend/src/components/workspace/ResultsPanel.tsx
+++ b/frontend/src/components/workspace/ResultsPanel.tsx
@@ -6,6 +6,7 @@ import {
   cancelJob,
   fetchJob,
   fetchJobImportance,
+  fetchJobImportanceKinds,
   fetchJobLog,
   fetchJobPlot,
   fetchJobPlots,
@@ -339,11 +340,32 @@ function CompletedView({
       (plots?.includes("learning-curve") ?? false),
   });
 
-  const { data: importance } = useQuery({
-    queryKey: ["job-importance", job.job_id],
-    queryFn: () => fetchJobImportance(job.job_id),
+  const [importanceKind, setImportanceKind] = useState("split");
+
+  const { data: importanceKinds } = useQuery({
+    queryKey: ["job-importance-kinds", job.job_id],
+    queryFn: () => fetchJobImportanceKinds(job.job_id),
   });
 
+  // Sync initial kind with backend response when it differs
+  useEffect(() => {
+    if (
+      importanceKinds &&
+      importanceKinds.length > 0 &&
+      !importanceKinds.includes(importanceKind)
+    ) {
+      setImportanceKind(importanceKinds[0]);
+    }
+  }, [importanceKinds, importanceKind]);
+
+  const { data: importance } = useQuery({
+    queryKey: ["job-importance", job.job_id, importanceKind],
+    queryFn: () => fetchJobImportance(job.job_id, importanceKind),
+  });
+
+  // Importance plot is kind-independent (shows default split importance).
+  // The backend plot API does not accept a kind parameter; the plot is
+  // generated once using the default kind by LizyML's importance_plot().
   const { data: importancePlot } = useQuery({
     queryKey: ["job-plot", job.job_id, "importance"],
     queryFn: () => fetchJobPlot(job.job_id, "importance"),
@@ -465,6 +487,9 @@ function CompletedView({
             splitSummary={splitSummary}
             importance={importance}
             importancePlot={importancePlot}
+            importanceKinds={importanceKinds}
+            selectedKind={importanceKind}
+            onKindChange={setImportanceKind}
           />
         )}
       </Accordion>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -41,6 +41,41 @@
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
 
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 217.2 91.2% 59.8%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 224.3 76.3% 48%;
+    --chart-1: 220 70% 50%;
+    --chart-2: 160 60% 45%;
+    --chart-3: 30 80% 55%;
+    --chart-4: 280 65% 60%;
+    --chart-5: 340 75% 55%;
+    --sidebar-background: 240 5.9% 10%;
+    --sidebar-foreground: 240 4.8% 95.9%;
+    --sidebar-primary: 217.2 91.2% 59.8%;
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 240 3.7% 15.9%;
+    --sidebar-accent-foreground: 240 4.8% 95.9%;
+    --sidebar-border: 240 3.7% 15.9%;
+    --sidebar-ring: 217.2 91.2% 59.8%;
+  }
+
   * {
     @apply border-border;
   }

--- a/src/lizystudio/api/jobs.py
+++ b/src/lizystudio/api/jobs.py
@@ -26,6 +26,7 @@ from lizystudio.services.jobs import (
     JobStore,
     get_available_plots,
     get_importance,
+    get_importance_kinds,
     get_job_plot,
     get_job_store,
     get_metrics_table,
@@ -217,6 +218,21 @@ def get_job_importance_endpoint(
     _require_completed(job)
     try:
         return get_importance(job, ws.backend, kind=kind)
+    except Exception as exc:
+        raise BackendError(exc) from exc
+
+
+@router.get("/{job_id}/importance-kinds")
+def get_job_importance_kinds_endpoint(
+    job_id: str,
+    job_store: JobStore = Depends(get_job_store),
+    ws: WorkspaceState = Depends(get_workspace),
+) -> list[str]:
+    """Get the list of valid importance kind identifiers."""
+    job = _get_job_or_404(job_id, job_store)
+    _require_completed(job)
+    try:
+        return get_importance_kinds(job, ws.backend)
     except Exception as exc:
         raise BackendError(exc) from exc
 

--- a/src/lizystudio/backends/base.py
+++ b/src/lizystudio/backends/base.py
@@ -92,6 +92,10 @@ class BackendAdapter(Protocol):
 
     def importance(self, model: Any, kind: str = "split") -> dict[str, float]: ...
 
+    def importance_kinds(self, model: Any) -> list[str]:
+        """Return the list of valid importance kind identifiers."""
+        return ["split"]
+
     def confusion_matrix(
         self, model: Any, threshold: float = 0.5
     ) -> dict[str, Any]: ...

--- a/src/lizystudio/backends/lizyml.py
+++ b/src/lizystudio/backends/lizyml.py
@@ -187,6 +187,10 @@ class LizyMLAdapter:
         result: dict[str, float] = model.importance(kind=kind)
         return result
 
+    def importance_kinds(self, model: Any) -> list[str]:
+        """Return valid importance kinds for LizyML models."""
+        return ["split", "gain", "shap"]
+
     def confusion_matrix(self, model: Any, threshold: float = 0.5) -> dict[str, Any]:
         result = model.confusion_matrix(threshold=threshold)
         return {

--- a/src/lizystudio/services/jobs.py
+++ b/src/lizystudio/services/jobs.py
@@ -262,6 +262,12 @@ def get_importance(
     return backend.importance(model, kind=kind)
 
 
+def get_importance_kinds(job: Job, backend: BackendAdapter) -> list[str]:
+    """Get the list of valid importance kind identifiers for a completed job."""
+    model = load_job_model(job, backend)
+    return backend.importance_kinds(model)
+
+
 def get_job_plot(job: Job, backend: BackendAdapter, plot_type: str) -> Any:
     """Get a plot for a completed job. Returns PlotData."""
     model = load_job_model(job, backend)

--- a/tests/test_backends_lizyml.py
+++ b/tests/test_backends_lizyml.py
@@ -566,6 +566,22 @@ def test_importance_custom_kind() -> None:
     mock_model.importance.assert_called_once_with(kind="gain")
 
 
+# --- importance_kinds ---
+
+
+def test_importance_kinds_returns_list() -> None:
+    """importance_kinds() returns the list of valid importance kinds."""
+    adapter = LizyMLAdapter()
+    mock_model = MagicMock()
+
+    result = adapter.importance_kinds(mock_model)
+
+    assert isinstance(result, list)
+    assert "split" in result
+    assert "gain" in result
+    assert "shap" in result
+
+
 # --- confusion_matrix ---
 
 

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -585,6 +585,57 @@ def test_get_job_importance_backend_error(
     assert res.json()["error"]["code"] == "BACKEND_ERROR"
 
 
+# --- Importance kinds ---
+
+
+def test_get_job_importance_kinds(
+    client: TestClient, sample_data_ref: DataRef, tmp_path: Path
+) -> None:
+    """GET /api/jobs/{job_id}/importance-kinds returns list of valid kinds."""
+    job_id = _create_completed_job_with_model(
+        client, sample_data_ref, str(tmp_path / "model")
+    )
+    mock_backend = _make_mock_backend()
+    mock_backend.importance_kinds.return_value = ["split", "gain", "shap"]  # type: ignore[union-attr]
+
+    app = client.app  # type: ignore[union-attr]
+    original = app.state.workspace.backend
+    app.state.workspace.backend = mock_backend
+    try:
+        res = client.get(f"/api/jobs/{job_id}/importance-kinds")
+    finally:
+        app.state.workspace.backend = original
+
+    assert res.status_code == 200
+    data = res.json()
+    assert isinstance(data, list)
+    assert "split" in data
+    assert "gain" in data
+    assert "shap" in data
+
+
+def test_get_job_importance_kinds_backend_error(
+    client: TestClient, sample_data_ref: DataRef, tmp_path: Path
+) -> None:
+    """GET importance-kinds propagates BackendError when the backend raises."""
+    job_id = _create_completed_job_with_model(
+        client, sample_data_ref, str(tmp_path / "model")
+    )
+    mock_backend = _make_mock_backend()
+    mock_backend.importance_kinds.side_effect = RuntimeError("no kinds")  # type: ignore[union-attr]
+
+    app = client.app  # type: ignore[union-attr]
+    original = app.state.workspace.backend
+    app.state.workspace.backend = mock_backend
+    try:
+        res = client.get(f"/api/jobs/{job_id}/importance-kinds")
+    finally:
+        app.state.workspace.backend = original
+
+    assert res.status_code == 500
+    assert res.json()["error"]["code"] == "BACKEND_ERROR"
+
+
 # --- Available plots ---
 
 


### PR DESCRIPTION
## Summary

- **Importance kind selector (H-0033):** Feature Importance was only showing "split". Added kind selector (split/gain/shap) with backend API and frontend SegmentGroup UI.
- **Dark mode:** CSS custom properties for `.dark` class were missing. Added all 33 design tokens, PlotlyChart theme integration, and dark variants for status icons.
- **Learning Curve metric (deferred):** LizyML v0.4.x hardcodes eval_metric per task (`_build_params()` strips user metric). Waiting for nbx-liz/LizyML#51 and nbx-liz/LizyML#52.

## Changes

### Bug 1: Importance kind selector
- `BackendAdapter.importance_kinds(model)` method with default `["split"]`
- LizyML adapter returns `["split", "gain", "shap"]`
- `GET /api/jobs/{job_id}/importance-kinds` endpoint
- `FoldDetailsSection` SegmentGroup kind selector
- `ResultsPanel` kind state management with backend sync

### Bug 3: Dark mode
- `.dark` CSS variables in `index.css` (33 tokens)
- `PlotlyChart` theme integration (`useIsDark` hook, transparent bg, themed grid/font)
- Dark hover/scrollbar styles in `design-tokens.css`
- `dark:` variants on `JobList` status icons

## Test plan

- [x] Backend: 353 tests passed (pytest)
- [x] Frontend: 721 tests passed (vitest)
- [x] Ruff lint/format: passed
- [x] Biome lint/format: passed
- [x] mypy: no issues
- [ ] Manual: verify kind selector toggles importance table data
- [ ] Manual: verify dark mode toggle applies to all panels and Plotly charts