### PR TITLE
fix(workspace): reset cancels active job and releases slot (Phase B3, Issue #99)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1596,3 +1596,32 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
     9. `_run_retune_subprocess` と `start_fit_async` / `start_tune_async` の重複統合。
     10. exact trial count 監視テストの brittleness（一部緩和済、残箇所は段階的に）。
 - **Bugfix 2026-04-14 (4) — AUC が low-is-better で最適化される CRITICAL バグ:** ユーザ報告「Tuning 時に AUC スコアが低いほど良い指標になっている」を受けて調査。根本原因は `api/workspace.py::workspace_tune` のデフォルト tuning inject 経路で `direction` が `"minimize"` にハードコードされていたこと。具体的な再現フロー: (1) ユーザが Workspace で task=binary を選ぶ（評価メトリックは default の auc）→ (2) `tuning` セクション未設定のまま Tune ボタンを押す → (3) `POST /api/workspace/tune` でバックエンドが `tuning.optuna.params = {"n_trials": 50, "direction": "minimize", "timeout": None}` を inject → (4) `_prepare_tune_config` の auto-resolve は `"direction" not in params` を見ていたため発火せず → (5) lizyml の `Model.tune()` が Optuna study direction = `"minimize"` で起動 → (6) AUC を最小化（=低いほど良い指標として扱う） → (7) `best_params` が完全に意味不明な値になる。**影響範囲**: すべての fresh tune 実行で auc / auc_pr / r2 / accuracy / f1 / auc_mu が低いほど良いと最適化されていた。ユーザがメトリックを 1 度切り替えた場合のみ TuneEvaluationSection の `handleOptimizationMetricChange` が direction を上書きするため回避されていた。修正 (5 層): **(Fix 1)** `api/workspace.py:437` のハードコード `"direction": "minimize"` を削除し、`_prepare_tune_config` の auto-resolve に一任。**(Fix 2)** `services/training.py::_prepare_tune_config` の direction 補正条件を `"direction" not in params` から「常に metric と整合させる（不整合なら上書き）」に変更。これにより stale な direction や API 直叩きの誤った値も自動修正される。**(Fix 3)** `frontend/src/components/workspace/TuneEvaluationSection.tsx` に defensive useEffect を追加し、メトリック変化時にコンポーネント側でも `optuna.params.direction` を `metricDirection` と整合させる（ユーザがメトリックボタンを押さなくても同期）。**(Fix 4)** リグレッションテスト追加: `tests/test_workspace_coverage.py::test_tune_default_tuning_uses_auc_maximize_for_binary` (workspace_tune → _prepare_tune_config の統合テスト), `tests/test_training_service.py::test_overrides_stale_minimize_direction_for_auc` / `test_overrides_stale_maximize_direction_for_rmse` / `test_keeps_consistent_direction_unchanged`, 既存 `test_preserves_explicit_direction` を `test_overwrites_inconsistent_direction` に差し替え (新しい契約: 「metric が direction の単一の真実」)。E2E `frontend/tests/e2e/workspace-tune.spec.ts` の fixture から `direction: "minimize"` ハードコードを削除し、`tune_result.direction === "maximize"` の assertion を追加。**Fix 5** (このエントリー)。**壊れた job 履歴**: 既存の `direction: minimize` で完了済みの binary + auc tune jobs は best_params が論理的に逆なので破棄推奨。マイグレーション script は不要、ユーザが手動 delete でよい。949 backend tests green, mypy / ruff clean。
+
+### H-0063: `POST /workspace/reset` がアクティブジョブを確実にキャンセルして slot を解放する
+- **Status:** accepted
+- **Scope:** API, Backend
+- **Related:** BLUEPRINT §5 Workspace API / §8 Jobs ライフサイクル, Issue #99
+- **Context:** 現状の `POST /workspace/reset` は `WorkspaceState` のみをクリアし、`JobStore._active_job_id` にはノータッチ。したがって前の fit / tune job がバックグラウンドで走っている状態で reset を押しても、次の fit / tune は `JOB_CONFLICT (409)` で弾かれる可能性がある。ユーザー期待値は「reset ボタンを押したら真っさらな状態から次の操作が始められる」であり、現在の挙動はそれを裏切っている。また E2E テスト側では PR #102 の `afterEach` baseline-diff ガードで workaround しており、そのガード自体が「reset は slot を touch しない」という暗黙の前提に依存している。
+- **Proposal:** `workspace_reset` エンドポイントの挙動を次のように拡張する。
+  1. `job_store.active_job_id` を取得し、非 None でかつ on-disk status が `running` / `pending` の場合に `job_store.request_cancel(active_id)` を呼ぶ。既存の cancel エンドポイント `POST /jobs/{id}/cancel` と同一経路なので、subprocess 経路は `subprocess_runner._poll_progress` が `is_cancel_requested` を検知して `proc.terminate()` → `run_job_in_subprocess.reconcile` で terminal 状態に遷移させる。in-process thread 経路は `_run_job_core` の cancel-aware callback が `CancelledError` を投げて finally で `release_active` を呼ぶ。
+  2. 上記の完了を同期的に短時間待機する: `_RESET_WAIT_TIMEOUT = 12.0s`（subprocess runner の `_WAIT_TIMEOUT = 10s` + buffer 2s）で `has_active_job()` が False になるまで polling（`_RESET_WAIT_INTERVAL = 0.05s`）。待機中に on-disk status が terminal に遷移した場合は runner finally を待たず直接 `force_release_active_if` を呼ぶ（crashed runner 対応）。
+  3. **Force-release on timeout:** タイムアウト内に解放されなかった場合、warn ログを残した上で `force_release_active_if(stuck_id)` で slot を強制解放する。Proposal 初稿では「warn だけ残して 409 は許容」としていたが、RED テストで runner が存在しない orphan slot ケースが露出したため、reset の約束（次の操作はクリーン状態から始められる）を守る方向に方針を強めた。`_RESET_WAIT_TIMEOUT` を subprocess の `_WAIT_TIMEOUT` より長く設定しているので、合法的な subprocess runner には `proc.terminate` + `proc.wait` + 自前の `release_active` まで完了する時間的余裕がある。それでもタイムアウトする場合は orphan slot と判断して差し支えない。
+  4. **Atomic compare-and-release:** force-release の root cause review で TOCTOU ホール（`active_job_id` 読み取り → 別スレッドが新 claim → `release_active` で新 claim を誤削除）を指摘されたため、`JobStore.force_release_active_if(expected_job_id)` を追加。`_active_lock` を保持した単一 critical section 内で compare-and-release を行うので、観測した id と実際の slot holder が一致した場合のみ release する。一致しない場合は no-op。
+  5. workspace state のクリアは 1. / 2. / 3. の **後**に実行する。データフレームやモデル参照が先にクリアされると、終了中の subprocess / thread が解放のタイミングで参照先を失ってクラッシュする余地がある。
+- **Impact:**
+  - `src/lizystudio/api/workspace.py::workspace_reset` — `job_store: JobStore = Depends(get_job_store)` を追加し、上記フローを実装。
+  - `src/lizystudio/services/jobs.py` — 変更なし（既存の `request_cancel` / `has_active_job` / `active_job_id` で十分）。
+  - `tests/regression/test_reg_NNNN_workspace_reset_releases_slot.py`（新規）— (a) active slot を持つ状態で reset を呼ぶと slot が解放される, (b) `request_cancel` が呼ばれる, (c) タイムアウト時も 200 を返して warn ログを残す, の 3 テストを追加。
+  - `frontend/tests/e2e/retune-flow.spec.ts` の `afterEach` baseline-diff ガードは **このPRでは残す**。ガードの撤去は別 PR（動作確認後）にする。
+- **Compatibility:** 非破壊的。既存クライアントから見ると「reset が少しだけ遅くなり、以前より多くの状態をクリアする」という拡張。reset のレスポンスボディは `{"status": "ok"}` で不変。
+- **Alternatives:**
+  1. **選択肢 A（却下）**: `workspace_reset` は現状維持で、新しい `POST /jobs/active/cancel` エンドポイントを追加する案。メリット: reset の影響範囲を変えず、セマンティクス分離が明確。デメリット: ユーザーが「reset」と「cancel active job」を区別して使いこなす必要があり、実際には「reset ボタンを押したのに次の Run が 409 になる」というユーザー期待値ギャップが残る。
+  2. **選択肢 B（却下）**: `JobStore` に heartbeat-based stale detection を追加し、`running` のまま一定時間経過したジョブを stale 扱いして slot を自動再取得する案。メリット: reset 以外の経路でも効く。デメリット: 正当な長時間 tune を誤検知する誤陽性リスクがあり、timeout 値のチューニングが難しい。本質的には root cause（reset が slot を触らない）を修正しないで症状を緩和するだけ。
+  3. **選択肢 C（採用、本提案）**: reset が active slot を同期的にキャンセルする。ユーザー期待値に最も近く、既存の cancel 経路を再利用するだけで実装リスクが低い。
+- **Acceptance Criteria:**
+  - (a) `POST /workspace/reset` 呼び出し前に active job が存在した場合、呼び出し後 `job_store.has_active_job()` は False を返す（タイムアウト内）。
+  - (b) active job に対して `request_cancel` が呼ばれたことが確認できる。
+  - (c) `_RESET_WAIT_TIMEOUT` 内に解放されなくても HTTP 200 を返し、サーバーログに warn を残す。
+  - (d) active job が無い通常ケースでは既存の挙動が変わらない。
+  - (e) 既存の `test_reg_0071` / `test_reg_0072` / retune-flow E2E が regression なく通る。
+- **Decision:** 2026-04-15 採択 (Phase B3)。Option 1 変種 C を採用。E2E workaround 撤去は本 PR 範囲外。

--- a/src/lizystudio/api/workspace.py
+++ b/src/lizystudio/api/workspace.py
@@ -6,7 +6,9 @@ Covers: status, reset, data, config, fit, tune.
 from __future__ import annotations
 
 import copy
+import logging
 import tempfile
+import time
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -71,6 +73,7 @@ from lizystudio.services.workspace import (
 from lizystudio.ws.progress import ProgressBroadcaster
 
 router = APIRouter()
+_log = logging.getLogger(__name__)
 
 
 # --- Status / Reset ---
@@ -100,9 +103,131 @@ def workspace_status(
     }
 
 
+# H-0063 / Issue #99: the reset wait must be long enough to let a
+# subprocess runner complete its cancel + proc.wait cycle. The
+# subprocess path uses ``_WAIT_TIMEOUT = 10s`` in
+# ``subprocess_runner.run_job_in_subprocess``, so we give the cancel
+# that much plus a small buffer before declaring the slot orphaned and
+# force-releasing. Without this margin, a reset during a legitimate
+# tune could force-release the slot seconds before the subprocess is
+# done tearing down, leaving a zombie child still writing to the
+# progress file while the parent has already accepted a new fit.
+_RESET_WAIT_TIMEOUT = 12.0
+_RESET_WAIT_INTERVAL = 0.05
+
+
 @router.post("/reset")
-def workspace_reset(ws: WorkspaceState = Depends(get_workspace)) -> dict[str, str]:
-    """Reset all workspace state."""
+def workspace_reset(
+    ws: WorkspaceState = Depends(get_workspace),
+    job_store: JobStore = Depends(get_job_store),
+) -> dict[str, str]:
+    """Reset all workspace state.
+
+    H-0063 / Issue #99: if a fit / tune is still running in the
+    background, reset must also cancel it and release the JobStore
+    active slot. Otherwise the next Fit / Tune click gets a
+    JOB_CONFLICT 409, directly contradicting the user's expectation
+    that "reset" yields a clean slate.
+
+    The cancel path mirrors the existing ``POST /jobs/{id}/cancel``
+    endpoint: we call ``request_cancel`` and rely on the runner (either
+    the in-process thread via ``_run_job_core``'s cancel-aware callback
+    or the subprocess via ``_poll_progress``'s cancel polling) to
+    transition the job to ``cancelled`` and release the slot from its
+    finally block. We then wait briefly for the slot to become free
+    so the caller can immediately start a new Fit / Tune without
+    racing the cancel.
+
+    Degraded paths we explicitly tolerate:
+
+    1. **Terminal holder (crashed runner finally)** — if the slot is
+       held but the job's on-disk status is already terminal, no one
+       will ever call ``release_active`` for it. We short-circuit by
+       calling ``force_release_active_if`` directly.
+    2. **No live runner (orphan slot)** — the slot may have been
+       claimed by a previous process / test / client that died
+       without draining the slot. The cancel flag lands in memory but
+       no runner observes it, so the wait loop would time out. In
+       that case we **force-release the slot** from reset itself.
+       Rationale: the user clicked reset expressly to clear state;
+       returning 200 with the slot still held would reintroduce the
+       exact ``JOB_CONFLICT`` regression this fix is trying to remove.
+       The wait budget (``_RESET_WAIT_TIMEOUT``) is deliberately set
+       longer than ``subprocess_runner._WAIT_TIMEOUT`` so that a
+       legitimate subprocess runner has time to finish its
+       ``proc.terminate`` / ``proc.wait`` cycle and call
+       ``release_active`` from its own finally, before we fall
+       through to the force-release branch. If we still time out,
+       the most plausible explanation is an orphaned slot with no
+       runner behind it, and force-releasing is strictly better than
+       leaving the user with a broken reset button.
+
+    The force-release uses ``force_release_active_if`` which is
+    atomic under ``JobStore._active_lock``: the slot is released only
+    if it still holds the exact id we observed, so a racy
+    ``create_and_claim_active`` from another thread between the
+    observation and the release cannot accidentally clear the new
+    owner's slot.
+
+    Workspace state is cleared AFTER the cancel + slot wait so the
+    shutting-down runner thread still sees live ``ws.dataframe`` /
+    ``ws.model`` references during its finally path.
+    """
+    active_id = job_store.active_job_id
+    if active_id is not None:
+        active_job = job_store.get(active_id)
+        is_terminal = active_job is not None and active_job.status in (
+            "completed",
+            "failed",
+            "cancelled",
+        )
+        if not is_terminal:
+            job_store.request_cancel(active_id)
+
+        deadline = time.monotonic() + _RESET_WAIT_TIMEOUT
+        released = False
+        while time.monotonic() < deadline:
+            if not job_store.has_active_job():
+                released = True
+                break
+            # Degraded path 1: the holder became terminal on disk
+            # without release_active being called (crashed runner
+            # finally block). Reclaim the slot atomically so we do
+            # not race a new claim from a parallel request.
+            current = job_store.active_job_id
+            if current is not None:
+                current_job = job_store.get(current)
+                if (
+                    current_job is not None
+                    and current_job.status
+                    in (
+                        "completed",
+                        "failed",
+                        "cancelled",
+                    )
+                    and job_store.force_release_active_if(current)
+                ):
+                    released = True
+                    break
+            time.sleep(_RESET_WAIT_INTERVAL)
+
+        if not released:
+            # Degraded path 2: no runner picked up the cancel within
+            # the budget. Force-release atomically to keep reset
+            # honest — the compare-and-release inside
+            # force_release_active_if guarantees we only clear the
+            # exact id we observed, never a new claim that landed in
+            # between.
+            stuck_id = job_store.active_job_id
+            if stuck_id is not None and job_store.force_release_active_if(stuck_id):
+                _log.warning(
+                    "workspace_reset: active slot %s did not release "
+                    "within %.2fs; force-released so the next fit / "
+                    "tune does not JOB_CONFLICT",
+                    stuck_id,
+                    _RESET_WAIT_TIMEOUT,
+                )
+
     ws.reset()
     return {"status": "ok"}
 

--- a/src/lizystudio/services/jobs.py
+++ b/src/lizystudio/services/jobs.py
@@ -448,6 +448,27 @@ class JobStore:
             if self._active_job_id == job_id:
                 self._active_job_id = None
 
+    def force_release_active_if(self, expected_job_id: str) -> bool:
+        """Atomically release the slot iff it is still held by *expected_job_id*.
+
+        H-0063: ``workspace_reset`` uses this to force-release a stuck
+        orphan slot after its cancel wait times out. The two-step
+        ``active_job_id`` read + ``release_active(active_id)`` dance is
+        racy — between the read and the release another thread could
+        claim the slot with a new job id, and the caller would end up
+        releasing someone else's slot. This helper keeps the compare
+        and the release under a single ``_active_lock`` critical
+        section so the operation either releases the exact id the
+        caller observed or is a no-op.
+
+        Returns True if the slot was released, False otherwise.
+        """
+        with self._active_lock:
+            if self._active_job_id == expected_job_id:
+                self._active_job_id = None
+                return True
+            return False
+
     def has_active_job(self) -> bool:
         """Check if a job is currently active (running or pending)."""
         with self._active_lock:

--- a/tests/regression/test_reg_0075_workspace_reset_releases_slot.py
+++ b/tests/regression/test_reg_0075_workspace_reset_releases_slot.py
@@ -1,0 +1,204 @@
+"""Regression test: ``POST /workspace/reset`` must free the active job slot.
+
+H-0063 / Issue #99: previously ``workspace_reset`` only cleared the
+``WorkspaceState`` and never touched ``JobStore._active_job_id``. A
+fit / tune that was still running from a previous session remained in
+the slot, so the next click on Fit / Tune got a 409 JOB_CONFLICT —
+directly contradicting the user's expectation that "reset" yields a
+clean slate.
+
+This test locks the fix contract:
+
+1. If an active job is present when reset is invoked, the reset must
+   cancel it (via ``request_cancel`` — the same path as the existing
+   ``POST /jobs/{id}/cancel`` endpoint) before returning.
+2. The slot must be empty after the call, within a short timeout.
+3. The endpoint must still return 200 even if the cancel does not land
+   before the timeout (degraded but forward-progress semantics — the
+   next fit / tune may still 409 once, which frontend clients already
+   handle).
+4. The no-active-job path must be unaffected so existing callers that
+   reset an idle workspace see identical behaviour.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from lizystudio.backends.types import DataRef
+from lizystudio.services.jobs import JobStore
+
+pytestmark = pytest.mark.unit
+
+
+def _get_job_store(client: TestClient) -> JobStore:
+    """Pull the app's live JobStore from FastAPI state."""
+    store = client.app.state.job_store  # type: ignore[attr-defined]
+    assert isinstance(store, JobStore)
+    return store
+
+
+def _seed_running_active_job(store: JobStore) -> str:
+    """Create a job, flip its disk status to ``running``, claim the slot.
+
+    Mirrors the shape of `_seed_running_holder` from
+    ``test_workspace_coverage.py`` — a real job directory on disk so
+    the JobStore's stale-slot auto-reclaim does not treat it as
+    terminal and release the slot prematurely.
+    """
+    data_ref = DataRef(
+        source_type="path",
+        path="/tmp/dummy.csv",
+        filename="dummy.csv",
+        fingerprint="abc",
+        shape=(10, 2),
+    )
+    job = store.create(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=data_ref,
+        job_type="fit",
+    )
+    job.status = "running"
+    store.update(job)
+    assert store.claim_active(job.job_id), "baseline precondition: slot free"
+    return job.job_id
+
+
+def test_reset_without_active_job_is_noop_for_slot(client: TestClient) -> None:
+    """Existing happy path: reset on an idle workspace behaves exactly as
+    before — slot stays empty, response is 200, no cancel side effects.
+    """
+    store = _get_job_store(client)
+    assert store.active_job_id is None
+
+    res = client.post("/api/workspace/reset")
+
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok"}
+    assert store.active_job_id is None
+
+
+def test_reset_cancels_and_releases_active_job(client: TestClient) -> None:
+    """The core fix. A running job holds the slot; reset must cancel it
+    and the slot must be empty afterwards.
+    """
+    store = _get_job_store(client)
+    job_id = _seed_running_active_job(store)
+    assert store.active_job_id == job_id
+    assert store.has_active_job()
+    assert not store.is_cancel_requested(job_id)
+
+    res = client.post("/api/workspace/reset")
+
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok"}
+    # The cancel flag must have been set. The real runner thread (which
+    # is not present in this unit test) is what would drain the slot
+    # normally, so the implementation must also release the slot
+    # directly when it observes that there is no live runner — see
+    # H-0063 for the degraded-path semantics.
+    assert store.is_cancel_requested(job_id) or not store.has_active_job(), (
+        "reset must either request cancel (live runner drains slot) or "
+        "directly release the slot (no runner present)"
+    )
+    assert not store.has_active_job(), (
+        "after reset completes, the active slot must be empty so a "
+        "subsequent fit / tune does not 409"
+    )
+
+
+def test_reset_with_completed_slot_holder_releases_slot(
+    client: TestClient,
+) -> None:
+    """Degraded / stale path: the slot holder is already terminal on disk
+    (e.g. the runner crashed before calling ``release_active``). Reset
+    must still free the slot rather than leaving the stale id behind.
+    """
+    store = _get_job_store(client)
+    data_ref = DataRef(
+        source_type="path",
+        path="/tmp/dummy.csv",
+        filename="dummy.csv",
+        fingerprint="abc",
+        shape=(10, 2),
+    )
+    job = store.create(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=data_ref,
+        job_type="fit",
+    )
+    # Deliberately set the on-disk status to ``completed`` but keep the
+    # slot claimed — this is exactly the leak shape PR #96 / #97 fixed
+    # in the runner finally, so it should not happen in the happy path,
+    # but reset must be robust against it.
+    job.status = "completed"
+    store.update(job)
+    store.claim_active(job.job_id)
+    assert store.has_active_job()
+
+    res = client.post("/api/workspace/reset")
+
+    assert res.status_code == 200
+    assert not store.has_active_job()
+
+
+def test_force_release_active_if_atomic_compare_and_release(
+    client: TestClient,
+) -> None:
+    """Unit guard for ``JobStore.force_release_active_if``.
+
+    The reset flow relies on this helper to avoid the TOCTOU hole
+    where a naive ``active_job_id`` read + ``release_active`` could
+    release a new claim that landed between the two steps. The
+    helper must release only the exact id the caller observed, and
+    no-op if the slot has been re-claimed by someone else in the
+    meantime.
+    """
+    store = _get_job_store(client)
+    first = _seed_running_active_job(store)
+    assert store.active_job_id == first
+
+    # Simulate the race: a concurrent writer re-claims the slot
+    # with a different id in between our observation and release.
+    store.release_active(first)
+    second = _seed_running_active_job(store)
+    assert store.active_job_id == second
+
+    # Force-releasing the OLD observed id must no-op — the slot
+    # belongs to a different job now.
+    released = store.force_release_active_if(first)
+    assert released is False
+    assert store.active_job_id == second
+
+    # Force-releasing the CURRENT id succeeds exactly once.
+    released = store.force_release_active_if(second)
+    assert released is True
+    assert store.active_job_id is None
+
+    # A second attempt is a safe no-op, not a crash.
+    released = store.force_release_active_if(second)
+    assert released is False
+
+
+def test_reset_preserves_jobs_on_disk(client: TestClient, tmp_path: Path) -> None:
+    """Reset clears workspace state and releases the slot, but the
+    historical job directory must survive — the Jobs page and lineage
+    features still rely on it.
+    """
+    store = _get_job_store(client)
+    job_id = _seed_running_active_job(store)
+    job_dir = store.jobs_dir / job_id
+    assert job_dir.exists()
+
+    res = client.post("/api/workspace/reset")
+
+    assert res.status_code == 200
+    assert job_dir.exists(), (
+        "reset must not delete job directories; only the active-slot "
+        "pointer and workspace state are cleared"
+    )


### PR DESCRIPTION
## Summary

Closes #99 (H-0063). `POST /workspace/reset` now cancels any active fit / tune job and frees the JobStore active slot before returning, so the next Fit / Tune click starts from a clean slate instead of hitting a 409 JOB_CONFLICT.

Before this PR, reset cleared `WorkspaceState` but left `JobStore._active_job_id` pointing at whatever background runner the previous session had started. Users clicked the reset button, immediately clicked Fit, and got rejected — directly contradicting the reset button's mental model.

This is also the root cause the `retune-flow.spec.ts` baseline-diff `afterEach` guard (from PR #102) works around. That workaround is **intentionally left in place** in this PR; a follow-up will remove it once this fix has baked on develop.

## Changes

### `src/lizystudio/api/workspace.py`
- `workspace_reset` now takes `job_store: JobStore = Depends(get_job_store)`.
- If the slot is occupied:
  1. If the on-disk status is not already terminal, call `request_cancel(active_id)` — same path as the existing `POST /jobs/{id}/cancel` endpoint.
  2. Poll `has_active_job()` every 50 ms for up to **12.0 s** (`_RESET_WAIT_TIMEOUT`). This is deliberately **longer than** `subprocess_runner._WAIT_TIMEOUT = 10 s` so a legitimate subprocess runner has time to finish `proc.terminate` → `proc.wait` → its own `release_active` before we give up.
  3. During the wait, if the slot holder's on-disk status turns terminal (the crashed-runner-finally case), reclaim the slot directly via the new atomic helper.
  4. If the budget is exhausted, **force-release** the slot with a warn log. Better to let the user proceed than to keep them staring at a reset button that does not reset.
- `ws.reset()` runs **after** the slot wait so a runner's finally block still sees live `ws.dataframe` / `ws.model` references during its teardown path.
- `logging` / `time` imports hoisted to module scope; `_log` is module-level.

### `src/lizystudio/services/jobs.py`
- New `JobStore.force_release_active_if(expected_job_id) -> bool`: atomic compare-and-release under `_active_lock`. Releases the slot only if it still holds the exact id the caller observed, no-op otherwise. Closes the TOCTOU window in the previous two-step "read `active_job_id`, call `release_active`" pattern where a racy concurrent claim could end up getting its slot cleared by the reset code path.

### `HISTORY.md`
- New **H-0063 proposal** block documenting:
  - The three options considered (reset cancels, dedicated cancel-active endpoint, heartbeat stale detection).
  - Why Option 1 was chosen.
  - The mid-implementation shift from "warn and accept 409" to "force-release", triggered by the orphan-slot case surfacing during RED.
  - Compatibility note (non-breaking, response body unchanged).
  - Acceptance criteria.

### `tests/regression/test_reg_0075_workspace_reset_releases_slot.py` (new, 5 tests)
- `test_reset_without_active_job_is_noop_for_slot` — idle happy path unchanged.
- `test_reset_cancels_and_releases_active_job` — core fix: seeds a running job in the slot, reset must free it.
- `test_reset_with_completed_slot_holder_releases_slot` — crashed-runner case: on-disk status already terminal but slot still claimed.
- `test_force_release_active_if_atomic_compare_and_release` — unit guard on the new `JobStore` helper: simulates a concurrent re-claim between observation and release and asserts the old-id force-release is a no-op while the current-id release succeeds exactly once.
- `test_reset_preserves_jobs_on_disk` — reset must not delete job directories, only clear the active pointer.

## Code review

Python reviewer flagged two HIGH and one MEDIUM, all addressed in the final version:

- **HIGH — force-release vs subprocess runner race.** Addressed by bumping `_RESET_WAIT_TIMEOUT` to 12s (above the 10s subprocess `_WAIT_TIMEOUT`) and updating the docstring to explain the budget reasoning.
- **HIGH — TOCTOU on `active_job_id` read.** Addressed by introducing `JobStore.force_release_active_if` and using it in both the terminal-holder short-circuit and the timeout branches.
- **MEDIUM — function-scope imports.** Addressed by hoisting `logging` and `time` to module level.

## Test plan

- [x] `uv run pytest tests/regression/test_reg_0075_workspace_reset_releases_slot.py` — **5 passed** (test 2 takes 12s due to the timeout budget).
- [x] Verified RED before the fix (2 of 4 tests failed; a third failure surfaced mid-GREEN and triggered the force-release semantics decision).
- [x] `uv run pytest tests/test_workspace_coverage.py tests/test_subprocess_runner.py tests/regression/` — 88 passed, no regressions in the existing workspace / subprocess / H-0062 coverage.
- [x] `uv run pytest` (full suite) — **999 passed**.
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` — all clean.

## Out of scope

- **Removing the E2E `afterEach` baseline-diff guard from `retune-flow.spec.ts`.** That belongs in a separate PR after this one merges — the guard is currently the last line of defense against future fire-and-forget regressions, and removing it in the same PR makes rollback harder.
- **Heartbeat-based stale slot detection** (Option 2 in H-0063). The reset-time clear is sufficient for the user-facing problem; a background heartbeat is a larger design change with its own timeout-tuning headaches.
- **Dedicated `POST /jobs/active/cancel` endpoint** (Option 3). Available later if we want to expose cancel independently of reset; not needed for the Issue #99 fix.
