### PR TITLE
fix(export): pin Plotly CDN bundle with SRI hash (Phase B1, Issue #92)

### DIFF
--- a/src/lizystudio/services/export.py
+++ b/src/lizystudio/services/export.py
@@ -13,6 +13,14 @@ from lizystudio.services.jobs import Job
 
 _log = logging.getLogger(__name__)
 
+# Plotly bundle pinned for the HTML report. The SRI hash is verified by
+# the browser before the script is allowed to execute, so a tampered
+# CDN cannot inject arbitrary JavaScript into the report. Bumping the
+# version requires recomputing the hash AND updating the matching
+# constants in tests/regression/test_reg_0074_export_report_plotly_sri.py.
+_PLOTLY_VERSION = "plotly-2.27.0.min.js"
+_PLOTLY_SRI = "sha384-Hl48Kq2HifOWdXEjMsKo6qxqvRLTYqIGbvlENBmkHAxZKIGCXv43H6W1jA671RzC"
+
 
 def export_model(
     *,
@@ -155,11 +163,34 @@ def _build_report_html(
         </script>
         """
 
-    # HIGH-5: Plotly is pulled from a CDN because bundling ~4 MB of JS
-    # into every HTML report is wasteful. We constrain what that CDN is
-    # allowed to execute via a CSP that only permits the CDN origin for
-    # scripts, and disallow every other active content source. A future
-    # Issue tracks migrating to a locally-bundled plotly with SRI.
+    # HIGH-5 / Issue #92: Plotly is pulled from a CDN because bundling
+    # ~4 MB of JS into every HTML report is wasteful. We layer two
+    # mitigations against a tampered or substituted bundle:
+    #
+    # 1. ``Content-Security-Policy`` whitelists ``cdn.plot.ly`` as the
+    #    only allowed script origin so the browser refuses to fetch
+    #    Plotly from anywhere else.
+    # 2. ``integrity="sha384-..."`` (Subresource Integrity) makes the
+    #    browser hash the fetched bundle and refuse to execute it if the
+    #    hash differs from the pinned value, so a compromised CDN cannot
+    #    silently swap in malicious JavaScript.
+    #
+    # ``crossorigin="anonymous"`` is required for SRI to actually take
+    # effect on cross-origin scripts (without it the browser silently
+    # drops the integrity check).
+    #
+    # Note on ``'unsafe-inline'`` below: it would normally weaken SRI on
+    # an HTTP-header-delivered CSP, but here the CSP is embedded in a
+    # ``<meta http-equiv>`` tag and the inline allowance only enables
+    # the ``Plotly.newPlot('plot-N', ...)`` bootstraps emitted above.
+    # SRI on the external Plotly bundle remains enforced regardless.
+    #
+    # When bumping the Plotly version, recompute the SRI hash and
+    # update both ``_PLOTLY_VERSION`` / ``_PLOTLY_SRI`` AND the matching
+    # constants in
+    # ``tests/regression/test_reg_0074_export_report_plotly_sri.py``.
+    # See that test's module docstring for the one-liner that computes
+    # the hash from the CDN bundle.
     csp = (
         "default-src 'none'; "
         "script-src https://cdn.plot.ly 'unsafe-inline'; "
@@ -173,7 +204,8 @@ def _build_report_html(
     <meta charset="utf-8">
     <meta http-equiv="Content-Security-Policy" content="{csp}">
     <title>{title}</title>
-    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"
+    <script src="https://cdn.plot.ly/{_PLOTLY_VERSION}"
+            integrity="{_PLOTLY_SRI}"
             crossorigin="anonymous"></script>
     <style>
         body {{ font-family: system-ui, sans-serif;

--- a/tests/regression/test_reg_0074_export_report_plotly_sri.py
+++ b/tests/regression/test_reg_0074_export_report_plotly_sri.py
@@ -1,0 +1,130 @@
+"""Regression test: HTML report must serve Plotly with an SRI hash.
+
+Issue #92: Loading Plotly from a CDN with no integrity attribute leaves
+the report vulnerable to a tampered or substituted bundle. The CSP
+restricts the script origin, but a compromised CDN bypasses that. This
+test pins a sha384 SRI on the plotly-2.27.0 script tag so the browser
+refuses to execute a modified payload.
+
+If you bump the Plotly version in ``export.py``, recompute the hash via:
+
+    python -c "import urllib.request, hashlib, base64; \\
+        d = urllib.request.urlopen('https://cdn.plot.ly/plotly-X.Y.Z.min.js').read(); \\
+        print('sha384-' + base64.b64encode(hashlib.sha384(d).digest()).decode())"
+
+and update both ``export.py`` and the expected hash in this test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from lizystudio.backends.types import DataRef, FitSummary, PlotData
+from lizystudio.services.export import export_report
+from lizystudio.services.jobs import Job, JobStore
+
+pytestmark = pytest.mark.unit
+
+EXPECTED_SRI = "sha384-Hl48Kq2HifOWdXEjMsKo6qxqvRLTYqIGbvlENBmkHAxZKIGCXv43H6W1jA671RzC"
+EXPECTED_PLOTLY_VERSION = "plotly-2.27.0.min.js"
+
+
+@pytest.fixture()
+def job_store(tmp_path: Path) -> JobStore:
+    return JobStore(tmp_path / "jobs")
+
+
+@pytest.fixture()
+def completed_job(job_store: JobStore) -> Job:
+    data_ref = DataRef(
+        source_type="path",
+        path="/data/train.csv",
+        filename="train.csv",
+        fingerprint="abc123",
+        shape=(100, 10),
+    )
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=data_ref,
+        job_type="fit",
+    )
+    job.status = "completed"
+    job.model_path = "/tmp/fake_model"
+    job.fit_result = FitSummary(
+        metrics={"auc": 0.95},
+        fold_count=5,
+        params=[{"n_estimators": 100}],
+    )
+    job_store.update(job)
+    return job
+
+
+@pytest.fixture()
+def mock_backend() -> MagicMock:
+    backend = MagicMock()
+    backend.load_model.return_value = MagicMock()
+    backend.evaluate_table.return_value = [{"metric": "auc", "IS": 0.95, "OOS": 0.90}]
+    backend.model_info.return_value = {"task": "binary", "model_name": "LightGBM"}
+    backend.available_plots.return_value = ["learning_curve"]
+    backend.plot.return_value = PlotData(plotly_json='{"data": [], "layout": {}}')
+    return backend
+
+
+def test_export_report_pins_plotly_sri_hash(
+    completed_job: Job, mock_backend: MagicMock, tmp_path: Path
+) -> None:
+    """Generated HTML must include integrity="sha384-..." on the Plotly tag.
+
+    Without this, a compromised CDN can ship arbitrary JavaScript that
+    runs inside the report's CSP-restricted script-src whitelist.
+    """
+    out_path = tmp_path / "report.html"
+    export_report(
+        job=completed_job,
+        backend=mock_backend,
+        output_path=str(out_path),
+    )
+    content = out_path.read_text(encoding="utf-8")
+
+    assert EXPECTED_PLOTLY_VERSION in content, (
+        "Plotly version reference missing from HTML; if you bumped the "
+        "version you must also bump EXPECTED_PLOTLY_VERSION and "
+        "EXPECTED_SRI in this test."
+    )
+    assert f'integrity="{EXPECTED_SRI}"' in content, (
+        "Plotly script tag is missing or has the wrong SRI hash. "
+        "Either the version was bumped without updating the hash, or "
+        "the hash was tampered with."
+    )
+    # SRI without crossorigin is silently ignored by some browsers.
+    assert 'crossorigin="anonymous"' in content
+
+
+def test_export_report_csp_still_restricts_plotly_origin(
+    completed_job: Job, mock_backend: MagicMock, tmp_path: Path
+) -> None:
+    """SRI does not replace CSP; both must remain in the report.
+
+    SRI guarantees integrity if the script reaches the browser, but CSP
+    is what restricts which origins the browser is allowed to fetch
+    from in the first place. A regression that removes either while
+    "fixing" the other would weaken the report's defense in depth.
+    """
+    out_path = tmp_path / "report.html"
+    export_report(
+        job=completed_job,
+        backend=mock_backend,
+        output_path=str(out_path),
+    )
+    content = out_path.read_text(encoding="utf-8")
+
+    assert "Content-Security-Policy" in content
+    # Match with a trailing space so a future regression that lengthens
+    # the origin (e.g. accidentally allowing
+    # `script-src https://cdn.plot.ly.attacker.com`) trips this test
+    # instead of silently passing on a substring match.
+    assert "script-src https://cdn.plot.ly " in content


### PR DESCRIPTION
## Summary

Closes #92. Pins the Plotly CDN bundle in the generated HTML report with a `sha384` Subresource Integrity hash so a tampered or substituted bundle cannot execute even within the existing CSP whitelist.

The CSP already restricts the script origin to `cdn.plot.ly`, but a compromised CDN serving a different file at the same URL would bypass that. SRI closes the gap by making the browser hash the fetched bundle and refuse to run it if the hash differs from the pinned value.

## Changes

### `src/lizystudio/services/export.py`

- Added module-level constants:
  ```python
  _PLOTLY_VERSION = "plotly-2.27.0.min.js"
  _PLOTLY_SRI = "sha384-Hl48Kq2HifOWdXEjMsKo6qxqvRLTYqIGbvlENBmkHAxZKIGCXv43H6W1jA671RzC"
  ```
- Updated the script tag in the generated HTML:
  ```html
  <script src="https://cdn.plot.ly/{_PLOTLY_VERSION}"
          integrity="{_PLOTLY_SRI}"
          crossorigin="anonymous"></script>
  ```
- Inline comment block above the return now explains:
  - The two-layer defense (CSP for origin, SRI for integrity).
  - Why `crossorigin="anonymous"` is required (without it the browser silently drops the SRI check on cross-origin scripts).
  - Why `'unsafe-inline'` in `script-src` does NOT weaken SRI here — the CSP is delivered via `<meta http-equiv>` and only enables the inline `Plotly.newPlot('plot-N', ...)` bootstrap blocks; SRI on the external bundle remains enforced regardless.
  - The bump procedure for future version upgrades.

### `tests/regression/test_reg_0074_export_report_plotly_sri.py` (new)

Two regression tests:

1. **`test_export_report_pins_plotly_sri_hash`** — generates the HTML and asserts the version string, `integrity="<sha384>"`, and `crossorigin="anonymous"` are all present.
2. **`test_export_report_csp_still_restricts_plotly_origin`** — defense-in-depth check that CSP and `script-src https://cdn.plot.ly ` (with a trailing space, so a future `cdn.plot.ly.attacker.com` cannot slip through a substring match) remain in the HTML. SRI does not replace CSP; a regression that removes either while "fixing" the other would weaken the report's defense in depth.

Module docstring documents the one-liner that recomputes the hash on a version bump.

## How the SRI was computed

```python
import urllib.request, hashlib, base64
data = urllib.request.urlopen("https://cdn.plot.ly/plotly-2.27.0.min.js").read()
print("sha384-" + base64.b64encode(hashlib.sha384(data).digest()).decode())
```

Downloaded twice and confirmed the hash is deterministic. The bundle is 3,598,158 bytes.

## Test plan

- [x] `uv run pytest tests/regression/test_reg_0074_export_report_plotly_sri.py` — 2 passed.
- [x] Verified RED before the fix (test asserted the `integrity` attribute, which did not exist).
- [x] `uv run pytest tests/test_export_service.py tests/regression/test_reg_0068_export_report_script_injection.py tests/regression/test_reg_0074_export_report_plotly_sri.py` — 15 passed.
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy src/lizystudio/services/export.py` — clean.

## Follow-up Issues

Filed during code review:

- **#104** — Drop `'unsafe-inline'` from `script-src` by emitting plot data as `application/json` blocks and a single bootstrap script. Removes the entire class of "data ended up in a `<script>` block" XSS sinks.
- **#105** — Nightly CI job to verify Plotly CDN reachability and SRI hash freshness so we detect bundle drift even when no one happens to open a report.

## Out of scope

- Migrating to a locally-bundled Plotly. Adds ~4 MB per report and was deemed not worth it in the original Issue. The CSP + SRI combination is sufficient for the threat model.
