### PR TITLE
feat(retune): H-0061 Phase A wrap-up + Phase B prep (Search Space Evolution + H-0062 draft)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -111,6 +111,10 @@ class TuningSummary:
     trials: list[dict[str, Any]]       # trial history (行のリスト)
     metric_name: str                   # 最適化対象メトリクス名 (H-0013)
     direction: str                     # "minimize" | "maximize" (H-0013)
+    # Re-tune (Phase A) — いずれも後方互換のため optional。
+    # re_tune 未指定の単一ラウンド tune では None が入る (H-0061)。
+    rounds: list[dict[str, Any]] | None = None         # 各ラウンドの n_trials / best_score_before / best_score_after / expanded_dims / space_snapshot
+    boundary_report: dict[str, Any] | None = None      # 最終ラウンド後の BoundaryReport（per-dim: best_value / position_pct / edge / expanded / new bounds）
 
 @dataclass
 class PredictionSummary:
@@ -781,6 +785,20 @@ SegmentedControl: プリセット値をボタン群で表示し、「カスタ�
 
 > 注: `direction` は廃止。Optimization Metric の選択に応じて `ui_schema.option_sets.metric_direction[task][metric]` から自動判定する（H-0031）。
 
+**Re-tune Settings セクション（config.tuning.re_tune, H-0061 Phase A）:**
+
+LizyML 0.9.0 (H-0068) の **Study Resume + Boundary Expansion** を GUI から利用するためのセクション。
+`re_tune` を有効化すると、単一の Tune ジョブ内で Optuna study を継続しつつ、最大 N ラウンドにわたって探索空間を動的に拡張する。`re_tune` 未指定時は従来の単一ラウンド tune として振る舞う。
+
+| 要素 | コンポーネント | Config パス | 選択肢 / 範囲 | デフォルト |
+|------|-------------|------------|--------------|----------|
+| enabled | Switch | `tuning.re_tune` (null/object) | OFF=null / ON=object | OFF |
+| n_rounds | NumberInput (int) | `tuning.re_tune.n_rounds` | 1–10 | 3 |
+| expand_boundary | Switch | `tuning.re_tune.expand_boundary` | ON/OFF | ON |
+| boundary_threshold | NumberInput (float) | `tuning.re_tune.boundary_threshold` | (0, 0.5) | 0.05 |
+
+> **DoS ガード**: バックエンドは `n_rounds <= 20` および `n_trials <= 10,000` を強制する (H-0061)。GUI 側は n_rounds 10 で上限、実際の API は 20 まで許容するが通常利用はしない。
+
 **Search Space セクション（config.tuning.optuna.space）:**
 
 Search Space は `model.params` のキーに対応する探索範囲を定義する。`tuning.optuna.space` は以下の形式の辞書:
@@ -1446,6 +1464,27 @@ Fit 完了と同じ評価項目に加え、探索結果（Best Params・収束�
 **Learning Curve:** Best Params モデルの学習曲線。Fit 完了と同じ仕様。
 
 **Plots（評価プロット）:** Fit 完了と同じ仕様・同じ選択肢。Best Params モデルの評価プロット。
+
+**Re-tune Dashboard（H-0061 Phase A）:**
+
+`TuningSummary.rounds` が非 null の場合（=`re_tune` 有効で実行された Tune ジョブ）、Optimization History の直下に Re-tune Dashboard を表示する。4 つのパネルで構成し、ユーザーがチューニングの収束状況を直感的に把握できるようにする。
+
+| パネル | コンポーネント | データソース | 表示条件 |
+|--------|-------------|-------------|---------|
+| Round History | `RoundHistoryTable` | `rounds[*].{n_rounds, best_score_before, best_score_after, expanded_dims}` | `rounds.length >= 1` |
+| Search Space Evolution | `SearchSpaceEvolutionPanel` | `rounds[*].space_snapshot` + `boundary_report` | 少なくとも 1 ラウンドが非 null の `space_snapshot` を持つ |
+| Boundary Expansion | `BoundaryExpansionPanel` | `boundary_report.dims[*].{best_value, position_pct, edge, expanded, new_low, new_high}` | `boundary_report != null` |
+| Convergence Signal | `ConvergenceSignalPanel` | 最終ラウンドの `expanded_dims` + `rounds[*].best_score_after` 推移 | `rounds.length >= 1` |
+
+**Convergence の判定ロジック（Studio 側の責務）:**
+
+| 条件 | 表示 |
+|------|------|
+| 最終ラウンドの `expanded_dims` が空 かつ `rounds.length >= 2` かつ 最終ラウンドの改善量 < `boundary_threshold` | "Converged — proceed to Fit" バナー（緑） |
+| 最終ラウンドの `expanded_dims` が非空 | "Active exploration — re-tune may help" バナー（青） |
+| それ以外（まだ安定化中） | "Stabilising — consider one more round" ソフトバナー |
+
+**Apply to Fit の動線**: Convergence Signal パネルから直接 `onApplyToFit` コールバックで Tune 時の全 Config を Fit タブに復元できる（既存 Apply to Fit と同じ挙動）。
 
 **Accordion セクション:**
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1495,3 +1495,48 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   7. Backend カバレッジ 80%+ を維持
 - **Decision:** 2026-04-13 accepted — ユーザ承認済、Phase A 実装開始
 - **Implemented:** 2026-04-13 in PR #72 (develop commits 5b14d6a..eac1936). BLUEPRINT §3.3.1 / §4.2.2 への仕様反映と Search Space Evolution パネル追加は後続 PR で対応。Phase B（Job lineage + Re-tune (+N trials) ボタン）は H-0062 として別 Proposal で起案する。
+
+---
+
+### H-0062: Re-tune Dashboard Phase B — Job lineage + [Re-tune (+N trials)] action (draft)
+- **Status:** draft
+- **Accepted:** no
+- **Scope:** API | Frontend | Backend | Persistence
+- **Related:** H-0061 (Phase A, implemented), Issue #59 要求 4a ([Re-tune (+N trials)] ボタン), LizyML H-0068 (Study Resume), BLUEPRINT §3.4.4 (Job 永続化)
+- **Context:** H-0061 Phase A は **単一ジョブ内の multi-round 実行** を導入した。Issue #59 の残る要求 4a 「完了済みの Tune ジョブから追加 N trials を走らせる [Re-tune (+N trials)] ボタン」は **別ジョブ間での Study Resume** を必要とし、Studio の既存永続化モデル「1 Tune Job = 1 Model インスタンス → 完了時に Model 破棄」では実現できない。Phase B では Model の永続化 + Job lineage を導入する。
+
+  なお Issue #59 要求 4b 「[Fit with best params] ボタン」は Phase A の `ConvergenceSignalPanel.onApplyToFit` および `TuneTrialsSection` の Apply to Fit 動線（Tune 時の全 Config snapshot を Fit タブに復元）で既にカバーされているため、Phase B のスコープからは除外する。
+- **Proposal (draft, 要検討):**
+  1. **Model pickle 永続化:** Tune Job 完了時に `{jobs_dir}/{job_id}/model.pkl` を書き出す。LizyML `Model` が cloudpickle 可能かを先行調査する必要がある（Optuna study / LGBM booster を含むため注意）。
+  2. **Job lineage:** `Job` dataclass に `parent_job_id: str | None` を追加。Re-tune 起動で生成される child job が parent を参照する。child の `config` は parent を copy + `tuning.re_tune` をオーバーライド。
+  3. **新 API:** `POST /api/jobs/{job_id}/retune` — body `{n_trials: int, expand_boundary?: bool, boundary_threshold?: float}`。既存 Job の model.pkl を load → `adapter.tune(re_tune=...)` を実行 → 新 Job を作成して TuningSummary を永続化。
+  4. **UI:**
+     - `ResultsCompletedView` の Tune 完了画面に `[Re-tune (+N trials)]` ボタン追加（parent_job_id のない Tune Job のみで有効）
+     - Jobs 詳細画面に lineage ツリー表示（parent ↔ children をたどれる簡易 UI）
+  5. **共通型:** `Job` Protocol / `JobDetail` 型に `parent_job_id`, `child_job_ids` を追加。
+- **Impact (draft):**
+  - Backend: `services/jobs.py` (persist pickle / parent_job_id), `api/jobs.py` (new retune endpoint), `backends/lizyml.py` (load_model_pickle helper), `backends/base.py` (optional `persist_model` API?)
+  - Frontend: `ResultsCompletedView.tsx`, 新 API helper, Jobs page lineage view
+  - Persistence: ディスク使用量増。model.pkl は通常数 MB〜数百 MB を想定
+- **Compatibility:** 非破壊的であること。parent_job_id は optional。既存 Tune Job（model.pkl を持たない）は Re-tune ボタン無効化でフォールバック。
+- **Open Questions:**
+  1. **Pickle 互換性:** LizyML / LightGBM / Optuna のバージョンアップ時に既存 pickle が読めなくなる可能性。pickle schema version を meta.json に記録し、ミスマッチ時は明確にエラー表示する？
+  2. **Subprocess 実行モード:** H-0036 で subprocess 実行がある。子プロセスで model を ivre して親 API から load する経路の互換性。
+  3. **Cancellation semantics:** 親 Re-tune ジョブ実行中に parent が削除された場合の挙動。
+  4. **Garbage collection:** 親 Job 削除時に children を cascade 削除するのか、orphan にするのか、削除を禁止するのか。
+  5. **Lineage ツリー UI:** シンプルなリスト vs. 木構造ビューア。MVP として何を採用するか。
+  6. **並行制御:** 同一 parent から同時に複数 re-tune を走らせると Optuna study が競合する。排他ロックが必要か、n_active_retune 制限か。
+  7. **ディスク使用量:** model.pkl を全 Tune Job で保存するか、Re-tune 対象だけオプトインか。
+- **Alternatives:**
+  - **A1: Weak resume (best_params を initial_params として新 Tune)** — Optuna study を継続しないので `expand_boundary` が機能しない。Phase A で既に却下済み。
+  - **A2: In-memory model registry** — Studio プロセス再起動で消失するため実用性なし。
+  - **A3: Model serialize via adapter.export_model()** — 既存 export_code API と同じ経路。Tune 状態（Optuna study）が含まれないため、単なる Fit モデルの復元にしかならない。
+- **Acceptance Criteria (placeholder, ユーザ承認時に確定):**
+  - [ ] Tune Job 完了後に `{jobs_dir}/{job_id}/model.pkl` が書き出される
+  - [ ] `POST /api/jobs/{id}/retune` が parent model を load して child Tune Job を起動する
+  - [ ] `[Re-tune (+N trials)]` ボタンが Tune 完了画面に表示され、クリックで child job が生成される
+  - [ ] `JobDetail.parent_job_id` が child で parent を参照できる
+  - [ ] Jobs 詳細画面から lineage がたどれる
+  - [ ] Pickle バージョンミスマッチ時に明確なエラーメッセージを表示
+  - [ ] Phase A の `re_tune` 同一ジョブ multi-round 実行が影響を受けない（後方互換）
+- **Decision:** draft — ユーザレビュー待ち。本 Proposal が accepted になり次第、PLAN.md に `v3-12` として実装フェーズを追加する。

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1457,7 +1457,7 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
 ---
 
 ### H-0061: Re-tune Dashboard — Round History / Boundary Expansion / Convergence Signal の可視化（Phase A）
-- **Status:** accepted
+- **Status:** implemented
 - **Scope:** API | Frontend | Backend | Adapter
 - **Related:** BLUEPRINT.md §3.3.1 (TuningSummary), §4.2.2 (Tune Tab), §5.2 (Workspace API), Issue #59, LizyML H-0068 (re-tune + boundary expansion), LizyML-Widget P-027/P-028
 - **Context:** LizyML 0.9.0 で H-0068 が `Model.tune(resume, n_trials, expand_boundary, boundary_threshold)` を追加し、追加ラウンド実行時に Optuna study を継続し搜索空間を動的に拡張する機能をリリースした。LizyStudio 側ではこの機能がまだ GUI から利用できない。Issue #59 は Round History / Search Space Evolution / Convergence Signal / Boundary Detail の4ビューを要求している。
@@ -1494,3 +1494,4 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   6. pytest / mypy / ruff / vitest / Biome / pnpm build がすべて緑
   7. Backend カバレッジ 80%+ を維持
 - **Decision:** 2026-04-13 accepted — ユーザ承認済、Phase A 実装開始
+- **Implemented:** 2026-04-13 in PR #72 (develop commits 5b14d6a..eac1936). BLUEPRINT §3.3.1 / §4.2.2 への仕様反映と Search Space Evolution パネル追加は後続 PR で対応。Phase B（Job lineage + Re-tune (+N trials) ボタン）は H-0062 として別 Proposal で起案する。

--- a/PLAN.md
+++ b/PLAN.md
@@ -48,6 +48,7 @@ Phase 0〜30 は v1 で完了済み。バックエンド（Python / FastAPI / Ad
 | v3-8 | BlockedGroupKFold 専用 2軸エディタ | H-0045 | v3-7 | ✅ |
 | v3-9 | Jobs 詳細画面の統一（KPI + LC フィルター + Importance） | H-0050, H-0051, H-0052 | v3-5 | ✅ |
 | v3-10 | Search Space デフォルト Range 自動ポピュレート | H-0053 | v3-3 | ✅ |
+| v3-11 | Re-tune Dashboard Phase A（Study Resume + Boundary Expansion 可視化） | H-0061 | v3-6 | ✅ |
 
 ---
 
@@ -1012,3 +1013,52 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 - [ ] Studio の SearchSpaceTable が Adapter 契約から Range デフォルトを取得する
 - [ ] Studio の `RANGE_DEFAULTS` ハードコードが削除されている
 - [ ] 既存テストが全パス + 新規テスト追加
+
+---
+
+## Phase v3-11: Re-tune Dashboard Phase A（H-0061）
+
+**対象:** H-0061
+
+**依存:** v3-6（Workspace UX 改善完了が前提）、lizyml >= 0.9.0（H-0068）
+
+**方針:** LizyML 0.9.0 の Study Resume + Boundary Expansion（H-0068）を Studio の GUI から利用できるようにする。Phase A では **単一ジョブ内の multi-round 実行** に絞り、真の Job 間 resume（Model pickle + Job lineage）は Phase B（H-0062）で別 Proposal として扱う。
+
+**成果物:**
+- `TuningSummary` に `rounds` / `boundary_report` フィールド追加（後方互換）
+- `LizyMLAdapter.tune()` の `re_tune` パラメータ対応（multi-round ループ + `TuningResult` シリアライズ）
+- `POST /api/workspace/tune` で `tuning.re_tune` を受理
+- Re-tune Settings アコーディオン（`RetuneSettingsSection.tsx`）
+- Re-tune Dashboard（`RetuneDashboard.tsx` + 4 子パネル）
+  - `RoundHistoryTable.tsx`
+  - `SearchSpaceEvolutionPanel.tsx`
+  - `BoundaryExpansionPanel.tsx`
+  - `ConvergenceSignalPanel.tsx`
+- `BLUEPRINT.md` §3.3.1 / §4.2.2 への仕様反映
+
+**タスク:**
+1. lizyml 依存を `>=0.9.0,<0.10.0` に pin 引き上げ
+2. 共通型 `TuningSummary` に optional フィールド追加 + Adapter Protocol 更新
+3. `LizyMLAdapter.tune()` の re_tune ループ実装 + n_rounds/n_trials の DoS ガード (20/10_000)
+4. API モデルで `re_tune` Pydantic スキーマ追加
+5. Frontend retune/ 配下に 5 コンポーネント新設（TDD 駆動）
+6. `ResultsCompletedView` / `TuneTrialsSection` への Dashboard 統合
+7. Learning Curve metric filter のバックエンド駆動化（H-0061 に巻き込まれた pre-existing bug）
+8. BLUEPRINT / HISTORY / PLAN の仕様同期
+9. 品質ゲート通過（pytest / mypy / ruff / vitest / biome / pnpm build）
+
+**DoD:**
+- [x] `TuningSummary` に `rounds` / `boundary_report` が追加されている（いずれも optional）
+- [x] `POST /api/workspace/tune` に `tuning.re_tune={n_rounds, expand_boundary, boundary_threshold}` を含む Config を送信すると multi-round 実行が走る
+- [x] Re-tune Dashboard 4 パネルが Tune 完了画面に表示される
+- [x] 最終ラウンドで `expanded_dims` が空かつ改善量が閾値未満なら "Converged — proceed to Fit" バナーが表示される
+- [x] `re_tune` 未指定の従来 Tune に影響がない
+- [x] Learning Curve metric filter が backend の `fit_result.history` ベースに修正されている（副次修正）
+- [x] pytest / mypy / ruff / vitest / biome / pnpm build がすべて緑
+- [x] Backend カバレッジ 80%+ を維持
+- [x] BLUEPRINT §3.3.1 / §4.2.2 に仕様が反映されている
+
+**Phase B (H-0062) で対応する項目:**
+- 完了ジョブからの Re-tune (+N trials) ボタン（Job 間 resume）
+- Model pickle 永続化 + `parent_job_id` によるジョブ系譜
+- Lineage ツリー表示 UI

--- a/frontend/src/components/workspace/retune/RetuneDashboard.test.tsx
+++ b/frontend/src/components/workspace/retune/RetuneDashboard.test.tsx
@@ -82,4 +82,36 @@ describe("RetuneDashboard", () => {
       screen.queryByRole("heading", { name: /round history/i }),
     ).not.toBeInTheDocument();
   });
+
+  it("shows Search Space Evolution when any round carries a snapshot", () => {
+    const withSnapshot: TuneRound[] = [
+      {
+        ...rounds[0],
+        space_snapshot: [
+          {
+            name: "lr",
+            type: "float",
+            category: "model",
+            low: 0.01,
+            high: 0.1,
+            log: true,
+          },
+        ],
+      },
+      rounds[1],
+    ];
+    render(
+      <RetuneDashboard rounds={withSnapshot} boundaryReport={boundaryReport} />,
+    );
+    expect(
+      screen.getByRole("heading", { name: /search space evolution/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides Search Space Evolution when no round carries a snapshot", () => {
+    render(<RetuneDashboard rounds={rounds} boundaryReport={boundaryReport} />);
+    expect(
+      screen.queryByRole("heading", { name: /search space evolution/i }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/workspace/retune/RetuneDashboard.tsx
+++ b/frontend/src/components/workspace/retune/RetuneDashboard.tsx
@@ -18,11 +18,13 @@ export function RetuneDashboard({
   const showConvergence = rounds != null && rounds.length >= 2;
   const showHistory = rounds != null && rounds.length > 0;
   const showBoundary = boundaryReport != null;
+  // showEvolution implies showHistory (a non-empty space_snapshot requires
+  // at least one round), so it does not need its own early-return clause.
   const showEvolution =
     rounds != null &&
     rounds.some((r) => r.space_snapshot != null && r.space_snapshot.length > 0);
 
-  if (!showConvergence && !showHistory && !showBoundary && !showEvolution) {
+  if (!showConvergence && !showHistory && !showBoundary) {
     return null;
   }
 

--- a/frontend/src/components/workspace/retune/RetuneDashboard.tsx
+++ b/frontend/src/components/workspace/retune/RetuneDashboard.tsx
@@ -1,6 +1,7 @@
 import { BoundaryExpansionPanel } from "./BoundaryExpansionPanel";
 import { ConvergenceSignalPanel } from "./ConvergenceSignalPanel";
 import { RoundHistoryTable } from "./RoundHistoryTable";
+import { SearchSpaceEvolutionPanel } from "./SearchSpaceEvolutionPanel";
 import type { BoundaryReport, TuneRound } from "./types";
 
 export interface RetuneDashboardProps {
@@ -17,8 +18,11 @@ export function RetuneDashboard({
   const showConvergence = rounds != null && rounds.length >= 2;
   const showHistory = rounds != null && rounds.length > 0;
   const showBoundary = boundaryReport != null;
+  const showEvolution =
+    rounds != null &&
+    rounds.some((r) => r.space_snapshot != null && r.space_snapshot.length > 0);
 
-  if (!showConvergence && !showHistory && !showBoundary) {
+  if (!showConvergence && !showHistory && !showBoundary && !showEvolution) {
     return null;
   }
 
@@ -28,6 +32,12 @@ export function RetuneDashboard({
         <ConvergenceSignalPanel rounds={rounds} onApplyToFit={onApplyToFit} />
       )}
       {showHistory && <RoundHistoryTable rounds={rounds} />}
+      {showEvolution && (
+        <SearchSpaceEvolutionPanel
+          rounds={rounds}
+          boundaryReport={boundaryReport}
+        />
+      )}
       {showBoundary && <BoundaryExpansionPanel report={boundaryReport} />}
     </div>
   );

--- a/frontend/src/components/workspace/retune/SearchSpaceEvolutionPanel.test.tsx
+++ b/frontend/src/components/workspace/retune/SearchSpaceEvolutionPanel.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SearchSpaceEvolutionPanel } from "./SearchSpaceEvolutionPanel";
+import type { BoundaryReport, TuneRound } from "./types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeRound(
+  round: number,
+  snapshot: Record<string, unknown>[] | null | undefined,
+  expanded_dims: string[] = [],
+): TuneRound {
+  return {
+    round,
+    n_trials: 50,
+    best_score_before: null,
+    best_score_after: 0.8,
+    expanded_dims,
+    space_snapshot: snapshot,
+  };
+}
+
+const numericSnapshot = (low: number, high: number, name = "lr") => ({
+  name,
+  type: "float",
+  category: "model",
+  low,
+  high,
+  log: true,
+});
+
+const categoricalSnapshot = (choices: string[], name = "boosting") => ({
+  name,
+  type: "categorical",
+  category: "model",
+  choices,
+});
+
+const boundaryReport = (name: string, best: number | null): BoundaryReport => ({
+  dims: [
+    {
+      name,
+      best_value: best,
+      low: null,
+      high: null,
+      position_pct: null,
+      edge: "none",
+      expanded: false,
+      new_low: null,
+      new_high: null,
+    },
+  ],
+  expanded_names: [],
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SearchSpaceEvolutionPanel", () => {
+  it("renders one row per dimension with a bar for each round", () => {
+    const rounds: TuneRound[] = [
+      makeRound(1, [numericSnapshot(0.01, 0.1)]),
+      makeRound(2, [numericSnapshot(0.001, 0.1)], ["lr"]),
+      makeRound(3, [numericSnapshot(0.001, 0.1)]),
+    ];
+
+    render(
+      <SearchSpaceEvolutionPanel
+        rounds={rounds}
+        boundaryReport={boundaryReport("lr", 0.05)}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /search space evolution/i }),
+    ).toBeInTheDocument();
+
+    // Dimension label is shown exactly once.
+    expect(screen.getAllByText("lr")).toHaveLength(1);
+
+    // Three round-bars are drawn.
+    const bars = screen.getAllByTestId("evolution-bar");
+    expect(bars).toHaveLength(3);
+
+    // The expanded round is marked so the user can see which round widened
+    // the range.
+    const expandedBars = screen.getAllByLabelText(/expanded in round 2/i);
+    expect(expandedBars.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows a single bar for a single-round tune", () => {
+    const rounds: TuneRound[] = [makeRound(1, [numericSnapshot(0.01, 0.1)])];
+
+    render(
+      <SearchSpaceEvolutionPanel
+        rounds={rounds}
+        boundaryReport={boundaryReport("lr", 0.05)}
+      />,
+    );
+
+    expect(screen.getAllByTestId("evolution-bar")).toHaveLength(1);
+  });
+
+  it("returns null when no round carries a space_snapshot", () => {
+    const rounds: TuneRound[] = [makeRound(1, null), makeRound(2, undefined)];
+
+    const { container } = render(
+      <SearchSpaceEvolutionPanel rounds={rounds} boundaryReport={null} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("handles dimensions that appear in a later round only", () => {
+    const rounds: TuneRound[] = [
+      makeRound(1, [numericSnapshot(0.01, 0.1, "lr")]),
+      makeRound(2, [
+        numericSnapshot(0.01, 0.1, "lr"),
+        numericSnapshot(10, 100, "num_leaves"),
+      ]),
+    ];
+
+    render(<SearchSpaceEvolutionPanel rounds={rounds} boundaryReport={null} />);
+
+    const lrRow = screen.getByTestId("evolution-row-lr");
+    const numLeavesRow = screen.getByTestId("evolution-row-num_leaves");
+
+    // lr appears in both rounds, num_leaves only in round 2. The panel shows
+    // a placeholder for the round where the dim was absent so the timeline
+    // stays aligned.
+    expect(within(lrRow).getAllByTestId("evolution-bar")).toHaveLength(2);
+    expect(within(numLeavesRow).getAllByTestId("evolution-bar")).toHaveLength(
+      1,
+    );
+    expect(
+      within(numLeavesRow).getByText(/not tuned in round 1/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders categorical dimensions as choice lists, not bars", () => {
+    const rounds: TuneRound[] = [
+      makeRound(1, [categoricalSnapshot(["gbdt"])]),
+      makeRound(2, [categoricalSnapshot(["gbdt", "dart"])], ["boosting"]),
+    ];
+
+    render(<SearchSpaceEvolutionPanel rounds={rounds} boundaryReport={null} />);
+
+    const row = screen.getByTestId("evolution-row-boosting");
+    // No numeric bars for categorical dims.
+    expect(within(row).queryByTestId("evolution-bar")).toBeNull();
+    // gbdt appears in both rounds, dart only in round 2.
+    expect(within(row).getAllByText(/gbdt/)).toHaveLength(2);
+    expect(within(row).getAllByText(/dart/)).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/workspace/retune/SearchSpaceEvolutionPanel.tsx
+++ b/frontend/src/components/workspace/retune/SearchSpaceEvolutionPanel.tsx
@@ -70,6 +70,9 @@ function buildTimelines(
 
     for (const r of rounds) {
       const snap = r.space_snapshot;
+      // First match wins — lizyml's SearchDim names are unique within a
+      // single snapshot, so the defensive find() never sees duplicates
+      // in practice.
       const raw = snap?.find(
         (d): d is Record<string, unknown> =>
           typeof d === "object" &&
@@ -147,10 +150,19 @@ function NumericBar({
   expanded,
   bestValue,
 }: NumericBarProps) {
+  // The shared axis is always linear, even when the underlying dim uses
+  // log scale. This slightly underweights log-scale expansions visually
+  // (e.g. 0.01→0.001 looks smaller than it is), which is why the title
+  // surfaces the (log) marker and the exact bounds.
   const span = globalHigh - globalLow || 1;
   const leftPct = ((dim.low - globalLow) / span) * 100;
   const widthPct = ((dim.high - dim.low) / span) * 100;
-  const label = `Round ${round}: [${formatBound(dim.low)}, ${formatBound(dim.high)}]${dim.log ? " (log)" : ""}${expanded ? ` — expanded in round ${round}` : ""}`;
+  const logHint = dim.log ? " (log scale shown on linear axis)" : "";
+  const label = `Round ${round}: [${formatBound(dim.low)}, ${formatBound(dim.high)}]${logHint}${expanded ? ` — expanded in round ${round}` : ""}`;
+  // best_value comes from the final round's boundary_report, so earlier
+  // rounds whose search range excluded that value correctly hide the
+  // tick, while the final round (whose range always contains it by
+  // construction) renders it.
   const bestLeftPct =
     bestValue !== null && bestValue >= dim.low && bestValue <= dim.high
       ? ((bestValue - globalLow) / span) * 100

--- a/frontend/src/components/workspace/retune/SearchSpaceEvolutionPanel.tsx
+++ b/frontend/src/components/workspace/retune/SearchSpaceEvolutionPanel.tsx
@@ -1,0 +1,303 @@
+import type { BoundaryReport, TuneRound } from "./types";
+
+export interface SearchSpaceEvolutionPanelProps {
+  rounds: TuneRound[] | null | undefined;
+  boundaryReport: BoundaryReport | null | undefined;
+}
+
+type NumericDim = {
+  name: string;
+  type: string;
+  low: number;
+  high: number;
+  log?: boolean;
+};
+
+type CategoricalDim = {
+  name: string;
+  type: string;
+  choices: unknown[];
+};
+
+type Dim = NumericDim | CategoricalDim;
+
+function isNumericDim(
+  raw: Record<string, unknown>,
+): raw is NumericDim & Record<string, unknown> {
+  return (
+    typeof raw.name === "string" &&
+    typeof raw.low === "number" &&
+    typeof raw.high === "number"
+  );
+}
+
+function isCategoricalDim(
+  raw: Record<string, unknown>,
+): raw is CategoricalDim & Record<string, unknown> {
+  return typeof raw.name === "string" && Array.isArray(raw.choices);
+}
+
+/** Per-round snapshot entry for a single dimension. null = not tuned in that round. */
+interface RoundCell {
+  round: number;
+  dim: Dim | null;
+  expanded: boolean;
+}
+
+/** Flatten {rounds, space_snapshot} into per-dim timelines. */
+function buildTimelines(
+  rounds: TuneRound[],
+): Map<string, { kind: "numeric" | "categorical"; cells: RoundCell[] }> {
+  const timelines = new Map<
+    string,
+    { kind: "numeric" | "categorical"; cells: RoundCell[] }
+  >();
+
+  // Collect every dim name that appears in any snapshot so we can render
+  // consistent rows even when a dim joins the search space mid-session.
+  const allNames = new Set<string>();
+  for (const r of rounds) {
+    const snap = r.space_snapshot;
+    if (!snap) continue;
+    for (const raw of snap) {
+      if (typeof raw.name === "string") allNames.add(raw.name);
+    }
+  }
+
+  for (const name of allNames) {
+    const cells: RoundCell[] = [];
+    let kind: "numeric" | "categorical" | null = null;
+
+    for (const r of rounds) {
+      const snap = r.space_snapshot;
+      const raw = snap?.find(
+        (d): d is Record<string, unknown> =>
+          typeof d === "object" &&
+          d !== null &&
+          (d as { name?: unknown }).name === name,
+      );
+
+      let dim: Dim | null = null;
+      if (raw) {
+        if (isNumericDim(raw)) {
+          dim = {
+            name: raw.name,
+            type: String(raw.type ?? "float"),
+            low: raw.low,
+            high: raw.high,
+            log: typeof raw.log === "boolean" ? raw.log : undefined,
+          };
+          kind ??= "numeric";
+        } else if (isCategoricalDim(raw)) {
+          dim = {
+            name: raw.name,
+            type: String(raw.type ?? "categorical"),
+            choices: raw.choices,
+          };
+          kind ??= "categorical";
+        }
+      }
+
+      cells.push({
+        round: r.round,
+        dim,
+        expanded: r.expanded_dims.includes(name),
+      });
+    }
+
+    if (kind !== null) {
+      timelines.set(name, { kind, cells });
+    }
+  }
+
+  return timelines;
+}
+
+function bestValueFor(
+  report: BoundaryReport | null | undefined,
+  name: string,
+): number | null {
+  if (!report) return null;
+  const dim = report.dims.find((d) => d.name === name);
+  if (!dim || dim.best_value === null) return null;
+  return typeof dim.best_value === "number" ? dim.best_value : null;
+}
+
+function formatBound(x: number): string {
+  if (x === 0) return "0";
+  const abs = Math.abs(x);
+  if (abs >= 0.01 && abs < 10000) return x.toFixed(4);
+  return x.toExponential(2);
+}
+
+interface NumericBarProps {
+  dim: NumericDim;
+  globalLow: number;
+  globalHigh: number;
+  round: number;
+  expanded: boolean;
+  bestValue: number | null;
+}
+
+function NumericBar({
+  dim,
+  globalLow,
+  globalHigh,
+  round,
+  expanded,
+  bestValue,
+}: NumericBarProps) {
+  const span = globalHigh - globalLow || 1;
+  const leftPct = ((dim.low - globalLow) / span) * 100;
+  const widthPct = ((dim.high - dim.low) / span) * 100;
+  const label = `Round ${round}: [${formatBound(dim.low)}, ${formatBound(dim.high)}]${dim.log ? " (log)" : ""}${expanded ? ` — expanded in round ${round}` : ""}`;
+  const bestLeftPct =
+    bestValue !== null && bestValue >= dim.low && bestValue <= dim.high
+      ? ((bestValue - globalLow) / span) * 100
+      : null;
+
+  return (
+    <div
+      data-testid="evolution-bar"
+      role="img"
+      aria-label={label}
+      title={label}
+      className="relative h-3 w-full rounded-sm bg-muted/40"
+    >
+      <div
+        className={
+          expanded
+            ? "absolute h-full rounded-sm bg-primary/80 border border-primary"
+            : "absolute h-full rounded-sm bg-primary/40"
+        }
+        style={{ left: `${leftPct}%`, width: `${widthPct}%` }}
+      />
+      {bestLeftPct !== null && (
+        <div
+          aria-hidden="true"
+          className="absolute top-[-2px] bottom-[-2px] w-[2px] bg-amber-500"
+          style={{ left: `${bestLeftPct}%` }}
+        />
+      )}
+    </div>
+  );
+}
+
+export function SearchSpaceEvolutionPanel({
+  rounds,
+  boundaryReport,
+}: SearchSpaceEvolutionPanelProps) {
+  if (!rounds || rounds.length === 0) return null;
+
+  const timelines = buildTimelines(rounds);
+  if (timelines.size === 0) return null;
+
+  return (
+    <section className="rounded-md border bg-card p-2">
+      <h3 className="text-sm font-medium mb-2 px-1">Search space evolution</h3>
+      <div className="space-y-3">
+        {[...timelines.entries()].map(([name, { kind, cells }]) => {
+          const bestValue = bestValueFor(boundaryReport, name);
+
+          // For numeric dims, compute a shared axis across every populated
+          // round so the bars are visually comparable.
+          let globalLow = Number.POSITIVE_INFINITY;
+          let globalHigh = Number.NEGATIVE_INFINITY;
+          for (const cell of cells) {
+            if (cell.dim && isNumericDimPure(cell.dim)) {
+              globalLow = Math.min(globalLow, cell.dim.low);
+              globalHigh = Math.max(globalHigh, cell.dim.high);
+            }
+          }
+          if (!Number.isFinite(globalLow) || !Number.isFinite(globalHigh)) {
+            globalLow = 0;
+            globalHigh = 1;
+          }
+
+          return (
+            <div
+              key={name}
+              data-testid={`evolution-row-${name}`}
+              className="grid grid-cols-[minmax(110px,140px)_1fr] gap-3 items-start"
+            >
+              <div className="text-xs font-mono text-muted-foreground pt-0.5 break-all">
+                {name}
+                {bestValue !== null && (
+                  <span className="block text-[10px] text-amber-600 dark:text-amber-400">
+                    best = {formatBound(bestValue)}
+                  </span>
+                )}
+              </div>
+              <div className="space-y-1">
+                {cells.map((cell) => {
+                  if (cell.dim === null) {
+                    return (
+                      <div
+                        key={cell.round}
+                        className="text-[10px] text-muted-foreground italic"
+                      >
+                        not tuned in round {cell.round}
+                      </div>
+                    );
+                  }
+                  if (kind === "numeric" && isNumericDimPure(cell.dim)) {
+                    return (
+                      <NumericBar
+                        key={cell.round}
+                        dim={cell.dim}
+                        globalLow={globalLow}
+                        globalHigh={globalHigh}
+                        round={cell.round}
+                        expanded={cell.expanded}
+                        bestValue={bestValue}
+                      />
+                    );
+                  }
+                  if (
+                    kind === "categorical" &&
+                    isCategoricalDimPure(cell.dim)
+                  ) {
+                    const label = `Round ${cell.round}${cell.expanded ? " — expanded" : ""}`;
+                    return (
+                      <div
+                        key={cell.round}
+                        className="flex flex-wrap gap-1 text-xs"
+                        title={label}
+                      >
+                        <span className="text-[10px] text-muted-foreground w-12 shrink-0">
+                          R{cell.round}
+                        </span>
+                        {cell.dim.choices.map((choice, idx) => (
+                          <span
+                            key={`${cell.round}-${idx}`}
+                            className="inline-block rounded bg-muted px-1.5 py-0.5 text-[10px] font-mono"
+                          >
+                            {String(choice)}
+                          </span>
+                        ))}
+                      </div>
+                    );
+                  }
+                  return null;
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+// --- Narrower type guards used inside the render loop to keep TS happy ---
+
+function isNumericDimPure(dim: Dim): dim is NumericDim {
+  return (
+    typeof (dim as NumericDim).low === "number" &&
+    typeof (dim as NumericDim).high === "number"
+  );
+}
+
+function isCategoricalDimPure(dim: Dim): dim is CategoricalDim {
+  return Array.isArray((dim as CategoricalDim).choices);
+}

--- a/frontend/src/components/workspace/retune/index.ts
+++ b/frontend/src/components/workspace/retune/index.ts
@@ -2,4 +2,6 @@ export type { RetuneDashboardProps } from "./RetuneDashboard";
 export { RetuneDashboard } from "./RetuneDashboard";
 export type { RetuneSettingsSectionProps } from "./RetuneSettingsSection";
 export { RetuneSettingsSection } from "./RetuneSettingsSection";
+export type { SearchSpaceEvolutionPanelProps } from "./SearchSpaceEvolutionPanel";
+export { SearchSpaceEvolutionPanel } from "./SearchSpaceEvolutionPanel";
 export type { BoundaryReport, TuneRound } from "./types";

--- a/frontend/src/components/workspace/retune/index.ts
+++ b/frontend/src/components/workspace/retune/index.ts
@@ -2,6 +2,4 @@ export type { RetuneDashboardProps } from "./RetuneDashboard";
 export { RetuneDashboard } from "./RetuneDashboard";
 export type { RetuneSettingsSectionProps } from "./RetuneSettingsSection";
 export { RetuneSettingsSection } from "./RetuneSettingsSection";
-export type { SearchSpaceEvolutionPanelProps } from "./SearchSpaceEvolutionPanel";
-export { SearchSpaceEvolutionPanel } from "./SearchSpaceEvolutionPanel";
 export type { BoundaryReport, TuneRound } from "./types";


### PR DESCRIPTION
## Summary

Wraps up the loose ends left after PR #72 shipped H-0061 Re-tune Dashboard Phase A, and prepares Phase B for user review. Four commits on a single branch targeting `develop`.

1. **`docs(h0061): sync BLUEPRINT HISTORY PLAN with Phase A implementation`**
   - BLUEPRINT §3.3.1 `TuningSummary` now lists the optional `rounds` and `boundary_report` fields that already live in `src/lizystudio/backends/types.py`.
   - BLUEPRINT §4.2.2 gains a Re-tune Settings subsection (n_rounds / expand_boundary / boundary_threshold) and a Re-tune Dashboard subsection describing the four panels plus the convergence decision table.
   - HISTORY H-0061 flips from `accepted` to `implemented` with the PR #72 commit range.
   - PLAN gets a new `v3-11` entry with DoD checked.

2. **`feat(retune): add search space evolution panel`**
   - New `SearchSpaceEvolutionPanel` renders per-dimension timelines of how the search range evolved across re-tune rounds. Numeric dims get stacked range bars on a shared linear axis with a best_value tick from the final round's `boundary_report`; categorical dims get a choice list per round; rows where a dim joins mid-session show a "not tuned in round N" placeholder.
   - Wired into `RetuneDashboard` between Round History and Boundary Expansion. Returns `null` when no round carries a `space_snapshot`, so existing Phase A fixtures remain unaffected.
   - 5 new vitest cases on the panel + 2 new `RetuneDashboard` cases covering visible/hidden transitions. This closes Issue #59 requirement 2.

3. **`docs(history): draft H-0062 re-tune Phase B proposal`**
   - Drafts `H-0062: Re-tune Dashboard Phase B — Job lineage + [Re-tune (+N trials)] action` (status: draft, accepted: no) so the user can review and accept the follow-up scope. The draft sketches model.pkl persistence, `parent_job_id`, `POST /api/jobs/{id}/retune`, and the lineage tree UI, and lists the open questions (pickle compat, subprocess mode, cancellation, GC, concurrency) that need to be answered before promotion.
   - Notes that Issue #59 requirement 4b (Fit with best params) is already covered by the existing Apply to Fit link in `ConvergenceSignalPanel` / `TuneTrialsSection`, so Phase B scopes itself to requirement 4a.

4. **`refactor(retune): address code review feedback on evolution panel`**
   - Drops a redundant `showEvolution` clause from the `RetuneDashboard` early-return guard (`showHistory` already covers it by construction).
   - Documents the linear-axis approximation for log-scale dims in the NumericBar title.
   - Explains why the best_value tick only shows on bars whose range contains it.
   - Adds a one-line note in `buildTimelines` about lizyml's per-snapshot uniqueness contract.
   - Drops `SearchSpaceEvolutionPanel` from the retune barrel — only externally consumed exports belong there per PR #72 refactor `828ed61`.

## Issue #59 status

Issue #59 stays OPEN after this PR. Requirements 1 (Round History), 3 (Convergence Signal), and 5 (Boundary Detail) were closed by PR #72 Phase A. Requirement 2 (Search Space Evolution) is closed by commit 2 above. Requirement 4a ([Re-tune (+N trials)] button) will be closed by Phase B once H-0062 is accepted and implemented. Requirement 4b (Fit with best params) is already satisfied by the existing Apply to Fit link.

## Test plan

- [x] `uv run pytest tests/ -q` — 822 passed
- [x] `pnpm test` — 1228 passed, 2 skipped
- [x] `pnpm check` — 0 errors (16 pre-existing warnings untouched)
- [x] `pnpm build` — success
- [x] `uv run ruff check .` — All checks passed
- [x] `uv run ruff format --check .` — 77 files already formatted
- [x] `uv run mypy src/lizystudio/` — 33 source files, no issues
- [x] Frontend coverage: 89.77% lines (retune/ 96.68%, new panel 94.87%)
- [x] Backend coverage: 96% lines
- [x] Code review via `code-reviewer` agent (HIGH + 3 MEDIUM issues addressed, 2 LOW deferred with justification)
