### PR TITLE
refactor(services): consolidate retune subprocess into shared orchestrator (Issue #118)

### DIFF
--- a/src/lizystudio/services/training.py
+++ b/src/lizystudio/services/training.py
@@ -422,45 +422,68 @@ def _run_subprocess_job(
     ws: WorkspaceState,
     job: Job,
     job_store: JobStore,
-    broadcaster: ProgressBroadcaster,
-) -> None:
-    """Run a job via subprocess and update workspace state (H-0036).
+    broadcaster: ProgressBroadcaster | None,
+    *,
+    mode: str | None = None,
+    parent_job_id: str | None = None,
+    retune_n_trials: int | None = None,
+    retune_expand_boundary: bool | None = None,
+    retune_boundary_threshold: float | None = None,
+    on_data_missing: Callable[[Job], None] | None = None,
+) -> Job:
+    """Run a job via subprocess and update workspace state.
 
-    CRITICAL-2 follow-up: the active-slot claim performed by
-    ``create_and_claim_active`` in the API layer must be released here
-    too. The in-process ``_run_job_core`` path does that via its
-    ``finally`` block, but subprocess execution bypasses that code
-    entirely — the child process has its own ``JobStore`` instance, so
-    the parent's slot stays held until server restart. This broke the
-    second tune request in a row whenever OpenMP routed jobs through
-    the subprocess path.
+    Shared by fit, tune, and retune subprocess paths. Optional keyword
+    arguments carry retune-specific inputs so they can be forwarded to
+    the child process without duplicating the orchestration logic.
+
+    *on_data_missing* is called instead of the default inline failure
+    handling when ``ws.data_ref.path`` is absent; retune uses this to
+    route through ``_mark_retune_child_failed`` which also releases
+    the parent lock.
     """
     from lizystudio.services.subprocess_runner import run_job_in_subprocess
     from lizystudio.services.workspace import get_backend_name
 
     try:
         if ws.data_ref is None or not ws.data_ref.path:
-            job.status = "failed"
-            job.error = "No data loaded — cannot run subprocess job"
-            job.completed_at = datetime.now(timezone.utc).isoformat()
-            job_store.update(job)
-            if broadcaster is not None:
-                broadcaster.send_error(job.job_id, job.error)
-            with ws._lock:
-                ws.current_job_id = job.job_id
-            return
+            if on_data_missing is not None:
+                on_data_missing(job)
+            else:
+                job.status = "failed"
+                job.error = "No data loaded — cannot run subprocess job"
+                job.completed_at = datetime.now(timezone.utc).isoformat()
+                job_store.update(job)
+                if broadcaster is not None:
+                    broadcaster.send_error(job.job_id, job.error)
+                with ws._lock:
+                    ws.current_job_id = job.job_id
+            return job
         data_path = ws.data_ref.path
+        extra_kwargs: dict[str, Any] = {}
+        if mode is not None:
+            extra_kwargs["mode"] = mode
+        if parent_job_id is not None:
+            extra_kwargs["parent_job_id"] = parent_job_id
+        if retune_n_trials is not None:
+            extra_kwargs["retune_n_trials"] = retune_n_trials
+        if retune_expand_boundary is not None:
+            extra_kwargs["retune_expand_boundary"] = retune_expand_boundary
+        if retune_boundary_threshold is not None:
+            extra_kwargs["retune_boundary_threshold"] = retune_boundary_threshold
         finished = run_job_in_subprocess(
             job=job,
             job_store=job_store,
             broadcaster=broadcaster,
             backend_name=get_backend_name(ws),
             data_path=data_path,
+            **extra_kwargs,
         )
         with ws._lock:
             ws.workspace_fit_result = finished.fit_result
             ws.workspace_tune_result = finished.tune_result
             ws.current_job_id = finished.job_id
+        return finished
     finally:
         job_store.release_active(job.job_id)
 

--- a/src/lizystudio/services/training_retune.py
+++ b/src/lizystudio/services/training_retune.py
@@ -159,25 +159,16 @@ def _run_retune_subprocess(
     expand_boundary: bool | None,
     boundary_threshold: float | None,
 ) -> Job:
-    """Execute a Re-tune child job in a subprocess (H-0062 Bugfix 2026-04-14).
+    """Execute a Re-tune child job in a subprocess (H-0062).
 
-    The parent thread cannot run lizyml / LightGBM because OpenMP would
-    bind its thread pool to the daemon thread and cause ~8-50× slowdown
-    (see ``openmp_detect.should_use_subprocess``). Mirrors the path used
-    by ``start_fit_async`` / ``start_tune_async`` but forwards the
-    Re-tune specific inputs so the child process can reconstruct the
-    run without accessing the parent's in-memory WorkspaceState.
-
-    The caller (``start_retune_async``) is responsible for guaranteeing
-    ``ws.data_ref.path`` is set before invoking this helper. Bugfix
-    2026-04-14 (6): previously this used ``assert`` which left the
-    child job in ``pending`` forever when the invariant was violated.
-    Now a runtime check marks the child failed via the shared helper.
+    Delegates to the shared ``_run_subprocess_job`` orchestrator
+    (Issue #118) so subprocess lifecycle management (data-ref check,
+    ``run_job_in_subprocess`` call, workspace state update, and
+    active-slot release) is not duplicated.
     """
-    from lizystudio.services.subprocess_runner import run_job_in_subprocess
-    from lizystudio.services.workspace import get_backend_name
+    from lizystudio.services.training import _run_subprocess_job
 
-    if ws.data_ref is None or not ws.data_ref.path:
+    def _on_data_missing(_job: Job) -> None:
         _mark_retune_child_failed(
             ws=ws,
             job_store=job_store,
@@ -188,33 +179,19 @@ def _run_retune_subprocess(
                 "(ws.data_ref.path is empty)"
             ),
         )
-        return child_job
 
-    try:
-        finished = run_job_in_subprocess(
-            job=child_job,
-            job_store=job_store,
-            broadcaster=broadcaster,
-            backend_name=get_backend_name(ws),
-            data_path=ws.data_ref.path,
-            mode="retune",
-            parent_job_id=parent_job.job_id,
-            retune_n_trials=n_trials,
-            retune_expand_boundary=expand_boundary,
-            retune_boundary_threshold=boundary_threshold,
-        )
-        with ws._lock:
-            ws.workspace_fit_result = finished.fit_result
-            ws.workspace_tune_result = finished.tune_result
-            ws.current_job_id = finished.job_id
-        return finished
-    finally:
-        # CRITICAL-2 follow-up: release the parent-process active slot
-        # that ``create_and_claim_active`` took when this retune was
-        # started. The subprocess path has its own child JobStore so
-        # the in-process _run_job_core finally does not touch the
-        # parent's _active_job_id.
-        job_store.release_active(child_job.job_id)
+    return _run_subprocess_job(
+        ws,
+        child_job,
+        job_store,
+        broadcaster,
+        mode="retune",
+        parent_job_id=parent_job.job_id,
+        retune_n_trials=n_trials,
+        retune_expand_boundary=expand_boundary,
+        retune_boundary_threshold=boundary_threshold,
+        on_data_missing=_on_data_missing,
+    )
 
 
 def start_retune_async(


### PR DESCRIPTION
## Summary

Closes #118.

\`_run_retune_subprocess\` duplicated most of \`_run_subprocess_job\`: data-ref check, \`run_job_in_subprocess\` call, workspace state update, and active slot release. The only differences were retune-specific kwargs and the error-handling callback.

## Changes

- **\`training.py\`**: Extend \`_run_subprocess_job\` with optional keyword arguments (\`mode\`, \`parent_job_id\`, \`retune_n_trials\`, \`retune_expand_boundary\`, \`retune_boundary_threshold\`) and an \`on_data_missing\` callback. The function now returns \`Job\` and accepts \`broadcaster: ProgressBroadcaster | None\`.
- **\`training_retune.py\`**: \`_run_retune_subprocess\` now delegates to \`_run_subprocess_job\` in a five-line body, passing retune-specific kwargs and its own \`_on_data_missing\` handler.

Net change: 64 insertions, 64 deletions — the line count is identical, but the duplication is eliminated.

## Test plan

- [x] \`uv run pytest\` — **1006 passed** (unchanged, all retune tests green)
- [x] \`ruff check\` / \`mypy\` — clean
- [x] CI green