### PR TITLE
fix(frontend): prevent partial config PUT race on target selection

### DIFF
--- a/frontend/src/components/workspace/DataPanel.test.tsx
+++ b/frontend/src/components/workspace/DataPanel.test.tsx
@@ -862,6 +862,58 @@ describe("DataPanel — handleTargetChange", () => {
     });
   });
 
+  // Regression for H-0063: data load + target select caused a race between
+  // syncConfig (fired by useEffect on target change) and handleTargetChange's
+  // fetchConfigDefaults flow. The earlier syncConfig PUT shipped a partial
+  // config (fetchConfig returned {}) and the backend responded with
+  // "config_version: Field required" etc. After the fix, updateConfig must be
+  // called exactly once per target selection and the payload must come from
+  // fetchConfigDefaults (i.e. contain config_version).
+  it("does not emit a partial updateConfig PUT during target selection", async () => {
+    mockFetchConfig.mockResolvedValue({});
+    mockFetchConfigDefaults.mockResolvedValue({
+      config_version: 1,
+      task: "binary",
+      data: { target: "target" },
+      features: {},
+      split: { method: "kfold", n_splits: 5 },
+      model: { name: "lgbm", params: {} },
+      training: {},
+    });
+    mockUpdateConfig.mockResolvedValue({
+      config: {},
+      errors: [],
+      saved: true,
+    });
+
+    render(<DataPanel onDataChanged={vi.fn()} />);
+    await loadDataViaPath();
+
+    mockFetchColumns.mockClear();
+    mockFetchColumns.mockResolvedValue({
+      columns: COLUMNS_BINARY,
+      suggested_task: "binary",
+      target: "target",
+    });
+    mockUpdateConfig.mockClear();
+
+    await selectTarget("target");
+
+    await waitFor(() => {
+      expect(mockFetchConfigDefaults).toHaveBeenCalledWith("binary", "target");
+    });
+    await waitFor(() => {
+      expect(mockUpdateConfig).toHaveBeenCalled();
+    });
+
+    // No partial PUT: every updateConfig call during target selection must
+    // carry config_version (i.e. be based on fetchConfigDefaults output).
+    for (const call of mockUpdateConfig.mock.calls) {
+      const payload = call[0] as Record<string, unknown>;
+      expect(payload.config_version).toBe(1);
+    }
+  });
+
   it("does not call fetchConfigDefaults when suggested_task is null", async () => {
     mockFetchConfig.mockResolvedValue({});
     mockFetchConfigDefaults.mockResolvedValue({});

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -74,6 +74,11 @@ export function useDataPanel({
 
   const abortRef = useRef<AbortController | null>(null);
   const prevCvStrategyRef = useRef<string>(cv.strategy);
+  // H-0063: handleTargetChange owns the full config PUT for target selection
+  // (via fetchConfigDefaults). Setting this ref to true makes the
+  // target/task/overrides/cv effect skip one syncConfig run so it does not
+  // race ahead with a partial config derived from an empty fetchConfig().
+  const skipNextSyncRef = useRef(false);
 
   const syncConfig = useCallback(async () => {
     abortRef.current?.abort();
@@ -88,8 +93,17 @@ export function useDataPanel({
         .filter(([, v]) => v.excluded)
         .map(([k]) => k);
 
-      const base = await fetchConfig({ signal: controller.signal });
+      let base = await fetchConfig({ signal: controller.signal });
       if (controller.signal.aborted) return;
+      // H-0063: if the server-side config has not been seeded yet (e.g. the
+      // user just picked a Task for the first time after loading data), fall
+      // back to fetchConfigDefaults so the PUT carries a full validatable
+      // config instead of a partial one that fails Pydantic.
+      const hasConfigVersion =
+        (base as Record<string, unknown>).config_version !== undefined;
+      if (!hasConfigVersion && task && target) {
+        base = await fetchConfigDefaults(task, target);
+      }
 
       const baseData = (base as Record<string, unknown>).data as Record<
         string,
@@ -141,6 +155,13 @@ export function useDataPanel({
     const key = JSON.stringify({ target, task, overrides, cv, blocked });
     if (key === prevSyncKey.current) return;
     prevSyncKey.current = key;
+    // H-0063: suppress syncConfig while handleTargetChange is assembling the
+    // full defaults-backed config. The flag stays set until that flow
+    // finishes so every intermediate render (setTask, setOverrides, setCv)
+    // is skipped, not just the first one after setTarget.
+    if (skipNextSyncRef.current) {
+      return;
+    }
     syncConfig();
   }, [target, task, overrides, cv, blocked, syncConfig]);
 
@@ -198,6 +219,12 @@ export function useDataPanel({
 
   const handleTargetChange = useCallback(
     async (value: string) => {
+      // H-0063: block the target/task/overrides/cv effect from firing
+      // syncConfig while we assemble the full defaults-backed config below.
+      // Without this guard, setTarget(value) schedules syncConfig synchronously
+      // on the next render, which runs ahead with an empty fetchConfig() and
+      // PUTs a partial config that fails Pydantic validation.
+      skipNextSyncRef.current = true;
       setTarget(value);
       try {
         const cols = await fetchColumns(value);
@@ -254,6 +281,10 @@ export function useDataPanel({
         }
       } catch (err) {
         toast.error(`Column detection failed: ${getErrorMessage(err)}`);
+      } finally {
+        // H-0063: release the guard so subsequent legitimate state changes
+        // (e.g. user toggling include/exclude) can trigger syncConfig again.
+        skipNextSyncRef.current = false;
       }
     },
     [task, cv, dataPath, onDataChanged, onTaskChanged],


### PR DESCRIPTION
## Summary

Fixes the Pydantic validation errors reported after loading data and selecting a Target:

```
config_version: Field required
task: Field required
data: Field required
split: Field required
model: Unable to extract tag using discriminator 'name'
```

## Root Cause

`handleTargetChange` calls `setTarget(value)`, which synchronously schedules a re-render. The `useEffect` on `[target, task, overrides, cv, blocked]` in [`useDataPanel.ts`](frontend/src/hooks/useDataPanel.ts) fires `syncConfig` **before** `handleTargetChange` finishes the `fetchConfigDefaults` → `updateConfig` flow.

At that moment `ws.config` is still empty (`{}`) server-side, so `syncConfig` builds a partial PUT body (missing `config_version`, `model`, etc.) and the backend rejects it. The second `updateConfig` call from `handleTargetChange` then succeeds, so the UI eventually looks fine — but the first failing PUT surfaces as a validation error in the network tab and (in edge cases) as a user-visible toast.

The same error path also triggers when `suggested_task` is `null`: the user selects a Task manually, `syncConfig` runs with an empty `fetchConfig()` result, and the first PUT is partial again.

## Fix

Two guards in [`useDataPanel.ts`](frontend/src/hooks/useDataPanel.ts):

1. **`skipNextSyncRef`** — set before `setTarget`, stays `true` across every intermediate render inside `handleTargetChange` (`setTarget`, batched `setTask`/`setCv`/`setOverrides`), released in a `finally` block. This prevents the effect from racing ahead while the defaults-backed config is being assembled.

2. **`syncConfig` self-heal** — when `fetchConfig()` returns a body without `config_version` but `task` and `target` are available, fall back to `fetchConfigDefaults(task, target)` instead of shipping a partial PUT. Handles the `suggested_task === null` path where the user picks the task manually.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm build` — success
- [x] `pnpm exec biome check` on changed files — no new warnings
- [x] Regression test added: [`DataPanel.test.tsx`](frontend/src/components/workspace/DataPanel.test.tsx) "does not emit a partial updateConfig PUT during target selection" — asserts every `updateConfig` call during target selection carries `config_version: 1` (i.e. originated from `fetchConfigDefaults`, not an empty `fetchConfig`).
- [ ] Manual QA: load a CSV, pick a Target, confirm no `422` in the network tab, confirm `config_version` present on the final `PUT /api/workspace/config` request.

## Note on local Vitest

Local Node 18 hits a pre-existing jsdom transitive bug (`require() of ES Module ... @exodus/bytes/encoding-lite.js`), so the new Vitest case could not be executed locally. CI runs on Node 20 and is unaffected — the regression test will run there.
