### PR TITLE
test(e2e): drain orphan retunes and add leak guard in retune-flow spec

### DIFF
--- a/frontend/tests/e2e/retune-flow.spec.ts
+++ b/frontend/tests/e2e/retune-flow.spec.ts
@@ -79,8 +79,63 @@ async function setupTuneJob(
 test.describe("Re-tune / Resume / Lineage flow (H-0062)", () => {
   test.setTimeout(180_000);
 
+  // Per-test baseline of non-terminal jobs captured in beforeEach so the
+  // afterEach regression guard only flags jobs introduced BY the current
+  // test. The job store directory (/tmp/e2e_jobs) is shared across runs
+  // and may already hold stale `running` rows from earlier sessions —
+  // those are tracked separately in Issue #99 and must not make this
+  // guard flaky.
+  let baselineAlive = new Set<string>();
+
+  async function fetchAliveJobIds(
+    request: import("@playwright/test").APIRequestContext,
+  ): Promise<Set<string>> {
+    const res = await request.get(`${API}/jobs/`);
+    // Fail loud on any non-200 so the baseline snapshot and the
+    // afterEach comparison stay symmetric. A silently empty baseline
+    // after a transient 5xx would flag every pre-existing running row
+    // as a fresh leak in the next afterEach.
+    expect(res.status(), "GET /jobs/ must succeed").toBe(200);
+    const jobs = (await res.json()) as Array<{
+      job_id: string;
+      status: string;
+    }>;
+    return new Set(
+      jobs
+        .filter((j) => j.status === "running" || j.status === "pending")
+        .map((j) => j.job_id),
+    );
+  }
+
   test.beforeEach(async ({ request }) => {
     await request.post(`${API}/workspace/reset`);
+    baselineAlive = await fetchAliveJobIds(request);
+  });
+
+  // Regression guard for the fire-and-forget orphan pattern that once
+  // leaked a retune child's active slot into subsequent tests, causing
+  // a cascade of 409 JOB_CONFLICT failures. workspace/reset intentionally
+  // does NOT clear JobStore._active_job_id (see Issue #99), so any test
+  // that starts a background job must drive it to a terminal state before
+  // returning. Computing the diff against the per-test baseline ensures
+  // this guard fires on NEW leaks only, not on stale pre-existing rows.
+  //
+  // Known blind spot: a job whose on-disk status is already terminal
+  // but whose _active_job_id slot has not yet been released will NOT be
+  // flagged here (it is filtered out of `fetchAliveJobIds`). That tiny
+  // window is real — _run_job_core writes status then releases the slot
+  // in finally — but it closes as soon as the runner thread returns, so
+  // every existing test that calls `pollJobUntilDone` or cancel+poll
+  // ends up in a fully-clean state by the time afterEach runs. If a
+  // future test ever hits a 409 without an observed leak here, check
+  // for a new fire-and-forget that skips `pollJobUntilDone`.
+  test.afterEach(async ({ request }) => {
+    const currentAlive = await fetchAliveJobIds(request);
+    const leaked = [...currentAlive].filter((id) => !baselineAlive.has(id));
+    expect(
+      leaked,
+      `Test leaked non-terminal jobs introduced during this test: ${leaked.join(", ")}`,
+    ).toHaveLength(0);
   });
 
   test("API: completed parent can be retuned into a child with parent_job_id", async ({
@@ -260,6 +315,18 @@ test.describe("Re-tune / Resume / Lineage flow (H-0062)", () => {
       data: { n_trials: 2 },
     });
     expect(second.status()).toBe(200);
+    const { job_id: secondChildId } = await second.json();
+    // Drain the second retune before returning so it does not hold the
+    // JobStore active slot into the next test (workspace/reset does not
+    // clear _active_job_id — see Issue #99). Cancel first to keep this
+    // test fast; pollJobUntilDone accepts any terminal state.
+    const cancelSecond = await request.post(`${API}/jobs/${secondChildId}/cancel`);
+    // 200 (running) or 400 (already finished) are both acceptable; a
+    // 5xx would mean the backend crashed and we should fail loud rather
+    // than let `pollJobUntilDone` time out 90 seconds later with a
+    // misleading error.
+    expect([200, 400]).toContain(cancelSecond.status());
+    await pollJobUntilDone(request, secondChildId);
   });
 
   test("API: second retune on the same parent returns 409 PARENT_LOCKED while first runs", async ({
@@ -462,5 +529,9 @@ test.describe("Re-tune / Resume / Lineage flow (H-0062)", () => {
     const bcBody = await bc.json();
     expect(bcBody.job_id).not.toBe(childB);
     expect(bcBody.parent_job_id).toBe(childB);
+    // Drain C before returning — the test only asserts API acceptance,
+    // but leaving it running would orphan the active slot for the next
+    // test (see Issue #99 and this spec's afterEach guard).
+    await pollJobUntilDone(request, bcBody.job_id as string);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the slot-leak cascade in `retune-flow.spec.ts` discovered while verifying PRs #97 and #98 on develop. Two tests fired retunes as positive-path assertions but never polled them, leaking the JobStore active slot into the next test through `workspace/reset` (which intentionally does not touch `_active_job_id` — see Issue #99). The cascade caused 6 of 11 tests to fail with `409 JOB_CONFLICT` inside `setupTuneJob`.

After this change the spec runs **7 passed / 1 skipped / 3 failed**, where the 3 remaining failures are unrelated to slot leakage (tracked as Issues #100 and #101 below).

## Changes

`frontend/tests/e2e/retune-flow.spec.ts` (only file touched):

- **test 5** ("API: cancel during retune frees the parent lock") — drain the second retune child with `cancel + pollJobUntilDone`. Cancel response asserted as `200/400` so a 5xx fails loud instead of timing out 90 s later in `pollJobUntilDone`.
- **test 11** ("API: grandchild retune is allowed") — `pollJobUntilDone` the B→C child before returning.
- **Baseline-diff `afterEach` regression guard**: `beforeEach` snapshots the set of running/pending job ids after `workspace/reset`, `afterEach` asserts no NEW non-terminal ids appear. The baseline diff (vs. absolute "no running jobs") is required because `/tmp/e2e_jobs` is shared across runs and may already hold stale rows from earlier sessions — those should not make the guard flaky.
- **`fetchAliveJobIds` asserts `GET /jobs/` returns 200** so a transient 5xx cannot silently empty the baseline and trigger a false leak the next test.
- Inline comment documents the known blind spot where on-disk status is terminal but `_active_job_id` has not yet been released — that window closes as soon as `_run_job_core.finally` runs and is not reachable from any current test.

## Out of Scope (filed as separate Issues)

- **Issue #99** — Harden JobStore active slot against test/runtime leakage. Considers whether `workspace/reset` should clear `_active_job_id`, or whether an explicit endpoint should exist. Avoiding this here keeps the patch test-only.
- **Issue #100** — `retune-flow:165` float-precision comparison (`0.9800000000000001 <= 0.98`). Reproduces deterministically in isolation; needs an epsilon or rounding fix.
- **Issue #101** — `retune-flow:371` and `:449` UI tests fail with `getByText(jobId)` timeout. Reproduces in isolation; likely the Workspace Completed view no longer renders raw job ids in a queryable form.

## Test plan

- [x] `pnpm exec playwright test tests/e2e/retune-flow.spec.ts --project=chromium --reporter=line` × 3 runs back-to-back: same `7 passed / 1 skipped / 3 failed` each time, no flakes.
- [x] Verified the `afterEach` guard catches a fresh leak by temporarily reverting Change 1 — guard fired on test 5 with the exact orphan job id.
- [x] Verified Change 1 makes the guard pass for test 5 and the cascade unblocks tests 6+ that depend on a clean active slot.
- [x] `pnpm check tests/e2e/retune-flow.spec.ts` — no new warnings (existing 15 baseline warnings unrelated to this file).
- [ ] Manual: trigger the full retune flow in the dev server once to make sure the production cancel + poll path is unaffected (the spec changes are test-only, so this is for paranoia only).
