### PR TITLE
feat(ui): Onboarding walkthrough and background notifications

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { Toaster } from "sonner";
 import { AppLayout } from "./components/layout/AppLayout";
 import { ErrorBoundary } from "./components/layout/ErrorBoundary";
+import { Onboarding } from "./components/layout/Onboarding";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { InferencePage } from "./pages/InferencePage";
 import { JobsPage } from "./pages/JobsPage";
@@ -33,6 +34,7 @@ export function App() {
               </Routes>
             </AppLayout>
           </ErrorBoundary>
+          <Onboarding />
           <Toaster richColors position="bottom-right" />
         </BrowserRouter>
       </TooltipProvider>

--- a/frontend/src/components/layout/Onboarding.test.tsx
+++ b/frontend/src/components/layout/Onboarding.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Onboarding } from "./Onboarding";
+
+const STORAGE_KEY = "lizystudio-onboarding-completed";
+
+describe("Onboarding", () => {
+  afterEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+  });
+
+  it("shows onboarding dialog on first visit", () => {
+    render(<Onboarding />);
+    expect(screen.getByText("Welcome to LizyStudio")).toBeInTheDocument();
+  });
+
+  it("does not show when already completed", () => {
+    localStorage.setItem(STORAGE_KEY, "true");
+    render(<Onboarding />);
+    expect(screen.queryByText("Welcome to LizyStudio")).toBeNull();
+  });
+
+  it("navigates through steps with Next button", () => {
+    render(<Onboarding />);
+
+    expect(screen.getByText("Welcome to LizyStudio")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Next"));
+    expect(screen.getByText("1. Load Your Data")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Next"));
+    expect(screen.getByText("2. Configure Your Model")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Next"));
+    expect(screen.getByText("3. Run & Analyze")).toBeInTheDocument();
+  });
+
+  it("closes and persists on Get Started", () => {
+    render(<Onboarding />);
+
+    // Navigate to last step
+    fireEvent.click(screen.getByText("Next"));
+    fireEvent.click(screen.getByText("Next"));
+    fireEvent.click(screen.getByText("Next"));
+    fireEvent.click(screen.getByText("Get Started"));
+
+    expect(screen.queryByText("3. Run & Analyze")).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+  });
+
+  it("closes and persists on Skip", () => {
+    render(<Onboarding />);
+    fireEvent.click(screen.getByText("Skip"));
+
+    expect(screen.queryByText("Welcome to LizyStudio")).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+  });
+});

--- a/frontend/src/components/layout/Onboarding.tsx
+++ b/frontend/src/components/layout/Onboarding.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+const STORAGE_KEY = "lizystudio-onboarding-completed";
+
+const STEPS = [
+  {
+    title: "Welcome to LizyStudio",
+    description:
+      "LizyStudio is a web GUI for ML analysis workflows. Let's walk through the basics.",
+  },
+  {
+    title: "1. Load Your Data",
+    description:
+      "Start in the Data Panel (left). Upload a CSV or enter a file path, then select your target column.",
+  },
+  {
+    title: "2. Configure Your Model",
+    description:
+      "In the Model Panel (center), adjust parameters. Essential params are shown first — click 'Show advanced' for more options.",
+  },
+  {
+    title: "3. Run & Analyze",
+    description:
+      "Click Fit to train, or Tune to optimize hyperparameters. Results appear in the right panel with metrics, plots, and feature importance.",
+  },
+];
+
+export function Onboarding() {
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    try {
+      if (!localStorage.getItem(STORAGE_KEY)) {
+        setOpen(true);
+      }
+    } catch {
+      // localStorage unavailable
+    }
+  }, []);
+
+  const handleClose = () => {
+    setOpen(false);
+    try {
+      localStorage.setItem(STORAGE_KEY, "true");
+    } catch {
+      // localStorage unavailable
+    }
+  };
+
+  const isLast = step === STEPS.length - 1;
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && handleClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{STEPS[step].title}</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          {STEPS[step].description}
+        </p>
+        <div className="flex justify-center gap-1 py-2">
+          {STEPS.map((_, i) => (
+            <div
+              key={`step-${i}`}
+              className={`h-1.5 w-6 rounded-full ${i === step ? "bg-primary" : "bg-muted"}`}
+            />
+          ))}
+        </div>
+        <DialogFooter className="flex gap-2 sm:justify-between">
+          <Button variant="ghost" size="sm" onClick={handleClose}>
+            Skip
+          </Button>
+          <div className="flex gap-2">
+            {step > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setStep((s) => s - 1)}
+              >
+                Back
+              </Button>
+            )}
+            {isLast ? (
+              <Button size="sm" onClick={handleClose}>
+                Get Started
+              </Button>
+            ) : (
+              <Button size="sm" onClick={() => setStep((s) => s + 1)}>
+                Next
+              </Button>
+            )}
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/hooks/useBackgroundNotification.ts
+++ b/frontend/src/hooks/useBackgroundNotification.ts
@@ -1,0 +1,20 @@
+/**
+ * Send a browser notification when the tab is not focused.
+ * Requests permission on first call if not yet granted.
+ */
+export function useBackgroundNotification() {
+  return (title: string, body?: string) => {
+    if (typeof Notification === "undefined") return;
+    if (document.hasFocus()) return;
+
+    if (Notification.permission === "granted") {
+      new Notification(title, { body, icon: "/favicon.ico" });
+    } else if (Notification.permission !== "denied") {
+      Notification.requestPermission().then((permission) => {
+        if (permission === "granted") {
+          new Notification(title, { body, icon: "/favicon.ico" });
+        }
+      });
+    }
+  };
+}

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -10,6 +10,7 @@ import {
 import { DataPanel } from "@/components/workspace/DataPanel";
 import { ModelPanel } from "@/components/workspace/ModelPanel";
 import { ResultsPanel } from "@/components/workspace/ResultsPanel";
+import { useBackgroundNotification } from "@/hooks/useBackgroundNotification";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export function WorkspacePage() {
@@ -20,6 +21,7 @@ export function WorkspacePage() {
   const [running, setRunning] = useState(false);
 
   useDocumentTitle(running ? "Running..." : null);
+  const notify = useBackgroundNotification();
 
   const { data: uiSchema } = useQuery({
     queryKey: ["ui-schema"],
@@ -98,7 +100,10 @@ export function WorkspacePage() {
         <ResultsPanel
           jobId={currentJobId}
           onApplyToFit={handleApplyToFit}
-          onJobDone={() => setRunning(false)}
+          onJobDone={() => {
+            setRunning(false);
+            notify("LizyStudio", "Job completed");
+          }}
         />
       </ResizablePanel>
     </ResizablePanelGroup>


### PR DESCRIPTION
## Summary

First-time user guidance and background job completion alerts.

## Changes

- **Onboarding dialog**: 4-step walkthrough shown on first visit, persists completion to localStorage. Skip button always available.
- **useBackgroundNotification hook**: Browser Notification API for job completion when tab is unfocused. Permission requested on first use.
- **WorkspacePage**: Sends notification when job completes while user is on another tab.

## Test plan
- [x] Frontend: 735 tests passed (63 files)
- [x] Biome check pass
- [x] 5 new Onboarding tests (show, hide, navigate, persist, skip)
- [ ] Manual: Clear localStorage, reload to see onboarding
- [ ] Manual: Start Fit, switch tabs, wait for notification