### PR TITLE
docs(ci): add branch target and DoD sections to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,23 +11,48 @@
 - [ ] Refactoring (no behavior change)
 - [ ] Documentation
 - [ ] CI / Build
+- [ ] Release (develop → main only)
 - [ ] Other: <!-- describe -->
+
+## Branch target
+
+<!-- Required: confirm the base branch matches project workflow. -->
+<!-- Feature / fix / refactor / docs / chore / ci PRs MUST target `develop`. -->
+<!-- Only release PRs target `main`, and only when cut from `develop`. -->
+
+- [ ] Base branch is `develop` (feature / fix / refactor / docs / chore / ci)
+- [ ] Base branch is `main` **and** this PR is cut from `develop` as a release PR
 
 ## Related issues / proposals
 
 <!-- Link issues (Fixes #123) or HISTORY.md proposals (H-XXXX) -->
 
+## DoD (Definition of Done)
+
+### Backend
+- [ ] `uv run ruff check .` clean
+- [ ] `uv run ruff format --check .` clean
+- [ ] `uv run mypy src/lizystudio/` clean
+- [ ] `uv run pytest` passing
+
+### Frontend
+- [ ] `pnpm check` clean (Biome lint + format)
+- [ ] `pnpm test -- --run` passing
+- [ ] `pnpm build` success
+
+### Common
+- [ ] API / Adapter Protocol / shared type changes have a HISTORY.md H-XXXX proposal
+- [ ] Frontend dependency additions have a HISTORY.md H-XXXX proposal
+- [ ] CHANGELOG.md updated (if user-facing change)
+
 ## Test plan
 
-- [ ] Backend tests pass (`uv run pytest`)
-- [ ] Frontend tests pass (`pnpm test`)
-- [ ] Linters pass (`uv run ruff check .` / `pnpm check`)
-- [ ] Type checks pass (`uv run mypy src/lizystudio/` / `pnpm build`)
-- [ ] Manual verification in browser (if UI change)
+<!-- How was this verified? Include manual steps if UI changed. -->
+
+-
 
 ## Checklist
 
 - [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
 - [ ] No secrets or credentials in the diff
-- [ ] API changes have a HISTORY.md proposal (if gate-required)
-- [ ] CHANGELOG.md updated (if user-facing change)
+- [ ] No direct commits to `main` or `develop`


### PR DESCRIPTION
## Summary

- Strengthens `.github/PULL_REQUEST_TEMPLATE.md` with an explicit **Branch target** section and a structured **DoD** checklist.
- Direct response to the workflow violation in PR #83, which was cut from `main` and merged to `main` instead of going through `develop`.

## Type of change

- [x] Documentation
- [x] CI / Build

## Branch target

- [x] Base branch is `develop` (feature / fix / refactor / docs / chore / ci)
- [ ] Base branch is `main` **and** this PR is cut from `develop` as a release PR

## Related issues / proposals

- Follow-up to PR #83 (direct-to-main violation) and PR #84 (backport to develop).

## DoD

### Backend
- [ ] N/A — documentation-only change.

### Frontend
- [x] `pnpm check` clean
- [x] `pnpm build` success (after `pnpm install --frozen-lockfile` resynced Storybook 10)
- [ ] `pnpm test -- --run` — not run locally (pre-existing jsdom/`@exodus/bytes` ESM issue on Node 18; CI uses Node 20)

### Common
- [x] No API / Adapter Protocol / shared type changes
- [x] No new dependencies

## Test plan

- [x] Render the template on GitHub PR preview (implicit — this PR itself uses the new template).
- [x] `git diff` reviewed: only `.github/PULL_REQUEST_TEMPLATE.md` changed.

## Checklist

- [x] Commit message follows Conventional Commits
- [x] No secrets in the diff
- [x] No direct commits to `main` or `develop`
