### PR TITLE
ux(workspace): promote Re-Tune, Resume, and Export Code buttons to default variant (Issue #121)

### DIFF
--- a/frontend/src/components/workspace/ResultsCompletedView.tsx
+++ b/frontend/src/components/workspace/ResultsCompletedView.tsx
@@ -261,7 +261,7 @@ export function ResultsCompletedView({
             />
           )}
           <Button
-            variant="outline"
+            variant="default"
             size="sm"
             onClick={() => {
               window.open(`/api/jobs/${job.job_id}/export-code`, "_blank");

--- a/frontend/src/components/workspace/retune/ResumeActionButton.tsx
+++ b/frontend/src/components/workspace/retune/ResumeActionButton.tsx
@@ -84,7 +84,7 @@ export function ResumeActionButton({
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button
-          variant="outline"
+          variant="default"
           size="sm"
           disabled={disabled}
           title={tooltip}

--- a/frontend/src/components/workspace/retune/RetuneActionButton.tsx
+++ b/frontend/src/components/workspace/retune/RetuneActionButton.tsx
@@ -90,7 +90,7 @@ export function RetuneActionButton({
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button
-          variant="outline"
+          variant="default"
           size="sm"
           disabled={disabled}
           title={tooltip}


### PR DESCRIPTION
## Summary

Closes #121.

The Re-Tune, Resume, and Export Code action buttons in the completed job view were styled as \`variant="outline"\` (ghost appearance) while Apply to Fit used the default filled-primary variant. This made the other actions visually recede despite being equally important next-step actions.

## Before / After

| Button | Before | After |
|---|---|---|
| Apply to Fit | \`default\` (filled primary) | \`default\` (unchanged) |
| Re-Tune (+N trials) | \`outline\` (border only) | **\`default\`** (filled primary) |
| Resume (X trials remaining) | \`outline\` (border only) | **\`default\`** (filled primary) |
| Export Code | \`outline\` (border only) | **\`default\`** (filled primary) |

All four buttons now share equal visual weight. Each retains its distinguishing icon (\`ArrowRight\`, \`Repeat\`, \`PlayCircle\`, \`Download\`) for identification. Dialog-internal Cancel buttons remain \`outline\` as they are secondary actions.

## Changes

- \`RetuneActionButton.tsx\`: trigger button \`variant="outline"\` → \`"default"\`
- \`ResumeActionButton.tsx\`: trigger button \`variant="outline"\` → \`"default"\`
- \`ResultsCompletedView.tsx\`: Export Code button \`variant="outline"\` → \`"default"\`

Minimal diff: 3 files, 3 lines changed.

## Test plan

- [x] \`pnpm vitest run\` — 1299 passed / 2 skipped (unchanged)
- [x] \`pnpm check\` — 0 warnings
- [x] \`pnpm build\` — green
- [x] Visual smoke test: run a tune job, verify all four buttons render with equal prominence on the completed view
- [x] CI green