### PR TITLE
feat(ui): Config Undo/Redo and Presets

### DIFF
--- a/frontend/src/components/workspace/ModelPanel.tsx
+++ b/frontend/src/components/workspace/ModelPanel.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Download, FileText, FileUp } from "lucide-react";
+import { Download, FileText, FileUp, Redo2, Save, Undo2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { ConfigError } from "@/api/types";
@@ -16,7 +16,16 @@ import {
 } from "@/api/workspace";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useConfigHistory } from "@/hooks/useConfigHistory";
+import { useConfigPresets } from "@/hooks/useConfigPresets";
 import { ConfigForm } from "./ConfigForm";
 import { RawConfigDialog } from "./RawConfigDialog";
 import { TuneTab } from "./TuneTab";
@@ -40,6 +49,8 @@ export function ModelPanel({
   const [errors, setErrors] = useState<ConfigError[]>([]);
   const queryClient = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const history = useConfigHistory();
+  const { presets, save: savePreset, load: loadPreset } = useConfigPresets();
 
   const { data: schema } = useQuery({
     queryKey: ["config-schema"],
@@ -89,6 +100,7 @@ export function ModelPanel({
       try {
         await updateConfig(newConfig);
         queryClient.setQueryData(["config"], newConfig);
+        history.push(newConfig);
       } catch {
         toast.error("Failed to update config");
         return;
@@ -104,7 +116,7 @@ export function ModelPanel({
         }
       }, 500);
     },
-    [queryClient, running],
+    [queryClient, running, history.push],
   );
 
   useEffect(() => {
@@ -129,6 +141,45 @@ export function ModelPanel({
 
   const handleExport = () => {
     window.open(getConfigDownloadUrl(), "_blank");
+  };
+
+  const handleUndo = useCallback(async () => {
+    const prev = history.undo();
+    if (!prev) return;
+    try {
+      await updateConfig(prev);
+      queryClient.setQueryData(["config"], prev);
+      toast.info("Config undone");
+    } catch {
+      toast.error("Undo failed");
+    }
+  }, [history, queryClient]);
+
+  const handleRedo = useCallback(async () => {
+    const next = history.redo();
+    if (!next) return;
+    try {
+      await updateConfig(next);
+      queryClient.setQueryData(["config"], next);
+      toast.info("Config redone");
+    } catch {
+      toast.error("Redo failed");
+    }
+  }, [history, queryClient]);
+
+  const handleSavePreset = () => {
+    if (!config) return;
+    const name = prompt("Preset name:");
+    if (!name?.trim()) return;
+    savePreset(name.trim(), config);
+    toast.success(`Preset "${name.trim()}" saved`);
+  };
+
+  const handleLoadPreset = (name: string) => {
+    const preset = loadPreset(name);
+    if (!preset) return;
+    handleConfigChange(preset);
+    toast.success(`Preset "${name}" loaded`);
   };
 
   const fitEnabled = hasData && !!config && !running && errors.length === 0;
@@ -237,6 +288,42 @@ export function ModelPanel({
             <Download className="mr-1 h-3 w-3" />
             Export YAML
           </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleUndo}
+            disabled={!history.canUndo}
+            aria-label="Undo"
+          >
+            <Undo2 className="h-3 w-3" />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRedo}
+            disabled={!history.canRedo}
+            aria-label="Redo"
+          >
+            <Redo2 className="h-3 w-3" />
+          </Button>
+          <Button variant="outline" size="sm" onClick={handleSavePreset}>
+            <Save className="mr-1 h-3 w-3" />
+            Save Preset
+          </Button>
+          {presets.length > 0 && (
+            <Select onValueChange={handleLoadPreset}>
+              <SelectTrigger className="h-8 w-36 text-xs">
+                <SelectValue placeholder="Load Preset" />
+              </SelectTrigger>
+              <SelectContent>
+                {presets.map((p) => (
+                  <SelectItem key={p.name} value={p.name}>
+                    {p.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
           <RawConfigDialog
             config={config}
             trigger={

--- a/frontend/src/hooks/useConfigHistory.test.ts
+++ b/frontend/src/hooks/useConfigHistory.test.ts
@@ -1,0 +1,91 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useConfigHistory } from "./useConfigHistory";
+
+describe("useConfigHistory", () => {
+  it("starts with canUndo=false and canRedo=false", () => {
+    const { result } = renderHook(() => useConfigHistory());
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("push enables undo after second config", () => {
+    const { result } = renderHook(() => useConfigHistory());
+
+    act(() => result.current.push({ a: 1 }));
+    expect(result.current.canUndo).toBe(false);
+
+    act(() => result.current.push({ a: 2 }));
+    expect(result.current.canUndo).toBe(true);
+  });
+
+  it("undo returns previous config", () => {
+    const { result } = renderHook(() => useConfigHistory());
+
+    act(() => result.current.push({ v: 1 }));
+    act(() => result.current.push({ v: 2 }));
+    act(() => result.current.push({ v: 3 }));
+
+    let prev: Record<string, unknown> | null = null;
+    act(() => {
+      prev = result.current.undo();
+    });
+    expect(prev).toEqual({ v: 2 });
+    expect(result.current.canRedo).toBe(true);
+  });
+
+  it("redo returns next config", () => {
+    const { result } = renderHook(() => useConfigHistory());
+
+    act(() => result.current.push({ v: 1 }));
+    act(() => result.current.push({ v: 2 }));
+    act(() => result.current.undo());
+
+    let next: Record<string, unknown> | null = null;
+    act(() => {
+      next = result.current.redo();
+    });
+    expect(next).toEqual({ v: 2 });
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("push after undo clears redo stack", () => {
+    const { result } = renderHook(() => useConfigHistory());
+
+    act(() => result.current.push({ v: 1 }));
+    act(() => result.current.push({ v: 2 }));
+    act(() => result.current.undo());
+    act(() => result.current.push({ v: 3 }));
+
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("ignores duplicate pushes", () => {
+    const { result } = renderHook(() => useConfigHistory());
+
+    act(() => result.current.push({ v: 1 }));
+    act(() => result.current.push({ v: 1 }));
+
+    expect(result.current.canUndo).toBe(false);
+  });
+
+  it("undo returns null when history is empty", () => {
+    const { result } = renderHook(() => useConfigHistory());
+
+    let prev: Record<string, unknown> | null = null;
+    act(() => {
+      prev = result.current.undo();
+    });
+    expect(prev).toBeNull();
+  });
+
+  it("redo returns null when future is empty", () => {
+    const { result } = renderHook(() => useConfigHistory());
+
+    let next: Record<string, unknown> | null = null;
+    act(() => {
+      next = result.current.redo();
+    });
+    expect(next).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useConfigHistory.ts
+++ b/frontend/src/hooks/useConfigHistory.ts
@@ -1,0 +1,53 @@
+import { useCallback, useRef, useState } from "react";
+
+const MAX_HISTORY = 50;
+
+/**
+ * Track config changes with undo/redo support.
+ * Does NOT manage the config state itself — just records snapshots.
+ */
+export function useConfigHistory() {
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+  const pastRef = useRef<string[]>([]);
+  const futureRef = useRef<string[]>([]);
+  const currentRef = useRef<string>("");
+
+  const push = useCallback((config: Record<string, unknown>) => {
+    const json = JSON.stringify(config);
+    if (json === currentRef.current) return;
+
+    if (currentRef.current) {
+      pastRef.current = [
+        ...pastRef.current.slice(-(MAX_HISTORY - 1)),
+        currentRef.current,
+      ];
+    }
+    currentRef.current = json;
+    futureRef.current = [];
+    setCanUndo(pastRef.current.length > 0);
+    setCanRedo(false);
+  }, []);
+
+  const undo = useCallback((): Record<string, unknown> | null => {
+    if (pastRef.current.length === 0) return null;
+    const prev = pastRef.current.pop() ?? "";
+    futureRef.current.push(currentRef.current);
+    currentRef.current = prev;
+    setCanUndo(pastRef.current.length > 0);
+    setCanRedo(true);
+    return JSON.parse(prev) as Record<string, unknown>;
+  }, []);
+
+  const redo = useCallback((): Record<string, unknown> | null => {
+    if (futureRef.current.length === 0) return null;
+    const next = futureRef.current.pop() ?? "";
+    pastRef.current.push(currentRef.current);
+    currentRef.current = next;
+    setCanUndo(true);
+    setCanRedo(futureRef.current.length > 0);
+    return JSON.parse(next) as Record<string, unknown>;
+  }, []);
+
+  return { push, undo, redo, canUndo, canRedo };
+}

--- a/frontend/src/hooks/useConfigPresets.test.ts
+++ b/frontend/src/hooks/useConfigPresets.test.ts
@@ -1,0 +1,76 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useConfigPresets } from "./useConfigPresets";
+
+const STORAGE_KEY = "lizystudio-config-presets";
+
+describe("useConfigPresets", () => {
+  afterEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+  });
+
+  it("starts with empty presets", () => {
+    const { result } = renderHook(() => useConfigPresets());
+    expect(result.current.presets).toEqual([]);
+  });
+
+  it("saves and loads a preset", () => {
+    const { result } = renderHook(() => useConfigPresets());
+    const config = { model: { name: "lgbm" } };
+
+    act(() => result.current.save("my-preset", config));
+
+    expect(result.current.presets).toHaveLength(1);
+    expect(result.current.presets[0].name).toBe("my-preset");
+    expect(result.current.load("my-preset")).toEqual(config);
+  });
+
+  it("overwrites preset with same name", () => {
+    const { result } = renderHook(() => useConfigPresets());
+
+    act(() => result.current.save("test", { v: 1 }));
+    act(() => result.current.save("test", { v: 2 }));
+
+    expect(result.current.presets).toHaveLength(1);
+    expect(result.current.load("test")).toEqual({ v: 2 });
+  });
+
+  it("removes a preset", () => {
+    const { result } = renderHook(() => useConfigPresets());
+
+    act(() => result.current.save("a", { v: 1 }));
+    act(() => result.current.save("b", { v: 2 }));
+    act(() => result.current.remove("a"));
+
+    expect(result.current.presets).toHaveLength(1);
+    expect(result.current.load("a")).toBeNull();
+  });
+
+  it("persists to localStorage", () => {
+    const { result } = renderHook(() => useConfigPresets());
+
+    act(() => result.current.save("persist", { ok: true }));
+
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw ?? "[]");
+    expect(parsed[0].name).toBe("persist");
+  });
+
+  it("loads presets from localStorage on init", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        {
+          name: "existing",
+          config: { x: 1 },
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      ]),
+    );
+
+    const { result } = renderHook(() => useConfigPresets());
+    expect(result.current.presets).toHaveLength(1);
+    expect(result.current.load("existing")).toEqual({ x: 1 });
+  });
+});

--- a/frontend/src/hooks/useConfigPresets.ts
+++ b/frontend/src/hooks/useConfigPresets.ts
@@ -1,0 +1,63 @@
+import { useCallback, useState } from "react";
+
+const STORAGE_KEY = "lizystudio-config-presets";
+
+export interface ConfigPreset {
+  name: string;
+  config: Record<string, unknown>;
+  createdAt: string;
+}
+
+function loadPresets(): ConfigPreset[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as ConfigPreset[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function savePresets(presets: ConfigPreset[]) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(presets));
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+/**
+ * Manage named config presets in localStorage.
+ */
+export function useConfigPresets() {
+  const [presets, setPresets] = useState<ConfigPreset[]>(loadPresets);
+
+  const save = useCallback(
+    (name: string, config: Record<string, unknown>) => {
+      const updated = [
+        ...presets.filter((p) => p.name !== name),
+        { name, config, createdAt: new Date().toISOString() },
+      ];
+      savePresets(updated);
+      setPresets(updated);
+    },
+    [presets],
+  );
+
+  const remove = useCallback(
+    (name: string) => {
+      const updated = presets.filter((p) => p.name !== name);
+      savePresets(updated);
+      setPresets(updated);
+    },
+    [presets],
+  );
+
+  const load = useCallback(
+    (name: string): Record<string, unknown> | null => {
+      return presets.find((p) => p.name === name)?.config ?? null;
+    },
+    [presets],
+  );
+
+  return { presets, save, remove, load };
+}


### PR DESCRIPTION
## Summary

Config management for power users: undo/redo parameter changes and save/load named presets.

## Changes

- **useConfigHistory hook**: Stack-based undo/redo (max 50 entries), deduplicates identical configs
- **useConfigPresets hook**: Named presets in localStorage, save/load/remove
- **ModelPanel**: Undo/Redo buttons, Save Preset button, Load Preset dropdown
- History tracks all config changes from ConfigForm and TuneTab

## Test plan
- [x] Frontend: 744 tests passed (64 files)
- [x] Biome check pass
- [x] 14 new hook tests (useConfigHistory + useConfigPresets)
- [ ] Manual: Change params, click Undo, verify rollback
- [ ] Manual: Save preset, reload page, load preset