### PR TITLE
feat(workspace): add ConfigDiffBadge for stale results

### DIFF
--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,0 +1,87 @@
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/frontend/src/components/workspace/ConfigDiffBadge.test.tsx
+++ b/frontend/src/components/workspace/ConfigDiffBadge.test.tsx
@@ -1,0 +1,129 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { renderWithQuery } from "@/test/helpers";
+import { ConfigDiffBadge } from "./ConfigDiffBadge";
+
+describe("ConfigDiffBadge", () => {
+  const baseConfig = {
+    data: { target: "price" },
+    features: {
+      exclude: ["id", "date"],
+      categorical: ["color"],
+    },
+  };
+
+  it("renders nothing when configs are identical", () => {
+    const jobConfig = {
+      data: { target: "price" },
+      features: { exclude: ["id", "date"], categorical: ["color"] },
+    };
+    const currentConfig = {
+      data: { target: "price" },
+      features: { exclude: ["id", "date"], categorical: ["color"] },
+    };
+    const { container } = renderWithQuery(
+      <ConfigDiffBadge jobConfig={jobConfig} currentConfig={currentConfig} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when currentConfig is undefined", () => {
+    const { container } = renderWithQuery(
+      <ConfigDiffBadge jobConfig={baseConfig} currentConfig={undefined} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders badge when exclude lists differ", () => {
+    const currentConfig = {
+      ...baseConfig,
+      features: { ...baseConfig.features, exclude: ["id"] },
+    };
+    renderWithQuery(
+      <ConfigDiffBadge jobConfig={baseConfig} currentConfig={currentConfig} />,
+    );
+    expect(screen.getByText("Settings changed")).toBeInTheDocument();
+  });
+
+  it("renders badge when categorical lists differ", () => {
+    const currentConfig = {
+      ...baseConfig,
+      features: {
+        ...baseConfig.features,
+        categorical: ["color", "size"],
+      },
+    };
+    renderWithQuery(
+      <ConfigDiffBadge jobConfig={baseConfig} currentConfig={currentConfig} />,
+    );
+    expect(screen.getByText("Settings changed")).toBeInTheDocument();
+  });
+
+  it("renders badge when target differs", () => {
+    const currentConfig = {
+      ...baseConfig,
+      data: { target: "quantity" },
+    };
+    renderWithQuery(
+      <ConfigDiffBadge jobConfig={baseConfig} currentConfig={currentConfig} />,
+    );
+    expect(screen.getByText("Settings changed")).toBeInTheDocument();
+  });
+
+  it("shows diff details on click", async () => {
+    const user = userEvent.setup();
+    const currentConfig = {
+      data: { target: "quantity" },
+      features: {
+        exclude: ["id"],
+        categorical: ["color", "size"],
+      },
+    };
+    renderWithQuery(
+      <ConfigDiffBadge jobConfig={baseConfig} currentConfig={currentConfig} />,
+    );
+    await user.click(screen.getByText("Settings changed"));
+    expect(screen.getByText(/Target/)).toBeInTheDocument();
+    expect(screen.getByText(/Excluded/)).toBeInTheDocument();
+    expect(screen.getByText(/Categorical/)).toBeInTheDocument();
+  });
+
+  it("treats missing features as empty arrays", () => {
+    const jobConfig = { data: { target: "price" } };
+    const currentConfig = {
+      data: { target: "price" },
+      features: { exclude: ["id"], categorical: [] },
+    };
+    renderWithQuery(
+      <ConfigDiffBadge jobConfig={jobConfig} currentConfig={currentConfig} />,
+    );
+    expect(screen.getByText("Settings changed")).toBeInTheDocument();
+  });
+
+  it("ignores order differences in exclude/categorical arrays", () => {
+    const jobConfig = {
+      ...baseConfig,
+      features: { exclude: ["date", "id"], categorical: ["color"] },
+    };
+    const currentConfig = {
+      ...baseConfig,
+      features: { exclude: ["id", "date"], categorical: ["color"] },
+    };
+    const { container } = renderWithQuery(
+      <ConfigDiffBadge jobConfig={jobConfig} currentConfig={currentConfig} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("has accessible role=button on the badge trigger", () => {
+    const currentConfig = {
+      ...baseConfig,
+      data: { target: "quantity" },
+    };
+    renderWithQuery(
+      <ConfigDiffBadge jobConfig={baseConfig} currentConfig={currentConfig} />,
+    );
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/workspace/ConfigDiffBadge.tsx
+++ b/frontend/src/components/workspace/ConfigDiffBadge.tsx
@@ -1,0 +1,147 @@
+import { AlertTriangle } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+interface ConfigDiffBadgeProps {
+  jobConfig: Record<string, unknown>;
+  currentConfig: Record<string, unknown> | undefined;
+}
+
+interface ConfigDiff {
+  target: { job: string | null; current: string | null } | null;
+  exclude: { job: string[]; current: string[] } | null;
+  categorical: { job: string[]; current: string[] } | null;
+}
+
+function extractTarget(config: Record<string, unknown>): string | null {
+  const data = config.data as Record<string, unknown> | undefined;
+  const target = data?.target;
+  return typeof target === "string" ? target : null;
+}
+
+function extractStringArray(
+  config: Record<string, unknown>,
+  field: string,
+): string[] {
+  const features = config.features as Record<string, unknown> | undefined;
+  const raw = features?.[field];
+  return Array.isArray(raw)
+    ? raw.filter((v): v is string => typeof v === "string").sort()
+    : [];
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function computeDiff(
+  jobConfig: Record<string, unknown>,
+  currentConfig: Record<string, unknown>,
+): ConfigDiff | null {
+  const jobTarget = extractTarget(jobConfig);
+  const curTarget = extractTarget(currentConfig);
+  const jobExclude = extractStringArray(jobConfig, "exclude");
+  const curExclude = extractStringArray(currentConfig, "exclude");
+  const jobCat = extractStringArray(jobConfig, "categorical");
+  const curCat = extractStringArray(currentConfig, "categorical");
+
+  const targetDiff =
+    jobTarget !== curTarget ? { job: jobTarget, current: curTarget } : null;
+  const excludeDiff = !arraysEqual(jobExclude, curExclude)
+    ? { job: jobExclude, current: curExclude }
+    : null;
+  const catDiff = !arraysEqual(jobCat, curCat)
+    ? { job: jobCat, current: curCat }
+    : null;
+
+  if (!targetDiff && !excludeDiff && !catDiff) return null;
+  return { target: targetDiff, exclude: excludeDiff, categorical: catDiff };
+}
+
+export function ConfigDiffBadge({
+  jobConfig,
+  currentConfig,
+}: ConfigDiffBadgeProps) {
+  if (!currentConfig) return null;
+
+  const diff = computeDiff(jobConfig, currentConfig);
+  if (!diff) return null;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Badge
+          variant="outline"
+          className="cursor-pointer border-amber-400 text-amber-700 hover:bg-amber-50 dark:text-amber-400 dark:hover:bg-amber-950"
+          role="button"
+          tabIndex={0}
+        >
+          <AlertTriangle className="mr-1 h-3 w-3" aria-hidden="true" />
+          Settings changed
+        </Badge>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-72 text-xs">
+        <p className="mb-2 font-medium">
+          Current settings differ from this job&apos;s snapshot:
+        </p>
+        {diff.target && (
+          <DiffRow
+            label="Target"
+            job={diff.target.job ?? "(none)"}
+            current={diff.target.current ?? "(none)"}
+          />
+        )}
+        {diff.exclude && (
+          <DiffRow
+            label="Excluded"
+            job={formatList(diff.exclude.job)}
+            current={formatList(diff.exclude.current)}
+          />
+        )}
+        {diff.categorical && (
+          <DiffRow
+            label="Categorical"
+            job={formatList(diff.categorical.job)}
+            current={formatList(diff.categorical.current)}
+          />
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function DiffRow({
+  label,
+  job,
+  current,
+}: {
+  label: string;
+  job: string;
+  current: string;
+}) {
+  return (
+    <div className="mb-1.5 last:mb-0">
+      <span className="font-medium">{label}:</span>
+      <div className="ml-2 text-muted-foreground">
+        <div>
+          Job: <span className="text-foreground">{job}</span>
+        </div>
+        <div>
+          Now: <span className="text-foreground">{current}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatList(items: string[]): string {
+  return items.length === 0 ? "(none)" : items.join(", ");
+}

--- a/frontend/src/components/workspace/ResultsCompletedView.tsx
+++ b/frontend/src/components/workspace/ResultsCompletedView.tsx
@@ -17,6 +17,7 @@ import { Accordion } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { pivotMetrics } from "@/lib/metrics";
+import { ConfigDiffBadge } from "./ConfigDiffBadge";
 import { FoldDetailsSection } from "./FoldDetailsSection";
 import { PlotSection } from "./PlotSection";
 import { JobLineageTree } from "./retune/JobLineageTree";
@@ -30,6 +31,7 @@ interface ResultsCompletedViewProps {
   job: JobDetail;
   headerLabel: string;
   modelName?: string;
+  currentConfig?: Record<string, unknown>;
   selectedPlot: string;
   onSelectPlot: (p: string) => void;
   onApplyToFit?: (params: Record<string, unknown>) => void;
@@ -41,6 +43,7 @@ export function ResultsCompletedView({
   job,
   headerLabel,
   modelName,
+  currentConfig,
   selectedPlot,
   onSelectPlot,
   onJobStarted,
@@ -252,6 +255,10 @@ export function ResultsCompletedView({
           Completed
         </Badge>
         {primaryMetric && <Badge variant="secondary">{primaryMetric}</Badge>}
+        <ConfigDiffBadge
+          jobConfig={(job.config ?? {}) as Record<string, unknown>}
+          currentConfig={currentConfig}
+        />
         <div className="ml-auto flex gap-2">
           {job.job_type === "tune" && tuneResult && (
             <RetuneActionButton

--- a/frontend/src/components/workspace/ResultsPanel.tsx
+++ b/frontend/src/components/workspace/ResultsPanel.tsx
@@ -21,6 +21,7 @@ interface ResultsPanelProps {
   jobId: string | null;
   hasData?: boolean;
   hasConfig?: boolean;
+  currentConfig?: Record<string, unknown>;
   onApplyToFit?: (params: Record<string, unknown>) => void;
   onJobDone?: () => void;
   /**
@@ -35,6 +36,7 @@ export function ResultsPanel({
   jobId,
   hasData = false,
   hasConfig = false,
+  currentConfig,
   onApplyToFit,
   onJobDone,
   onJobStarted,
@@ -308,6 +310,7 @@ export function ResultsPanel({
       job={job}
       headerLabel={headerLabel}
       modelName={modelName}
+      currentConfig={currentConfig}
       selectedPlot={selectedPlot}
       onSelectPlot={setSelectedPlot}
       onApplyToFit={onApplyToFit}

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -184,6 +184,7 @@ export function WorkspacePage() {
           jobId={currentJobId}
           hasData={hasData}
           hasConfig={hasData && config != null}
+          currentConfig={config ?? undefined}
           onApplyToFit={handleApplyToFit}
           onJobDone={handleJobDone}
           onJobStarted={handleJobStarted}


### PR DESCRIPTION
## Summary

- Add a "Settings changed" badge (`ConfigDiffBadge`) to the completed job results header that appears when Column Settings have been modified after a job run
- Badge opens a Popover on click showing the specific diffs (Target, Excluded, Categorical columns) between current config and the job's frozen snapshot
- Add shadcn/ui Popover component (`frontend/src/components/ui/popover.tsx`)
- Wire `currentConfig` prop through `WorkspacePage` → `ResultsPanel` → `ResultsCompletedView`

## Test plan

- [ ] `ConfigDiffBadge.test.tsx` unit tests pass (`pnpm test`)
- [ ] Badge is hidden when config matches the job snapshot
- [ ] Badge appears when any Column Setting differs from the snapshot
- [ ] Clicking badge opens Popover with correct diff details
- [ ] Popover closes on outside click / Escape
- [ ] Visual regression: no layout shift in results header

Closes #108