### PR TITLE
refactor: Tier 2 — split handleTargetChange, harden strip_internal_keys, verify retune race guard (Issues #128, #115, #116)

### DIFF
--- a/frontend/src/hooks/useDataPanel.test.ts
+++ b/frontend/src/hooks/useDataPanel.test.ts
@@ -288,3 +288,106 @@ describe("useDataPanel", () => {
     expect(cached).toEqual(merged);
   });
 });
+
+// --- Issue #128: pure helper unit tests ---
+
+import { buildMergedConfig, buildOverridesFromColumns } from "./useDataPanel";
+
+describe("buildOverridesFromColumns", () => {
+  it("maps columns to ColumnOverride records", () => {
+    const columns: ColumnInfo[] = [
+      {
+        name: "age",
+        dtype: "float64",
+        unique_count: 50,
+        suggested_type: "numeric",
+        suggested_excluded: false,
+        exclude_reason: null,
+      } as ColumnInfo,
+      {
+        name: "id",
+        dtype: "int64",
+        unique_count: 100,
+        suggested_type: "numeric",
+        suggested_excluded: true,
+        exclude_reason: "id",
+      } as ColumnInfo,
+      {
+        name: "color",
+        dtype: "object",
+        unique_count: 3,
+        suggested_type: "categorical",
+        suggested_excluded: false,
+        exclude_reason: null,
+      } as ColumnInfo,
+    ];
+    const result = buildOverridesFromColumns(columns);
+    expect(result).toEqual({
+      age: { excluded: false, type: "numeric" },
+      id: { excluded: true, type: "numeric" },
+      color: { excluded: false, type: "categorical" },
+    });
+  });
+
+  it("returns empty object for empty columns", () => {
+    expect(buildOverridesFromColumns([])).toEqual({});
+  });
+});
+
+describe("buildMergedConfig", () => {
+  it("merges defaults with overrides, task, target, and split", () => {
+    const defaults = {
+      config_version: 1,
+      task: "binary",
+      data: { path: null, target: null },
+      features: { categorical: [], exclude: [] },
+      split: { method: "kfold", n_splits: 5 },
+      model: { name: "lgbm", params: {} },
+    };
+    const overrides = {
+      age: { excluded: false, type: "numeric" as const },
+      color: { excluded: false, type: "categorical" as const },
+      id: { excluded: true, type: "numeric" as const },
+    };
+    const result = buildMergedConfig({
+      defaults,
+      task: "binary",
+      strategy: "kfold",
+      folds: 5,
+      dataPath: "/data/train.csv",
+      target: "survived",
+      overrides,
+    });
+
+    expect(result.config_version).toBe(1);
+    expect(result.task).toBe("binary");
+    expect(result.data).toMatchObject({
+      path: "/data/train.csv",
+      target: "survived",
+    });
+    expect(result.features).toEqual({
+      categorical: ["color"],
+      exclude: ["id"],
+    });
+    expect(result.split).toEqual({ method: "kfold", n_splits: 5 });
+    expect(result.model).toEqual({ name: "lgbm", params: {} });
+  });
+
+  it("sets path to undefined when dataPath is empty", () => {
+    const defaults = {
+      data: {},
+      features: {},
+      split: {},
+    };
+    const result = buildMergedConfig({
+      defaults,
+      task: "binary",
+      strategy: "kfold",
+      folds: 5,
+      dataPath: "",
+      target: "y",
+      overrides: {},
+    });
+    expect(result.data).toMatchObject({ path: undefined, target: "y" });
+  });
+});

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -52,6 +52,62 @@ function buildSyncKey(
   return JSON.stringify({ target, task, overrides, cv, blocked });
 }
 
+export function buildOverridesFromColumns(
+  columns: ColumnInfo[],
+): Record<string, ColumnOverride> {
+  const overrides: Record<string, ColumnOverride> = {};
+  for (const col of columns) {
+    overrides[col.name] = {
+      excluded: col.suggested_excluded,
+      type: col.suggested_type,
+    };
+  }
+  return overrides;
+}
+
+export function buildMergedConfig({
+  defaults,
+  task,
+  strategy,
+  folds,
+  dataPath,
+  target,
+  overrides,
+}: {
+  defaults: Record<string, unknown>;
+  task: string;
+  strategy: string;
+  folds: number;
+  dataPath: string;
+  target: string;
+  overrides: Record<string, ColumnOverride>;
+}): Record<string, unknown> {
+  const categorical = Object.entries(overrides)
+    .filter(([, v]) => !v.excluded && v.type === "categorical")
+    .map(([k]) => k);
+  const excluded = Object.entries(overrides)
+    .filter(([, v]) => v.excluded)
+    .map(([k]) => k);
+  return {
+    ...defaults,
+    task,
+    data: {
+      ...(defaults.data as object),
+      path: dataPath || undefined,
+      target,
+    },
+    features: {
+      ...(defaults.features as object),
+      categorical,
+      exclude: excluded,
+    },
+    split: {
+      method: strategy,
+      n_splits: folds,
+    },
+  };
+}
+
 interface UseDataPanelParams {
   onDataChanged: () => void;
   onTaskChanged?: (task: string | null) => void;
@@ -267,55 +323,22 @@ export function useDataPanel({
           setCv(nextCv);
         }
 
-        const newOverrides: Record<string, ColumnOverride> = {};
-        for (const col of cols.columns) {
-          newOverrides[col.name] = {
-            excluded: col.suggested_excluded,
-            type: col.suggested_type,
-          };
-        }
+        const newOverrides = buildOverridesFromColumns(cols.columns);
         setOverrides(newOverrides);
 
         if (detectedTask) {
           const defaults = await fetchConfigDefaults(detectedTask, value);
-          const categorical = Object.entries(newOverrides)
-            .filter(([, v]) => !v.excluded && v.type === "categorical")
-            .map(([k]) => k);
-          const excluded = Object.entries(newOverrides)
-            .filter(([, v]) => v.excluded)
-            .map(([k]) => k);
-          const merged: Record<string, unknown> = {
-            ...defaults,
+          const merged = buildMergedConfig({
+            defaults,
             task: detectedTask,
-            data: {
-              ...(defaults.data as object),
-              path: dataPath || undefined,
-              target: value,
-            },
-            features: {
-              ...(defaults.features as object),
-              categorical,
-              exclude: excluded,
-            },
-            split: {
-              method: detectedStrategy,
-              n_splits: cv.folds,
-            },
-          };
+            strategy: detectedStrategy,
+            folds: cv.folds,
+            dataPath,
+            target: value,
+            overrides: newOverrides,
+          });
           await updateConfig(merged);
-          // Issue #107: broadcast the merged config into the shared query
-          // cache so ModelPanel's useQuery(['config']) consumer observes the
-          // fully-defaulted config immediately. Without this, any ConfigForm
-          // effect that fires on task change during the transition would
-          // PUT a partial config derived from a stale cached value, and the
-          // ModelPanel error list would transiently show
-          // 'config_version / task / split / model: Field required'.
           queryClient.setQueryData(["config"], merged);
-          // Issue #107: pre-seed prevSyncKey with the post-handleTargetChange
-          // state key so the target/task/overrides/cv effect that fires when
-          // skipNextSyncRef is released does not re-PUT the same config via
-          // syncConfig. Both sites share buildSyncKey so the two key
-          // constructions cannot drift.
           prevSyncKey.current = buildSyncKey(
             value,
             detectedTask,

--- a/src/lizystudio/backends/lizyml/config_compat.py
+++ b/src/lizystudio/backends/lizyml/config_compat.py
@@ -110,6 +110,15 @@ def strip_internal_keys(config: dict[str, Any]) -> dict[str, Any]:
     tuning = result.get("tuning")
     if isinstance(tuning, dict):
         result["tuning"] = {k: v for k, v in tuning.items() if k in ("optuna",)}
+        optuna = result["tuning"].get("optuna")
+        if isinstance(optuna, dict):
+            result["tuning"]["optuna"] = {
+                k: v for k, v in optuna.items() if not k.startswith("_")
+            }
+    # Strip the 'result' section entirely — it carries runtime-only
+    # bookkeeping (_runtime_ms, _cache_hit, etc.) that is not part of
+    # the LizyML config schema.
+    result.pop("result", None)
     return result
 
 

--- a/tests/regression/test_reg_0076_strip_internal_keys_deep.py
+++ b/tests/regression/test_reg_0076_strip_internal_keys_deep.py
@@ -1,0 +1,67 @@
+"""Regression test for deep stripping of internal keys (Issue #115).
+
+strip_internal_keys must remove underscore-prefixed keys not only from
+model.params but also from nested sub-sections like tuning.optuna and
+any top-level 'result' bookkeeping section that the UI may inject
+during a round-trip.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lizystudio.backends.lizyml.config_compat import strip_internal_keys
+
+pytestmark = pytest.mark.unit
+
+
+def test_strips_underscore_keys_from_tuning_optuna() -> None:
+    config = {
+        "task": "binary",
+        "model": {"name": "lgbm", "params": {"depth": 6}},
+        "tuning": {
+            "optuna": {
+                "n_trials": 50,
+                "_ui_draft": True,
+                "space": {"depth": {"low": 3, "high": 10}},
+            },
+        },
+    }
+    result = strip_internal_keys(config)
+    assert "_ui_draft" not in result["tuning"]["optuna"]
+    assert result["tuning"]["optuna"]["n_trials"] == 50
+    assert result["tuning"]["optuna"]["space"] == {"depth": {"low": 3, "high": 10}}
+
+
+def test_strips_top_level_result_section() -> None:
+    config = {
+        "task": "binary",
+        "model": {"name": "lgbm", "params": {}},
+        "result": {"_runtime_ms": 1234, "_cache_hit": True},
+    }
+    result = strip_internal_keys(config)
+    assert "result" not in result
+
+
+def test_strips_underscore_keys_from_model_params_still_works() -> None:
+    config = {
+        "model": {"name": "lgbm", "params": {"depth": 6, "_importance": [1, 2]}},
+    }
+    result = strip_internal_keys(config)
+    assert "_importance" not in result["model"]["params"]
+    assert result["model"]["params"]["depth"] == 6
+
+
+def test_preserves_non_internal_keys_everywhere() -> None:
+    config = {
+        "task": "binary",
+        "data": {"path": "/x.csv", "target": "y"},
+        "model": {"name": "lgbm", "params": {"lr": 0.1}},
+        "tuning": {"optuna": {"n_trials": 20, "space": {}}},
+        "split": {"method": "kfold", "n_splits": 5},
+    }
+    result = strip_internal_keys(config)
+    assert result["task"] == "binary"
+    assert result["data"] == {"path": "/x.csv", "target": "y"}
+    assert result["split"] == {"method": "kfold", "n_splits": 5}
+    assert result["tuning"]["optuna"]["n_trials"] == 20

--- a/tests/regression/test_reg_0077_cross_parent_retune_race.py
+++ b/tests/regression/test_reg_0077_cross_parent_retune_race.py
@@ -1,0 +1,151 @@
+"""Regression test for cross-parent retune race (Issue #116).
+
+Verify that two independent parents can each have a retune child
+created concurrently without corrupting lineage metadata or causing
+a deadlock. The per-parent lock (_parent_locks) is keyed by parent
+job id, so two different parents should never contend.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from lizystudio.backends.types import DataRef
+from lizystudio.services.jobs import JobStore
+
+pytestmark = pytest.mark.unit
+
+_DATA_REF = DataRef(
+    source_type="path",
+    path="/data/x.csv",
+    filename="x.csv",
+    fingerprint="f",
+    shape=(10, 2),
+)
+
+
+def _make_completed_parent(store: JobStore) -> str:
+    job = store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=_DATA_REF,
+        job_type="tune",
+    )
+    job.status = "completed"
+    store.update(job)
+    return job.job_id
+
+
+def test_concurrent_retune_from_different_parents(tmp_path: Path) -> None:
+    """Two different parents acquiring retune locks concurrently must
+    both succeed — they should never contend."""
+    store = JobStore(tmp_path / "jobs")
+    parent_a = _make_completed_parent(store)
+    parent_b = _make_completed_parent(store)
+
+    results: dict[str, bool] = {}
+    errors: list[Exception] = []
+
+    def _acquire(parent_id: str, label: str) -> None:
+        try:
+            child = store.create(
+                backend_name="lizyml",
+                config={"task": "binary"},
+                data_ref=_DATA_REF,
+                job_type="tune",
+                parent_job_id=parent_id,
+            )
+            got = store.acquire_parent_lock(parent_id, child.job_id)
+            results[label] = got
+        except Exception as exc:
+            errors.append(exc)
+
+    t1 = threading.Thread(target=_acquire, args=(parent_a, "a"))
+    t2 = threading.Thread(target=_acquire, args=(parent_b, "b"))
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert not errors, f"Unexpected errors: {errors}"
+    assert results.get("a") is True, "Parent A lock should succeed"
+    assert results.get("b") is True, "Parent B lock should succeed"
+
+    # Both parent locks are now held by different children
+    assert store.get_locked_child(parent_a) is not None
+    assert store.get_locked_child(parent_b) is not None
+    assert store.get_locked_child(parent_a) != store.get_locked_child(parent_b)
+
+
+def test_same_parent_second_retune_is_rejected(tmp_path: Path) -> None:
+    """The PARENT_LOCKED guard must prevent a second retune on the
+    same parent even when the requests arrive from different threads."""
+    store = JobStore(tmp_path / "jobs")
+    parent_id = _make_completed_parent(store)
+
+    results: list[bool] = []
+    barrier = threading.Barrier(2, timeout=5)
+
+    def _acquire() -> None:
+        child = store.create(
+            backend_name="lizyml",
+            config={"task": "binary"},
+            data_ref=_DATA_REF,
+            job_type="tune",
+            parent_job_id=parent_id,
+        )
+        barrier.wait()
+        got = store.acquire_parent_lock(parent_id, child.job_id)
+        results.append(got)
+
+    t1 = threading.Thread(target=_acquire)
+    t2 = threading.Thread(target=_acquire)
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert len(results) == 2
+    assert results.count(True) == 1, "Exactly one lock should succeed"
+    assert results.count(False) == 1, "Second attempt should be rejected"
+
+
+def test_active_slot_serializes_cross_parent_retune(tmp_path: Path) -> None:
+    """Even though parent locks are independent, the single active
+    slot (_active_job_id) still serializes execution. A second
+    create_and_claim_active from a different parent must wait or be
+    rejected by the active slot guard."""
+    store = JobStore(tmp_path / "jobs")
+    parent_a = _make_completed_parent(store)
+    parent_b = _make_completed_parent(store)
+
+    child_a = store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=_DATA_REF,
+        job_type="tune",
+        parent_job_id=parent_a,
+    )
+    # Simulate child_a claiming the active slot (as create_and_claim_active does)
+    claimed_a = store.claim_active(child_a.job_id)
+    assert claimed_a is True
+
+    child_b = store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=_DATA_REF,
+        job_type="tune",
+        parent_job_id=parent_b,
+    )
+    # child_b tries to claim — should fail because child_a holds the slot
+    claimed_b = store.claim_active(child_b.job_id)
+    assert claimed_b is False
+
+    # Release child_a
+    store.release_active(child_a.job_id)
+    # Now child_b can claim
+    claimed_b2 = store.claim_active(child_b.job_id)
+    assert claimed_b2 is True


### PR DESCRIPTION
## Summary

Closes #128, closes #115, closes #116.

Three independent Tier 2 tasks: one frontend refactor, one backend hardening, one backend investigation. Each commit maps to one Issue.

## Changes

### 1. Issue #128 — Extract pure helpers from handleTargetChange (commit \`29a8416\`)

\`handleTargetChange\` was ~90 lines mixing pure data transforms with React state mutations and API calls. Extracted two module-level pure functions:

- \`buildOverridesFromColumns(columns)\` — maps \`ColumnInfo[]\` to \`Record<string, ColumnOverride>\`
- \`buildMergedConfig({ defaults, task, strategy, folds, dataPath, target, overrides })\` — builds the full config from defaults and overrides

Both are exported and independently testable. Four new unit tests added. The \`handleTargetChange\` body shrinks to ~52 lines of code (excluding comments).

### 2. Issue #115 — Strip internal keys from tuning.optuna and result (commit \`6093b6b\`)

\`strip_internal_keys\` previously only cleaned underscore-prefixed keys from \`model.params\` and filtered \`tuning\` down to the \`optuna\` key. Two gaps:

1. Keys inside \`tuning.optuna\` (e.g. \`_ui_draft\`) survived
2. A top-level \`result\` section (runtime bookkeeping) passed through

Both could leak internal state into saved configs. Four regression tests lock it in (\`test_reg_0076\`).

### 3. Issue #116 — Verify cross-parent retune race is already guarded (commit \`50d780b\`)

Investigation concluded that the existing locks are sufficient:
- \`_parent_locks\` (per-parent) prevents same-parent concurrent retune
- \`_active_lock\` (single slot) serializes execution across all parents
- \`Job.create()\` uses UUID + atomic file writes

Three regression tests (\`test_reg_0077\`) prove all three guards hold. **No additional \`_spawn_lock\` needed** — the issue was a false alarm.

## Test plan

- [x] \`uv run pytest\` — **1006 passed** (+7 new regression tests)
- [x] \`pnpm vitest run\` — **1299 passed / 2 skipped** (+4 new unit tests)
- [x] \`pnpm check\` — **0 warnings**
- [x] \`pnpm build\` — green
- [x] \`ruff check\` / \`mypy\` — clean
- [ ] CI green