### PR TITLE
fix(workspace): eliminate transient target-selection validation errors (Issue #107)

### DIFF
--- a/frontend/src/components/workspace/DataPanel.test.tsx
+++ b/frontend/src/components/workspace/DataPanel.test.tsx
@@ -1,12 +1,7 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { renderWithQuery as render } from "@/test/helpers";
 
 const mockLoadDataFromPath = vi.fn();
 const mockUploadData = vi.fn();
@@ -1283,18 +1278,18 @@ describe("DataPanel — syncConfig AbortController", () => {
     vi.clearAllMocks();
   });
 
+  // Issue #107: after handleTargetChange completes, useDataPanel now
+  // pre-seeds prevSyncKey with the post-change state so the
+  // target/task/overrides/cv effect does not re-fire syncConfig for an
+  // identical body. These tests therefore trigger syncConfig via a
+  // subsequent column exclude toggle (which legitimately changes
+  // overrides) instead of the target selection itself.
+
   it("does not call onDataChanged when request is aborted mid-flight", async () => {
-    // Simulate a slow fetchConfig that gets aborted
-    let rejectFn!: (reason: unknown) => void;
-    mockFetchConfig.mockImplementation(
-      ({ signal }: { signal?: AbortSignal }) =>
-        new Promise((_, reject) => {
-          rejectFn = reject;
-          signal?.addEventListener("abort", () => {
-            reject(new DOMException("Aborted", "AbortError"));
-          });
-        }),
-    );
+    // handleTargetChange's inlined updateConfig should succeed so we reach
+    // the post-target state where the column grid is mounted. The slow
+    // fetchConfig mock governs the *follow-up* syncConfig triggered by
+    // toggling a column exclude.
     mockFetchConfigDefaults.mockResolvedValue({
       task: "binary",
       data: {},
@@ -1302,19 +1297,42 @@ describe("DataPanel — syncConfig AbortController", () => {
       split: {},
     });
     mockUpdateConfig.mockResolvedValue({ config: {}, errors: [] });
-
-    const onDataChanged = vi.fn();
-    render(<DataPanel onDataChanged={onDataChanged} />);
-    await loadDataViaPath();
-
-    mockFetchColumns.mockClear();
     mockFetchColumns.mockResolvedValue({
       columns: COLUMNS_BINARY,
       suggested_task: "binary",
       target: "target",
     });
 
+    const onDataChanged = vi.fn();
+    render(<DataPanel onDataChanged={onDataChanged} />);
+    await loadDataViaPath();
+
     await selectTarget("target");
+
+    // Let handleTargetChange complete and the column grid render.
+    await waitFor(() => {
+      expect(screen.getByTestId("column-row-age")).toBeInTheDocument();
+    });
+
+    // Now arm fetchConfig as a slow, abortable request that will govern
+    // the follow-up syncConfig triggered by the exclude toggle below.
+    let rejectFn!: (reason: unknown) => void;
+    mockFetchConfig.mockImplementation(
+      ({ signal }: { signal?: AbortSignal } = {}) =>
+        new Promise((_, reject) => {
+          rejectFn = reject;
+          signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    );
+    const callsBeforeToggle = onDataChanged.mock.calls.length;
+
+    // Toggle an exclude checkbox — this changes overrides, which the
+    // target/task/overrides/cv effect observes and dispatches syncConfig.
+    const ageRow = screen.getByTestId("column-row-age");
+    const checkbox = ageRow.querySelector('[role="checkbox"]') as HTMLElement;
+    await userEvent.click(checkbox);
 
     // Wait for syncConfig to start
     await waitFor(() => {
@@ -1324,18 +1342,14 @@ describe("DataPanel — syncConfig AbortController", () => {
     // Abort the in-flight request
     rejectFn(new DOMException("Aborted", "AbortError"));
 
-    // onDataChanged should not be called from the aborted sync
+    // onDataChanged should not be called from the aborted sync.
     await new Promise((r) => setTimeout(r, 50));
-    // Only calls from the initial load path, not from the aborted sync
-    const callCount = onDataChanged.mock.calls.length;
-
-    // Re-verify: no extra onDataChanged calls after abort
-    await new Promise((r) => setTimeout(r, 50));
-    expect(onDataChanged.mock.calls.length).toBe(callCount);
+    expect(onDataChanged.mock.calls.length).toBe(callsBeforeToggle);
   });
 
   it("shows error toast when syncConfig encounters a non-abort error", async () => {
-    mockFetchConfig.mockRejectedValue(new Error("network error"));
+    // Same rationale: trigger syncConfig via a column exclude toggle so
+    // the post-Issue-#107 prevSyncKey pre-seed does not prevent it.
     mockFetchConfigDefaults.mockResolvedValue({
       task: "binary",
       data: {},
@@ -1343,19 +1357,29 @@ describe("DataPanel — syncConfig AbortController", () => {
       split: {},
     });
     mockUpdateConfig.mockResolvedValue({ config: {}, errors: [] });
-    const { toast } = await import("sonner");
-
-    render(<DataPanel onDataChanged={vi.fn()} />);
-    await loadDataViaPath();
-
-    mockFetchColumns.mockClear();
     mockFetchColumns.mockResolvedValue({
       columns: COLUMNS_BINARY,
       suggested_task: "binary",
       target: "target",
     });
+    const { toast } = await import("sonner");
+
+    render(<DataPanel onDataChanged={vi.fn()} />);
+    await loadDataViaPath();
 
     await selectTarget("target");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("column-row-age")).toBeInTheDocument();
+    });
+
+    // Now arm fetchConfig to reject with a non-abort error for the
+    // follow-up syncConfig.
+    mockFetchConfig.mockRejectedValue(new Error("network error"));
+
+    const ageRow = screen.getByTestId("column-row-age");
+    const checkbox = ageRow.querySelector('[role="checkbox"]') as HTMLElement;
+    await userEvent.click(checkbox);
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(

--- a/frontend/src/components/workspace/ModelPanel.test.tsx
+++ b/frontend/src/components/workspace/ModelPanel.test.tsx
@@ -1066,4 +1066,87 @@ describe("ModelPanel", () => {
     );
     expect(screen.getByText("A job is currently running")).toBeInTheDocument();
   });
+
+  // --- Issue #107: deep-equal guard in handleConfigChange ---
+
+  it("skips handleConfigChange PUT when newConfig equals the cached config", async () => {
+    // Regression guard for Issue #107. When useDataPanel.handleTargetChange
+    // broadcasts the merged config into the query cache, ConfigForm's
+    // task/metric auto-select effect may re-fire with an identical config
+    // body. Without a deep-equal guard, this would produce a duplicate
+    // updateConfig PUT and a debounced validate roundtrip, briefly
+    // re-surfacing the transient 'Field required' validation error.
+    const { fetchConfig, updateConfig: mockUpdate } = await import(
+      "@/api/workspace"
+    );
+    const cachedConfig = { model: { name: "lgbm", params: {} } };
+    (fetchConfig as ReturnType<typeof vi.fn>).mockResolvedValue(cachedConfig);
+    (mockUpdate as ReturnType<typeof vi.fn>).mockClear();
+    captured.onChange = null;
+
+    renderWithQuery(
+      <ModelPanel
+        hasData={true}
+        task="binary"
+        onFit={vi.fn()}
+        onTune={vi.fn()}
+        running={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(captured.onChange).not.toBeNull();
+    });
+    const onChange = captured.onChange;
+    if (!onChange) throw new Error("ConfigForm onChange not captured");
+
+    // Emit an onChange with a body that is deep-equal to the cached config.
+    onChange({ model: { name: "lgbm", params: {} } });
+
+    // Give the promise chain a tick to settle.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // updateConfig must NOT have been called: the deep-equal guard should
+    // short-circuit the PUT and the debounced validate.
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("still PUTs when newConfig differs from the cached config", async () => {
+    // Dual guard: make sure the deep-equal short-circuit does not block
+    // legitimate config edits. A changed model name must still trigger
+    // updateConfig.
+    const { fetchConfig, updateConfig: mockUpdate } = await import(
+      "@/api/workspace"
+    );
+    (fetchConfig as ReturnType<typeof vi.fn>).mockResolvedValue({
+      model: { name: "lgbm", params: {} },
+    });
+    (mockUpdate as ReturnType<typeof vi.fn>).mockClear();
+    (mockUpdate as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    captured.onChange = null;
+
+    renderWithQuery(
+      <ModelPanel
+        hasData={true}
+        task="binary"
+        onFit={vi.fn()}
+        onTune={vi.fn()}
+        running={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(captured.onChange).not.toBeNull();
+    });
+    const onChange = captured.onChange;
+    if (!onChange) throw new Error("ConfigForm onChange not captured");
+
+    onChange({ model: { name: "xgb", params: {} } });
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith({
+        model: { name: "xgb", params: {} },
+      });
+    });
+  });
 });

--- a/frontend/src/components/workspace/ModelPanel.test.tsx
+++ b/frontend/src/components/workspace/ModelPanel.test.tsx
@@ -1097,11 +1097,8 @@ describe("ModelPanel", () => {
     await waitFor(() => {
       expect(captured.onChange).not.toBeNull();
     });
-    const onChange = captured.onChange;
-    if (!onChange) throw new Error("ConfigForm onChange not captured");
-
-    // Emit an onChange with a body that is deep-equal to the cached config.
-    onChange({ model: { name: "lgbm", params: {} } });
+    // biome-ignore lint/style/noNonNullAssertion: guaranteed non-null by the waitFor above; matches sibling handleConfigChange tests in this file.
+    captured.onChange!({ model: { name: "lgbm", params: {} } });
 
     // Give the promise chain a tick to settle.
     await new Promise((r) => setTimeout(r, 50));
@@ -1138,10 +1135,8 @@ describe("ModelPanel", () => {
     await waitFor(() => {
       expect(captured.onChange).not.toBeNull();
     });
-    const onChange = captured.onChange;
-    if (!onChange) throw new Error("ConfigForm onChange not captured");
-
-    onChange({ model: { name: "xgb", params: {} } });
+    // biome-ignore lint/style/noNonNullAssertion: guaranteed non-null by the waitFor above; matches sibling handleConfigChange tests in this file.
+    captured.onChange!({ model: { name: "xgb", params: {} } });
 
     await waitFor(() => {
       expect(mockUpdate).toHaveBeenCalledWith({

--- a/frontend/src/components/workspace/ModelPanel.tsx
+++ b/frontend/src/components/workspace/ModelPanel.tsx
@@ -121,6 +121,21 @@ export function ModelPanel({
   const handleConfigChange = useCallback(
     async (newConfig: Record<string, unknown>) => {
       if (running) return;
+      // Issue #107: deep-equal guard against duplicate PUTs. When
+      // useDataPanel.handleTargetChange broadcasts the merged config into
+      // the query cache, ConfigForm's task/metric auto-select effect can
+      // re-fire with an identical body on the next render. Without this
+      // guard the duplicate PUT races the upstream flow and briefly
+      // resurfaces the transient 'Field required' validation error the
+      // broadcast was meant to prevent. JSON.stringify is sufficient here
+      // because the config shape is a plain JSON object produced by
+      // setNestedValue, so key order is stable.
+      const cached = queryClient.getQueryData<Record<string, unknown>>([
+        "config",
+      ]);
+      if (cached && JSON.stringify(cached) === JSON.stringify(newConfig)) {
+        return;
+      }
       try {
         await updateConfig(newConfig);
         queryClient.setQueryData(["config"], newConfig);

--- a/frontend/src/hooks/useDataPanel.test.ts
+++ b/frontend/src/hooks/useDataPanel.test.ts
@@ -1,4 +1,6 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ColumnInfo, ColumnsResponse } from "@/api/types";
 
@@ -64,6 +66,18 @@ const COLS_OK: ColumnsResponse = {
   ],
 };
 
+function createWrapper(): {
+  wrapper: ({ children }: { children: ReactNode }) => ReactNode;
+  queryClient: QueryClient;
+} {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { wrapper, queryClient };
+}
+
 describe("useDataPanel", () => {
   beforeEach(() => {
     for (const m of Object.values(mocks)) m.mockReset?.();
@@ -80,8 +94,10 @@ describe("useDataPanel", () => {
 
     const onDataChanged = vi.fn();
     const onTaskChanged = vi.fn();
-    const { result } = renderHook(() =>
-      useDataPanel({ onDataChanged, onTaskChanged }),
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useDataPanel({ onDataChanged, onTaskChanged }),
+      { wrapper },
     );
 
     await act(async () => {
@@ -100,8 +116,10 @@ describe("useDataPanel", () => {
   it("loadDataFromPath reverts loading to false and shows toast on failure", async () => {
     mocks.loadDataFromPath.mockRejectedValue(new Error("path not found"));
 
-    const { result } = renderHook(() =>
-      useDataPanel({ onDataChanged: vi.fn() }),
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useDataPanel({ onDataChanged: vi.fn() }),
+      { wrapper },
     );
 
     await act(async () => {
@@ -116,8 +134,10 @@ describe("useDataPanel", () => {
   });
 
   it("loadDataFromPath skips empty input silently", async () => {
-    const { result } = renderHook(() =>
-      useDataPanel({ onDataChanged: vi.fn() }),
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useDataPanel({ onDataChanged: vi.fn() }),
+      { wrapper },
     );
 
     await act(async () => {
@@ -133,8 +153,10 @@ describe("useDataPanel", () => {
   it("uploadData error keeps loading=false", async () => {
     mocks.uploadData.mockRejectedValue(new Error("too large"));
 
-    const { result } = renderHook(() =>
-      useDataPanel({ onDataChanged: vi.fn() }),
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useDataPanel({ onDataChanged: vi.fn() }),
+      { wrapper },
     );
 
     const file = new File(["a,b\n1,2"], "x.csv", { type: "text/csv" });
@@ -164,8 +186,10 @@ describe("useDataPanel", () => {
       value_counts: [{ value: "1", count: 50 }],
     }));
 
-    const { result } = renderHook(() =>
-      useDataPanel({ onDataChanged: vi.fn() }),
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useDataPanel({ onDataChanged: vi.fn() }),
+      { wrapper },
     );
 
     await act(async () => {
@@ -194,8 +218,10 @@ describe("useDataPanel", () => {
     // marker for HIGH-1.
     mocks.fetchColumnStats.mockRejectedValue(new Error("stats unavailable"));
 
-    const { result } = renderHook(() =>
-      useDataPanel({ onDataChanged: vi.fn() }),
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useDataPanel({ onDataChanged: vi.fn() }),
+      { wrapper },
     );
 
     await act(async () => {
@@ -208,5 +234,57 @@ describe("useDataPanel", () => {
     );
     // colStats[a] must remain undefined so later code can branch correctly.
     expect(result.current.colStats.a).toBeUndefined();
+  });
+
+  // --- Issue #107: handleTargetChange broadcasts merged config ---
+
+  it("handleTargetChange seeds the 'config' query cache with the merged config", async () => {
+    // Regression guard for Issue #107. When target selection completes,
+    // the merged defaults-backed config must be written into the React
+    // Query cache so ModelPanel's useQuery(['config']) sees the full
+    // config immediately. Without this, any ConfigForm effect that fires
+    // on task change can PUT a partial config derived from an empty
+    // cached value, producing transient "Field required" validation
+    // errors from the Pydantic validator on the server.
+    mocks.fetchColumns.mockResolvedValue(COLS_OK);
+    mocks.fetchConfigDefaults.mockResolvedValue({
+      config_version: 1,
+      task: "binary",
+      data: { path: null, target: null },
+      features: { categorical: [], exclude: [] },
+      split: { method: "kfold", n_splits: 5 },
+      model: { name: "lgbm", params: {} },
+    });
+
+    const { wrapper, queryClient } = createWrapper();
+    const { result } = renderHook(
+      () =>
+        useDataPanel({
+          onDataChanged: vi.fn(),
+          onTaskChanged: vi.fn(),
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.handleTargetChange("a");
+    });
+
+    // updateConfig must have been called exactly once with a fully
+    // validatable config.
+    expect(mocks.updateConfig).toHaveBeenCalledTimes(1);
+    const merged = mocks.updateConfig.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(merged.config_version).toBe(1);
+    expect(merged.task).toBe("binary");
+    expect(merged.data).toMatchObject({ target: "a" });
+
+    // The merged config must be present in the query cache so the
+    // ModelPanel-side useQuery(['config']) consumer sees it without
+    // waiting for a refetch.
+    const cached = queryClient.getQueryData(["config"]);
+    expect(cached).toEqual(merged);
   });
 });

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { getErrorMessage } from "@/api/errors";
@@ -45,6 +46,7 @@ export function useDataPanel({
   onTaskChanged,
   uiSchema: _uiSchema,
 }: UseDataPanelParams) {
+  const queryClient = useQueryClient();
   const [sourceType, setSourceType] = useState<SourceType>("upload");
   const [dataPath, setDataPath] = useState("");
   const [shape, setShape] = useState<[number, number] | null>(null);
@@ -277,6 +279,27 @@ export function useDataPanel({
             },
           };
           await updateConfig(merged);
+          // Issue #107: broadcast the merged config into the shared query
+          // cache so ModelPanel's useQuery(['config']) consumer observes the
+          // fully-defaulted config immediately. Without this, any ConfigForm
+          // effect that fires on task change during the transition would
+          // PUT a partial config derived from a stale cached value, and the
+          // ModelPanel error list would transiently show
+          // 'config_version / task / split / model: Field required'.
+          queryClient.setQueryData(["config"], merged);
+          // Issue #107: pre-seed prevSyncKey with the post-handleTargetChange
+          // state key so the target/task/overrides/cv effect that fires when
+          // skipNextSyncRef is released does not re-PUT the same config via
+          // syncConfig. Without this, the effect sees a new key (because
+          // task/overrides/cv all just changed) and fires a second PUT with
+          // an equivalent body.
+          prevSyncKey.current = JSON.stringify({
+            target: value,
+            task: detectedTask,
+            overrides: newOverrides,
+            cv: resetCvState(detectedStrategy),
+            blocked,
+          });
           onDataChanged();
         }
       } catch (err) {
@@ -287,7 +310,7 @@ export function useDataPanel({
         skipNextSyncRef.current = false;
       }
     },
-    [task, cv, dataPath, onDataChanged, onTaskChanged],
+    [task, cv, dataPath, blocked, onDataChanged, onTaskChanged, queryClient],
   );
 
   const handleTaskChange = (newTask: TaskType) => {

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -35,6 +35,23 @@ export interface ColumnOverride {
   type: "numeric" | "categorical";
 }
 
+// Issue #107: key used by the target/task/overrides/cv effect to de-dup
+// syncConfig runs AND by handleTargetChange to pre-seed that de-dup after
+// a target-selection flow completes. Both sites MUST produce byte-identical
+// strings for the same logical state — otherwise the effect fires a
+// redundant syncConfig immediately after skipNextSyncRef is released,
+// which race-PUTs the same config and re-surfaces Issue #107. Keeping the
+// key construction in one place prevents that drift.
+function buildSyncKey(
+  target: string | null,
+  task: TaskType | null,
+  overrides: Record<string, ColumnOverride>,
+  cv: CvState,
+  blocked: BlockedGroupKFoldState,
+): string {
+  return JSON.stringify({ target, task, overrides, cv, blocked });
+}
+
 interface UseDataPanelParams {
   onDataChanged: () => void;
   onTaskChanged?: (task: string | null) => void;
@@ -154,7 +171,7 @@ export function useDataPanel({
   const prevSyncKey = useRef("");
   useEffect(() => {
     if (!target) return;
-    const key = JSON.stringify({ target, task, overrides, cv, blocked });
+    const key = buildSyncKey(target, task, overrides, cv, blocked);
     if (key === prevSyncKey.current) return;
     prevSyncKey.current = key;
     // H-0063: suppress syncConfig while handleTargetChange is assembling the
@@ -234,13 +251,20 @@ export function useDataPanel({
 
         let detectedTask: TaskType | null = task;
         let detectedStrategy = cv.strategy;
+        // Issue #107: mirror the cv state update here so buildSyncKey at
+        // the end of this function can use the same post-change cv value
+        // the effect will observe on its next run. If cols.suggested_task
+        // is absent, cv is not updated and nextCv stays as the current
+        // closure value — the effect will also see that same value.
+        let nextCv = cv;
         if (cols.suggested_task) {
           const t = cols.suggested_task as TaskType;
           detectedTask = t;
           setTask(t);
           onTaskChanged?.(t);
           detectedStrategy = getDefaultCvStrategy(t);
-          setCv(resetCvState(detectedStrategy));
+          nextCv = resetCvState(detectedStrategy);
+          setCv(nextCv);
         }
 
         const newOverrides: Record<string, ColumnOverride> = {};
@@ -290,16 +314,15 @@ export function useDataPanel({
           // Issue #107: pre-seed prevSyncKey with the post-handleTargetChange
           // state key so the target/task/overrides/cv effect that fires when
           // skipNextSyncRef is released does not re-PUT the same config via
-          // syncConfig. Without this, the effect sees a new key (because
-          // task/overrides/cv all just changed) and fires a second PUT with
-          // an equivalent body.
-          prevSyncKey.current = JSON.stringify({
-            target: value,
-            task: detectedTask,
-            overrides: newOverrides,
-            cv: resetCvState(detectedStrategy),
+          // syncConfig. Both sites share buildSyncKey so the two key
+          // constructions cannot drift.
+          prevSyncKey.current = buildSyncKey(
+            value,
+            detectedTask,
+            newOverrides,
+            nextCv,
             blocked,
-          });
+          );
           onDataChanged();
         }
       } catch (err) {


### PR DESCRIPTION
## Summary

Closes #107.

Fixes the transient `config_version / task / split / model: Field required` validation errors that flashed in the ModelPanel error list during Target selection. H-0063 suppressed one class of race but three remaining defects combined to resurface the same symptom.

## Root cause (three overlapping races)

1. **Missing query cache broadcast**
   `useDataPanel.handleTargetChange` called `updateConfig(merged)` but never wrote `merged` into the React Query cache. `ModelPanel`'s `useQuery(['config'])` kept serving the pre-target value until the next refetch landed, so anything running during the transition saw a stale config.

2. **prevSyncKey drift after skipNextSyncRef release**
   The target/task/overrides/cv effect released `skipNextSyncRef` in `finally`, then re-fired `syncConfig` on the next render because `task`, `overrides`, and `cv` had all just changed — a new composite key that missed the de-dup. The duplicate PUT carried an equivalent body but raced the ModelPanel validation path and briefly exposed the same partial-config error the H-0063 guard was meant to prevent.

3. **ConfigForm task/metric effect feeding duplicates**
   `ConfigForm.tsx` has two effects that re-auto-select `objective` / `metric` on every `task` change. When those fired immediately after target selection, they emitted `onChange` with a body deep-equal to the now-broadcast cached config, and `ModelPanel.handleConfigChange` happily PUT it through again.

## Fix

Three complementary changes that each close one of the races:

- **`useDataPanel.handleTargetChange`**: after `updateConfig(merged)` succeeds, write `merged` into `queryClient.setQueryData(['config'], merged)` AND pre-seed `prevSyncKey.current` with the post-change state key. The effect's existing de-dup now short-circuits the redundant `syncConfig` that used to race the release of `skipNextSyncRef`.
- **`ModelPanel.handleConfigChange`**: add a `JSON.stringify` deep-equal guard against the cached config. Duplicate bodies short-circuit before the PUT and the debounced `validateConfig`, so no transient errors can surface from this path even if a downstream effect emits a redundant `onChange`.
- **`useDataPanel`**: injects `useQueryClient()` to own the broadcast.

## Test plan

- [x] **New unit test**: `useDataPanel.test.ts` — `handleTargetChange seeds the 'config' query cache with the merged config`. Asserts `updateConfig` is called exactly once AND the merged config is present in `queryClient.getQueryData(['config'])` immediately afterwards.
- [x] **New unit test**: `ModelPanel.test.tsx` — `skips handleConfigChange PUT when newConfig equals the cached config`. Emits an `onChange` with a body deep-equal to the cached config and asserts `updateConfig` is NOT called.
- [x] **New unit test**: `ModelPanel.test.tsx` — `still PUTs when newConfig differs from the cached config`. Dual guard: verifies the deep-equal short-circuit does not block legitimate edits (e.g. model name change).
- [x] **Adjusted**: `DataPanel.test.tsx` two `syncConfig AbortController` tests. These previously relied on target selection to fire `syncConfig`. With the pre-seeded `prevSyncKey`, that path no longer re-fires `syncConfig`, so the tests now trigger `syncConfig` via a legitimate column exclude checkbox toggle (changing `overrides`). The abort / error assertions are preserved unchanged.
- [x] `pnpm vitest run` — **93 files, 1294 passed, 2 skipped, 0 errors** (previous baseline: 1291 → 1294 after adding three new tests).
- [x] `pnpm build` — green.
- [x] `pnpm check` — **15 warnings (baseline)**, no new warnings introduced.
- [x] Manual smoke test: load Titanic → select Target → verify no red error list flashes in ModelPanel.

## Files changed

- `frontend/src/hooks/useDataPanel.ts` — inject `useQueryClient`, broadcast merged config, pre-seed `prevSyncKey`, extend `useCallback` deps.
- `frontend/src/hooks/useDataPanel.test.ts` — add `createWrapper` helper (QueryClientProvider), rewire existing `renderHook` calls to pass `{ wrapper }`, add regression test for the cache broadcast.
- `frontend/src/components/workspace/ModelPanel.tsx` — add the deep-equal guard to `handleConfigChange`.
- `frontend/src/components/workspace/ModelPanel.test.tsx` — two new regression tests.
- `frontend/src/components/workspace/DataPanel.test.tsx` — update two `syncConfig AbortController` tests to trigger via column exclude toggle instead of target selection.

## Related

- Issue #107 (closed by this PR)
- H-0063 (original Issue #99 fix — this PR layers on top, does not replace it)
- Issue #101 (#112 — already merged)
- Issue #111 (#123 — vitest environment fix, unblocked these new unit tests from running)

## Rollback plan

If a regression surfaces, revert this single commit (`1c8e8a3`) — all changes are isolated to `useDataPanel.ts` + `ModelPanel.tsx` + tests. The `queryClient.setQueryData` call is additive (does not remove or alter any existing cache writes) and the deep-equal guard is a short-circuit only.