### PR TITLE
fix(frontend): code review fixes — 2 CRITICAL + 5 HIGH + tests

### DIFF
--- a/frontend/src/components/workspace/ConfigForm.tsx
+++ b/frontend/src/components/workspace/ConfigForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   Accordion,
   AccordionContent,
@@ -57,12 +57,22 @@ export function ConfigForm({
   uiSchema,
   columns = [],
 }: ConfigFormProps) {
+  // HIGH-5: keep a ref to the latest config so field-change updates
+  // always apply on top of the freshest snapshot. Previously the
+  // inner_valid reset effect and the objective/metric auto-select
+  // effect could both capture the same ``config`` closure in a single
+  // render. When both fired the second call would rebuild the config
+  // from the stale snapshot and wipe the first effect's write.
+  const configRef = useRef(config);
+  configRef.current = config;
+
   const handleFieldChange = useCallback(
     (path: string[], value: unknown) => {
-      const updated = setNestedValue(config, path, value);
+      const updated = setNestedValue(configRef.current, path, value);
+      configRef.current = updated;
       onChange(updated);
     },
-    [config, onChange],
+    [onChange],
   );
 
   const defs = useMemo(

--- a/frontend/src/components/workspace/DataPanel.test.tsx
+++ b/frontend/src/components/workspace/DataPanel.test.tsx
@@ -1147,7 +1147,12 @@ describe("DataPanel — handleColumnExpand (column statistics)", () => {
     expect(mockFetchColumnStats).toHaveBeenCalledTimes(1);
   });
 
-  it("silently ignores fetchColumnStats errors (no toast shown)", async () => {
+  it("surfaces fetchColumnStats errors via toast (HIGH-1)", async () => {
+    // Before the fix, fetchColumnStats failures were silently dropped
+    // and users only saw "the bar never renders" with no explanation.
+    // The contract now is: a toast is shown so the failure is visible,
+    // and the distribution bar remains hidden so UI state is still
+    // consistent with the missing stats.
     mockFetchColumnStats.mockRejectedValue(new Error("stats API down"));
     const { toast } = await import("sonner");
 
@@ -1155,14 +1160,15 @@ describe("DataPanel — handleColumnExpand (column statistics)", () => {
 
     await userEvent.click(screen.getByTestId("column-row-age"));
 
-    // Wait briefly to let the rejection settle
     await waitFor(() => {
       expect(mockFetchColumnStats).toHaveBeenCalled();
     });
 
-    // No error toast should be shown — errors are silently swallowed per spec
-    expect(toast.error).not.toHaveBeenCalled();
-    // Distribution bar should not appear
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to load column stats"),
+      );
+    });
     expect(screen.queryByTestId("column-dist-age")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/workspace/ModelPanel.test.tsx
+++ b/frontend/src/components/workspace/ModelPanel.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { renderWithQuery } from "@/test/helpers";
@@ -800,10 +801,10 @@ describe("ModelPanel", () => {
 
   // --- handleSavePreset ---
 
-  it("saves preset when Save Preset is clicked and name is provided", async () => {
+  it("saves preset via dialog when Save Preset is clicked and name is provided", async () => {
     const { toast } = await import("sonner");
     (toast.success as ReturnType<typeof vi.fn>).mockClear();
-    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("My Preset");
+    const user = userEvent.setup();
 
     renderWithQuery(
       <ModelPanel
@@ -820,19 +821,21 @@ describe("ModelPanel", () => {
       expect(screen.getByTestId("mock-config-form")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Save Preset/i }));
+    await user.click(screen.getByRole("button", { name: /Save Preset/i }));
 
-    expect(promptSpy).toHaveBeenCalled();
+    // Dialog mounts and auto-focuses the name input.
+    const nameInput = await screen.findByLabelText(/name/i);
+    await user.type(nameInput, "My Preset");
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
     expect(toast.success).toHaveBeenCalledWith(
       expect.stringContaining("My Preset"),
     );
-
-    promptSpy.mockRestore();
   });
 
-  it("does nothing when Save Preset prompt is cancelled", async () => {
+  it("does nothing when Save Preset dialog is cancelled", async () => {
     const { toast } = await import("sonner");
-    vi.spyOn(window, "prompt").mockReturnValue(null);
+    const user = userEvent.setup();
 
     renderWithQuery(
       <ModelPanel
@@ -844,12 +847,18 @@ describe("ModelPanel", () => {
       />,
     );
 
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-config-form")).toBeInTheDocument();
+    });
+
     (toast.success as ReturnType<typeof vi.fn>).mockClear();
-    const saveBtn = screen.getByRole("button", { name: /Save Preset/i });
-    fireEvent.click(saveBtn);
+    await user.click(screen.getByRole("button", { name: /Save Preset/i }));
+
+    // Cancel via the dialog's Cancel button.
+    const cancel = await screen.findByRole("button", { name: /cancel/i });
+    await user.click(cancel);
 
     expect(toast.success).not.toHaveBeenCalled();
-    vi.restoreAllMocks();
   });
 
   // --- handleRedo ---

--- a/frontend/src/components/workspace/ModelPanel.tsx
+++ b/frontend/src/components/workspace/ModelPanel.tsx
@@ -41,6 +41,7 @@ import { useConfigHistory } from "@/hooks/useConfigHistory";
 import { useConfigPresets } from "@/hooks/useConfigPresets";
 import { ConfigForm } from "./ConfigForm";
 import { RawConfigDialog } from "./RawConfigDialog";
+import { SavePresetDialog } from "./SavePresetDialog";
 import { TuneTab } from "./TuneTab";
 
 interface ModelPanelProps {
@@ -69,6 +70,7 @@ export function ModelPanel({
     onActiveTabChange?.(tab);
   };
   const [errors, setErrors] = useState<ConfigError[]>([]);
+  const [savePresetOpen, setSavePresetOpen] = useState(false);
   const queryClient = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const history = useConfigHistory();
@@ -189,10 +191,13 @@ export function ModelPanel({
 
   const handleSavePreset = () => {
     if (!config) return;
-    const name = prompt("Preset name:");
-    if (!name?.trim()) return;
-    savePreset(name.trim(), config);
-    toast.success(`Preset "${name.trim()}" saved`);
+    setSavePresetOpen(true);
+  };
+
+  const confirmSavePreset = (name: string) => {
+    if (!config) return;
+    savePreset(name, config);
+    toast.success(`Preset "${name}" saved`);
   };
 
   const handleLoadPreset = (name: string) => {
@@ -429,6 +434,12 @@ export function ModelPanel({
           />
         </div>
       </div>
+      <SavePresetDialog
+        open={savePresetOpen}
+        onOpenChange={setSavePresetOpen}
+        onSave={confirmSavePreset}
+        existingNames={presets.map((p) => p.name)}
+      />
     </div>
   );
 }

--- a/frontend/src/components/workspace/SavePresetDialog.test.tsx
+++ b/frontend/src/components/workspace/SavePresetDialog.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SavePresetDialog } from "./SavePresetDialog";
+
+describe("SavePresetDialog", () => {
+  it("renders dialog with themed input and focuses it on open", async () => {
+    render(<SavePresetDialog open onOpenChange={() => {}} onSave={() => {}} />);
+
+    const input = await screen.findByLabelText(/name/i);
+    expect(input).toBeInTheDocument();
+
+    // Dialog auto-focuses the input shortly after mount.
+    await waitFor(() => {
+      expect(input).toHaveFocus();
+    });
+  });
+
+  it("disables save button when name is empty", async () => {
+    render(<SavePresetDialog open onOpenChange={() => {}} onSave={() => {}} />);
+
+    const save = await screen.findByRole("button", { name: /^save$/i });
+    expect(save).toBeDisabled();
+  });
+
+  it("enables save button and calls onSave with the trimmed name", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <SavePresetDialog open onOpenChange={onOpenChange} onSave={onSave} />,
+    );
+
+    const input = await screen.findByLabelText(/name/i);
+    await user.type(input, "  my-preset  ");
+
+    const save = screen.getByRole("button", { name: /^save$/i });
+    expect(save).not.toBeDisabled();
+    await user.click(save);
+
+    expect(onSave).toHaveBeenCalledWith("my-preset");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("rejects duplicate names with a visible error and blocks save", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+
+    render(
+      <SavePresetDialog
+        open
+        onOpenChange={() => {}}
+        onSave={onSave}
+        existingNames={["dup"]}
+      />,
+    );
+
+    const input = await screen.findByLabelText(/name/i);
+    await user.type(input, "dup");
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /already exists/i,
+    );
+    const save = screen.getByRole("button", { name: /^save$/i });
+    expect(save).toBeDisabled();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("cancel button closes the dialog without saving", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <SavePresetDialog open onOpenChange={onOpenChange} onSave={onSave} />,
+    );
+
+    const input = await screen.findByLabelText(/name/i);
+    await user.type(input, "x");
+
+    const cancel = screen.getByRole("button", { name: /cancel/i });
+    await user.click(cancel);
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("submit via Enter key saves when valid", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+
+    render(<SavePresetDialog open onOpenChange={() => {}} onSave={onSave} />);
+
+    const input = await screen.findByLabelText(/name/i);
+    await user.type(input, "via-enter{Enter}");
+
+    expect(onSave).toHaveBeenCalledWith("via-enter");
+  });
+});

--- a/frontend/src/components/workspace/SavePresetDialog.tsx
+++ b/frontend/src/components/workspace/SavePresetDialog.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface SavePresetDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (name: string) => void;
+  existingNames?: readonly string[];
+}
+
+/**
+ * Modal used to ask the user for a new preset name.
+ *
+ * Replaces the previous `window.prompt()` call which was not themed,
+ * not accessible, and blocked by some iframe embeddings.
+ */
+export function SavePresetDialog({
+  open,
+  onOpenChange,
+  onSave,
+  existingNames = [],
+}: SavePresetDialogProps) {
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Reset the input whenever the dialog is (re)opened.
+  useEffect(() => {
+    if (open) {
+      setValue("");
+      // Focus on next tick so the dialog mount finishes first.
+      const id = window.setTimeout(() => inputRef.current?.focus(), 0);
+      return () => window.clearTimeout(id);
+    }
+  }, [open]);
+
+  const trimmed = value.trim();
+  const isDuplicate = trimmed.length > 0 && existingNames.includes(trimmed);
+  const isValid = trimmed.length > 0 && !isDuplicate;
+
+  const handleSubmit = (event?: React.FormEvent) => {
+    event?.preventDefault();
+    if (!isValid) return;
+    onSave(trimmed);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Save preset</DialogTitle>
+          <DialogDescription>
+            Preset name is stored locally. Data paths and feature selections are
+            not saved.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="preset-name">Name</Label>
+            <Input
+              ref={inputRef}
+              id="preset-name"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder="e.g. lgbm-tuned"
+              aria-invalid={isDuplicate}
+              aria-describedby={isDuplicate ? "preset-name-error" : undefined}
+            />
+            {isDuplicate && (
+              <p
+                id="preset-name-error"
+                className="text-sm text-destructive"
+                role="alert"
+              >
+                A preset with this name already exists.
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!isValid}>
+              Save
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/workspace/TuneTrialsSection.tsx
+++ b/frontend/src/components/workspace/TuneTrialsSection.tsx
@@ -159,9 +159,18 @@ export function TrialResultsAccordionItem({
                   const isBest =
                     Math.abs(trialScore - Number(tuneResult.best_score ?? 0)) <
                     1e-10;
+                  // HIGH-7: key by the trial's stable number (set by
+                  // Optuna) so sort order changes do not blow away row
+                  // state. Fall back to a synthetic key only if number
+                  // is missing on legacy payloads.
+                  const trialNumber = trialRecord.number;
+                  const rowKey =
+                    typeof trialNumber === "number"
+                      ? `trial-num-${trialNumber}`
+                      : `trial-idx-${i}`;
                   return (
                     <TableRow
-                      key={`trial-${i}`}
+                      key={rowKey}
                       className={
                         isBest
                           ? "bg-green-50 dark:bg-green-950/30 font-medium"

--- a/frontend/src/components/workspace/field-renderers.tsx
+++ b/frontend/src/components/workspace/field-renderers.tsx
@@ -201,6 +201,18 @@ function renderArrayField(
 
   // Array of objects
   if (prop.items?.type === "object" && prop.items.properties) {
+    // HIGH-9: avoid bare index keys. On Remove, React would otherwise
+    // keep the trailing child components' state on the wrong row. Use
+    // a content-derived key plus the index so that (a) removing a row
+    // shifts the key for subsequent rows along with their state, and
+    // (b) duplicate structural items still remain distinguishable.
+    const itemKey = (item: Record<string, unknown>, idx: number) => {
+      try {
+        return `${idx}-${JSON.stringify(item)}`;
+      } catch {
+        return `${idx}`;
+      }
+    };
     return (
       <div key={name} className="space-y-2">
         <FormField label={label} description={description}>
@@ -208,7 +220,10 @@ function renderArrayField(
         </FormField>
         <div className="space-y-3">
           {(arrValue as Record<string, unknown>[]).map((item, idx) => (
-            <div key={String(idx)} className="space-y-2 border-l pl-3 relative">
+            <div
+              key={itemKey(item, idx)}
+              className="space-y-2 border-l pl-3 relative"
+            >
               <div className="flex items-center justify-between">
                 <span className="text-xs text-muted-foreground font-medium">
                   Item {idx + 1}

--- a/frontend/src/hooks/useConfigPresets.test.ts
+++ b/frontend/src/hooks/useConfigPresets.test.ts
@@ -111,4 +111,79 @@ describe("useConfigPresets", () => {
     const { result } = renderHook(() => useConfigPresets());
     expect(result.current.presets).toEqual([]);
   });
+
+  // --- CRITICAL-5: sanitize before localStorage persistence ---
+
+  it("strips data source and column selection from persisted presets", () => {
+    const { result } = renderHook(() => useConfigPresets());
+    const fullConfig = {
+      task: "binary",
+      data: {
+        target: "y",
+        path: "/home/user/secret/project/data.csv",
+        source_type: "path",
+      },
+      features: { exclude: ["col_a", "col_b"] },
+      model: { name: "lgbm" },
+    };
+
+    act(() => result.current.save("with-secrets", fullConfig));
+
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    const stored = JSON.parse(raw ?? "[]");
+    const storedConfig = stored[0].config as Record<string, unknown>;
+
+    // The sensitive keys must not appear in localStorage at all.
+    expect(storedConfig.data).toBeUndefined();
+    expect(storedConfig.features).toBeUndefined();
+    // Model config is still preserved for legitimate reuse.
+    expect(storedConfig.model).toEqual({ name: "lgbm" });
+    expect(storedConfig.task).toBe("binary");
+  });
+
+  it("in-memory presets also omit sensitive fields so load() cannot return them", () => {
+    const { result } = renderHook(() => useConfigPresets());
+    const fullConfig = {
+      task: "regression",
+      data: { target: "y", path: "/leak/here.csv" },
+      features: { exclude: ["pii"] },
+      model: { name: "lgbm" },
+    };
+
+    act(() => result.current.save("in-mem", fullConfig));
+
+    const loaded = result.current.load("in-mem");
+    expect(loaded).not.toBeNull();
+    expect((loaded as Record<string, unknown>).data).toBeUndefined();
+    expect((loaded as Record<string, unknown>).features).toBeUndefined();
+  });
+
+  it("migrates legacy presets by stripping sensitive keys on read", () => {
+    // A preset written by an older version still has data + features.
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        {
+          name: "legacy",
+          config: {
+            task: "binary",
+            data: { target: "y", path: "/leak.csv" },
+            features: { exclude: ["ssn"] },
+            model: { name: "lgbm" },
+          },
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      ]),
+    );
+
+    const { result } = renderHook(() => useConfigPresets());
+    const loaded = result.current.load("legacy");
+
+    expect(loaded).not.toBeNull();
+    expect((loaded as Record<string, unknown>).data).toBeUndefined();
+    expect((loaded as Record<string, unknown>).features).toBeUndefined();
+    // model and task are preserved so the rest of the config still loads.
+    expect((loaded as Record<string, unknown>).model).toEqual({ name: "lgbm" });
+  });
 });

--- a/frontend/src/hooks/useConfigPresets.ts
+++ b/frontend/src/hooks/useConfigPresets.ts
@@ -8,10 +8,36 @@ interface ConfigPreset {
   createdAt: string;
 }
 
+// CRITICAL-5: ML configs can include the user-selected data path, the
+// list of excluded feature columns, and other project-specific context
+// that should never be persisted to localStorage (XSS would otherwise
+// leak it to any attacker who lands a script on the page). Only the
+// ML-tuning portion of the config is worth saving as a "preset".
+const SENSITIVE_KEYS = new Set(["data", "features"]);
+
+function sanitizeConfig(
+  config: Record<string, unknown>,
+): Record<string, unknown> {
+  const safe: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    if (SENSITIVE_KEYS.has(key)) continue;
+    safe[key] = value;
+  }
+  return safe;
+}
+
+function sanitizePreset(preset: ConfigPreset): ConfigPreset {
+  return { ...preset, config: sanitizeConfig(preset.config) };
+}
+
 function loadPresets(): ConfigPreset[] {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as ConfigPreset[]) : [];
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as ConfigPreset[];
+    // Migrate legacy presets on read so previously-written secrets are
+    // dropped the next time this hook runs.
+    return parsed.map(sanitizePreset);
   } catch {
     return [];
   }
@@ -33,9 +59,10 @@ export function useConfigPresets() {
 
   const save = useCallback(
     (name: string, config: Record<string, unknown>) => {
+      const sanitized = sanitizeConfig(config);
       const updated = [
         ...presets.filter((p) => p.name !== name),
-        { name, config, createdAt: new Date().toISOString() },
+        { name, config: sanitized, createdAt: new Date().toISOString() },
       ];
       savePresets(updated);
       setPresets(updated);

--- a/frontend/src/hooks/useDataPanel.test.ts
+++ b/frontend/src/hooks/useDataPanel.test.ts
@@ -1,0 +1,212 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ColumnInfo, ColumnsResponse } from "@/api/types";
+
+const mocks = vi.hoisted(() => ({
+  loadDataFromPath: vi.fn(),
+  uploadData: vi.fn(),
+  fetchPreview: vi.fn(),
+  fetchColumns: vi.fn(),
+  fetchColumnStats: vi.fn(),
+  fetchConfig: vi.fn(),
+  fetchConfigDefaults: vi.fn(),
+  updateConfig: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@/api/workspace", () => ({
+  loadDataFromPath: mocks.loadDataFromPath,
+  uploadData: mocks.uploadData,
+  fetchPreview: mocks.fetchPreview,
+  fetchColumns: mocks.fetchColumns,
+  fetchColumnStats: mocks.fetchColumnStats,
+  fetchConfig: mocks.fetchConfig,
+  fetchConfigDefaults: mocks.fetchConfigDefaults,
+  updateConfig: mocks.updateConfig,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+import { useDataPanel } from "./useDataPanel";
+
+const DATA_LOAD_OK = {
+  data_ref: { path: "/data/x.csv", shape: [100, 5] as [number, number] },
+};
+
+const COLS_OK: ColumnsResponse = {
+  target: null,
+  suggested_task: "binary",
+  columns: [
+    {
+      name: "a",
+      dtype: "float64",
+      unique_count: 10,
+      suggested_type: "numeric",
+      suggested_excluded: false,
+      exclude_reason: null,
+    } as ColumnInfo,
+    {
+      name: "b",
+      dtype: "object",
+      unique_count: 4,
+      suggested_type: "categorical",
+      suggested_excluded: false,
+      exclude_reason: null,
+    } as ColumnInfo,
+  ],
+};
+
+describe("useDataPanel", () => {
+  beforeEach(() => {
+    for (const m of Object.values(mocks)) m.mockReset?.();
+    mocks.fetchConfig.mockResolvedValue({});
+    mocks.updateConfig.mockResolvedValue(undefined);
+    mocks.fetchPreview.mockResolvedValue({ columns: [], data: [] });
+  });
+
+  // --- loadDataFromPath happy + error ---
+
+  it("loadDataFromPath populates shape, preview, columns and fires callbacks", async () => {
+    mocks.loadDataFromPath.mockResolvedValue(DATA_LOAD_OK);
+    mocks.fetchColumns.mockResolvedValue(COLS_OK);
+
+    const onDataChanged = vi.fn();
+    const onTaskChanged = vi.fn();
+    const { result } = renderHook(() =>
+      useDataPanel({ onDataChanged, onTaskChanged }),
+    );
+
+    await act(async () => {
+      await result.current.handleLoadPathByValue("/data/x.csv");
+    });
+
+    expect(mocks.loadDataFromPath).toHaveBeenCalledWith("/data/x.csv");
+    expect(result.current.shape).toEqual([100, 5]);
+    expect(result.current.columns).toHaveLength(2);
+    expect(onDataChanged).toHaveBeenCalledTimes(1);
+    expect(onTaskChanged).toHaveBeenCalledWith(null);
+    expect(mocks.toastSuccess).toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("loadDataFromPath reverts loading to false and shows toast on failure", async () => {
+    mocks.loadDataFromPath.mockRejectedValue(new Error("path not found"));
+
+    const { result } = renderHook(() =>
+      useDataPanel({ onDataChanged: vi.fn() }),
+    );
+
+    await act(async () => {
+      await result.current.handleLoadPathByValue("/does/not/exist.csv");
+    });
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to load data"),
+    );
+    expect(result.current.loading).toBe(false);
+    expect(result.current.shape).toBeNull();
+  });
+
+  it("loadDataFromPath skips empty input silently", async () => {
+    const { result } = renderHook(() =>
+      useDataPanel({ onDataChanged: vi.fn() }),
+    );
+
+    await act(async () => {
+      await result.current.handleLoadPathByValue("   ");
+    });
+
+    expect(mocks.loadDataFromPath).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+  });
+
+  // --- uploadData error path ---
+
+  it("uploadData error keeps loading=false", async () => {
+    mocks.uploadData.mockRejectedValue(new Error("too large"));
+
+    const { result } = renderHook(() =>
+      useDataPanel({ onDataChanged: vi.fn() }),
+    );
+
+    const file = new File(["a,b\n1,2"], "x.csv", { type: "text/csv" });
+    const event = {
+      target: { files: [file] as unknown as FileList },
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+    await act(async () => {
+      await result.current.handleUpload(event);
+    });
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      expect.stringContaining("Upload failed"),
+    );
+    expect(result.current.loading).toBe(false);
+  });
+
+  // --- handleColumnExpand ---
+
+  it("handleColumnExpand caches stats per column", async () => {
+    mocks.fetchColumnStats.mockImplementation(async (name: string) => ({
+      name,
+      dtype: "int64",
+      unique_count: 10,
+      total_count: 100,
+      null_count: 0,
+      value_counts: [{ value: "1", count: 50 }],
+    }));
+
+    const { result } = renderHook(() =>
+      useDataPanel({ onDataChanged: vi.fn() }),
+    );
+
+    await act(async () => {
+      await result.current.handleColumnExpand("a");
+    });
+    await waitFor(() => {
+      expect(result.current.expandedCol).toBe("a");
+      expect(result.current.colStats.a).toBeDefined();
+    });
+    expect(mocks.fetchColumnStats).toHaveBeenCalledTimes(1);
+
+    // Expanding again should NOT re-fetch (cached).
+    await act(async () => {
+      await result.current.handleColumnExpand("a"); // collapse
+    });
+    await act(async () => {
+      await result.current.handleColumnExpand("a"); // re-expand
+    });
+    expect(mocks.fetchColumnStats).toHaveBeenCalledTimes(1);
+  });
+
+  it("handleColumnExpand surfaces errors via toast instead of failing silently", async () => {
+    // Currently the hook swallows errors silently. This test documents
+    // the desired behaviour: the user should at least see a toast so
+    // they know why the bar did not render. Marked as the regression
+    // marker for HIGH-1.
+    mocks.fetchColumnStats.mockRejectedValue(new Error("stats unavailable"));
+
+    const { result } = renderHook(() =>
+      useDataPanel({ onDataChanged: vi.fn() }),
+    );
+
+    await act(async () => {
+      await result.current.handleColumnExpand("a");
+    });
+
+    expect(result.current.expandedCol).toBe("a");
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to load column stats"),
+    );
+    // colStats[a] must remain undefined so later code can branch correctly.
+    expect(result.current.colStats.a).toBeUndefined();
+  });
+});

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -324,8 +324,11 @@ export function useDataPanel({
         try {
           const stats = await fetchColumnStats(colName);
           setColStats((prev) => ({ ...prev, [colName]: stats }));
-        } catch {
-          // Silently fail — bar just won't show
+        } catch (err) {
+          // HIGH-1: surface the failure instead of silently dropping
+          // the bar so the user has a chance to understand why the
+          // column statistics never rendered.
+          toast.error(`Failed to load column stats: ${getErrorMessage(err)}`);
         }
       }
     },

--- a/frontend/src/pages/InferencePage.tsx
+++ b/frontend/src/pages/InferencePage.tsx
@@ -16,10 +16,9 @@ import { SetupPanel } from "@/components/inference/SetupPanel";
 export function InferencePage() {
   const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
-  const initialJobId = searchParams.get("job_id");
 
-  const [selectedJobId, setSelectedJobId] = useState<string | null>(
-    initialJobId,
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(() =>
+    searchParams.get("job_id"),
   );
   const [selectedInfId, setSelectedInfId] = useState<string | null>(null);
 
@@ -34,19 +33,31 @@ export function InferencePage() {
     [allJobs],
   );
 
-  // Auto-select job from URL param
+  // Auto-select job from URL param.
+  //
+  // HIGH-4: read the current value of the `job_id` query param on each
+  // run instead of closing over `initialJobId` from first render. That
+  // older pattern missed subsequent URL updates because the constant
+  // was never recomputed, so navigating to a different job via the URL
+  // bar silently kept the first-loaded selection.
   useEffect(() => {
-    if (initialJobId && completedJobs.some((j) => j.job_id === initialJobId)) {
-      setSelectedJobId(initialJobId);
+    const jobIdParam = searchParams.get("job_id");
+    if (jobIdParam && completedJobs.some((j) => j.job_id === jobIdParam)) {
+      setSelectedJobId(jobIdParam);
     }
-  }, [initialJobId, completedJobs]);
+  }, [searchParams, completedJobs]);
 
-  // Fetch inference history for selected job
+  // Fetch inference history for selected job.
+  //
+  // HIGH-4: inference records are created explicitly by the mutation
+  // below (see onSuccess → invalidate). There is no background source
+  // that can produce new records on its own, so the previous five-second
+  // `refetchInterval` was pure wasted bandwidth. Rely on the mutation's
+  // invalidation instead.
   const { data: history = [] } = useQuery({
     queryKey: ["inf-history", selectedJobId],
     queryFn: () => fetchInferenceHistory(selectedJobId ?? undefined),
     enabled: selectedJobId != null,
-    refetchInterval: 5000,
   });
 
   // Fetch selected inference record

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -89,6 +89,20 @@ export function WorkspacePage() {
     [queryClient],
   );
 
+  // HIGH-3: stable handler references so ResultsPanel's effect does not
+  // tear down and re-subscribe its WebSocket every WorkspacePage render.
+  const handleJobDone = useCallback(() => {
+    setRunning(false);
+    notify("LizyStudio", "Job completed");
+  }, [notify]);
+
+  const handleJobStarted = useCallback((childJobId: string) => {
+    // H-0062: Re-tune / Resume created a new child job — switch
+    // the workspace selection so the user sees its progress.
+    setCurrentJobId(childJobId);
+    setRunning(true);
+  }, []);
+
   const shortcuts = useMemo(
     () => [
       { key: "Enter", ctrl: true, action: () => handleFit() },
@@ -130,16 +144,8 @@ export function WorkspacePage() {
           hasData={hasData}
           hasConfig={hasData && config != null}
           onApplyToFit={handleApplyToFit}
-          onJobDone={() => {
-            setRunning(false);
-            notify("LizyStudio", "Job completed");
-          }}
-          onJobStarted={(childJobId) => {
-            // H-0062: Re-tune / Resume created a new child job — switch
-            // the workspace selection so the user sees its progress.
-            setCurrentJobId(childJobId);
-            setRunning(true);
-          }}
+          onJobDone={handleJobDone}
+          onJobStarted={handleJobStarted}
         />
       </ResizablePanel>
     </ResizablePanelGroup>

--- a/tests/test_error_paths.py
+++ b/tests/test_error_paths.py
@@ -1,4 +1,10 @@
-"""Tests for error handling and edge cases across API endpoints."""
+"""Tests for error handling and edge cases across API endpoints.
+
+These used to assert ``status_code in (200, 400, 422)`` so a silent
+regression that returned 200 for an empty config was indistinguishable
+from a properly-rejected one. Each case now pins the exact status code
+and the ``error.code`` string from the StudioError envelope.
+"""
 
 from __future__ import annotations
 
@@ -12,58 +18,95 @@ class TestDataErrors:
     """Error paths for data loading endpoints."""
 
     def test_load_nonexistent_path(self, client: TestClient) -> None:
-        """POST /workspace/data/path with missing file returns error."""
+        """POST /workspace/data/path with missing file returns PATH_NOT_FOUND."""
         resp = client.post(
             "/api/workspace/data/path",
             json={"path": "/tmp/nonexistent_e2e_file.csv"},
         )
-        assert resp.status_code >= 400
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "PATH_NOT_FOUND"
 
     def test_load_empty_path(self, client: TestClient) -> None:
-        """POST /workspace/data/path with empty path returns error."""
+        """POST /workspace/data/path with empty path returns PATH_NOT_FOUND."""
         resp = client.post("/api/workspace/data/path", json={"path": ""})
-        assert resp.status_code >= 400
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "PATH_NOT_FOUND"
 
     def test_upload_empty_file(self, client: TestClient) -> None:
-        """POST /workspace/data/upload with empty file returns error."""
+        """POST /workspace/data/upload with empty file returns FILE_INVALID."""
         resp = client.post(
             "/api/workspace/data/upload",
             files={"file": ("empty.csv", b"", "text/csv")},
         )
-        assert resp.status_code >= 400
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "FILE_INVALID"
 
 
 class TestConfigErrors:
     """Error paths for config endpoints."""
 
-    def test_validate_empty_config(self, client: TestClient) -> None:
-        """POST /workspace/config/validate with empty config."""
-        resp = client.post("/api/workspace/config/validate", json={})
-        # Should return 200 with errors list, or 400/422
-        assert resp.status_code in (200, 400, 422)
+    def test_validate_empty_config_rejects_with_no_config_error(
+        self, client: TestClient
+    ) -> None:
+        """POST /workspace/config/validate with an empty body.
 
-    def test_put_config_without_data(self, client: TestClient) -> None:
-        """PUT /workspace/config before loading data."""
+        The endpoint validates the *current* workspace config, not the
+        request body, so calling it with an empty workspace returns
+        WORKSPACE_NO_CONFIG rather than a 200 with a validation errors
+        list. Pinning the exact code keeps the contract explicit.
+        """
+        resp = client.post("/api/workspace/config/validate", json={})
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "WORKSPACE_NO_CONFIG"
+
+    def test_put_config_without_data_returns_preview_not_save(
+        self, client: TestClient
+    ) -> None:
+        """PUT /workspace/config before loading data — non-destructive preview.
+
+        The endpoint returns 200 with ``saved: false`` and the list of
+        schema validation errors, so the UI can show inline errors
+        without persisting a broken config. Pinning ``saved: false``
+        and requiring at least one error guarantees that a future
+        regression which silently writes an invalid config will be
+        caught by this test.
+        """
         resp = client.put(
             "/api/workspace/config",
             json={"model": {"name": "lgbm", "params": {}}},
         )
-        # Backend may accept config before data or return error
-        assert resp.status_code in (200, 400)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body.get("saved") is False, "an invalid config must not be persisted"
+        assert isinstance(body.get("errors"), list)
+        assert len(body["errors"]) > 0, "invalid config must produce at least one error"
+
+        # Confirm the preview did not mutate server state.
+        get_resp = client.get("/api/workspace/config")
+        assert get_resp.status_code == 200
+        assert get_resp.json() == {}
 
 
 class TestFitErrors:
     """Error paths for fit/tune execution."""
 
     def test_fit_without_data(self, client: TestClient) -> None:
-        """POST /workspace/fit without loading data returns error."""
+        """POST /workspace/fit without loading data returns a specific error."""
         resp = client.post("/api/workspace/fit")
-        assert resp.status_code >= 400
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] in {
+            "WORKSPACE_NO_CONFIG",
+            "WORKSPACE_NO_DATA",
+        }
 
     def test_tune_without_data(self, client: TestClient) -> None:
-        """POST /workspace/tune without loading data returns error."""
+        """POST /workspace/tune without loading data returns a specific error."""
         resp = client.post("/api/workspace/tune")
-        assert resp.status_code >= 400
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] in {
+            "WORKSPACE_NO_CONFIG",
+            "WORKSPACE_NO_DATA",
+        }
 
 
 class TestJobErrors:
@@ -107,7 +150,13 @@ class TestInferenceErrors:
     """Error paths for inference endpoints."""
 
     def test_inference_nonexistent_job(self, client: TestClient) -> None:
-        """POST /inference/run with non-existent job returns error."""
+        """POST /inference/run with non-existent job returns a precise error.
+
+        The path validation runs first, so if the data path is outside
+        the allowed root the error is PATH_NOT_FOUND (400); otherwise
+        we expect JOB_NOT_FOUND (404). Either is an explicit code, not
+        a wildcard ``status >= 400``.
+        """
         resp = client.post(
             "/api/inference/run",
             json={
@@ -117,7 +166,11 @@ class TestInferenceErrors:
                 "evaluate": False,
             },
         )
-        assert resp.status_code >= 400
+        assert resp.status_code in (400, 404)
+        assert resp.json()["error"]["code"] in {
+            "PATH_NOT_FOUND",
+            "JOB_NOT_FOUND",
+        }
 
     def test_inference_record_nonexistent(self, client: TestClient) -> None:
         """GET /inference/{non_existent_id} returns 404."""
@@ -137,8 +190,13 @@ class TestInferenceErrors:
 class TestFileErrors:
     """Error paths for file browsing."""
 
-    def test_browse_nonexistent_path(self, client: TestClient) -> None:
-        """GET /files/browse with non-existent directory."""
+    def test_browse_endpoint_does_not_exist(self, client: TestClient) -> None:
+        """GET /files/browse is not a real endpoint.
+
+        The previous test silently allowed a 200 response for this
+        path, masking the fact that no such route exists. We now pin
+        the 404 so that a later PR adding the endpoint must
+        deliberately update this test as well.
+        """
         resp = client.get("/api/files/browse?path=/tmp/nonexistent_dir_xyz")
-        # Either returns empty list or 404
-        assert resp.status_code in (200, 404)
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Batches D + E from the full-repo code review. Resolves 2 CRITICAL and 5 HIGH frontend findings, and adds the long-missing `useDataPanel` unit coverage.

Must be reviewed alongside #93 (backend batches A-C). They are independent branches cut from develop and can land in either order.

### Batch D — frontend quality

- **CRITICAL**: `useConfigPresets` no longer persists `data` or `features` to localStorage. The full config previously included the user's data path and feature exclude list, which any XSS could exfiltrate. Legacy presets are migrated on read.
- **CRITICAL**: `ModelPanel` uses a themed, a11y-friendly `SavePresetDialog` instead of `window.prompt()`. The prompt was unblocked from iframe embeds, untouched by the shadcn theme, and unreachable for keyboard-only users. New component ships with 6 unit tests.
- **HIGH**: `WorkspacePage.onJobDone` and `onJobStarted` are wrapped in `useCallback`, so `ResultsPanel` no longer tears down its WebSocket subscription on every WorkspacePage render.
- **HIGH**: `InferencePage` reads `job_id` from `searchParams` inside the auto-select effect instead of closing over `initialJobId` from first render, fixing a stale-closure that missed subsequent URL updates. Also drops the unconditional 5s `refetchInterval` on `["inf-history"]` — the mutation already invalidates the cache on success.
- **HIGH**: `TuneTrialsSection` keys trial rows by `trial.number`, so sort-order toggles keep row state attached to the right trial.
- **HIGH**: `field-renderers` array-of-objects rows use content-derived keys instead of bare index, so Remove no longer drags trailing children's state onto the wrong row.
- **HIGH**: `ConfigForm.handleFieldChange` reads from a ref to the latest `config` so the inner_valid reset effect and the objective/metric auto-select effect can no longer overwrite each other inside the same render.

### Batch E — tests

- **New**: `useDataPanel.test.ts` (400-line hook, previously zero tests). Covers `loadDataFromPath` happy + error + empty-input, `handleUpload` error path, and `handleColumnExpand` cache + error handling.
- **Fix**: `useDataPanel.handleColumnExpand` surfaces `fetchColumnStats` errors via toast instead of swallowing them. Addresses HIGH-1 from the review — users got a blank bar with no explanation.
- **Fix**: the old DataPanel spec that pinned the silent-fail behaviour is flipped to assert the new toast contract.
- **Fix**: `test_error_paths.py` weak `status_code in (...)` assertions are replaced with precise status + `error.code` checks for `WORKSPACE_NO_CONFIG`, `PATH_NOT_FOUND`, `FILE_INVALID`, and the non-existent `/files/browse` 404. The probe also surfaced that `PUT /workspace/config` returns 200 with `saved: false` and an errors list — a non-destructive preview contract — now pinned in the test.

### Out of scope — tracked as follow-up issues

- #87 subprocess runner streaming read
- #88 `useDataPanel` split into focused hooks
- #89 `*_coverage.py` TDD refit
- #90 a11y `KNOWN_ISSUES` remediation
- #91 E2E upload + session restore
- #92 Plotly SRI / local bundle

## Test plan

- [x] `pnpm vitest run` — 1286 passed, 2 skipped
- [x] `pnpm build` — tsc + vite green
- [x] `pnpm check` — no new warnings beyond pre-existing
- [x] `uv run pytest tests/test_error_paths.py` — 17 passed
- [x] `uv run ruff check .` — clean
- [ ] Manual QA: Save Preset dialog focus, keyboard submit, duplicate detection, migration of any existing localStorage presets
- [ ] Manual QA: InferencePage browsing via URL `?job_id=...` across different jobs
