### PR TITLE
refactor(subprocess_runner): tail-read progress file (Phase B2, Issue #87)

### DIFF
--- a/src/lizystudio/services/subprocess_runner.py
+++ b/src/lizystudio/services/subprocess_runner.py
@@ -40,6 +40,14 @@ _POLL_INTERVAL = 0.2  # seconds between progress file polls
 # keep the daemon worker thread alive forever (H-0062 Bugfix 2026-04-14).
 _WAIT_TIMEOUT = 10.0
 
+# Issue #87: after the subprocess exits, retry the progress reader a
+# handful of times so writes that the child flushed moments before
+# ``SIGTERM`` still land on the parent's WebSocket broadcaster. The
+# legacy single 50 ms sleep was unreliable on NFS / docker overlay2
+# where the flush->visibility delay is occasionally above that budget.
+_FINAL_FLUSH_RETRIES = 5
+_FINAL_FLUSH_INTERVAL = 0.05
+
 
 def run_job_in_subprocess(
     *,
@@ -181,6 +189,101 @@ def run_job_in_subprocess(
     return updated
 
 
+class _ProgressReader:
+    """Tail-read the progress JSONL file one new chunk at a time.
+
+    Issue #87: the legacy poll loop read the whole progress file via
+    ``Path.read_text().splitlines()`` on every 200 ms tick and tracked a
+    consumed-line counter. That is O(N) per poll in the number of lines
+    already seen, so a long tune with hundreds of trials quadratically
+    degrades the parent thread as the file grows. It also silently
+    dropped partial writes (a ``write()`` that landed but whose
+    terminating newline had not flushed yet was parsed as invalid JSON
+    and thrown away, never to be retried).
+
+    This reader keeps an open file handle and reads only the new bytes
+    since the last call (``file.read()`` on a regular file with a live
+    offset). A small ``_buffer`` holds any unterminated trailing text
+    across calls so it is never lost — the next call stitches the
+    continuation on and returns the completed line.
+
+    The reader also handles the common "file does not exist yet"
+    startup case: ``_ensure_open`` retries on every call until the
+    child creates the file, at which point the handle opens and
+    subsequent calls stream from offset 0.
+    """
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._file: Any = None  # typing.IO[str] once opened
+        self._buffer = ""
+
+    def _ensure_open(self) -> bool:
+        """Open the file lazily if it has appeared on disk.
+
+        Returns True if a live handle is available after the call, and
+        False if the file still does not exist.
+        """
+        if self._file is not None:
+            return True
+        if not Path(self._path).exists():
+            return False
+        # Text mode with UTF-8 to match _write_progress; errors="replace"
+        # so a corrupt byte sequence in the middle of a long tune does
+        # not raise UnicodeDecodeError and kill the poll loop. A broken
+        # line will fail JSON parsing in _forward_progress and be
+        # dropped there with logging, which is the right failure mode.
+        self._file = open(  # noqa: SIM115 — handle lives with the reader
+            self._path, encoding="utf-8", errors="replace"
+        )
+        return True
+
+    def read_new_lines(self) -> list[str]:
+        """Return complete lines written since the last call.
+
+        Any partial trailing content (no terminating newline) is stashed
+        on ``self._buffer`` and only released once its continuation has
+        been written.
+        """
+        if not self._ensure_open():
+            return []
+        chunk = self._file.read()
+        if not chunk:
+            return []
+        data = self._buffer + chunk
+        # If the chunk ends with a newline, every line is complete and
+        # the buffer is empty; otherwise the last fragment is partial
+        # and we hold it until a later call completes it.
+        if data.endswith("\n"):
+            self._buffer = ""
+            return [ln for ln in data.splitlines() if ln]
+        parts = data.split("\n")
+        self._buffer = parts[-1]
+        return [ln for ln in parts[:-1] if ln]
+
+    def final_flush(self) -> list[str]:
+        """Return any buffered partial line and clear the buffer.
+
+        Called by ``_poll_progress`` after the subprocess has exited and
+        the poll retries have finished. If the child was killed
+        mid-write, its last bytes live here as a best-effort tail; the
+        caller decides whether to forward them (they probably fail JSON
+        parsing, but at least they land in logs).
+        """
+        if not self._buffer:
+            return []
+        tail = self._buffer
+        self._buffer = ""
+        return [tail]
+
+    def close(self) -> None:
+        """Release the file handle. Safe to call multiple times."""
+        if self._file is not None:
+            with contextlib.suppress(Exception):
+                self._file.close()
+            self._file = None
+
+
 def _poll_progress(
     proc: subprocess.Popen[bytes],
     progress_path: str,
@@ -197,40 +300,58 @@ def _poll_progress(
     Without this escape hatch, a hung child process kept the daemon
     worker thread alive forever and the next retune attempt permanently
     failed with ``PreviousJobStillRunningError``.
+
+    Issue #87: uses an incremental ``_ProgressReader`` instead of
+    re-reading the entire file each tick. See that class's docstring
+    for the rationale; the behavioural contract here is unchanged —
+    only the cost model is.
     """
-    lines_read = 0
-    path = Path(progress_path)
+    reader = _ProgressReader(progress_path)
     terminated = False
 
-    while proc.poll() is None:
-        if path.exists():
-            lines = path.read_text(encoding="utf-8").splitlines()
-            for line in lines[lines_read:]:
-                lines_read += 1
+    try:
+        while proc.poll() is None:
+            for line in reader.read_new_lines():
                 _forward_progress(line, job_id, broadcaster)
-        if (
-            not terminated
-            and job_store is not None
-            and job_store.is_cancel_requested(job_id)
-        ):
-            _logger.info("cancel requested for job %s; terminating subprocess", job_id)
-            terminated = True
-            with contextlib.suppress(Exception):
-                proc.terminate()
-            # Give the child a brief moment to flush then escalate if
-            # still alive. The outer run_job_in_subprocess does the
-            # real proc.wait() with _WAIT_TIMEOUT, so here we just
-            # break out of the polling loop.
-            break
-        time.sleep(_POLL_INTERVAL)
+            if (
+                not terminated
+                and job_store is not None
+                and job_store.is_cancel_requested(job_id)
+            ):
+                _logger.info(
+                    "cancel requested for job %s; terminating subprocess", job_id
+                )
+                terminated = True
+                with contextlib.suppress(Exception):
+                    proc.terminate()
+                # Give the child a brief moment to flush then escalate
+                # if still alive. The outer run_job_in_subprocess does
+                # the real proc.wait() with _WAIT_TIMEOUT, so here we
+                # just break out of the polling loop.
+                break
+            time.sleep(_POLL_INTERVAL)
 
-    # Final flush — read any remaining lines after subprocess exits.
-    # Retry once to handle partial writes at EOF.
-    time.sleep(0.05)
-    if path.exists():
-        lines = path.read_text(encoding="utf-8").splitlines()
-        for line in lines[lines_read:]:
+        # Final flush — the child has exited (or we terminated it).
+        # Retry a handful of times to cover the NFS / overlay2 visibility
+        # gap where the kernel flushed the bytes but the parent's view
+        # has not caught up yet. Each iteration reads whatever new lines
+        # are now visible; if nothing arrives in a full retry cycle we
+        # give up and forward the buffered partial as best-effort.
+        for _ in range(_FINAL_FLUSH_RETRIES):
+            time.sleep(_FINAL_FLUSH_INTERVAL)
+            new_lines = reader.read_new_lines()
+            if not new_lines:
+                continue
+            for line in new_lines:
+                _forward_progress(line, job_id, broadcaster)
+
+        # Anything still buffered is an incomplete last write — forward
+        # it so the information at least reaches _forward_progress's
+        # logging path, even if it fails JSON parsing.
+        for line in reader.final_flush():
             _forward_progress(line, job_id, broadcaster)
+    finally:
+        reader.close()
 
 
 def _forward_progress(

--- a/tests/test_progress_reader.py
+++ b/tests/test_progress_reader.py
@@ -1,0 +1,225 @@
+"""Unit tests for the incremental ``_ProgressReader`` (Issue #87).
+
+The legacy ``_poll_progress`` read the progress file in full on every
+poll via ``read_text().splitlines()[lines_read:]``. That is O(N) per
+poll in the number of already-consumed lines, so a long tune (hundreds
+of trials + per-fold progress) stalls the parent thread proportionally
+as the file grows. It also dropped partial writes: if a poll raced the
+child between ``f.write(...)`` and the trailing newline, the incomplete
+tail got parsed as JSON, failed, and was never retried.
+
+The replacement is a file-handle-backed reader that:
+
+1. Keeps an open ``open(path, 'rb')`` handle and reads only new bytes
+   since the last call (``os.read``-style tail semantics).
+2. Buffers a partial trailing line across calls so it is never dropped.
+3. Decodes and splits into *complete* lines on each call, leaving any
+   unterminated tail in the buffer.
+4. Exposes a ``final_flush()`` that returns whatever is still in the
+   buffer when the subprocess has exited — the caller can choose to
+   forward it even without a terminating newline (end-of-stream).
+
+These tests lock the contract before the implementation lands.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _append_text(path: Path, text: str) -> None:
+    """Append ``text`` to ``path`` using the same flush semantics as
+    the real ``_write_progress`` helper (write -> flush -> fsync).
+    """
+    import os
+
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(text)
+        f.flush()
+        os.fsync(f.fileno())
+
+
+@pytest.fixture()
+def progress_path(tmp_path: Path) -> Path:
+    return tmp_path / "progress.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Core contract: incremental reads, no full re-parse
+# ---------------------------------------------------------------------------
+class TestProgressReaderIncremental:
+    def test_returns_empty_list_when_file_missing(self, progress_path: Path) -> None:
+        from lizystudio.services.subprocess_runner import _ProgressReader
+
+        reader = _ProgressReader(str(progress_path))
+        assert reader.read_new_lines() == []
+
+    def test_returns_complete_lines_on_first_call(self, progress_path: Path) -> None:
+        from lizystudio.services.subprocess_runner import _ProgressReader
+
+        _append_text(progress_path, '{"type": "progress", "n": 1}\n')
+        _append_text(progress_path, '{"type": "progress", "n": 2}\n')
+
+        reader = _ProgressReader(str(progress_path))
+        lines = reader.read_new_lines()
+
+        assert lines == [
+            '{"type": "progress", "n": 1}',
+            '{"type": "progress", "n": 2}',
+        ]
+
+    def test_subsequent_calls_only_return_new_lines(self, progress_path: Path) -> None:
+        from lizystudio.services.subprocess_runner import _ProgressReader
+
+        _append_text(progress_path, "line-1\n")
+        reader = _ProgressReader(str(progress_path))
+        assert reader.read_new_lines() == ["line-1"]
+
+        # Second call with no new data must return nothing.
+        assert reader.read_new_lines() == []
+
+        # New data appended -> only the new line is returned.
+        _append_text(progress_path, "line-2\n")
+        assert reader.read_new_lines() == ["line-2"]
+
+    def test_does_not_re_emit_already_returned_lines(self, progress_path: Path) -> None:
+        """Regression guard for the legacy ``lines[lines_read:]`` slicing.
+
+        If a future refactor goes back to re-reading from offset 0, the
+        earlier lines will be returned again. This is an explicit "no
+        duplicates" assertion.
+        """
+        from lizystudio.services.subprocess_runner import _ProgressReader
+
+        for i in range(5):
+            _append_text(progress_path, f"line-{i}\n")
+        reader = _ProgressReader(str(progress_path))
+
+        first_batch = reader.read_new_lines()
+        assert len(first_batch) == 5
+
+        # Append two more lines.
+        _append_text(progress_path, "line-5\n")
+        _append_text(progress_path, "line-6\n")
+
+        second_batch = reader.read_new_lines()
+        assert second_batch == ["line-5", "line-6"]
+
+
+# ---------------------------------------------------------------------------
+# Partial-line buffering: the core bug fix
+# ---------------------------------------------------------------------------
+class TestProgressReaderPartialLines:
+    def test_partial_tail_is_buffered_not_returned(self, progress_path: Path) -> None:
+        from lizystudio.services.subprocess_runner import _ProgressReader
+
+        # Simulate a child that wrote the JSON payload then died before
+        # appending the newline. The caller should NOT see a half line.
+        _append_text(progress_path, '{"type": "progress"')
+
+        reader = _ProgressReader(str(progress_path))
+        assert reader.read_new_lines() == []
+
+    def test_partial_tail_is_completed_by_next_write(self, progress_path: Path) -> None:
+        from lizystudio.services.subprocess_runner import _ProgressReader
+
+        reader = _ProgressReader(str(progress_path))
+        # Partial line written before first poll.
+        _append_text(progress_path, '{"type": "progress"')
+        assert reader.read_new_lines() == []
+
+        # Rest of the line arrives.
+        _append_text(progress_path, ', "n": 1}\n')
+        assert reader.read_new_lines() == ['{"type": "progress", "n": 1}']
+
+    def test_mixed_complete_and_partial_in_single_read(
+        self, progress_path: Path
+    ) -> None:
+        from lizystudio.services.subprocess_runner import _ProgressReader
+
+        _append_text(progress_path, "complete-1\ncomplete-2\npartial-ta")
+
+        reader = _ProgressReader(str(progress_path))
+        first = reader.read_new_lines()
+        assert first == ["complete-1", "complete-2"]
+
+        _append_text(progress_path, "il\n")
+        assert reader.read_new_lines() == ["partial-tail"]
+
+
+# ---------------------------------------------------------------------------
+# final_flush: end-of-stream handling
+# ---------------------------------------------------------------------------
+class TestProgressReaderFinalFlush:
+    def test_final_flush_returns_any_buffered_partial_line(
+        self, progress_path: Path
+    ) -> None:
+        """At subprocess EOF, any unterminated tail should be emitted.
+
+        This is the "child was killed mid-write" path. The legacy code
+        silently dropped these; with an explicit ``final_flush``, the
+        caller can forward them as best-effort messages (or at least
+        log them) instead of losing the information.
+        """
+        from lizystudio.services.subprocess_runner import _ProgressReader
+
+        _append_text(progress_path, "complete-line\nhalf-")
+        reader = _ProgressReader(str(progress_path))
+
+        complete = reader.read_new_lines()
+        assert complete == ["complete-line"]
+
+        remaining = reader.final_flush()
+        assert remaining == ["half-"]
+
+    def test_final_flush_empty_when_no_buffered_partial(
+        self, progress_path: Path
+    ) -> None:
+        from lizystudio.services.subprocess_runner import _ProgressReader
+
+        _append_text(progress_path, "a\nb\n")
+        reader = _ProgressReader(str(progress_path))
+        assert reader.read_new_lines() == ["a", "b"]
+        assert reader.final_flush() == []
+
+    def test_final_flush_is_idempotent(self, progress_path: Path) -> None:
+        from lizystudio.services.subprocess_runner import _ProgressReader
+
+        _append_text(progress_path, "partial")
+        reader = _ProgressReader(str(progress_path))
+        assert reader.read_new_lines() == []
+        assert reader.final_flush() == ["partial"]
+        # Second flush must not re-emit the same buffered line.
+        assert reader.final_flush() == []
+
+
+# ---------------------------------------------------------------------------
+# File-descriptor lifecycle: close is safe, reopen after missing is safe
+# ---------------------------------------------------------------------------
+class TestProgressReaderLifecycle:
+    def test_close_releases_file_handle_safely(self, progress_path: Path) -> None:
+        from lizystudio.services.subprocess_runner import _ProgressReader
+
+        _append_text(progress_path, "line\n")
+        reader = _ProgressReader(str(progress_path))
+        assert reader.read_new_lines() == ["line"]
+        reader.close()
+        # Calling close twice must not raise.
+        reader.close()
+
+    def test_file_created_after_reader_init(self, progress_path: Path) -> None:
+        """Reader is typically instantiated before the subprocess has
+        written anything. It must handle the "file does not exist yet"
+        state and start streaming as soon as writes begin.
+        """
+        from lizystudio.services.subprocess_runner import _ProgressReader
+
+        reader = _ProgressReader(str(progress_path))
+        assert reader.read_new_lines() == []
+
+        _append_text(progress_path, "first-write\n")
+        assert reader.read_new_lines() == ["first-write"]


### PR DESCRIPTION
## Summary

Closes #87 (CRITICAL-3). Replaces the O(N)-per-poll full re-read of the progress JSONL file with an incremental tail reader that keeps a live file handle and only consumes new bytes. Also fixes the partial-write drop and the unreliable 50 ms final flush.

## Problem

Before this PR, `_poll_progress` called `Path.read_text().splitlines()[lines_read:]` every 200 ms. Two concrete bugs:

1. **Quadratic cost as the file grows.** A long tune (hundreds of trials, per-fold progress rows per trial) produces thousands of lines. Re-parsing all of them every tick stalls the parent thread proportionally to the file size, starving the cancel check and the broadcaster.
2. **Dropped partial writes.** A child `write(...)` whose trailing newline had not flushed yet was parsed as invalid JSON in `_forward_progress` and silently thrown away. The continuation never reached the broadcaster.
3. **Final-flush race.** The "retry once after `time.sleep(0.05)`" was flagged in the original ticket as "insufficient on NFS / docker overlay2". On a slow filesystem the final lines — including the terminal `completed` / `error` message — could be lost entirely.

## Changes

### `src/lizystudio/services/subprocess_runner.py`

- **New private class `_ProgressReader`** (~90 lines with docstrings):
  - `_ensure_open()` lazily opens the file (the parent typically starts polling before the child creates it) and caches the handle.
  - `read_new_lines()` reads only new bytes via the live offset, concatenates them with any buffered partial tail, splits on `\n`, leaves any unterminated trailing fragment back in the buffer.
  - `final_flush()` returns `[self._buffer]` if there is an incomplete last write. Idempotent. Called once after the subprocess has exited.
  - `close()` releases the handle via `contextlib.suppress` so re-close is safe.
  - Uses `encoding="utf-8", errors="replace"` — a corrupt byte anywhere in a long tune fails JSON parsing in `_forward_progress` (the correct failure mode) instead of crashing the poll loop with `UnicodeDecodeError`.

- **`_poll_progress` rewritten** to use `_ProgressReader`. Signature unchanged; the cancel-escape path and terminate semantics are identical so existing H-0062 regression tests pass untouched. The only behavioural change is the final flush: five attempts at 50 ms each (250 ms total) instead of one 50 ms sleep, covering the NFS / overlay2 visibility gap.

- **Two new module constants** for the retry cadence:
  ```python
  _FINAL_FLUSH_RETRIES = 5
  _FINAL_FLUSH_INTERVAL = 0.05
  ```

### `tests/test_progress_reader.py` (new, 12 tests)

Four test classes locking the contract:

- **`TestProgressReaderIncremental`** — file missing, first-call returns all lines, subsequent calls only return new ones, no duplicate emission across batches.
- **`TestProgressReaderPartialLines`** — partial trailing content buffered not returned, partial completed by next write, mixed complete + partial in a single read.
- **`TestProgressReaderFinalFlush`** — buffered partial returned at EOF, empty when no partial, idempotent across double flush.
- **`TestProgressReaderLifecycle`** — `close` safe to call twice, reader instantiated before the file exists must still work.

The test helper `_append_text` mirrors `_write_progress`'s `write + flush + fsync` semantics so the behaviour under test matches production.

## Test plan

- [x] `uv run pytest tests/test_progress_reader.py` — **12 passed** (TDD RED verified with `ImportError` before implementation; GREEN after).
- [x] `uv run pytest tests/test_subprocess_runner.py tests/regression/test_reg_0071_* tests/regression/test_reg_0072_* tests/regression/test_reg_0065_*` — **55 passed**, no regressions in the existing poll / cancel / terminate coverage.
- [x] `uv run pytest` (full suite) — **994 passed**, 2 warnings (pre-existing, unrelated).
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy src/lizystudio/services/subprocess_runner.py` — all clean.
- [x] Python reviewer: APPROVE, no CRITICAL/HIGH, verified corner cases (`\n\n`, `\r\n`, `SIM115` justification, Linux read semantics, `errors="replace"` choice).

## Out of scope

- **`inotify` / `select`-based non-polling reader.** OS-dependent (no Windows support), and the 200 ms poll interval is not currently a bottleneck. Issue #87's original ticket mentioned this as a future option; the tail-read fix alone already removes the O(N) behaviour that made the loop expensive.
- **Configurable `_POLL_INTERVAL`.** Not needed for this fix; can be revisited if a benchmark shows the 200 ms choice is wrong.
- **Broadcaster retry on forward failure.** Separate concern — `_forward_progress` already handles JSON decode failures gracefully.
