### PR TITLE
fix(frontend): backport H-0063 target-selection fix to develop

### DIFF
--- a/frontend/src/components/workspace/DataPanel.test.tsx
+++ b/frontend/src/components/workspace/DataPanel.test.tsx
@@ -862,6 +862,58 @@ describe("DataPanel — handleTargetChange", () => {
     });
   });
 
+  // Regression for H-0063: data load + target select caused a race between
+  // syncConfig (fired by useEffect on target change) and handleTargetChange's
+  // fetchConfigDefaults flow. The earlier syncConfig PUT shipped a partial
+  // config (fetchConfig returned {}) and the backend responded with
+  // "config_version: Field required" etc. After the fix, updateConfig must be
+  // called exactly once per target selection and the payload must come from
+  // fetchConfigDefaults (i.e. contain config_version).
+  it("does not emit a partial updateConfig PUT during target selection", async () => {
+    mockFetchConfig.mockResolvedValue({});
+    mockFetchConfigDefaults.mockResolvedValue({
+      config_version: 1,
+      task: "binary",
+      data: { target: "target" },
+      features: {},
+      split: { method: "kfold", n_splits: 5 },
+      model: { name: "lgbm", params: {} },
+      training: {},
+    });
+    mockUpdateConfig.mockResolvedValue({
+      config: {},
+      errors: [],
+      saved: true,
+    });
+
+    render(<DataPanel onDataChanged={vi.fn()} />);
+    await loadDataViaPath();
+
+    mockFetchColumns.mockClear();
+    mockFetchColumns.mockResolvedValue({
+      columns: COLUMNS_BINARY,
+      suggested_task: "binary",
+      target: "target",
+    });
+    mockUpdateConfig.mockClear();
+
+    await selectTarget("target");
+
+    await waitFor(() => {
+      expect(mockFetchConfigDefaults).toHaveBeenCalledWith("binary", "target");
+    });
+    await waitFor(() => {
+      expect(mockUpdateConfig).toHaveBeenCalled();
+    });
+
+    // No partial PUT: every updateConfig call during target selection must
+    // carry config_version (i.e. be based on fetchConfigDefaults output).
+    for (const call of mockUpdateConfig.mock.calls) {
+      const payload = call[0] as Record<string, unknown>;
+      expect(payload.config_version).toBe(1);
+    }
+  });
+
   it("does not call fetchConfigDefaults when suggested_task is null", async () => {
     mockFetchConfig.mockResolvedValue({});
     mockFetchConfigDefaults.mockResolvedValue({});

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -74,6 +74,11 @@ export function useDataPanel({
 
   const abortRef = useRef<AbortController | null>(null);
   const prevCvStrategyRef = useRef<string>(cv.strategy);
+  // H-0063: handleTargetChange owns the full config PUT for target selection
+  // (via fetchConfigDefaults). Setting this ref to true makes the
+  // target/task/overrides/cv effect skip one syncConfig run so it does not
+  // race ahead with a partial config derived from an empty fetchConfig().
+  const skipNextSyncRef = useRef(false);
 
   const syncConfig = useCallback(async () => {
     abortRef.current?.abort();
@@ -88,8 +93,17 @@ export function useDataPanel({
         .filter(([, v]) => v.excluded)
         .map(([k]) => k);
 
-      const base = await fetchConfig({ signal: controller.signal });
+      let base = await fetchConfig({ signal: controller.signal });
       if (controller.signal.aborted) return;
+      // H-0063: if the server-side config has not been seeded yet (e.g. the
+      // user just picked a Task for the first time after loading data), fall
+      // back to fetchConfigDefaults so the PUT carries a full validatable
+      // config instead of a partial one that fails Pydantic.
+      const hasConfigVersion =
+        (base as Record<string, unknown>).config_version !== undefined;
+      if (!hasConfigVersion && task && target) {
+        base = await fetchConfigDefaults(task, target);
+      }
 
       const baseData = (base as Record<string, unknown>).data as Record<
         string,
@@ -141,6 +155,13 @@ export function useDataPanel({
     const key = JSON.stringify({ target, task, overrides, cv, blocked });
     if (key === prevSyncKey.current) return;
     prevSyncKey.current = key;
+    // H-0063: suppress syncConfig while handleTargetChange is assembling the
+    // full defaults-backed config. The flag stays set until that flow
+    // finishes so every intermediate render (setTask, setOverrides, setCv)
+    // is skipped, not just the first one after setTarget.
+    if (skipNextSyncRef.current) {
+      return;
+    }
     syncConfig();
   }, [target, task, overrides, cv, blocked, syncConfig]);
 
@@ -198,6 +219,12 @@ export function useDataPanel({
 
   const handleTargetChange = useCallback(
     async (value: string) => {
+      // H-0063: block the target/task/overrides/cv effect from firing
+      // syncConfig while we assemble the full defaults-backed config below.
+      // Without this guard, setTarget(value) schedules syncConfig synchronously
+      // on the next render, which runs ahead with an empty fetchConfig() and
+      // PUTs a partial config that fails Pydantic validation.
+      skipNextSyncRef.current = true;
       setTarget(value);
       try {
         const cols = await fetchColumns(value);
@@ -254,6 +281,10 @@ export function useDataPanel({
         }
       } catch (err) {
         toast.error(`Column detection failed: ${getErrorMessage(err)}`);
+      } finally {
+        // H-0063: release the guard so subsequent legitimate state changes
+        // (e.g. user toggling include/exclude) can trigger syncConfig again.
+        skipNextSyncRef.current = false;
       }
     },
     [task, cv, dataPath, onDataChanged, onTaskChanged],


### PR DESCRIPTION
## Summary

Backports the H-0063 fix from `main` (PR #83) into `develop`.

`main` diverged from `develop` because PR #83 was accidentally targeted at `main` instead of `develop` (violating the project git workflow). This PR restores `develop` with the same fix so the two branches converge again. No functional changes compared to PR #83.

## Why a backport is needed

- PR #83 merged directly to `main` on 2026-04-14, bringing `8a74423 fix(frontend): prevent partial config PUT race on target selection`.
- `develop` does not contain that commit, so any future `develop → main` release PR will either revert the fix or produce merge conflicts.
- This PR cherry-picks `8a74423` onto `develop` to restore linear history.

## DoD

### Frontend
- [x] `pnpm exec biome check` on changed files — clean
- [x] `pnpm exec tsc --noEmit` — no new errors introduced by this commit (the pre-existing `storybook/test` import errors on `develop` from PR #82 are unrelated and tracked separately)
- [ ] `pnpm build` — fails on `develop` due to the pre-existing Storybook 10 migration errors (`Cannot find module 'storybook/test'`). Not caused by this PR; verified by running the same command on `develop` HEAD.
- [ ] `pnpm test -- --run` — not run locally (pre-existing jsdom/`@exodus/bytes` ESM issue on Node 18; CI uses Node 20).

### Backend
- N/A — frontend-only change.

## Test plan

- [x] Cherry-pick applied cleanly, no conflict resolution needed.
- [x] `git diff develop..HEAD` equals the fix diff from PR #83 exactly.
- [ ] CI (Node 20) will run the regression test `does not emit a partial updateConfig PUT during target selection`.

## Follow-ups

- The pre-existing `storybook/test` import errors on `develop` should be addressed in a separate PR (not blocking this backport).
- Git workflow recurrence prevention: see forthcoming PRs updating `feedback_branch_workflow.md`, adding `.github/pull_request_template.md`, and a pre-push hook that blocks feature→main PRs.
