### PR TITLE
fix: Tier 1 — remove dead dep, harden deep-equal, eliminate CSP unsafe-inline (Issues #131, #129, #104)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,6 @@
     "clsx": "^2.1.1",
     "js-yaml": "^4.1.1",
     "lucide-react": "^1.8.0",
-    "plotly.js-dist-min": "^3.5.0",
     "postcss": "^8.5.9",
     "radix-ui": "^1.4.3",
     "react": "^19.2.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "autoprefixer": "^10.4.27",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "fast-deep-equal": "^3.1.3",
     "js-yaml": "^4.1.1",
     "lucide-react": "^1.8.0",
     "postcss": "^8.5.9",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.5)
-      plotly.js-dist-min:
-        specifier: ^3.5.0
-        version: 3.5.0
       postcss:
         specifier: ^8.5.9
         version: 8.5.9
@@ -4309,9 +4306,6 @@ packages:
     resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
-
-  plotly.js-dist-min@3.5.0:
-    resolution: {integrity: sha512-rN+0P4M6eIHiNeKsyv4F0cCmA3pslxIjUpGpEh6PbNzEQQMjHbXFbC7nVUbK805TaLxnjh6FnwsVau/DlWimUA==}
 
   plotly.js@3.4.0:
     resolution: {integrity: sha512-jdWfHLB8AxlGUmVhqJTGEKdwjCKGn9Yi8yg16067/JyqseuSado7F6IOM1XPZspdZyO/cf8IPuy7ROlVhqZZNw==}
@@ -9896,8 +9890,6 @@ snapshots:
       playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
-
-  plotly.js-dist-min@3.5.0: {}
 
   plotly.js@3.4.0(mapbox-gl@1.13.3):
     dependencies:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      fast-deep-equal:
+        specifier: ^3.1.3
+        version: 3.1.3
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1

--- a/frontend/src/components/workspace/ModelPanel.test.tsx
+++ b/frontend/src/components/workspace/ModelPanel.test.tsx
@@ -1107,6 +1107,36 @@ describe("ModelPanel", () => {
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
+  it("skips PUT when newConfig is deep-equal but has different key order", async () => {
+    const { fetchConfig, updateConfig: mockUpdate } = await import(
+      "@/api/workspace"
+    );
+    (fetchConfig as ReturnType<typeof vi.fn>).mockResolvedValue({
+      model: { name: "lgbm", params: { depth: 6 } },
+    });
+    (mockUpdate as ReturnType<typeof vi.fn>).mockClear();
+    captured.onChange = null;
+
+    renderWithQuery(
+      <ModelPanel
+        hasData={true}
+        task="binary"
+        onFit={vi.fn()}
+        onTune={vi.fn()}
+        running={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(captured.onChange).not.toBeNull();
+    });
+    // Same values, different key insertion order
+    captured.onChange!({ model: { params: { depth: 6 }, name: "lgbm" } });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it("still PUTs when newConfig differs from the cached config", async () => {
     // Dual guard: make sure the deep-equal short-circuit does not block
     // legitimate config edits. A changed model name must still trigger

--- a/frontend/src/components/workspace/ModelPanel.tsx
+++ b/frontend/src/components/workspace/ModelPanel.tsx
@@ -1,4 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import equal from "fast-deep-equal";
 import {
   Download,
   FileText,
@@ -121,19 +122,10 @@ export function ModelPanel({
   const handleConfigChange = useCallback(
     async (newConfig: Record<string, unknown>) => {
       if (running) return;
-      // Issue #107: deep-equal guard against duplicate PUTs. When
-      // useDataPanel.handleTargetChange broadcasts the merged config into
-      // the query cache, ConfigForm's task/metric auto-select effect can
-      // re-fire with an identical body on the next render. Without this
-      // guard the duplicate PUT races the upstream flow and briefly
-      // resurfaces the transient 'Field required' validation error the
-      // broadcast was meant to prevent. JSON.stringify is sufficient here
-      // because the config shape is a plain JSON object produced by
-      // setNestedValue, so key order is stable.
       const cached = queryClient.getQueryData<Record<string, unknown>>([
         "config",
       ]);
-      if (cached && JSON.stringify(cached) === JSON.stringify(newConfig)) {
+      if (cached && equal(cached, newConfig)) {
         return;
       }
       try {

--- a/src/lizystudio/services/export.py
+++ b/src/lizystudio/services/export.py
@@ -124,7 +124,9 @@ def _build_report_html(
     """Build a minimal self-contained HTML report."""
     import html
     import json
+    import secrets
 
+    nonce = secrets.token_urlsafe(16)
     title = html.escape(f"Job {job.job_id} — {job.job_type.title()} Report")
     task = html.escape(str(info.get("task", "")))
     model_name = html.escape(str(info.get("model_name", "")))
@@ -158,42 +160,36 @@ def _build_report_html(
         layout_js = _js_safe(parsed.get("layout", {}))
         plot_divs += f"""
         <div id="plot-{i}" style="width:100%;height:500px;margin-bottom:20px;"></div>
-        <script>
+        <script nonce="{nonce}">
             Plotly.newPlot('plot-{i}', {data_js}, {layout_js});
         </script>
         """
 
-    # HIGH-5 / Issue #92: Plotly is pulled from a CDN because bundling
-    # ~4 MB of JS into every HTML report is wasteful. We layer two
-    # mitigations against a tampered or substituted bundle:
+    # HIGH-5 / Issue #92 / Issue #104: Plotly is pulled from a CDN
+    # because bundling ~4 MB of JS into every HTML report is wasteful.
+    # We layer three mitigations against script injection:
     #
     # 1. ``Content-Security-Policy`` whitelists ``cdn.plot.ly`` as the
-    #    only allowed script origin so the browser refuses to fetch
-    #    Plotly from anywhere else.
+    #    only allowed external script origin.
     # 2. ``integrity="sha384-..."`` (Subresource Integrity) makes the
     #    browser hash the fetched bundle and refuse to execute it if the
-    #    hash differs from the pinned value, so a compromised CDN cannot
-    #    silently swap in malicious JavaScript.
+    #    hash differs from the pinned value.
+    # 3. A per-report CSP **nonce** authorises the inline
+    #    ``Plotly.newPlot(...)`` bootstraps without ``'unsafe-inline'``.
+    #    Each report gets a fresh nonce via ``secrets.token_urlsafe``,
+    #    so an attacker who can inject markup still cannot execute
+    #    scripts unless they also guess the nonce.
     #
-    # ``crossorigin="anonymous"`` is required for SRI to actually take
-    # effect on cross-origin scripts (without it the browser silently
-    # drops the integrity check).
-    #
-    # Note on ``'unsafe-inline'`` below: it would normally weaken SRI on
-    # an HTTP-header-delivered CSP, but here the CSP is embedded in a
-    # ``<meta http-equiv>`` tag and the inline allowance only enables
-    # the ``Plotly.newPlot('plot-N', ...)`` bootstraps emitted above.
-    # SRI on the external Plotly bundle remains enforced regardless.
+    # ``crossorigin="anonymous"`` is required for SRI to take effect on
+    # cross-origin scripts.
     #
     # When bumping the Plotly version, recompute the SRI hash and
     # update both ``_PLOTLY_VERSION`` / ``_PLOTLY_SRI`` AND the matching
     # constants in
     # ``tests/regression/test_reg_0074_export_report_plotly_sri.py``.
-    # See that test's module docstring for the one-liner that computes
-    # the hash from the CDN bundle.
     csp = (
         "default-src 'none'; "
-        "script-src https://cdn.plot.ly 'unsafe-inline'; "
+        f"script-src https://cdn.plot.ly 'nonce-{nonce}'; "
         "style-src 'unsafe-inline'; "
         "img-src data:;"
     )
@@ -206,7 +202,8 @@ def _build_report_html(
     <title>{title}</title>
     <script src="https://cdn.plot.ly/{_PLOTLY_VERSION}"
             integrity="{_PLOTLY_SRI}"
-            crossorigin="anonymous"></script>
+            crossorigin="anonymous"
+            nonce="{nonce}"></script>
     <style>
         body {{ font-family: system-ui, sans-serif;
                max-width: 1000px; margin: 0 auto;

--- a/tests/regression/test_reg_0068_export_report_script_injection.py
+++ b/tests/regression/test_reg_0068_export_report_script_injection.py
@@ -101,3 +101,7 @@ def test_report_has_csp_meta_restricting_scripts(tmp_path: Path) -> None:
     assert 'http-equiv="Content-Security-Policy"' in html
     assert "script-src https://cdn.plot.ly" in html
     assert "default-src 'none'" in html
+    # Issue #104: unsafe-inline must not appear in script-src.
+    # Inline scripts are authorised via a per-report CSP nonce instead.
+    assert "'unsafe-inline'" not in html.split("script-src")[1].split(";")[0]
+    assert "'nonce-" in html


### PR DESCRIPTION
## Summary

Closes #131, closes #129, closes #104.

Three independent Tier 1 tasks batched into a single PR. Each commit maps to one Issue.

## Changes

### 1. Issue #131 — Remove unused plotly.js-dist-min (commit `ba8374b`)

`plotly.js-dist-min` was declared as a direct dependency but never imported anywhere. The only plotly consumer (`PlotlyChart.tsx`) uses `react-plotly.js`, which transitively resolves `plotly.js` via its peer dependency. The duplicate package was dead weight in `node_modules`.

- Removed `plotly.js-dist-min` from `frontend/package.json`
- Regenerated `pnpm-lock.yaml`

### 2. Issue #129 — Replace JSON.stringify deep-equal with fast-deep-equal (commit `b23d651`)

The deep-equal guard in `ModelPanel.handleConfigChange` (Issue #107 fix) used `JSON.stringify` to compare config objects. This is key-order sensitive — two objects with identical values but different key insertion order would produce different strings, silently disabling the guard.

- Added `fast-deep-equal@3.1.3` as a production dependency (zero deps, ~500 bytes)
- Replaced `JSON.stringify(a) === JSON.stringify(b)` with `equal(a, b)` in `ModelPanel.tsx`
- Added regression test: "skips PUT when newConfig is deep-equal but has different key order"

### 3. Issue #104 — Remove `'unsafe-inline'` from export report CSP (commit `3af85b2`)

The HTML export report used `'unsafe-inline'` in its `script-src` Content-Security-Policy directive to allow inline `Plotly.newPlot(...)` bootstraps. This weakens the CSP because any injected markup could also execute scripts.

Replaced with a per-report **CSP nonce** generated via `secrets.token_urlsafe(16)`:
- Every `<script>` tag (CDN bundle + inline bootstraps) receives `nonce="{nonce}"`
- CSP `script-src` changed from `'unsafe-inline'` to `'nonce-{nonce}'`
- `style-src 'unsafe-inline'` is retained (Plotly renders inline styles dynamically)
- Regression test updated to assert `'unsafe-inline'` is absent from `script-src` and a nonce is present

## Test plan

- [x] `uv run pytest` — **999 passed** (backend, unchanged)
- [x] `pnpm vitest run` — **1295 passed / 2 skipped** (+1 new key-order test)
- [x] `pnpm check` — **0 warnings**
- [x] `pnpm build` — green
- [x] `ruff check` / `mypy` — clean
- [x] CI green