### PR TITLE
fix(ci): add fetch-depth 0 for correct hatch-vcs versioning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v5
       - uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
hatch-vcs needs full git history to resolve version from tags. Without fetch-depth: 0, the CI produces dev versions like 0.1.1.dev0+g... instead of 0.1.0.