### PR TITLE
fix(api): include parent_job_id in job summary responses

### DIFF
--- a/frontend/src/api/api-contract.test.ts
+++ b/frontend/src/api/api-contract.test.ts
@@ -203,6 +203,7 @@ describe("JobSummary", () => {
       completed_at: "2026-01-01T00:05:00Z",
       error: null,
       primary_score: 0.95,
+      parent_job_id: null,
     };
     assertDefined(job.job_id, "job_id");
     assertDefined(job.job_type, "job_type");
@@ -239,6 +240,7 @@ describe("JobSummary", () => {
       completed_at: null,
       error: "Out of memory",
       primary_score: null,
+      parent_job_id: null,
     };
     expect(job.completed_at).toBeNull();
     expect(job.primary_score).toBeNull();
@@ -276,6 +278,7 @@ describe("JobDetail", () => {
       },
       tune_result: null,
       model_path: "/models/job-detail-1.pkl",
+      parent_job_id: null,
     };
     assertDefined(detail.fit_result, "fit_result");
     expect(detail.tune_result).toBeNull();

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -112,6 +112,11 @@ export interface JobSummary {
   completed_at: string | null;
   error: string | null;
   primary_score: number | null;
+  // H-0062: lineage link — null for standalone / root jobs, set to the
+  // parent job id for Re-tune and Resume children. Always present in
+  // the API response so callers can rely on === null rather than
+  // checking for the key's existence.
+  parent_job_id: string | null;
 }
 
 export interface JobDetail extends JobSummary {
@@ -120,9 +125,6 @@ export interface JobDetail extends JobSummary {
   fit_result: FitResult | null;
   tune_result: TuneResult | null;
   model_path: string | null;
-  // H-0062: optional parent lineage link. null for standalone jobs and
-  // for legacy jobs written before Phase B.
-  parent_job_id?: string | null;
 }
 
 export interface FitResultParam {

--- a/frontend/src/components/inference/SetupPanel.stories.tsx
+++ b/frontend/src/components/inference/SetupPanel.stories.tsx
@@ -28,6 +28,7 @@ function makeJob(overrides: Partial<JobSummary>): JobSummary {
     completed_at: new Date().toISOString(),
     error: null,
     primary_score: 0.95,
+    parent_job_id: null,
     ...overrides,
   };
 }

--- a/frontend/src/components/inference/SetupPanel.test.tsx
+++ b/frontend/src/components/inference/SetupPanel.test.tsx
@@ -139,6 +139,7 @@ describe("SetupPanel", () => {
       completed_at: "2025-01-01T00:01:00Z",
       error: null,
       primary_score: 0.9512,
+      parent_job_id: null,
     } as JobSummary;
     render(
       <SetupPanel {...baseProps} completedJobs={[job]} selectedJobId="j1" />,
@@ -272,6 +273,7 @@ describe("SetupPanel", () => {
       completed_at: "2025-01-01T00:01:00Z",
       error: null,
       primary_score: 0.95,
+      parent_job_id: null,
     } as JobSummary;
 
     render(
@@ -306,6 +308,7 @@ describe("SetupPanel", () => {
       completed_at: "2025-01-01T00:01:00Z",
       error: null,
       primary_score: 0.95,
+      parent_job_id: null,
     } as JobSummary;
 
     render(

--- a/frontend/src/components/jobs/CompletedContent.test.tsx
+++ b/frontend/src/components/jobs/CompletedContent.test.tsx
@@ -87,6 +87,7 @@ function makeFitJob(overrides?: Partial<JobDetail>): JobDetail {
     },
     tune_result: null,
     model_path: "/models/j1",
+    parent_job_id: null,
     ...overrides,
   };
 }

--- a/frontend/src/components/jobs/JobList.stories.tsx
+++ b/frontend/src/components/jobs/JobList.stories.tsx
@@ -26,6 +26,7 @@ function makeJob(overrides: Partial<JobSummary>): JobSummary {
     completed_at: new Date().toISOString(),
     error: null,
     primary_score: 0.95,
+    parent_job_id: null,
     ...overrides,
   };
 }

--- a/frontend/src/components/workspace/TuneTrialsSection.test.tsx
+++ b/frontend/src/components/workspace/TuneTrialsSection.test.tsx
@@ -40,6 +40,7 @@ function makeJob(overrides: Partial<JobDetail> = {}): JobDetail {
     fit_result: null,
     tune_result: null,
     model_path: null,
+    parent_job_id: null,
     ...overrides,
   };
 }

--- a/frontend/src/test/helpers.tsx
+++ b/frontend/src/test/helpers.tsx
@@ -54,6 +54,7 @@ export function makeJobSummary(
     completed_at: "2026-01-01T00:01:00Z",
     error: null,
     primary_score: 0.95,
+    parent_job_id: null,
     ...overrides,
   };
 }
@@ -81,6 +82,7 @@ export function makeJob(overrides: Partial<JobDetail> = {}): JobDetail {
     fit_result: null,
     tune_result: null,
     model_path: null,
+    parent_job_id: null,
     ...overrides,
   };
 }

--- a/src/lizystudio/api/jobs.py
+++ b/src/lizystudio/api/jobs.py
@@ -81,6 +81,10 @@ def _job_summary(job: Job) -> dict[str, Any]:
         "created_at": job.created_at,
         "completed_at": job.completed_at,
         "error": _sanitize_error(job.error),
+        # H-0062: lineage field for Re-tune / Resume children. Always
+        # present in the summary so consumers can distinguish "root
+        # job" (null) from "missing key" (undefined).
+        "parent_job_id": job.parent_job_id,
     }
 
     # Model name from config

--- a/src/lizystudio/api/models.py
+++ b/src/lizystudio/api/models.py
@@ -140,6 +140,8 @@ class JobSummaryResponse(BaseModel):
     error: str | None = None
     model_name: str | None = None
     primary_score: float | None = None
+    # H-0062 lineage: null for root jobs, set for Re-tune / Resume children.
+    parent_job_id: str | None = None
 
 
 class JobDetailResponse(JobSummaryResponse):

--- a/tests/regression/test_reg_0073_job_parent_id_serialization.py
+++ b/tests/regression/test_reg_0073_job_parent_id_serialization.py
@@ -1,0 +1,116 @@
+"""Regression test: GET /api/jobs/{id} must expose parent_job_id.
+
+The ``Job`` dataclass carries ``parent_job_id`` (optional, null for
+root jobs, set for Re-tune / Resume children), and the field is
+persisted to ``meta.json``. The public API consumers — the frontend
+lineage panel and the Playwright retune-flow E2E suite — rely on
+``parent_job_id`` being present on both the list (`GET /api/jobs/`)
+and detail (`GET /api/jobs/{id}`) responses.
+
+Before the fix, ``_job_summary`` did not copy the field into the
+summary dict, so the key was simply absent from the serialized
+response — ``undefined`` in TypeScript / JavaScript, which is not
+equal to ``null`` for ``expect(...).toBeNull()`` assertions.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from lizystudio.backends.types import DataRef
+from lizystudio.services.jobs import JobStore
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_parent_and_child(job_store: JobStore) -> tuple[str, str]:
+    """Create a root job and a child whose parent_job_id points at it."""
+    parent = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=DataRef(
+            source_type="path",
+            path="/data/x.csv",
+            filename="x.csv",
+            fingerprint="f",
+            shape=(100, 5),
+        ),
+        job_type="tune",
+    )
+    parent.status = "completed"
+    job_store.update(parent)
+
+    child = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=DataRef(
+            source_type="path",
+            path="/data/x.csv",
+            filename="x.csv",
+            fingerprint="f",
+            shape=(100, 5),
+        ),
+        job_type="tune",
+        parent_job_id=parent.job_id,
+    )
+    child.status = "completed"
+    job_store.update(child)
+
+    return parent.job_id, child.job_id
+
+
+def test_get_job_detail_includes_parent_job_id_null_for_root(
+    client: TestClient,
+) -> None:
+    """GET /api/jobs/{id} must return parent_job_id=null for a root job."""
+    job_store: JobStore = client.app.state.job_store  # type: ignore[union-attr]
+    parent_id, _ = _seed_parent_and_child(job_store)
+
+    resp = client.get(f"/api/jobs/{parent_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert "parent_job_id" in body, (
+        f"parent_job_id key must always be present, got keys {sorted(body.keys())}"
+    )
+    assert body["parent_job_id"] is None
+
+
+def test_get_job_detail_includes_parent_job_id_for_child(
+    client: TestClient,
+) -> None:
+    """GET /api/jobs/{id} must return the parent id for a Re-tune child."""
+    job_store: JobStore = client.app.state.job_store  # type: ignore[union-attr]
+    parent_id, child_id = _seed_parent_and_child(job_store)
+
+    resp = client.get(f"/api/jobs/{child_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body.get("parent_job_id") == parent_id
+
+
+def test_list_jobs_includes_parent_job_id_on_every_entry(
+    client: TestClient,
+) -> None:
+    """GET /api/jobs/ must include parent_job_id for every job in the list."""
+    job_store: JobStore = client.app.state.job_store  # type: ignore[union-attr]
+    parent_id, child_id = _seed_parent_and_child(job_store)
+
+    resp = client.get("/api/jobs/")
+    assert resp.status_code == 200
+    jobs = resp.json()
+    assert isinstance(jobs, list) and len(jobs) >= 2
+
+    by_id = {j["job_id"]: j for j in jobs}
+    assert parent_id in by_id and child_id in by_id
+
+    for job_id, entry in by_id.items():
+        assert "parent_job_id" in entry, (
+            f"parent_job_id missing from list entry {job_id}: "
+            f"keys={sorted(entry.keys())}"
+        )
+
+    assert by_id[parent_id]["parent_job_id"] is None
+    assert by_id[child_id]["parent_job_id"] == parent_id


### PR DESCRIPTION
## Summary

Fixes Bug #2 from the E2E verification: `GET /api/jobs/` and `GET /api/jobs/{id}` never serialized `parent_job_id`. Consumers saw `undefined` where they expected `null` for root jobs (and a string for Re-tune / Resume children).

This is what made `retune-flow.spec.ts:86` fail with `expect(parentBody.parent_job_id).toBeNull()` — JavaScript's `undefined !== null`, so the assertion blew up the moment the suite reached the first retune test. It also meant the frontend lineage panel could not detect child jobs reliably on a fresh reload.

## Changes

- `src/lizystudio/api/jobs.py` — `_job_summary` now always emits `parent_job_id`, copied from the `Job` dataclass that already carries it.
- `src/lizystudio/api/models.py` — `JobSummaryResponse` gains `parent_job_id: str | None = None` so the OpenAPI schema and `openapi-typescript` generator see the field.
- `frontend/src/api/types.ts` — `parent_job_id` is a required `string | null` on `JobSummary` (inherited by `JobDetail`). The previous optional declaration was removed; the server contract is now "always present".
- Frontend test/story fixtures and factories — populate `parent_job_id: null` on every generated `JobSummary` / `JobDetail` so the stricter type is satisfied. No runtime behaviour changes.

## Regression test

`tests/regression/test_reg_0073_job_parent_id_serialization.py`:
1. `test_get_job_detail_includes_parent_job_id_null_for_root` — root job returns `null`
2. `test_get_job_detail_includes_parent_job_id_for_child` — child job returns the parent id
3. `test_list_jobs_includes_parent_job_id_on_every_entry` — `parent_job_id` present on every row of `GET /api/jobs/`

Confirmed RED before the fix, GREEN after. Three tests failed on develop with exactly the same message Playwright saw: the key was absent from the response dict.

## Test plan

- [x] `uv run pytest` — **977 passed** (974 develop + 3 new regression)
- [x] `uv run ruff check .` / `uv run mypy src/lizystudio/`
- [x] `pnpm build` — tsc + vite green (required fixture updates applied)
- [x] `pnpm vitest run` — **1286 passed**, 2 skipped
- [x] `pnpm check` — no new warnings beyond the pre-existing baseline
- [x] Manual QA: open Jobs page, confirm Re-tune children show their parent link in the lineage panel
- [x] Manual QA: `curl /api/jobs/ | jq '.[].parent_job_id'` returns `null` for root jobs and ids for children
