### PR TITLE
ci(nightly): add Plotly CDN SRI check (Issue #105)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,6 +28,38 @@ jobs:
       - run: uv run mypy src/lizystudio/
       - run: uv run pytest --cov=src/lizystudio --cov-report=term-missing --cov-fail-under=80 -q
 
+  plotly-cdn:
+    name: Plotly CDN reachability & SRI freshness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: develop
+      - name: Verify CDN bundle is reachable and SRI hash matches
+        run: |
+          set -euo pipefail
+          # Extract pinned version and SRI from the source of truth
+          VERSION=$(grep '_PLOTLY_VERSION = ' src/lizystudio/services/export.py \
+            | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          EXPECTED_SRI=$(grep '_PLOTLY_SRI = ' src/lizystudio/services/export.py \
+            | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          URL="https://cdn.plot.ly/${VERSION}"
+          echo "Fetching ${URL} ..."
+          # Download the bundle (fail loudly on non-200)
+          curl -fsSL -o /tmp/plotly-bundle.js "${URL}"
+          echo "✓ CDN returned 200"
+          # Compute the actual SRI hash (sha384, base64)
+          ACTUAL_HASH=$(openssl dgst -sha384 -binary /tmp/plotly-bundle.js | openssl base64 -A)
+          ACTUAL_SRI="sha384-${ACTUAL_HASH}"
+          echo "Expected: ${EXPECTED_SRI}"
+          echo "Actual:   ${ACTUAL_SRI}"
+          if [ "${EXPECTED_SRI}" != "${ACTUAL_SRI}" ]; then
+            echo "::error::SRI hash mismatch! The CDN bundle has changed since the hash was pinned."
+            echo "Recompute with: curl -fsSL ${URL} | openssl dgst -sha384 -binary | openssl base64 -A"
+            exit 1
+          fi
+          echo "✓ SRI hash matches"
+
   frontend:
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
## Summary

Closes #105.

Adds a new nightly job that verifies the Plotly CDN bundle used by the HTML export report is still reachable and its SRI hash still matches the value pinned in \`export.py\`.

## Changes

- \`nightly.yml\`: new \`plotly-cdn\` job that downloads the pinned bundle, computes sha384, and compares against \`_PLOTLY_SRI\`. Fails with an actionable error and recomputation one-liner if the hash diverges.

## Verification

Tested locally — the SRI hash matches:
\`\`\`
Expected: sha384-Hl48Kq2HifOWdXEjMsKo6qxqvRLTYqIGbvlENBmkHAxZKIGCXv43H6W1jA671RzC
Actual:   sha384-Hl48Kq2HifOWdXEjMsKo6qxqvRLTYqIGbvlENBmkHAxZKIGCXv43H6W1jA671RzC
MATCH
\`\`\`

## Also closed

- **#119** (trial count test brittleness): investigation found all remaining exact-count assertions are justified. No code changes needed. Closed with a detailed audit comment.

## Test plan

- [x] Local verification of CDN reachability + SRI match
- [x] No code changes to existing tests or production code
- [x] CI — verify the nightly workflow file parses correctly