### PR TITLE
feat(ui): UX improvements — parameter coverage, progressive disclosure, error handling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,9 +2,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { Toaster } from "sonner";
 import { AppLayout } from "./components/layout/AppLayout";
+import { ErrorBoundary } from "./components/layout/ErrorBoundary";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { InferencePage } from "./pages/InferencePage";
 import { JobsPage } from "./pages/JobsPage";
+import { NotFoundPage } from "./pages/NotFoundPage";
 import { WorkspacePage } from "./pages/WorkspacePage";
 
 const queryClient = new QueryClient({
@@ -21,13 +23,16 @@ export function App() {
     <QueryClientProvider client={queryClient}>
       <TooltipProvider delayDuration={300}>
         <BrowserRouter>
-          <AppLayout>
-            <Routes>
-              <Route path="/" element={<WorkspacePage />} />
-              <Route path="/jobs" element={<JobsPage />} />
-              <Route path="/inference" element={<InferencePage />} />
-            </Routes>
-          </AppLayout>
+          <ErrorBoundary>
+            <AppLayout>
+              <Routes>
+                <Route path="/" element={<WorkspacePage />} />
+                <Route path="/jobs" element={<JobsPage />} />
+                <Route path="/inference" element={<InferencePage />} />
+                <Route path="*" element={<NotFoundPage />} />
+              </Routes>
+            </AppLayout>
+          </ErrorBoundary>
           <Toaster richColors position="bottom-right" />
         </BrowserRouter>
       </TooltipProvider>

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -149,6 +149,7 @@ export interface ParameterHint {
   kind: string;
   step?: number;
   default?: unknown;
+  description?: string;
 }
 
 export interface SearchSpaceCatalogEntry {
@@ -174,7 +175,11 @@ export interface UiSchema {
   capabilities?: {
     cv_strategies: string[];
     tune: { allow_empty_space: boolean };
+    cv_strategy_fields?: Record<string, string[]>;
+    cv_defaults?: Record<string, unknown>;
+    cv_default_strategy?: Record<string, string>;
   };
   calibration_methods?: string[];
   additional_params?: string[];
+  special_search_space_fields?: Record<string, string>;
 }

--- a/frontend/src/components/inference/HistoryList.test.tsx
+++ b/frontend/src/components/inference/HistoryList.test.tsx
@@ -38,11 +38,11 @@ describe("HistoryList", () => {
     cleanup();
   });
 
-  it("renders nothing when records are empty", () => {
-    const { container } = render(
+  it("shows empty state message when records are empty", () => {
+    render(
       <HistoryList records={[]} selectedInfId={null} onSelect={mockOnSelect} />,
     );
-    expect(container.innerHTML).toBe("");
+    expect(screen.getByText("No inference history yet.")).toBeInTheDocument();
   });
 
   it("renders history heading when records exist", () => {

--- a/frontend/src/components/inference/HistoryList.tsx
+++ b/frontend/src/components/inference/HistoryList.tsx
@@ -12,7 +12,13 @@ export function HistoryList({
   selectedInfId,
   onSelect,
 }: HistoryListProps) {
-  if (records.length === 0) return null;
+  if (records.length === 0) {
+    return (
+      <div className="px-1 py-3 text-center text-xs text-muted-foreground">
+        No inference history yet.
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-1">

--- a/frontend/src/components/layout/ErrorBoundary.test.tsx
+++ b/frontend/src/components/layout/ErrorBoundary.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+function ThrowingComponent({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error("Test error message");
+  return <div>Normal content</div>;
+}
+
+describe("ErrorBoundary", () => {
+  it("renders children when no error", () => {
+    render(
+      <ErrorBoundary>
+        <div>Child content</div>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("Child content")).toBeInTheDocument();
+  });
+
+  it("renders error UI when child throws", () => {
+    // Suppress console.error for expected error
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByText("Test error message")).toBeInTheDocument();
+    expect(screen.getByText("Try again")).toBeInTheDocument();
+
+    spy.mockRestore();
+  });
+
+  it("recovers when 'Try again' is clicked", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    let shouldThrow = true;
+
+    function ConditionalThrow() {
+      if (shouldThrow) throw new Error("Boom");
+      return <div>Recovered</div>;
+    }
+
+    const { rerender } = render(
+      <ErrorBoundary>
+        <ConditionalThrow />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    // Stop throwing and click retry
+    shouldThrow = false;
+    fireEvent.click(screen.getByText("Try again"));
+
+    rerender(
+      <ErrorBoundary>
+        <ConditionalThrow />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Recovered")).toBeInTheDocument();
+    spy.mockRestore();
+  });
+});

--- a/frontend/src/components/layout/ErrorBoundary.tsx
+++ b/frontend/src/components/layout/ErrorBoundary.tsx
@@ -1,0 +1,53 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error("ErrorBoundary caught:", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          className="flex h-full min-h-[400px] flex-col items-center justify-center gap-4 p-8 text-center"
+          role="alert"
+        >
+          <div className="text-4xl">⚠</div>
+          <h2 className="text-lg font-semibold">Something went wrong</h2>
+          <p className="max-w-md text-sm text-muted-foreground">
+            {this.state.error?.message ?? "An unexpected error occurred."}
+          </p>
+          <Button
+            variant="outline"
+            onClick={() => {
+              this.setState({ hasError: false, error: null });
+            }}
+          >
+            Try again
+          </Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/layout/ErrorBoundary.tsx
+++ b/frontend/src/components/layout/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Component, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 
 interface Props {
@@ -18,10 +18,6 @@ export class ErrorBoundary extends Component<Props, State> {
 
   static getDerivedStateFromError(error: Error): State {
     return { hasError: true, error };
-  }
-
-  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
-    console.error("ErrorBoundary caught:", error, errorInfo);
   }
 
   render() {

--- a/frontend/src/components/workspace/ConfigForm.test.tsx
+++ b/frontend/src/components/workspace/ConfigForm.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { UiSchema } from "@/api/types";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -331,5 +331,72 @@ describe("ConfigForm", () => {
     });
 
     expect(screen.getByTestId("dyn-param")).toBeInTheDocument();
+  });
+
+  describe("Progressive Disclosure (Essential / Advanced split)", () => {
+    const uiSchemaWithHints = {
+      parameter_hints: [
+        { key: "objective", kind: "objective", label: "Objective" },
+        { key: "learning_rate", kind: "number", label: "LR" },
+        { key: "n_estimators", kind: "integer", label: "N Est" },
+        { key: "max_depth", kind: "integer", label: "Depth" },
+        // Advanced params:
+        { key: "feature_fraction", kind: "number", label: "FF" },
+        { key: "lambda_l1", kind: "number", label: "L1" },
+        { key: "verbose", kind: "integer", label: "Verbose" },
+      ],
+    } as unknown as UiSchema;
+
+    it("shows 'Show advanced' toggle when advanced params exist", () => {
+      renderConfigForm({
+        schema: minimalSchema,
+        config: minimalConfig,
+        onChange: vi.fn(),
+        uiSchema: uiSchemaWithHints,
+      });
+
+      const toggle = screen.getByTestId("toggle-advanced-params");
+      expect(toggle).toBeInTheDocument();
+      expect(toggle.textContent).toContain("Show advanced");
+      expect(toggle.textContent).toContain("3");
+    });
+
+    it("hides advanced DynParam by default, shows on click", () => {
+      renderConfigForm({
+        schema: minimalSchema,
+        config: minimalConfig,
+        onChange: vi.fn(),
+        uiSchema: uiSchemaWithHints,
+      });
+
+      // Only essential params rendered initially (4 essential)
+      const initialParams = screen.getAllByTestId("dyn-param");
+      expect(initialParams.length).toBe(4);
+
+      // Click toggle
+      fireEvent.click(screen.getByTestId("toggle-advanced-params"));
+
+      // All params rendered (4 essential + 3 advanced = 7)
+      const allParams = screen.getAllByTestId("dyn-param");
+      expect(allParams.length).toBe(7);
+    });
+
+    it("does not show toggle when all params are essential", () => {
+      renderConfigForm({
+        schema: minimalSchema,
+        config: minimalConfig,
+        onChange: vi.fn(),
+        uiSchema: {
+          parameter_hints: [
+            { key: "objective", kind: "objective", label: "Obj" },
+            { key: "learning_rate", kind: "number", label: "LR" },
+          ],
+        } as unknown as UiSchema,
+      });
+
+      expect(
+        screen.queryByTestId("toggle-advanced-params"),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/workspace/ConfigForm.tsx
+++ b/frontend/src/components/workspace/ConfigForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Accordion,
   AccordionContent,
@@ -329,16 +329,13 @@ export function ConfigForm({
                       <p className="text-xs text-muted-foreground font-medium mb-2">
                         Model Params
                       </p>
-                      {uiSchema?.parameter_hints?.map((hint) => (
-                        <DynParam
-                          key={hint.key}
-                          hint={hint}
-                          value={getValueForHint(hint)}
-                          onChange={(v) => handleHintChange(hint, v)}
-                          options={getOptionsForHint(hint)}
-                          visible={shouldShowField(hint.key)}
-                        />
-                      ))}
+                      <ModelParamsSection
+                        hints={uiSchema?.parameter_hints ?? []}
+                        getValueForHint={getValueForHint}
+                        handleHintChange={handleHintChange}
+                        getOptionsForHint={getOptionsForHint}
+                        shouldShowField={shouldShowField}
+                      />
 
                       {/* ── Additional Params ── */}
                       <div className="border-t my-3" />
@@ -485,5 +482,78 @@ export function ConfigForm({
         )}
       </Accordion>
     </div>
+  );
+}
+
+// --- Model Params with Essential / Advanced split ---
+
+const ESSENTIAL_PARAM_KEYS = new Set([
+  "objective",
+  "metric",
+  "n_estimators",
+  "learning_rate",
+  "max_depth",
+  "num_leaves",
+]);
+
+function ModelParamsSection({
+  hints,
+  getValueForHint,
+  handleHintChange,
+  getOptionsForHint,
+  shouldShowField,
+}: {
+  hints: import("@/api/types").ParameterHint[];
+  getValueForHint: (hint: import("@/api/types").ParameterHint) => unknown;
+  handleHintChange: (
+    hint: import("@/api/types").ParameterHint,
+    value: unknown,
+  ) => void;
+  getOptionsForHint: (hint: import("@/api/types").ParameterHint) => string[];
+  shouldShowField: (key: string) => boolean;
+}) {
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  const essential = hints.filter((h) => ESSENTIAL_PARAM_KEYS.has(h.key));
+  const advanced = hints.filter((h) => !ESSENTIAL_PARAM_KEYS.has(h.key));
+
+  return (
+    <>
+      {essential.map((hint) => (
+        <DynParam
+          key={hint.key}
+          hint={hint}
+          value={getValueForHint(hint)}
+          onChange={(v) => handleHintChange(hint, v)}
+          options={getOptionsForHint(hint)}
+          visible={shouldShowField(hint.key)}
+        />
+      ))}
+      {advanced.length > 0 && (
+        <>
+          <button
+            type="button"
+            className="mt-1 mb-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            onClick={() => setShowAdvanced((v) => !v)}
+            data-testid="toggle-advanced-params"
+          >
+            {showAdvanced
+              ? `▾ Hide advanced (${advanced.length})`
+              : `▸ Show advanced (${advanced.length})`}
+          </button>
+          {showAdvanced &&
+            advanced.map((hint) => (
+              <DynParam
+                key={hint.key}
+                hint={hint}
+                value={getValueForHint(hint)}
+                onChange={(v) => handleHintChange(hint, v)}
+                options={getOptionsForHint(hint)}
+                visible={shouldShowField(hint.key)}
+              />
+            ))}
+        </>
+      )}
+    </>
   );
 }

--- a/frontend/src/components/workspace/DynParam.test.tsx
+++ b/frontend/src/components/workspace/DynParam.test.tsx
@@ -251,6 +251,37 @@ describe("DynParam", () => {
     });
   });
 
+  describe("description tooltip", () => {
+    it("passes description to FormRow as title attribute", () => {
+      render(
+        <DynParam
+          hint={hint({
+            kind: "integer",
+            key: "n",
+            label: "Estimators",
+            description: "Number of boosting rounds",
+          })}
+          value={100}
+          onChange={vi.fn()}
+        />,
+      );
+      const label = screen.getByText("Estimators");
+      expect(label).toHaveAttribute("title", "Number of boosting rounds");
+    });
+
+    it("falls back to label when no description", () => {
+      render(
+        <DynParam
+          hint={hint({ kind: "integer", key: "n", label: "Estimators" })}
+          value={100}
+          onChange={vi.fn()}
+        />,
+      );
+      const label = screen.getByText("Estimators");
+      expect(label).toHaveAttribute("title", "Estimators");
+    });
+  });
+
   describe("undefined value → hint.default used as actual value", () => {
     it("CompactStepper shows default value when value is undefined", () => {
       const onChange = vi.fn();

--- a/frontend/src/components/workspace/DynParam.tsx
+++ b/frontend/src/components/workspace/DynParam.tsx
@@ -39,7 +39,7 @@ export function DynParam({
       const opts = options ?? [];
       if (opts.length === 0) return null;
       return (
-        <FormRow label={hint.label}>
+        <FormRow label={hint.label} description={hint.description}>
           <SegmentGroup
             options={opts}
             value={typeof value === "string" ? value : ""}
@@ -58,7 +58,7 @@ export function DynParam({
           ? [value]
           : [];
       return (
-        <FormRow label={hint.label}>
+        <FormRow label={hint.label} description={hint.description}>
           <ChipGroup
             options={opts}
             selected={selected}
@@ -80,7 +80,7 @@ export function DynParam({
       const numValue = rawValue ?? defaultNum;
       const step = hint.step ?? (hint.kind === "integer" ? 1 : 0.01);
       return (
-        <FormRow label={hint.label}>
+        <FormRow label={hint.label} description={hint.description}>
           <CompactStepper
             value={numValue}
             onChange={(v) => onChange(v)}
@@ -93,7 +93,7 @@ export function DynParam({
     case "boolean": {
       const boolValue = value === true;
       return (
-        <FormRow label={hint.label}>
+        <FormRow label={hint.label} description={hint.description}>
           <CompactToggle checked={boolValue} onChange={(v) => onChange(v)} />
         </FormRow>
       );

--- a/frontend/src/hooks/useDocumentTitle.ts
+++ b/frontend/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+
+const DEFAULT_TITLE = "LizyStudio";
+
+/**
+ * Sets the browser tab title. Restores default on unmount.
+ */
+export function useDocumentTitle(title: string | null) {
+  useEffect(() => {
+    document.title = title ? `${title} — ${DEFAULT_TITLE}` : DEFAULT_TITLE;
+    return () => {
+      document.title = DEFAULT_TITLE;
+    };
+  }, [title]);
+}

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,17 @@
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+export function NotFoundPage() {
+  return (
+    <div className="flex h-full min-h-[400px] flex-col items-center justify-center gap-4 p-8 text-center">
+      <div className="text-5xl font-bold text-muted-foreground">404</div>
+      <h2 className="text-lg font-semibold">Page not found</h2>
+      <p className="text-sm text-muted-foreground">
+        The page you're looking for doesn't exist.
+      </p>
+      <Button asChild variant="outline">
+        <Link to="/">Go to Workspace</Link>
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -10,6 +10,7 @@ import {
 import { DataPanel } from "@/components/workspace/DataPanel";
 import { ModelPanel } from "@/components/workspace/ModelPanel";
 import { ResultsPanel } from "@/components/workspace/ResultsPanel";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export function WorkspacePage() {
   const queryClient = useQueryClient();
@@ -17,6 +18,8 @@ export function WorkspacePage() {
   const [task, setTask] = useState<string | null>(null);
   const [currentJobId, setCurrentJobId] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
+
+  useDocumentTitle(running ? "Running..." : null);
 
   const { data: uiSchema } = useQuery({
     queryKey: ["ui-schema"],

--- a/src/lizystudio/backends/lizyml_ui_schema.py
+++ b/src/lizystudio/backends/lizyml_ui_schema.py
@@ -39,11 +39,8 @@ _KNOWN_PARAM_KEYS: frozenset[str] = frozenset(
         "min_child_weight",
         "min_split_gain",
         "min_gain_to_split",  # LightGBM alias for min_split_gain
-        "subsample",
-        "colsample_bytree",
         "scale_pos_weight",
-        "reg_alpha",
-        "reg_lambda",
+        "is_unbalance",  # LightGBM native; use `balanced` smart param instead
     }
 )
 
@@ -473,7 +470,7 @@ def build_ui_schema(
                 "key": "verbose",
                 "title": "Log Output",
                 "paramType": "integer",
-                "modes": ["fixed", "range"],
+                "modes": ["fixed"],
                 "group": "model_params",
                 "default": -1,
             },
@@ -552,22 +549,6 @@ def build_ui_schema(
                 "default": 0.0,
             },
             {
-                "key": "subsample",
-                "title": "Subsample",
-                "paramType": "number",
-                "modes": ["fixed", "range"],
-                "group": "additional",
-                "default": 1.0,
-            },
-            {
-                "key": "colsample_bytree",
-                "title": "Col Sample By Tree",
-                "paramType": "number",
-                "modes": ["fixed", "range"],
-                "group": "additional",
-                "default": 1.0,
-            },
-            {
                 "key": "scale_pos_weight",
                 "title": "Scale Pos Weight",
                 "paramType": "number",
@@ -575,22 +556,9 @@ def build_ui_schema(
                 "group": "additional",
                 "default": 1.0,
             },
-            {
-                "key": "reg_alpha",
-                "title": "Reg Alpha (L1)",
-                "paramType": "number",
-                "modes": ["fixed", "range"],
-                "group": "additional",
-                "default": 0.0,
-            },
-            {
-                "key": "reg_lambda",
-                "title": "Reg Lambda (L2)",
-                "paramType": "number",
-                "modes": ["fixed", "range"],
-                "group": "additional",
-                "default": 0.0,
-            },
+            # Note: subsample/colsample_bytree/reg_alpha/reg_lambda are
+            # XGBoost aliases for bagging_fraction/feature_fraction/lambda_l1/lambda_l2
+            # and are available via additional_params only (not in catalog).
             # ── Training group ──
             {
                 "key": "seed",
@@ -653,11 +621,7 @@ def build_ui_schema(
             # Additional params step values
             "min_child_weight": 0.001,
             "min_split_gain": 0.001,
-            "subsample": 0.05,
-            "colsample_bytree": 0.05,
             "scale_pos_weight": 0.1,
-            "reg_alpha": 0.0001,
-            "reg_lambda": 0.0001,
         },
         "conditional_visibility": {
             "calibration": {"task": ["binary"]},

--- a/src/lizystudio/backends/lizyml_ui_schema.py
+++ b/src/lizystudio/backends/lizyml_ui_schema.py
@@ -26,7 +26,7 @@ _KNOWN_PARAM_KEYS: frozenset[str] = frozenset(
         "lambda_l2",
         "first_metric_only",
         "verbose",
-        "num_threads",
+        "num_threads",  # Excluded from UI intentionally (server-managed)
         "num_leaves",
         # Smart params (in search_space_catalog)
         "auto_num_leaves",
@@ -38,6 +38,7 @@ _KNOWN_PARAM_KEYS: frozenset[str] = frozenset(
         # Additional params promoted to search_space_catalog
         "min_child_weight",
         "min_split_gain",
+        "min_gain_to_split",  # LightGBM alias for min_split_gain
         "subsample",
         "colsample_bytree",
         "scale_pos_weight",

--- a/src/lizystudio/backends/lizyml_ui_schema.py
+++ b/src/lizystudio/backends/lizyml_ui_schema.py
@@ -9,6 +9,84 @@ from __future__ import annotations
 import threading
 from typing import Any
 
+# Keys already covered by parameter_hints or search_space_catalog.
+# additional_params must exclude these to avoid UI duplication.
+_KNOWN_PARAM_KEYS: frozenset[str] = frozenset(
+    {
+        "objective",
+        "metric",
+        "n_estimators",
+        "learning_rate",
+        "max_depth",
+        "max_bin",
+        "feature_fraction",
+        "bagging_fraction",
+        "bagging_freq",
+        "lambda_l1",
+        "lambda_l2",
+        "first_metric_only",
+        "verbose",
+        "num_threads",
+        "num_leaves",
+        # Smart params (in search_space_catalog)
+        "auto_num_leaves",
+        "num_leaves_ratio",
+        "min_data_in_leaf_ratio",
+        "min_data_in_bin_ratio",
+        "feature_weights",
+        "balanced",
+        # Additional params promoted to search_space_catalog
+        "min_child_weight",
+        "min_split_gain",
+        "subsample",
+        "colsample_bytree",
+        "scale_pos_weight",
+        "reg_alpha",
+        "reg_lambda",
+    }
+)
+
+# LightGBM parameters available as additional params (beyond hints/catalog).
+_LGBM_ADDITIONAL_PARAMS: list[str] = sorted(
+    [
+        "min_child_weight",
+        "min_child_samples",
+        "subsample",
+        "colsample_bytree",
+        "reg_alpha",
+        "reg_lambda",
+        "max_cat_threshold",
+        "cat_smooth",
+        "cat_l2",
+        "extra_trees",
+        "path_smooth",
+        "min_gain_to_split",
+        "min_data_in_leaf",
+        "min_data_in_bin",
+        "max_cat_to_onehot",
+        "top_k",
+        "min_sum_hessian_in_leaf",
+        "linear_tree",
+        "feature_pre_filter",
+        "force_col_wise",
+        "force_row_wise",
+        "histogram_pool_size",
+        "is_unbalance",
+        "scale_pos_weight",
+        "sigmoid",
+        "boost_from_average",
+        "bin_construct_sample_cnt",
+        "data_sample_strategy",
+        "interaction_constraints",
+    ]
+)
+
+
+def _build_additional_params() -> list[str]:
+    """Return LightGBM params not in parameter_hints or search_space_catalog."""
+    return [p for p in _LGBM_ADDITIONAL_PARAMS if p not in _KNOWN_PARAM_KEYS]
+
+
 # --- Eval metrics registry lookup (cached) ---
 
 _eval_metrics_cache: dict[str, list[str]] | None = None
@@ -134,17 +212,28 @@ def build_ui_schema(
             "metric": dict(all_metrics_by_task),
             "model_metric": {
                 "regression": [
-                    "huber",
-                    "mae",
-                    "mape",
+                    "l1",
+                    "l2",
                     "rmse",
+                    "quantile",
+                    "mape",
+                    "huber",
+                    "fair",
+                    "poisson",
+                    "gamma",
+                    "gamma_deviance",
+                    "tweedie",
                     "r2",
                     "rmsle",
                 ],
                 "binary": [
                     "auc",
-                    "logloss",
-                    "auc_pr",
+                    "binary_logloss",
+                    "binary_error",
+                    "average_precision",
+                    "cross_entropy",
+                    "cross_entropy_lambda",
+                    "kullback_leibler",
                     "f1",
                     "accuracy",
                     "brier",
@@ -152,9 +241,9 @@ def build_ui_schema(
                     "precision_at_k",
                 ],
                 "multiclass": [
-                    "logloss",
-                    "auc",
-                    "auc_pr",
+                    "multi_logloss",
+                    "multi_error",
+                    "auc_mu",
                     "f1",
                     "accuracy",
                     "brier",
@@ -252,6 +341,26 @@ def build_ui_schema(
                 "label": "First Metric Only",
                 "kind": "boolean",
                 "default": False,
+            },
+            {
+                "key": "verbose",
+                "label": "Log Output",
+                "kind": "integer",
+                "step": 1,
+                "default": -1,
+            },
+            {
+                "key": "balanced",
+                "label": "Balanced",
+                "kind": "boolean",
+                "default": False,
+            },
+            {
+                "key": "num_leaves",
+                "label": "Num Leaves",
+                "kind": "integer",
+                "step": 1,
+                "default": 256,
             },
         ],
         "search_space_catalog": [
@@ -360,6 +469,15 @@ def build_ui_schema(
                 "default": False,
             },
             {
+                "key": "verbose",
+                "title": "Log Output",
+                "paramType": "integer",
+                "modes": ["fixed", "range"],
+                "group": "model_params",
+                "default": -1,
+            },
+            # ── Smart Params group ──
+            {
                 "key": "auto_num_leaves",
                 "title": "Auto Num Leaves",
                 "paramType": "boolean",
@@ -390,6 +508,87 @@ def build_ui_schema(
                 "modes": ["fixed", "range"],
                 "group": "smart_params",
                 "default": 0.01,
+            },
+            {
+                "key": "num_leaves",
+                "title": "Num Leaves",
+                "paramType": "integer",
+                "modes": ["fixed", "range", "choice"],
+                "group": "smart_params",
+                "default": 256,
+            },
+            {
+                "key": "feature_weights",
+                "title": "Feature Weights",
+                "paramType": "object",
+                "modes": ["fixed"],
+                "group": "smart_params",
+                "default": None,
+            },
+            {
+                "key": "balanced",
+                "title": "Balanced",
+                "paramType": "boolean",
+                "modes": ["fixed", "choice"],
+                "group": "smart_params",
+                "default": False,
+            },
+            # ── Additional (commonly tuned LightGBM params) ──
+            {
+                "key": "min_child_weight",
+                "title": "Min Child Weight",
+                "paramType": "number",
+                "modes": ["fixed", "range"],
+                "group": "additional",
+                "default": 0.001,
+            },
+            {
+                "key": "min_split_gain",
+                "title": "Min Split Gain",
+                "paramType": "number",
+                "modes": ["fixed", "range"],
+                "group": "additional",
+                "default": 0.0,
+            },
+            {
+                "key": "subsample",
+                "title": "Subsample",
+                "paramType": "number",
+                "modes": ["fixed", "range"],
+                "group": "additional",
+                "default": 1.0,
+            },
+            {
+                "key": "colsample_bytree",
+                "title": "Col Sample By Tree",
+                "paramType": "number",
+                "modes": ["fixed", "range"],
+                "group": "additional",
+                "default": 1.0,
+            },
+            {
+                "key": "scale_pos_weight",
+                "title": "Scale Pos Weight",
+                "paramType": "number",
+                "modes": ["fixed", "range"],
+                "group": "additional",
+                "default": 1.0,
+            },
+            {
+                "key": "reg_alpha",
+                "title": "Reg Alpha (L1)",
+                "paramType": "number",
+                "modes": ["fixed", "range"],
+                "group": "additional",
+                "default": 0.0,
+            },
+            {
+                "key": "reg_lambda",
+                "title": "Reg Lambda (L2)",
+                "paramType": "number",
+                "modes": ["fixed", "range"],
+                "group": "additional",
+                "default": 0.0,
             },
             # ── Training group ──
             {
@@ -445,11 +644,19 @@ def build_ui_schema(
             "lambda_l2": 0.0001,
             "num_leaves_ratio": 0.05,
             "num_leaves": 1,
-            "min_data_in_leaf_ratio": 0.001,
-            "min_data_in_bin_ratio": 0.001,
+            "min_data_in_leaf_ratio": 0.01,
+            "min_data_in_bin_ratio": 0.01,
             "early_stopping.rounds": 50,
             "validation_ratio": 0.05,
             "seed": 1,
+            # Additional params step values
+            "min_child_weight": 0.001,
+            "min_split_gain": 0.001,
+            "subsample": 0.05,
+            "colsample_bytree": 0.05,
+            "scale_pos_weight": 0.1,
+            "reg_alpha": 0.0001,
+            "reg_lambda": 0.0001,
         },
         "conditional_visibility": {
             "calibration": {"task": ["binary"]},
@@ -483,20 +690,56 @@ def build_ui_schema(
                 "blocked_group_kfold",
             ],
             "tune": {"allow_empty_space": True},
+            "cv_strategy_fields": {
+                "kfold": ["n_splits", "shuffle", "random_state"],
+                "stratified_kfold": ["n_splits", "shuffle", "random_state"],
+                "group_kfold": ["n_splits", "group_col"],
+                "stratified_group_kfold": ["n_splits", "group_col"],
+                "time_series": [
+                    "n_splits",
+                    "gap",
+                    "max_train_size",
+                    "max_test_size",
+                ],
+                "purged_time_series": [
+                    "n_splits",
+                    "time_col",
+                    "purge_gap",
+                    "embargo",
+                ],
+                "group_time_series": [
+                    "n_splits",
+                    "group_col",
+                    "gap",
+                    "max_train_size",
+                    "max_test_size",
+                ],
+                "blocked_group_kfold": [
+                    "blocks_col",
+                    "groups_col",
+                    "mode",
+                    "train_window",
+                    "min_train_rows",
+                    "min_valid_rows",
+                ],
+            },
+            "cv_defaults": {
+                "n_splits": 5,
+                "shuffle": True,
+                "random_state": 42,
+                "gap": 0,
+            },
+            "cv_default_strategy": {
+                "binary": "stratified_kfold",
+                "multiclass": "stratified_kfold",
+                "regression": "kfold",
+            },
         },
         "calibration_methods": ["platt", "isotonic", "beta"],
-        "additional_params": [
-            "min_child_weight",
-            "min_split_gain",
-            "subsample",
-            "colsample_bytree",
-            "scale_pos_weight",
-            "cat_smooth",
-            "cat_l2",
-            "max_cat_threshold",
-            "path_smooth",
-            "extra_trees",
-            "num_leaves",
-            "log_output",
-        ],
+        "additional_params": _build_additional_params(),
+        "special_search_space_fields": {
+            "objective": "objective",
+            "metric": "model_metric",
+            "inner_valid": "inner_valid_picker",
+        },
     }

--- a/tests/test_ui_schema.py
+++ b/tests/test_ui_schema.py
@@ -22,6 +22,7 @@ UI_SCHEMA_KEYS = {
     "capabilities",
     "calibration_methods",
     "additional_params",
+    "special_search_space_fields",
 }
 
 
@@ -233,7 +234,7 @@ class TestLizyMLAdapterUiSchema:
     def test_search_space_catalog_has_group(self) -> None:
         """Each catalog entry has a valid 'group' key."""
         schema = LizyMLAdapter().get_ui_schema()
-        allowed_groups = {"model_params", "smart_params", "training"}
+        allowed_groups = {"model_params", "smart_params", "training", "additional"}
         for entry in schema["search_space_catalog"]:
             assert "group" in entry, f"Missing 'group' on catalog entry: {entry['key']}"
             assert entry["group"] in allowed_groups, (
@@ -401,12 +402,197 @@ class TestLizyMLAdapterUiSchema:
             assert m in binary_mm, f"binary model_metric missing feval metric: {m}"
 
     def test_model_metric_multiclass_uses_lizyml_names(self) -> None:
-        """model_metric for multiclass should use LizyML canonical metric names."""
+        """model_metric for multiclass should use LightGBM native metric names."""
         schema = LizyMLAdapter().get_ui_schema()
         mc_mm = schema["option_sets"]["model_metric"]["multiclass"]
-        # v0.6.0+ translates these automatically via metric bridge
-        assert "logloss" in mc_mm
-        assert "auc" in mc_mm
+        assert "multi_logloss" in mc_mm
+        assert "multi_error" in mc_mm
+        assert "auc_mu" in mc_mm
+
+    # --- Phase 1: Expanded parameter coverage (Widget parity) ---
+
+    def test_parameter_hints_include_balanced(self) -> None:
+        """balanced must be in parameter_hints as a boolean kind."""
+        schema = LizyMLAdapter().get_ui_schema()
+        hints = {h["key"]: h for h in schema["parameter_hints"]}
+        assert "balanced" in hints
+        assert hints["balanced"]["kind"] == "boolean"
+
+    def test_parameter_hints_include_num_leaves(self) -> None:
+        """num_leaves must be in parameter_hints as an integer kind."""
+        schema = LizyMLAdapter().get_ui_schema()
+        hints = {h["key"]: h for h in schema["parameter_hints"]}
+        assert "num_leaves" in hints
+        assert hints["num_leaves"]["kind"] == "integer"
+
+    def test_parameter_hints_include_verbose(self) -> None:
+        """verbose must be in parameter_hints as an integer kind."""
+        schema = LizyMLAdapter().get_ui_schema()
+        hints = {h["key"]: h for h in schema["parameter_hints"]}
+        assert "verbose" in hints
+        assert hints["verbose"]["kind"] == "integer"
+
+    def test_search_space_catalog_includes_balanced(self) -> None:
+        """balanced must be in search_space_catalog (smart_params group)."""
+        schema = LizyMLAdapter().get_ui_schema()
+        catalog = {e["key"]: e for e in schema["search_space_catalog"]}
+        assert "balanced" in catalog
+        assert catalog["balanced"]["group"] == "smart_params"
+        assert catalog["balanced"]["paramType"] == "boolean"
+
+    def test_search_space_catalog_includes_feature_weights(self) -> None:
+        """feature_weights must be in search_space_catalog (smart_params group)."""
+        schema = LizyMLAdapter().get_ui_schema()
+        catalog = {e["key"]: e for e in schema["search_space_catalog"]}
+        assert "feature_weights" in catalog
+        assert catalog["feature_weights"]["group"] == "smart_params"
+        assert catalog["feature_weights"]["paramType"] == "object"
+
+    def test_search_space_catalog_includes_num_leaves(self) -> None:
+        """num_leaves must be in search_space_catalog with range+choice modes."""
+        schema = LizyMLAdapter().get_ui_schema()
+        catalog = {e["key"]: e for e in schema["search_space_catalog"]}
+        assert "num_leaves" in catalog
+        assert catalog["num_leaves"]["group"] == "smart_params"
+        assert "range" in catalog["num_leaves"]["modes"]
+
+    def test_search_space_catalog_includes_verbose(self) -> None:
+        """verbose must be in search_space_catalog (model_params group)."""
+        schema = LizyMLAdapter().get_ui_schema()
+        catalog = {e["key"]: e for e in schema["search_space_catalog"]}
+        assert "verbose" in catalog
+        assert catalog["verbose"]["group"] == "model_params"
+
+    def test_additional_params_expanded(self) -> None:
+        """additional_params should include Widget-level LGBM params not in catalog."""
+        schema = LizyMLAdapter().get_ui_schema()
+        additional = set(schema["additional_params"])
+        # These should be in additional_params (not promoted to catalog)
+        expected_subset = {
+            "min_child_samples",
+            "min_gain_to_split",
+            "min_data_in_leaf",
+            "min_data_in_bin",
+            "max_cat_to_onehot",
+            "top_k",
+            "min_sum_hessian_in_leaf",
+            "linear_tree",
+            "feature_pre_filter",
+            "force_col_wise",
+            "force_row_wise",
+            "histogram_pool_size",
+            "is_unbalance",
+            "sigmoid",
+            "boost_from_average",
+            "bin_construct_sample_cnt",
+            "data_sample_strategy",
+            "interaction_constraints",
+        }
+        missing = expected_subset - additional
+        assert not missing, f"additional_params missing: {missing}"
+
+    def test_additional_params_not_in_hints_or_catalog(self) -> None:
+        """additional_params must not overlap with parameter_hints or catalog keys."""
+        schema = LizyMLAdapter().get_ui_schema()
+        hint_keys = {h["key"] for h in schema["parameter_hints"]}
+        catalog_keys = {e["key"] for e in schema["search_space_catalog"]}
+        known_keys = hint_keys | catalog_keys
+        for param in schema["additional_params"]:
+            assert param not in known_keys, (
+                f"additional_param '{param}' overlaps with hints/catalog"
+            )
+
+    def test_search_space_catalog_additional_group(self) -> None:
+        """Catalog has 'additional' group entries for tunable params."""
+        schema = LizyMLAdapter().get_ui_schema()
+        catalog = schema["search_space_catalog"]
+        additional_entries = [e for e in catalog if e.get("group") == "additional"]
+        # At least the commonly tuned additional params
+        additional_keys = {e["key"] for e in additional_entries}
+        expected_tunable = {
+            "min_child_weight",
+            "min_split_gain",
+            "subsample",
+            "colsample_bytree",
+            "scale_pos_weight",
+            "reg_alpha",
+            "reg_lambda",
+        }
+        missing = expected_tunable - additional_keys
+        assert not missing, f"Tunable additional params missing from catalog: {missing}"
+
+    def test_model_metric_regression_includes_lgbm_native(self) -> None:
+        """model_metric regression should include LightGBM native metrics."""
+        schema = LizyMLAdapter().get_ui_schema()
+        reg_mm = schema["option_sets"]["model_metric"]["regression"]
+        for m in ("l1", "l2", "rmse", "huber", "mape", "quantile"):
+            assert m in reg_mm, f"regression model_metric missing LGB native: {m}"
+
+    def test_model_metric_binary_includes_lgbm_native(self) -> None:
+        """model_metric binary should include LightGBM native metrics."""
+        schema = LizyMLAdapter().get_ui_schema()
+        binary_mm = schema["option_sets"]["model_metric"]["binary"]
+        for m in ("binary_logloss", "binary_error", "average_precision", "auc"):
+            assert m in binary_mm, f"binary model_metric missing LGB native: {m}"
+
+    def test_model_metric_multiclass_includes_lgbm_native(self) -> None:
+        """model_metric multiclass should include LightGBM native metrics."""
+        schema = LizyMLAdapter().get_ui_schema()
+        mc_mm = schema["option_sets"]["model_metric"]["multiclass"]
+        for m in ("multi_logloss", "multi_error", "auc_mu"):
+            assert m in mc_mm, f"multiclass model_metric missing LGB native: {m}"
+
+    def test_capabilities_cv_strategy_fields(self) -> None:
+        """capabilities must include cv_strategy_fields mapping."""
+        schema = LizyMLAdapter().get_ui_schema()
+        caps = schema["capabilities"]
+        assert "cv_strategy_fields" in caps
+        fields = caps["cv_strategy_fields"]
+        assert isinstance(fields, dict)
+        # All 8 strategies must have field lists
+        for strategy in caps["cv_strategies"]:
+            assert strategy in fields, f"cv_strategy_fields missing: {strategy}"
+            assert isinstance(fields[strategy], list)
+
+    def test_capabilities_cv_defaults(self) -> None:
+        """capabilities must include cv_defaults with n_splits."""
+        schema = LizyMLAdapter().get_ui_schema()
+        caps = schema["capabilities"]
+        assert "cv_defaults" in caps
+        defaults = caps["cv_defaults"]
+        assert "n_splits" in defaults
+        assert defaults["n_splits"] == 5
+
+    def test_capabilities_cv_default_strategy(self) -> None:
+        """capabilities must include cv_default_strategy per task."""
+        schema = LizyMLAdapter().get_ui_schema()
+        caps = schema["capabilities"]
+        assert "cv_default_strategy" in caps
+        ds = caps["cv_default_strategy"]
+        assert ds["binary"] == "stratified_kfold"
+        assert ds["regression"] == "kfold"
+        assert ds["multiclass"] == "stratified_kfold"
+
+    def test_special_search_space_fields(self) -> None:
+        """special_search_space_fields maps keys to picker types."""
+        schema = LizyMLAdapter().get_ui_schema()
+        assert "special_search_space_fields" in schema
+        ssf = schema["special_search_space_fields"]
+        assert ssf["objective"] == "objective"
+        assert ssf["metric"] == "model_metric"
+
+    def test_step_map_includes_expanded_params(self) -> None:
+        """step_map should include entries for newly added params."""
+        schema = LizyMLAdapter().get_ui_schema()
+        step_map = schema["step_map"]
+        for key in (
+            "min_child_weight",
+            "min_split_gain",
+            "subsample",
+            "reg_alpha",
+            "reg_lambda",
+        ):
+            assert key in step_map, f"step_map missing: {key}"
 
 
 def _reset_ui_schema_caches() -> None:

--- a/tests/test_ui_schema.py
+++ b/tests/test_ui_schema.py
@@ -468,9 +468,9 @@ class TestLizyMLAdapterUiSchema:
         schema = LizyMLAdapter().get_ui_schema()
         additional = set(schema["additional_params"])
         # These should be in additional_params (not promoted to catalog)
+        # min_gain_to_split excluded: alias for min_split_gain (in catalog)
         expected_subset = {
             "min_child_samples",
-            "min_gain_to_split",
             "min_data_in_leaf",
             "min_data_in_bin",
             "max_cat_to_onehot",

--- a/tests/test_ui_schema.py
+++ b/tests/test_ui_schema.py
@@ -469,6 +469,7 @@ class TestLizyMLAdapterUiSchema:
         additional = set(schema["additional_params"])
         # These should be in additional_params (not promoted to catalog)
         # min_gain_to_split excluded: alias for min_split_gain (in catalog)
+        # is_unbalance excluded: use `balanced` smart param instead
         expected_subset = {
             "min_child_samples",
             "min_data_in_leaf",
@@ -481,7 +482,6 @@ class TestLizyMLAdapterUiSchema:
             "force_col_wise",
             "force_row_wise",
             "histogram_pool_size",
-            "is_unbalance",
             "sigmoid",
             "boost_from_average",
             "bin_construct_sample_cnt",
@@ -509,14 +509,12 @@ class TestLizyMLAdapterUiSchema:
         additional_entries = [e for e in catalog if e.get("group") == "additional"]
         # At least the commonly tuned additional params
         additional_keys = {e["key"] for e in additional_entries}
+        # subsample/colsample_bytree/reg_alpha/reg_lambda excluded:
+        # XGBoost aliases for existing model_params entries
         expected_tunable = {
             "min_child_weight",
             "min_split_gain",
-            "subsample",
-            "colsample_bytree",
             "scale_pos_weight",
-            "reg_alpha",
-            "reg_lambda",
         }
         missing = expected_tunable - additional_keys
         assert not missing, f"Tunable additional params missing from catalog: {missing}"
@@ -588,9 +586,7 @@ class TestLizyMLAdapterUiSchema:
         for key in (
             "min_child_weight",
             "min_split_gain",
-            "subsample",
-            "reg_alpha",
-            "reg_lambda",
+            "scale_pos_weight",
         ):
             assert key in step_map, f"step_map missing: {key}"
 


### PR DESCRIPTION
## Summary

- **Parameter coverage**: Achieve LizyML Widget parity. Add balanced/num_leaves/verbose to parameter_hints, add additional group to search_space_catalog, expand model_metric to LightGBM native names, expand additional_params to 20+
- **Progressive Disclosure**: Split Model Params into Essential (6 key params) / Advanced (collapsible). Reduce information overload
- **UX Quick Wins**: Error Boundary, 404 page, HistoryList empty state, browser tab title updates

## Changes

### Backend (lizyml_ui_schema.py)
- Add `balanced`, `num_leaves`, `verbose` to `parameter_hints`
- Add `balanced`, `feature_weights`, `num_leaves`, `verbose` to `search_space_catalog`
- Expand `model_metric` with LightGBM native metrics (l1, l2, binary_logloss, etc.)
- Add `min_child_weight`, `min_split_gain`, `scale_pos_weight` to catalog (additional group)
- Expand `additional_params` to 20+ LightGBM parameters
- Add `capabilities.cv_strategy_fields`, `cv_defaults`, `cv_default_strategy`
- Add `special_search_space_fields` mapping
- Fix LightGBM alias duplicates (subsample vs bagging_fraction etc.)
- Fix `verbose` tune mode (fixed only, not range)

### Frontend
- `ParameterHint` type: add `description` field for tooltip
- `UiSchema` type: add `cv_strategy_fields`, `cv_defaults`, `special_search_space_fields`
- `DynParam`: pass `description` to `FormRow` for native title tooltips
- `ConfigForm`: split Model Params into Essential / Advanced (collapsible)
- `ErrorBoundary`: crash recovery UI wrapping app routes
- `NotFoundPage`: 404 fallback route
- `HistoryList`: empty state message (was returning null)
- `useDocumentTitle`: browser tab title during Fit/Tune

## Test plan
- [x] Backend: 379 tests passed, 95% coverage
- [x] Frontend: 730 tests passed (62 files)
- [x] 18 new backend tests for expanded ui_schema
- [x] 8 new frontend tests (DynParam tooltip, ConfigForm progressive disclosure, ErrorBoundary)
- [x] Ruff lint + format pass
- [x] Biome check pass
- [x] mypy pass
- [ ] Manual verification: Workspace > Model Panel > "Show advanced" toggle
- [ ] Manual verification: Navigate to /nonexistent > 404 page
- [ ] Manual verification: Fit execution > browser tab title changes