### PR TITLE
chore: batch Tier 1 quickwins — Issues #120, #122, #114

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,11 +4,11 @@ React + TypeScript + Vite UI for [LizyStudio](https://github.com/nbx-liz/LizyStu
 
 ## Prerequisites
 
-- **Node.js 18.19 or newer** — declared via `engines.node` in `package.json`. CI runs on Node 20, so 20 is the recommended version for parity. Versions below 18.19 are not supported.
+- **Node.js 20 or newer** — declared via `engines.node` in `package.json`. CI runs on Node 20. Older versions (including Node 18.x) have been observed to crash the production build (`pnpm build`) with a V8 fatal error under the current dependency graph, so 20 is the enforced floor rather than a recommendation.
 - **pnpm 10 or newer** — the project pins `pnpm@10.31.0` via the `packageManager` field. Enable corepack once with `corepack enable` and pnpm will match automatically.
 - A running backend on `http://localhost:8501` for `pnpm dev` (the Vite dev server proxies API calls there).
 
-Run `node -v` to confirm. If you see anything below `v18.19`, install a supported Node via your version manager (`nvm install 20`, `fnm install 20`, `volta install node@20`, etc.) before continuing.
+Run `node -v` to confirm. If you see anything below `v20`, install Node 20 via your version manager (`nvm install 20`, `fnm install 20`, `volta install node@20`, etc.) before continuing.
 
 ## Install
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,74 @@
+# LizyStudio Frontend
+
+React + TypeScript + Vite UI for [LizyStudio](https://github.com/nbx-liz/LizyStudio).
+
+## Prerequisites
+
+- **Node.js 18.19 or newer** — declared via `engines.node` in `package.json`. CI runs on Node 20, so 20 is the recommended version for parity. Versions below 18.19 are not supported.
+- **pnpm 10 or newer** — the project pins `pnpm@10.31.0` via the `packageManager` field. Enable corepack once with `corepack enable` and pnpm will match automatically.
+- A running backend on `http://localhost:8501` for `pnpm dev` (the Vite dev server proxies API calls there).
+
+Run `node -v` to confirm. If you see anything below `v18.19`, install a supported Node via your version manager (`nvm install 20`, `fnm install 20`, `volta install node@20`, etc.) before continuing.
+
+## Install
+
+```bash
+cd frontend
+pnpm install
+```
+
+## Develop
+
+```bash
+# Start the backend in another terminal first
+uv run lizystudio --reload            # from the repo root
+
+# Then in frontend/
+pnpm dev                              # Vite dev server on http://localhost:5173
+```
+
+The dev server proxies `/api/*` to `http://localhost:8501`.
+
+## Test
+
+```bash
+pnpm test                             # Vitest unit tests
+pnpm test:watch                       # Vitest in watch mode
+pnpm test:e2e                         # Playwright end-to-end
+pnpm test:e2e:visual                  # Playwright visual regression
+pnpm test:e2e:a11y                    # Playwright accessibility scan
+```
+
+## Check
+
+```bash
+pnpm check                            # Biome lint + format check
+pnpm format                           # Biome format, auto-fix
+pnpm build                            # tsc --build + Vite production build
+```
+
+The production build writes into `../src/lizystudio/static/` so it can be served by the FastAPI backend.
+
+## Component development
+
+```bash
+pnpm storybook                        # Storybook on http://localhost:6006
+pnpm build-storybook
+pnpm test:storybook                   # Storybook test runner
+```
+
+## Generated API types
+
+```bash
+# Backend must be running for this to work
+pnpm generate:api                     # Regenerate src/api/generated/schema.d.ts
+pnpm check:api-types                  # Verify the generated file is up to date
+```
+
+## Project links
+
+- Root repo: [../README.md](../README.md)
+- Technical spec: [../BLUEPRINT.md](../BLUEPRINT.md)
+- Proposal history: [../HISTORY.md](../HISTORY.md)
+- Phased roadmap: [../PLAN.md](../PLAN.md)
+- Development rules: [../CLAUDE.md](../CLAUDE.md)

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -66,6 +66,16 @@
       "assist": {
         "enabled": false
       }
+    },
+    {
+      "includes": ["src/**/*.test.ts", "src/**/*.test.tsx"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noNonNullAssertion": "off"
+          }
+        }
+      }
     }
   ]
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "packageManager": "pnpm@10.31.0",
+  "engines": {
+    "node": ">=18.19",
+    "pnpm": ">=10"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@10.31.0",
   "engines": {
-    "node": ">=18.19",
+    "node": ">=20",
     "pnpm": ">=10"
   },
   "scripts": {

--- a/frontend/src/components/workspace/ModelPanel.test.tsx
+++ b/frontend/src/components/workspace/ModelPanel.test.tsx
@@ -1097,7 +1097,6 @@ describe("ModelPanel", () => {
     await waitFor(() => {
       expect(captured.onChange).not.toBeNull();
     });
-    // biome-ignore lint/style/noNonNullAssertion: guaranteed non-null by the waitFor above; matches sibling handleConfigChange tests in this file.
     captured.onChange!({ model: { name: "lgbm", params: {} } });
 
     // Give the promise chain a tick to settle.
@@ -1135,7 +1134,6 @@ describe("ModelPanel", () => {
     await waitFor(() => {
       expect(captured.onChange).not.toBeNull();
     });
-    // biome-ignore lint/style/noNonNullAssertion: guaranteed non-null by the waitFor above; matches sibling handleConfigChange tests in this file.
     captured.onChange!({ model: { name: "xgb", params: {} } });
 
     await waitFor(() => {

--- a/frontend/tests/e2e/retune-flow.spec.ts
+++ b/frontend/tests/e2e/retune-flow.spec.ts
@@ -79,63 +79,13 @@ async function setupTuneJob(
 test.describe("Re-tune / Resume / Lineage flow (H-0062)", () => {
   test.setTimeout(180_000);
 
-  // Per-test baseline of non-terminal jobs captured in beforeEach so the
-  // afterEach regression guard only flags jobs introduced BY the current
-  // test. The job store directory (/tmp/e2e_jobs) is shared across runs
-  // and may already hold stale `running` rows from earlier sessions —
-  // those are tracked separately in Issue #99 and must not make this
-  // guard flaky.
-  let baselineAlive = new Set<string>();
-
-  async function fetchAliveJobIds(
-    request: import("@playwright/test").APIRequestContext,
-  ): Promise<Set<string>> {
-    const res = await request.get(`${API}/jobs/`);
-    // Fail loud on any non-200 so the baseline snapshot and the
-    // afterEach comparison stay symmetric. A silently empty baseline
-    // after a transient 5xx would flag every pre-existing running row
-    // as a fresh leak in the next afterEach.
-    expect(res.status(), "GET /jobs/ must succeed").toBe(200);
-    const jobs = (await res.json()) as Array<{
-      job_id: string;
-      status: string;
-    }>;
-    return new Set(
-      jobs
-        .filter((j) => j.status === "running" || j.status === "pending")
-        .map((j) => j.job_id),
-    );
-  }
-
+  // H-0063 (PR #110) made POST /workspace/reset synchronously cancel the
+  // active job and release its slot, so a plain reset between tests is
+  // now sufficient to leave JobStore in a clean state. The earlier
+  // afterEach baseline-diff regression guard (Issue #120) is no longer
+  // load-bearing and has been removed.
   test.beforeEach(async ({ request }) => {
     await request.post(`${API}/workspace/reset`);
-    baselineAlive = await fetchAliveJobIds(request);
-  });
-
-  // Regression guard for the fire-and-forget orphan pattern that once
-  // leaked a retune child's active slot into subsequent tests, causing
-  // a cascade of 409 JOB_CONFLICT failures. workspace/reset intentionally
-  // does NOT clear JobStore._active_job_id (see Issue #99), so any test
-  // that starts a background job must drive it to a terminal state before
-  // returning. Computing the diff against the per-test baseline ensures
-  // this guard fires on NEW leaks only, not on stale pre-existing rows.
-  //
-  // Known blind spot: a job whose on-disk status is already terminal
-  // but whose _active_job_id slot has not yet been released will NOT be
-  // flagged here (it is filtered out of `fetchAliveJobIds`). That tiny
-  // window is real — _run_job_core writes status then releases the slot
-  // in finally — but it closes as soon as the runner thread returns, so
-  // every existing test that calls `pollJobUntilDone` or cancel+poll
-  // ends up in a fully-clean state by the time afterEach runs. If a
-  // future test ever hits a 409 without an observed leak here, check
-  // for a new fire-and-forget that skips `pollJobUntilDone`.
-  test.afterEach(async ({ request }) => {
-    const currentAlive = await fetchAliveJobIds(request);
-    const leaked = [...currentAlive].filter((id) => !baselineAlive.has(id));
-    expect(
-      leaked,
-      `Test leaked non-terminal jobs introduced during this test: ${leaked.join(", ")}`,
-    ).toHaveLength(0);
   });
 
   test("API: completed parent can be retuned into a child with parent_job_id", async ({
@@ -322,10 +272,11 @@ test.describe("Re-tune / Resume / Lineage flow (H-0062)", () => {
     });
     expect(second.status()).toBe(200);
     const { job_id: secondChildId } = await second.json();
-    // Drain the second retune before returning so it does not hold the
-    // JobStore active slot into the next test (workspace/reset does not
-    // clear _active_job_id — see Issue #99). Cancel first to keep this
-    // test fast; pollJobUntilDone accepts any terminal state.
+    // Drain the second retune before returning so it terminates cleanly
+    // before the next test's workspace/reset. Even though H-0063 makes
+    // reset cancel the active slot, draining explicitly keeps this test
+    // fast and makes the lifecycle obvious. Cancel first and then poll;
+    // pollJobUntilDone accepts any terminal state.
     const cancelSecond = await request.post(`${API}/jobs/${secondChildId}/cancel`);
     // 200 (running) or 400 (already finished) are both acceptable; a
     // 5xx would mean the backend crashed and we should fail loud rather
@@ -544,8 +495,8 @@ test.describe("Re-tune / Resume / Lineage flow (H-0062)", () => {
     expect(bcBody.job_id).not.toBe(childB);
     expect(bcBody.parent_job_id).toBe(childB);
     // Drain C before returning — the test only asserts API acceptance,
-    // but leaving it running would orphan the active slot for the next
-    // test (see Issue #99 and this spec's afterEach guard).
+    // so polling it to terminal state keeps the lifecycle clean for the
+    // next test's workspace/reset.
     await pollJobUntilDone(request, bcBody.job_id as string);
   });
 });


### PR DESCRIPTION
## Summary

Closes #120, closes #122, closes #114.

Batch PR for four Tier 1 quickwin tasks identified during the Issue triage session. Each commit is independent and maps to a single Issue.

## Changes

### 1. Issue #120 — Remove retune-flow afterEach workaround (commit `a1f2a61`)

H-0063 (PR #110) made `POST /workspace/reset` synchronously cancel the active job and release its slot. The `afterEach` baseline-diff regression guard added in PR #102 is no longer load-bearing.

- Deleted `baselineAlive`, `fetchAliveJobIds`, and `test.afterEach` (57 lines removed)
- Updated two trailing comments that still referenced the pre-H-0063 behavior

### 2. Issue #122 — Declare engines field and add frontend README (commits `1856827` + `aa8d923`)

CI pins Node 20 but `package.json` had no `engines` field, so contributors running older versions get confusing failures.

- Added `engines.node >= 20` and `engines.pnpm >= 10`
- Created `frontend/README.md` with prerequisites, install, dev, test, check, Storybook, and API type sections
- Tightened from initially proposed `>=18.19` to `>=20` after observing intermittent V8 TurboFan crashes under Node 18.19 on WSL2 (tracked in Issue #132)

### 3. Issue #114 — Silence noNonNullAssertion warnings in test files (commit `feed946`)

All 15 Biome `noNonNullAssertion` warnings were in test files where the non-null assertion is the idiomatic pattern after a `waitFor` that guarantees the ref is populated.

- Added a `biome.json` override that disables `lint/style/noNonNullAssertion` for `*.test.ts(x)` files only
- Removed two now-unused `biome-ignore` suppressions from ModelPanel.test.tsx
- Production code still has the rule active at the recommended level

### 4. Issue #113 — plotly.js-dist-min peer dependency verification (no code change)

Investigation completed and posted as a comment on Issue #113 (now closed). Found that `plotly.js-dist-min` is a dead dependency — never imported anywhere. Filed Issue #131 for the cleanup.

## Test plan

- [x] `pnpm vitest run` — 1294 passed / 2 skipped (unchanged from baseline)
- [x] `pnpm check` (Biome) — **0 warnings** (down from 15 baseline)
- [x] `pnpm build` — green
- [x] CI green

## Related issues filed during this batch

- Issue #131 — remove unused `plotly.js-dist-min` dependency (from #113 investigation)
- Issue #132 — `pnpm build` intermittent V8 crash on WSL2 (from push-gate troubleshooting)