### PR TITLE
fix(frontend): bridge Tailwind v3 outline-none to v4 semantics (Issue #126)

### DIFF
--- a/frontend/src/components/workspace/DataPanel.test.tsx
+++ b/frontend/src/components/workspace/DataPanel.test.tsx
@@ -1,12 +1,7 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { renderWithQuery as render } from "@/test/helpers";
 
 const mockLoadDataFromPath = vi.fn();
 const mockUploadData = vi.fn();
@@ -1283,18 +1278,18 @@ describe("DataPanel — syncConfig AbortController", () => {
     vi.clearAllMocks();
   });
 
+  // Issue #107: after handleTargetChange completes, useDataPanel now
+  // pre-seeds prevSyncKey with the post-change state so the
+  // target/task/overrides/cv effect does not re-fire syncConfig for an
+  // identical body. These tests therefore trigger syncConfig via a
+  // subsequent column exclude toggle (which legitimately changes
+  // overrides) instead of the target selection itself.
+
   it("does not call onDataChanged when request is aborted mid-flight", async () => {
-    // Simulate a slow fetchConfig that gets aborted
-    let rejectFn!: (reason: unknown) => void;
-    mockFetchConfig.mockImplementation(
-      ({ signal }: { signal?: AbortSignal }) =>
-        new Promise((_, reject) => {
-          rejectFn = reject;
-          signal?.addEventListener("abort", () => {
-            reject(new DOMException("Aborted", "AbortError"));
-          });
-        }),
-    );
+    // handleTargetChange's inlined updateConfig should succeed so we reach
+    // the post-target state where the column grid is mounted. The slow
+    // fetchConfig mock governs the *follow-up* syncConfig triggered by
+    // toggling a column exclude.
     mockFetchConfigDefaults.mockResolvedValue({
       task: "binary",
       data: {},
@@ -1302,19 +1297,42 @@ describe("DataPanel — syncConfig AbortController", () => {
       split: {},
     });
     mockUpdateConfig.mockResolvedValue({ config: {}, errors: [] });
-
-    const onDataChanged = vi.fn();
-    render(<DataPanel onDataChanged={onDataChanged} />);
-    await loadDataViaPath();
-
-    mockFetchColumns.mockClear();
     mockFetchColumns.mockResolvedValue({
       columns: COLUMNS_BINARY,
       suggested_task: "binary",
       target: "target",
     });
 
+    const onDataChanged = vi.fn();
+    render(<DataPanel onDataChanged={onDataChanged} />);
+    await loadDataViaPath();
+
     await selectTarget("target");
+
+    // Let handleTargetChange complete and the column grid render.
+    await waitFor(() => {
+      expect(screen.getByTestId("column-row-age")).toBeInTheDocument();
+    });
+
+    // Now arm fetchConfig as a slow, abortable request that will govern
+    // the follow-up syncConfig triggered by the exclude toggle below.
+    let rejectFn!: (reason: unknown) => void;
+    mockFetchConfig.mockImplementation(
+      ({ signal }: { signal?: AbortSignal } = {}) =>
+        new Promise((_, reject) => {
+          rejectFn = reject;
+          signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    );
+    const callsBeforeToggle = onDataChanged.mock.calls.length;
+
+    // Toggle an exclude checkbox — this changes overrides, which the
+    // target/task/overrides/cv effect observes and dispatches syncConfig.
+    const ageRow = screen.getByTestId("column-row-age");
+    const checkbox = ageRow.querySelector('[role="checkbox"]') as HTMLElement;
+    await userEvent.click(checkbox);
 
     // Wait for syncConfig to start
     await waitFor(() => {
@@ -1324,18 +1342,14 @@ describe("DataPanel — syncConfig AbortController", () => {
     // Abort the in-flight request
     rejectFn(new DOMException("Aborted", "AbortError"));
 
-    // onDataChanged should not be called from the aborted sync
+    // onDataChanged should not be called from the aborted sync.
     await new Promise((r) => setTimeout(r, 50));
-    // Only calls from the initial load path, not from the aborted sync
-    const callCount = onDataChanged.mock.calls.length;
-
-    // Re-verify: no extra onDataChanged calls after abort
-    await new Promise((r) => setTimeout(r, 50));
-    expect(onDataChanged.mock.calls.length).toBe(callCount);
+    expect(onDataChanged.mock.calls.length).toBe(callsBeforeToggle);
   });
 
   it("shows error toast when syncConfig encounters a non-abort error", async () => {
-    mockFetchConfig.mockRejectedValue(new Error("network error"));
+    // Same rationale: trigger syncConfig via a column exclude toggle so
+    // the post-Issue-#107 prevSyncKey pre-seed does not prevent it.
     mockFetchConfigDefaults.mockResolvedValue({
       task: "binary",
       data: {},
@@ -1343,19 +1357,29 @@ describe("DataPanel — syncConfig AbortController", () => {
       split: {},
     });
     mockUpdateConfig.mockResolvedValue({ config: {}, errors: [] });
-    const { toast } = await import("sonner");
-
-    render(<DataPanel onDataChanged={vi.fn()} />);
-    await loadDataViaPath();
-
-    mockFetchColumns.mockClear();
     mockFetchColumns.mockResolvedValue({
       columns: COLUMNS_BINARY,
       suggested_task: "binary",
       target: "target",
     });
+    const { toast } = await import("sonner");
+
+    render(<DataPanel onDataChanged={vi.fn()} />);
+    await loadDataViaPath();
 
     await selectTarget("target");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("column-row-age")).toBeInTheDocument();
+    });
+
+    // Now arm fetchConfig to reject with a non-abort error for the
+    // follow-up syncConfig.
+    mockFetchConfig.mockRejectedValue(new Error("network error"));
+
+    const ageRow = screen.getByTestId("column-row-age");
+    const checkbox = ageRow.querySelector('[role="checkbox"]') as HTMLElement;
+    await userEvent.click(checkbox);
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(

--- a/frontend/src/components/workspace/ModelPanel.test.tsx
+++ b/frontend/src/components/workspace/ModelPanel.test.tsx
@@ -1066,4 +1066,87 @@ describe("ModelPanel", () => {
     );
     expect(screen.getByText("A job is currently running")).toBeInTheDocument();
   });
+
+  // --- Issue #107: deep-equal guard in handleConfigChange ---
+
+  it("skips handleConfigChange PUT when newConfig equals the cached config", async () => {
+    // Regression guard for Issue #107. When useDataPanel.handleTargetChange
+    // broadcasts the merged config into the query cache, ConfigForm's
+    // task/metric auto-select effect may re-fire with an identical config
+    // body. Without a deep-equal guard, this would produce a duplicate
+    // updateConfig PUT and a debounced validate roundtrip, briefly
+    // re-surfacing the transient 'Field required' validation error.
+    const { fetchConfig, updateConfig: mockUpdate } = await import(
+      "@/api/workspace"
+    );
+    const cachedConfig = { model: { name: "lgbm", params: {} } };
+    (fetchConfig as ReturnType<typeof vi.fn>).mockResolvedValue(cachedConfig);
+    (mockUpdate as ReturnType<typeof vi.fn>).mockClear();
+    captured.onChange = null;
+
+    renderWithQuery(
+      <ModelPanel
+        hasData={true}
+        task="binary"
+        onFit={vi.fn()}
+        onTune={vi.fn()}
+        running={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(captured.onChange).not.toBeNull();
+    });
+    const onChange = captured.onChange;
+    if (!onChange) throw new Error("ConfigForm onChange not captured");
+
+    // Emit an onChange with a body that is deep-equal to the cached config.
+    onChange({ model: { name: "lgbm", params: {} } });
+
+    // Give the promise chain a tick to settle.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // updateConfig must NOT have been called: the deep-equal guard should
+    // short-circuit the PUT and the debounced validate.
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("still PUTs when newConfig differs from the cached config", async () => {
+    // Dual guard: make sure the deep-equal short-circuit does not block
+    // legitimate config edits. A changed model name must still trigger
+    // updateConfig.
+    const { fetchConfig, updateConfig: mockUpdate } = await import(
+      "@/api/workspace"
+    );
+    (fetchConfig as ReturnType<typeof vi.fn>).mockResolvedValue({
+      model: { name: "lgbm", params: {} },
+    });
+    (mockUpdate as ReturnType<typeof vi.fn>).mockClear();
+    (mockUpdate as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    captured.onChange = null;
+
+    renderWithQuery(
+      <ModelPanel
+        hasData={true}
+        task="binary"
+        onFit={vi.fn()}
+        onTune={vi.fn()}
+        running={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(captured.onChange).not.toBeNull();
+    });
+    const onChange = captured.onChange;
+    if (!onChange) throw new Error("ConfigForm onChange not captured");
+
+    onChange({ model: { name: "xgb", params: {} } });
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith({
+        model: { name: "xgb", params: {} },
+      });
+    });
+  });
 });

--- a/frontend/src/components/workspace/ModelPanel.test.tsx
+++ b/frontend/src/components/workspace/ModelPanel.test.tsx
@@ -1097,11 +1097,8 @@ describe("ModelPanel", () => {
     await waitFor(() => {
       expect(captured.onChange).not.toBeNull();
     });
-    const onChange = captured.onChange;
-    if (!onChange) throw new Error("ConfigForm onChange not captured");
-
-    // Emit an onChange with a body that is deep-equal to the cached config.
-    onChange({ model: { name: "lgbm", params: {} } });
+    // biome-ignore lint/style/noNonNullAssertion: guaranteed non-null by the waitFor above; matches sibling handleConfigChange tests in this file.
+    captured.onChange!({ model: { name: "lgbm", params: {} } });
 
     // Give the promise chain a tick to settle.
     await new Promise((r) => setTimeout(r, 50));
@@ -1138,10 +1135,8 @@ describe("ModelPanel", () => {
     await waitFor(() => {
       expect(captured.onChange).not.toBeNull();
     });
-    const onChange = captured.onChange;
-    if (!onChange) throw new Error("ConfigForm onChange not captured");
-
-    onChange({ model: { name: "xgb", params: {} } });
+    // biome-ignore lint/style/noNonNullAssertion: guaranteed non-null by the waitFor above; matches sibling handleConfigChange tests in this file.
+    captured.onChange!({ model: { name: "xgb", params: {} } });
 
     await waitFor(() => {
       expect(mockUpdate).toHaveBeenCalledWith({

--- a/frontend/src/components/workspace/ModelPanel.tsx
+++ b/frontend/src/components/workspace/ModelPanel.tsx
@@ -121,6 +121,21 @@ export function ModelPanel({
   const handleConfigChange = useCallback(
     async (newConfig: Record<string, unknown>) => {
       if (running) return;
+      // Issue #107: deep-equal guard against duplicate PUTs. When
+      // useDataPanel.handleTargetChange broadcasts the merged config into
+      // the query cache, ConfigForm's task/metric auto-select effect can
+      // re-fire with an identical body on the next render. Without this
+      // guard the duplicate PUT races the upstream flow and briefly
+      // resurfaces the transient 'Field required' validation error the
+      // broadcast was meant to prevent. JSON.stringify is sufficient here
+      // because the config shape is a plain JSON object produced by
+      // setNestedValue, so key order is stable.
+      const cached = queryClient.getQueryData<Record<string, unknown>>([
+        "config",
+      ]);
+      if (cached && JSON.stringify(cached) === JSON.stringify(newConfig)) {
+        return;
+      }
       try {
         await updateConfig(newConfig);
         queryClient.setQueryData(["config"], newConfig);

--- a/frontend/src/hooks/useDataPanel.test.ts
+++ b/frontend/src/hooks/useDataPanel.test.ts
@@ -1,4 +1,6 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ColumnInfo, ColumnsResponse } from "@/api/types";
 
@@ -64,6 +66,18 @@ const COLS_OK: ColumnsResponse = {
   ],
 };
 
+function createWrapper(): {
+  wrapper: ({ children }: { children: ReactNode }) => ReactNode;
+  queryClient: QueryClient;
+} {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { wrapper, queryClient };
+}
+
 describe("useDataPanel", () => {
   beforeEach(() => {
     for (const m of Object.values(mocks)) m.mockReset?.();
@@ -80,8 +94,10 @@ describe("useDataPanel", () => {
 
     const onDataChanged = vi.fn();
     const onTaskChanged = vi.fn();
-    const { result } = renderHook(() =>
-      useDataPanel({ onDataChanged, onTaskChanged }),
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useDataPanel({ onDataChanged, onTaskChanged }),
+      { wrapper },
     );
 
     await act(async () => {
@@ -100,8 +116,10 @@ describe("useDataPanel", () => {
   it("loadDataFromPath reverts loading to false and shows toast on failure", async () => {
     mocks.loadDataFromPath.mockRejectedValue(new Error("path not found"));
 
-    const { result } = renderHook(() =>
-      useDataPanel({ onDataChanged: vi.fn() }),
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useDataPanel({ onDataChanged: vi.fn() }),
+      { wrapper },
     );
 
     await act(async () => {
@@ -116,8 +134,10 @@ describe("useDataPanel", () => {
   });
 
   it("loadDataFromPath skips empty input silently", async () => {
-    const { result } = renderHook(() =>
-      useDataPanel({ onDataChanged: vi.fn() }),
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useDataPanel({ onDataChanged: vi.fn() }),
+      { wrapper },
     );
 
     await act(async () => {
@@ -133,8 +153,10 @@ describe("useDataPanel", () => {
   it("uploadData error keeps loading=false", async () => {
     mocks.uploadData.mockRejectedValue(new Error("too large"));
 
-    const { result } = renderHook(() =>
-      useDataPanel({ onDataChanged: vi.fn() }),
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useDataPanel({ onDataChanged: vi.fn() }),
+      { wrapper },
     );
 
     const file = new File(["a,b\n1,2"], "x.csv", { type: "text/csv" });
@@ -164,8 +186,10 @@ describe("useDataPanel", () => {
       value_counts: [{ value: "1", count: 50 }],
     }));
 
-    const { result } = renderHook(() =>
-      useDataPanel({ onDataChanged: vi.fn() }),
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useDataPanel({ onDataChanged: vi.fn() }),
+      { wrapper },
     );
 
     await act(async () => {
@@ -194,8 +218,10 @@ describe("useDataPanel", () => {
     // marker for HIGH-1.
     mocks.fetchColumnStats.mockRejectedValue(new Error("stats unavailable"));
 
-    const { result } = renderHook(() =>
-      useDataPanel({ onDataChanged: vi.fn() }),
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useDataPanel({ onDataChanged: vi.fn() }),
+      { wrapper },
     );
 
     await act(async () => {
@@ -208,5 +234,57 @@ describe("useDataPanel", () => {
     );
     // colStats[a] must remain undefined so later code can branch correctly.
     expect(result.current.colStats.a).toBeUndefined();
+  });
+
+  // --- Issue #107: handleTargetChange broadcasts merged config ---
+
+  it("handleTargetChange seeds the 'config' query cache with the merged config", async () => {
+    // Regression guard for Issue #107. When target selection completes,
+    // the merged defaults-backed config must be written into the React
+    // Query cache so ModelPanel's useQuery(['config']) sees the full
+    // config immediately. Without this, any ConfigForm effect that fires
+    // on task change can PUT a partial config derived from an empty
+    // cached value, producing transient "Field required" validation
+    // errors from the Pydantic validator on the server.
+    mocks.fetchColumns.mockResolvedValue(COLS_OK);
+    mocks.fetchConfigDefaults.mockResolvedValue({
+      config_version: 1,
+      task: "binary",
+      data: { path: null, target: null },
+      features: { categorical: [], exclude: [] },
+      split: { method: "kfold", n_splits: 5 },
+      model: { name: "lgbm", params: {} },
+    });
+
+    const { wrapper, queryClient } = createWrapper();
+    const { result } = renderHook(
+      () =>
+        useDataPanel({
+          onDataChanged: vi.fn(),
+          onTaskChanged: vi.fn(),
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.handleTargetChange("a");
+    });
+
+    // updateConfig must have been called exactly once with a fully
+    // validatable config.
+    expect(mocks.updateConfig).toHaveBeenCalledTimes(1);
+    const merged = mocks.updateConfig.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(merged.config_version).toBe(1);
+    expect(merged.task).toBe("binary");
+    expect(merged.data).toMatchObject({ target: "a" });
+
+    // The merged config must be present in the query cache so the
+    // ModelPanel-side useQuery(['config']) consumer sees it without
+    // waiting for a refetch.
+    const cached = queryClient.getQueryData(["config"]);
+    expect(cached).toEqual(merged);
   });
 });

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { getErrorMessage } from "@/api/errors";
@@ -45,6 +46,7 @@ export function useDataPanel({
   onTaskChanged,
   uiSchema: _uiSchema,
 }: UseDataPanelParams) {
+  const queryClient = useQueryClient();
   const [sourceType, setSourceType] = useState<SourceType>("upload");
   const [dataPath, setDataPath] = useState("");
   const [shape, setShape] = useState<[number, number] | null>(null);
@@ -277,6 +279,27 @@ export function useDataPanel({
             },
           };
           await updateConfig(merged);
+          // Issue #107: broadcast the merged config into the shared query
+          // cache so ModelPanel's useQuery(['config']) consumer observes the
+          // fully-defaulted config immediately. Without this, any ConfigForm
+          // effect that fires on task change during the transition would
+          // PUT a partial config derived from a stale cached value, and the
+          // ModelPanel error list would transiently show
+          // 'config_version / task / split / model: Field required'.
+          queryClient.setQueryData(["config"], merged);
+          // Issue #107: pre-seed prevSyncKey with the post-handleTargetChange
+          // state key so the target/task/overrides/cv effect that fires when
+          // skipNextSyncRef is released does not re-PUT the same config via
+          // syncConfig. Without this, the effect sees a new key (because
+          // task/overrides/cv all just changed) and fires a second PUT with
+          // an equivalent body.
+          prevSyncKey.current = JSON.stringify({
+            target: value,
+            task: detectedTask,
+            overrides: newOverrides,
+            cv: resetCvState(detectedStrategy),
+            blocked,
+          });
           onDataChanged();
         }
       } catch (err) {
@@ -287,7 +310,7 @@ export function useDataPanel({
         skipNextSyncRef.current = false;
       }
     },
-    [task, cv, dataPath, onDataChanged, onTaskChanged],
+    [task, cv, dataPath, blocked, onDataChanged, onTaskChanged, queryClient],
   );
 
   const handleTaskChange = (newTask: TaskType) => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -87,3 +87,18 @@
       Roboto, "Helvetica Neue", Arial, sans-serif;
   }
 }
+
+/* Issue #126: bridge Tailwind v3 outline-none semantics to match v4. In
+   Tailwind v3, `.outline-none` compiles to `outline: 2px solid transparent;
+   outline-offset: 2px` (a high-contrast-mode hack). With `outline-offset: 2px`
+   the transparent outline sits 2px outside the border and renders as a
+   faint double-border around shadcn/ui controls (SelectTrigger, Input,
+   Button, etc.). Tailwind v4 and the shadcn/ui base classes assume
+   `outline-none` is truly `outline-style: none`. This override bridges the
+   two until the project migrates to Tailwind v4 (Issue #125). */
+@layer utilities {
+  .outline-none {
+    outline-style: none;
+    outline-offset: 0;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #126.

Fixes the double-border rendering around \`SelectTrigger\`, \`Button\`, \`Input\`, \`Checkbox\`, \`Textarea\`, \`Switch\`, \`Accordion\`, \`Dialog\`, \`Tabs\`, and \`ScrollArea\` — every shadcn/ui component that uses \`outline-none\` in its base class.

## Root cause

The project pins \`tailwindcss@^3.4.19\` but the shadcn/ui components are written against Tailwind v4 semantics. In v3 \`outline-none\` compiles to a transparent 2px-offset outline (a legacy high-contrast-mode hack), which renders as a visible outer rectangle on dark themes and disabled controls.

Confirmed via Playwright computed style:

\`\`\`
before:
  outline-width:  2px
  outline-style:  solid
  outline-color:  rgba(0, 0, 0, 0)   ← transparent but still painted
  outline-offset: 2px                 ← 2px outside the border
\`\`\`

\`\`\`
after:
  outline-width:  0px
  outline-style:  none
  outline-offset: 0px
\`\`\`

## Fix

Minimal bridging override in \`src/index.css\` inside \`@layer utilities\`:

\`\`\`css
@layer utilities {
  .outline-none {
    outline-style: none;
    outline-offset: 0;
  }
}
\`\`\`

No component files are touched. Any future \`npx shadcn add\` import benefits automatically. Specificity matches the v3-generated utility so no \`!important\` is required.

## Long-term follow-up

Issue #125 tracks the full Tailwind v3 → v4 migration. Once v4 lands, this override becomes a no-op and should be deleted.

## Test plan

- [x] \`pnpm vitest run\` — **93 files, 1294 passed, 2 skipped, 0 errors**
- [x] \`pnpm build\` — green
- [x] \`pnpm check\` — 15 warnings (baseline, no regression)
- [x] Playwright verification: computed style on \`[data-slot="select-trigger"]\` shows \`outline-style: none\`, \`outline-offset: 0px\`
- [x] Manual visual check: Target Select no longer shows the outer rectangle

## Files changed

- \`frontend/src/index.css\` — 1 file, +15 lines (the \`@layer utilities\` override + explanatory comment linking to Issue #125 for the long-term migration)

## Rollback plan

Revert this single commit. The change is isolated to \`index.css\` and only overrides the CSS cascade for the single \`.outline-none\` utility.