### PR TITLE
fix(jobs): release active slot from subprocess paths (subprocess CRITICAL-2 follow-up)

### DIFF
--- a/frontend/tests/e2e/workspace-model-panel.spec.ts
+++ b/frontend/tests/e2e/workspace-model-panel.spec.ts
@@ -107,14 +107,20 @@ test.describe("ModelPanel interactions", () => {
     const savePresetButton = page.getByRole("button", { name: "Save Preset" });
     await expect(savePresetButton).toBeVisible();
 
-    // Set up dialog handler before clicking
-    page.on("dialog", async (dialog) => {
-      expect(dialog.type()).toBe("prompt");
-      expect(dialog.message()).toBe("Preset name:");
-      await dialog.accept("my-test-preset");
-    });
-
+    // CRITICAL-4 (code review): window.prompt() was replaced with a
+    // shadcn Dialog-based SavePresetDialog. The test now drives the
+    // real modal instead of listening for a native dialog event.
     await savePresetButton.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+    await expect(dialog.getByText("Save preset")).toBeVisible();
+
+    const nameInput = dialog.getByLabel("Name");
+    await expect(nameInput).toBeFocused();
+    await nameInput.fill("my-test-preset");
+
+    await dialog.getByRole("button", { name: /^save$/i }).click();
 
     // After saving, a toast notification should appear
     await expect(

--- a/frontend/tests/e2e/workspace-tune.spec.ts
+++ b/frontend/tests/e2e/workspace-tune.spec.ts
@@ -233,8 +233,11 @@ test.describe("Workspace tune flow", () => {
     const jobDetail = await pollJobUntilDone(request, jobId);
     expect(jobDetail.status).toBe("completed");
 
-    // 3. Export code — should return a ZIP file
-    const exportRes = await request.post(`${API}/jobs/${jobId}/export-code`);
+    // 3. Export code — should return a ZIP file.
+    // NOTE: the backend route is ``GET /jobs/{id}/export-code`` (see
+    // api/jobs.py). The original v2-11 test used POST, which returned
+    // 405 Method Not Allowed and never exercised the real export path.
+    const exportRes = await request.get(`${API}/jobs/${jobId}/export-code`);
     expect(exportRes.status()).toBe(200);
 
     // Verify response is a ZIP (content-type header)

--- a/src/lizystudio/services/jobs.py
+++ b/src/lizystudio/services/jobs.py
@@ -374,10 +374,34 @@ class JobStore:
         The subsequent ``_run_job_core`` will re-invoke ``claim_active``
         with the same job_id; that call is a no-op because the slot is
         already owned by this job.
+
+        Before refusing a request, this method checks whether the
+        currently-held slot is actually still running. Terminal jobs
+        (``completed`` / ``failed`` / ``cancelled``) have no business
+        occupying the slot and can happen if:
+
+        - a subprocess path returned without going through
+          ``_run_job_core.finally`` (e.g. the subprocess was killed and
+          the release call was skipped),
+        - the server restarted mid-job and the in-memory slot was
+          re-initialised from disk state, or
+        - a cancel request left the runner thread unable to reach the
+          release call.
+
+        Rather than locking the workspace out permanently, the slot is
+        reclaimed from the stale owner so the user's next fit/tune can
+        proceed. The stale job's on-disk state is left untouched.
         """
         with self._active_lock:
             if self._active_job_id is not None:
-                return None
+                stale = self._is_slot_holder_stale_locked()
+                if not stale:
+                    return None
+                _logger.warning(
+                    "Active slot held by stale job %s; reclaiming",
+                    self._active_job_id,
+                )
+                self._active_job_id = None
             job = self.create(
                 backend_name=backend_name,
                 config=config,
@@ -387,6 +411,21 @@ class JobStore:
             )
             self._active_job_id = job.job_id
             return job
+
+    def _is_slot_holder_stale_locked(self) -> bool:
+        """Return True when the current slot holder is in a terminal state.
+
+        Caller must hold ``self._active_lock``.
+        """
+        holder = self._active_job_id
+        if holder is None:
+            return False
+        try:
+            job = self._load_job(holder)
+        except (FileNotFoundError, OSError, json.JSONDecodeError, KeyError):
+            # Meta gone or unreadable -> definitely stale.
+            return True
+        return job.status in ("completed", "failed", "cancelled")
 
     def claim_active(self, job_id: str) -> bool:
         """Attempt to claim the active slot.

--- a/src/lizystudio/services/training.py
+++ b/src/lizystudio/services/training.py
@@ -424,32 +424,45 @@ def _run_subprocess_job(
     job_store: JobStore,
     broadcaster: ProgressBroadcaster,
 ) -> None:
-    """Run a job via subprocess and update workspace state (H-0036)."""
+    """Run a job via subprocess and update workspace state (H-0036).
+
+    CRITICAL-2 follow-up: the active-slot claim performed by
+    ``create_and_claim_active`` in the API layer must be released here
+    too. The in-process ``_run_job_core`` path does that via its
+    ``finally`` block, but subprocess execution bypasses that code
+    entirely — the child process has its own ``JobStore`` instance, so
+    the parent's slot stays held until server restart. This broke the
+    second tune request in a row whenever OpenMP routed jobs through
+    the subprocess path.
+    """
     from lizystudio.services.subprocess_runner import run_job_in_subprocess
     from lizystudio.services.workspace import get_backend_name
 
-    if ws.data_ref is None or not ws.data_ref.path:
-        job.status = "failed"
-        job.error = "No data loaded — cannot run subprocess job"
-        job.completed_at = datetime.now(timezone.utc).isoformat()
-        job_store.update(job)
-        if broadcaster is not None:
-            broadcaster.send_error(job.job_id, job.error)
+    try:
+        if ws.data_ref is None or not ws.data_ref.path:
+            job.status = "failed"
+            job.error = "No data loaded — cannot run subprocess job"
+            job.completed_at = datetime.now(timezone.utc).isoformat()
+            job_store.update(job)
+            if broadcaster is not None:
+                broadcaster.send_error(job.job_id, job.error)
+            with ws._lock:
+                ws.current_job_id = job.job_id
+            return
+        data_path = ws.data_ref.path
+        finished = run_job_in_subprocess(
+            job=job,
+            job_store=job_store,
+            broadcaster=broadcaster,
+            backend_name=get_backend_name(ws),
+            data_path=data_path,
+        )
         with ws._lock:
-            ws.current_job_id = job.job_id
-        return
-    data_path = ws.data_ref.path
-    finished = run_job_in_subprocess(
-        job=job,
-        job_store=job_store,
-        broadcaster=broadcaster,
-        backend_name=get_backend_name(ws),
-        data_path=data_path,
-    )
-    with ws._lock:
-        ws.workspace_fit_result = finished.fit_result
-        ws.workspace_tune_result = finished.tune_result
-        ws.current_job_id = finished.job_id
+            ws.workspace_fit_result = finished.fit_result
+            ws.workspace_tune_result = finished.tune_result
+            ws.current_job_id = finished.job_id
+    finally:
+        job_store.release_active(job.job_id)
 
 
 def start_fit_async(

--- a/src/lizystudio/services/training_retune.py
+++ b/src/lizystudio/services/training_retune.py
@@ -190,23 +190,31 @@ def _run_retune_subprocess(
         )
         return child_job
 
-    finished = run_job_in_subprocess(
-        job=child_job,
-        job_store=job_store,
-        broadcaster=broadcaster,
-        backend_name=get_backend_name(ws),
-        data_path=ws.data_ref.path,
-        mode="retune",
-        parent_job_id=parent_job.job_id,
-        retune_n_trials=n_trials,
-        retune_expand_boundary=expand_boundary,
-        retune_boundary_threshold=boundary_threshold,
-    )
-    with ws._lock:
-        ws.workspace_fit_result = finished.fit_result
-        ws.workspace_tune_result = finished.tune_result
-        ws.current_job_id = finished.job_id
-    return finished
+    try:
+        finished = run_job_in_subprocess(
+            job=child_job,
+            job_store=job_store,
+            broadcaster=broadcaster,
+            backend_name=get_backend_name(ws),
+            data_path=ws.data_ref.path,
+            mode="retune",
+            parent_job_id=parent_job.job_id,
+            retune_n_trials=n_trials,
+            retune_expand_boundary=expand_boundary,
+            retune_boundary_threshold=boundary_threshold,
+        )
+        with ws._lock:
+            ws.workspace_fit_result = finished.fit_result
+            ws.workspace_tune_result = finished.tune_result
+            ws.current_job_id = finished.job_id
+        return finished
+    finally:
+        # CRITICAL-2 follow-up: release the parent-process active slot
+        # that ``create_and_claim_active`` took when this retune was
+        # started. The subprocess path has its own child JobStore so
+        # the in-process _run_job_core finally does not touch the
+        # parent's _active_job_id.
+        job_store.release_active(child_job.job_id)
 
 
 def start_retune_async(

--- a/tests/regression/test_reg_0071_subprocess_releases_active_slot.py
+++ b/tests/regression/test_reg_0071_subprocess_releases_active_slot.py
@@ -1,0 +1,211 @@
+"""Regression test for CRITICAL-2 follow-up: subprocess must release slot.
+
+``create_and_claim_active`` (introduced in Batch C) claims the active
+slot in the parent process before kicking off a background thread.
+When OpenMP routes the job through ``_run_subprocess_job``, the actual
+execution happens in a child process that has its own ``JobStore``
+instance — so the in-process ``_run_job_core.finally`` does not touch
+the parent's ``_active_job_id``. Without an explicit release in the
+subprocess path the slot stayed held forever and every subsequent
+``/workspace/fit`` or ``/workspace/tune`` returned 409.
+
+This test exercises the real ``_run_subprocess_job`` with
+``run_job_in_subprocess`` monkeypatched to a no-op so it runs offline,
+and verifies the active slot is empty afterwards.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from lizystudio.backends.types import DataRef
+from lizystudio.services.jobs import JobStore
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def job_store(tmp_path: Path) -> JobStore:
+    return JobStore(tmp_path / "jobs")
+
+
+def _make_claimed_job(store: JobStore, job_type: str = "fit"):
+    job = store.create_and_claim_active(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=DataRef(
+            source_type="path",
+            path="/data/x.csv",
+            filename="x.csv",
+            fingerprint="f",
+            shape=(10, 2),
+        ),
+        job_type=job_type,
+    )
+    assert job is not None
+    return job
+
+
+def _make_ws_mock() -> MagicMock:
+    ws = MagicMock()
+    ws.data_ref = DataRef(
+        source_type="path",
+        path="/data/x.csv",
+        filename="x.csv",
+        fingerprint="f",
+        shape=(10, 2),
+    )
+    ws.backend.info.name = "lizyml"
+    ws._lock = MagicMock()
+    ws._lock.__enter__ = MagicMock(return_value=None)
+    ws._lock.__exit__ = MagicMock(return_value=None)
+    return ws
+
+
+def test_subprocess_job_releases_slot_on_success(
+    job_store: JobStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from lizystudio.services import training as training_module
+
+    ws = _make_ws_mock()
+    job = _make_claimed_job(job_store)
+    assert job_store.active_job_id == job.job_id
+
+    def _fake_run_subprocess(**kwargs):  # type: ignore[no-untyped-def]
+        finished = kwargs["job"]
+        finished.status = "completed"
+        return finished
+
+    monkeypatch.setattr(
+        "lizystudio.services.subprocess_runner.run_job_in_subprocess",
+        _fake_run_subprocess,
+    )
+
+    training_module._run_subprocess_job(ws, job, job_store, broadcaster=MagicMock())
+
+    assert job_store.active_job_id is None, (
+        "subprocess success path must release the active slot"
+    )
+
+
+def test_subprocess_job_releases_slot_on_exception(
+    job_store: JobStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from lizystudio.services import training as training_module
+
+    ws = _make_ws_mock()
+    job = _make_claimed_job(job_store)
+
+    def _boom(**kwargs):  # type: ignore[no-untyped-def]
+        raise RuntimeError("simulated subprocess failure")
+
+    monkeypatch.setattr(
+        "lizystudio.services.subprocess_runner.run_job_in_subprocess",
+        _boom,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated"):
+        training_module._run_subprocess_job(ws, job, job_store, broadcaster=MagicMock())
+
+    assert job_store.active_job_id is None, (
+        "subprocess failure path must still release the slot"
+    )
+
+
+def test_subprocess_job_releases_slot_when_data_ref_missing(
+    job_store: JobStore,
+) -> None:
+    from lizystudio.services import training as training_module
+
+    ws = _make_ws_mock()
+    ws.data_ref = None
+    job = _make_claimed_job(job_store)
+
+    training_module._run_subprocess_job(ws, job, job_store, broadcaster=MagicMock())
+
+    assert job_store.active_job_id is None
+    reloaded = job_store.get(job.job_id)
+    assert reloaded is not None
+    assert reloaded.status == "failed"
+
+
+def test_create_and_claim_active_reclaims_stale_slot(job_store: JobStore) -> None:
+    """A terminal-state owner must not lock out future callers.
+
+    Safety net for any subprocess / cancel path that fails to release
+    the slot cleanly. Without this, the E2E "Delete running job" ->
+    "Job export model" sequence left the slot held forever.
+    """
+    first = _make_claimed_job(job_store)
+    # Simulate the runner thread crashing before release: mark the
+    # job completed on disk but do not call release_active.
+    first.status = "completed"
+    job_store.update(first)
+    assert job_store.active_job_id == first.job_id
+
+    second = job_store.create_and_claim_active(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=DataRef(
+            source_type="path",
+            path="/data/y.csv",
+            filename="y.csv",
+            fingerprint="g",
+            shape=(10, 2),
+        ),
+        job_type="fit",
+    )
+    assert second is not None, "stale slot must be reclaimed for new callers"
+    assert second.job_id != first.job_id
+    assert job_store.active_job_id == second.job_id
+
+
+def test_create_and_claim_active_refuses_when_holder_is_running(
+    job_store: JobStore,
+) -> None:
+    """A genuinely running holder still blocks the new caller."""
+    first = _make_claimed_job(job_store)
+    first.status = "running"
+    job_store.update(first)
+
+    second = job_store.create_and_claim_active(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=DataRef(
+            source_type="path",
+            path="/data/y.csv",
+            filename="y.csv",
+            fingerprint="g",
+            shape=(10, 2),
+        ),
+        job_type="fit",
+    )
+    assert second is None
+    assert job_store.active_job_id == first.job_id
+
+
+def test_create_and_claim_active_reclaims_when_holder_meta_missing(
+    job_store: JobStore,
+) -> None:
+    """If the on-disk meta is gone, the slot is reclaimable too."""
+    first = _make_claimed_job(job_store)
+    # Wipe the meta to simulate a concurrent delete / corruption.
+    (job_store.jobs_dir / first.job_id / "meta.json").unlink()
+
+    second = job_store.create_and_claim_active(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=DataRef(
+            source_type="path",
+            path="/data/y.csv",
+            filename="y.csv",
+            fingerprint="g",
+            shape=(10, 2),
+        ),
+        job_type="fit",
+    )
+    assert second is not None
+    assert job_store.active_job_id == second.job_id

--- a/tests/test_workspace_coverage.py
+++ b/tests/test_workspace_coverage.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import csv
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -183,6 +184,35 @@ def test_fit_starts_job_when_data_and_config_present(
     _mock_start.assert_called_once()
 
 
+def _seed_running_holder(job_store: Any) -> str:
+    """Create a real running job on disk and claim the active slot.
+
+    ``create_and_claim_active`` refuses new callers when the current
+    slot holder is still running. Simulating that needs real on-disk
+    meta — a bare ``claim_active("dummy-id")`` no longer works because
+    the stale-slot auto-reclaim path sees the missing meta file and
+    treats the slot as reclaimable.
+    """
+    from lizystudio.backends.types import DataRef
+
+    holder = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=DataRef(
+            source_type="path",
+            path="/data/holder.csv",
+            filename="holder.csv",
+            fingerprint="h",
+            shape=(10, 2),
+        ),
+        job_type="fit",
+    )
+    holder.status = "running"
+    job_store.update(holder)
+    assert job_store.claim_active(holder.job_id)
+    return holder.job_id
+
+
 def test_fit_returns_409_when_job_active(
     client: TestClient,
     tmp_path: Path,
@@ -191,13 +221,13 @@ def test_fit_returns_409_when_job_active(
     _load_data_and_config(client, tmp_path)
 
     job_store = client.app.state.job_store  # type: ignore[union-attr]
-    job_store.claim_active("existing-job-123")
+    holder_id = _seed_running_holder(job_store)
     try:
         res = client.post("/api/workspace/fit")
         assert res.status_code == 409
         assert res.json()["error"]["code"] == "JOB_CONFLICT"
     finally:
-        job_store.release_active("existing-job-123")
+        job_store.release_active(holder_id)
 
 
 def test_tune_returns_409_when_job_active(
@@ -208,13 +238,13 @@ def test_tune_returns_409_when_job_active(
     _load_data_and_config(client, tmp_path)
 
     job_store = client.app.state.job_store  # type: ignore[union-attr]
-    job_store.claim_active("existing-job-456")
+    holder_id = _seed_running_holder(job_store)
     try:
         res = client.post("/api/workspace/tune")
         assert res.status_code == 409
         assert res.json()["error"]["code"] == "JOB_CONFLICT"
     finally:
-        job_store.release_active("existing-job-456")
+        job_store.release_active(holder_id)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #93 (Batch C `create_and_claim_active`). Discovered while running the full Playwright E2E suite on merged develop: every second `/workspace/fit` or `/workspace/tune` returned 409 `JOB_CONFLICT` under OpenMP (Linux / CI), because the subprocess execution path did not release the parent-process active slot that was claimed atomically at request time.

### Root cause

- #93 added `JobStore.create_and_claim_active` so the `/fit` and `/tune` routes atomically claim the active slot before kicking off the runner thread.
- The in-process `_run_job_core` path releases the slot via its `finally` block.
- `_run_subprocess_job` and `_run_retune_subprocess` bypass `_run_job_core` entirely — the child process has its own `JobStore` instance, so the parent's `_active_job_id` stays held until server restart.
- `openmp_detect.should_use_subprocess()` returns `True` whenever `libgomp` / `libomp` is present (i.e. always on Linux), so the subprocess path is the default.

### Fix

- **`_run_subprocess_job`**: wrap the body in `try/finally` and call `job_store.release_active(job.job_id)` in the finally — success, exception, and the `data_ref` guard clause all release cleanly.
- **`_run_retune_subprocess`**: same try/finally around `run_job_in_subprocess` so Re-tune / Resume also releases.
- **`JobStore.create_and_claim_active` — safety net**: if the current slot holder is already terminal (`completed` / `failed` / `cancelled`) or its on-disk meta is missing, reclaim the slot instead of refusing the new caller. This protects against any future path that forgets to release, server restarts with stale in-memory state, or cancel flows that leave the runner thread unable to reach the release call.
- **`test_workspace_coverage`**: the existing `test_{fit,tune}_returns_409_when_job_active` tests used synthetic `"existing-job-123"` ids that have no on-disk meta. The new stale-reclaim logic now treats that as reclaimable, so the tests seed a real running job instead.
- **E2E drift discovered while verifying**:
  - `workspace-tune.spec.ts:238` used `POST /jobs/{id}/export-code` but the route is GET-only — 405 since the original v2-11 test landed. Fixed.
  - `workspace-model-panel.spec.ts:98` drove the old `window.prompt` Save Preset UI which #94 replaced with a shadcn `SavePresetDialog`. Updated to drive the real modal.

### Regression tests

New `tests/regression/test_reg_0071_subprocess_releases_active_slot.py`:
- `test_subprocess_job_releases_slot_on_success`
- `test_subprocess_job_releases_slot_on_exception`
- `test_subprocess_job_releases_slot_when_data_ref_missing`
- `test_create_and_claim_active_reclaims_stale_slot`
- `test_create_and_claim_active_refuses_when_holder_is_running`
- `test_create_and_claim_active_reclaims_when_holder_meta_missing`

### Out of scope — tracked as follow-up

- #95 `workspace-ui-improvements` visual snapshot drift + data-less Tune tab state (pre-existing, unrelated).

## Test plan

- [x] `uv run pytest` — **974 passed**, 0 failed (+6 regression tests)
- [x] `uv run ruff check .`
- [x] `uv run mypy src/lizystudio/`
- [x] Manual API probe: 3 sequential `/workspace/tune` runs on a real server — all 3 completed, `active_job_id` cycled correctly
- [x] Manual API probe: 20 concurrent `create_and_claim_active` calls — exactly 1 winner, 0 orphan job dirs on disk
- [x] Playwright `workspace-fit.spec.ts` — **6/6**
- [x] Playwright `inference-flow.spec.ts` — **4/4**
- [x] Playwright `workspace-flow.spec.ts` — **5/5**
- [x] Playwright `security-fixes.spec.ts` — **7/7**
- [x] Playwright `jobs-flow.spec.ts` — **4/4** (was 3/4 before fix)
- [x] Playwright `workspace-tune.spec.ts` — **3/3** (was 1/3 before fix + export-code GET)
- [x] Playwright `workspace-model-panel.spec.ts` — **7/7** (was 6/7 before SavePresetDialog update)
- [x] Manual API probe for HIGH-2 binary comparison — `positive_pct` returned as expected
