### PR TITLE
fix(ci): restore _version.py before uv build to prevent dirty version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,5 +29,6 @@ jobs:
       - run: uv run mypy src/lizystudio/
       - run: cd frontend && pnpm install --frozen-lockfile
       - run: cd frontend && pnpm build
+      - run: git checkout -- src/lizystudio/_version.py
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
uv sync rewrites _version.py making the worktree dirty, causing hatch-vcs to generate dev versions. Restoring from git before uv build ensures clean version resolution from tags.