### PR TITLE
fix(frontend): resolve PR #141 regressions in target selection and UI

### DIFF
--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -27,8 +27,11 @@ function PopoverContent({
         data-slot="popover-content"
         align={align}
         sideOffset={sideOffset}
+        // NOTE: Keep origin-[var(...)] bracket syntax — Tailwind v3 cannot
+        // parse the v4 paren form `origin-(--var)`. Do not upgrade until
+        // the whole project moves to Tailwind v4 (Issue #125).
         className={cn(
-          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "z-50 w-72 origin-[var(--radix-popover-content-transform-origin)] rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
         {...props}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -61,8 +61,11 @@ function SelectContent({
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
         data-slot="select-content"
+        // NOTE: Keep max-h-[var(...)] and origin-[var(...)] bracket syntax —
+        // Tailwind v3 cannot parse the v4 paren form `max-h-(--var)`. Do not
+        // upgrade until the whole project moves to Tailwind v4 (Issue #125).
         className={cn(
-          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "relative z-50 max-h-[var(--radix-select-content-available-height)] min-w-[8rem] origin-[var(--radix-select-content-transform-origin)] overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -39,8 +39,11 @@ function TooltipContent({
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
         sideOffset={sideOffset}
+        // NOTE: Keep origin-[var(...)] bracket syntax — Tailwind v3 cannot
+        // parse the v4 paren form `origin-(--var)`. Do not upgrade until
+        // the whole project moves to Tailwind v4 (Issue #125).
         className={cn(
-          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          "z-50 w-fit origin-[var(--radix-tooltip-content-transform-origin)] animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
           className
         )}
         {...props}

--- a/frontend/src/components/workspace/ConfigForm.test.tsx
+++ b/frontend/src/components/workspace/ConfigForm.test.tsx
@@ -764,7 +764,7 @@ describe("ConfigForm — auto-select useEffect", () => {
     const onChange = vi.fn();
     renderConfigForm({
       schema: minimalSchema,
-      config: { model: { name: "lgbm", params: {} } },
+      config: { config_version: 1, model: { name: "lgbm", params: {} } },
       onChange,
       task: "binary",
       uiSchema: {
@@ -789,7 +789,7 @@ describe("ConfigForm — auto-select useEffect", () => {
     const onChange = vi.fn();
     renderConfigForm({
       schema: minimalSchema,
-      config: { model: { name: "lgbm", params: {} } },
+      config: { config_version: 1, model: { name: "lgbm", params: {} } },
       onChange,
       task: "binary",
       uiSchema: {
@@ -837,7 +837,7 @@ describe("ConfigForm — auto-select useEffect", () => {
     const onChange = vi.fn();
     renderConfigForm({
       schema: minimalSchema,
-      config: { model: { name: "lgbm", params: {} } },
+      config: { config_version: 1, model: { name: "lgbm", params: {} } },
       onChange,
       task: null,
       uiSchema: {
@@ -856,7 +856,7 @@ describe("ConfigForm — auto-select useEffect", () => {
     const onChange = vi.fn();
     renderConfigForm({
       schema: minimalSchema,
-      config: { model: { name: "lgbm", params: {} } },
+      config: { config_version: 1, model: { name: "lgbm", params: {} } },
       onChange,
       task: "binary",
       uiSchema: {
@@ -888,6 +888,7 @@ describe("ConfigForm — auto-select useEffect", () => {
       schema: minimalSchema,
       // Incompatible state: task is binary but objective is multiclass.
       config: {
+        config_version: 1,
         model: {
           name: "lgbm",
           params: { objective: "multiclass" },
@@ -919,6 +920,7 @@ describe("ConfigForm — auto-select useEffect", () => {
     renderConfigForm({
       schema: minimalSchema,
       config: {
+        config_version: 1,
         model: {
           name: "lgbm",
           // Incompatible state: task is binary but metric is multiclass-only.

--- a/frontend/src/components/workspace/ConfigForm.tsx
+++ b/frontend/src/components/workspace/ConfigForm.tsx
@@ -119,13 +119,21 @@ export function ConfigForm({
   // Auto-reset inner_valid when current selection is not in filtered options
   const currentInnerValid = (innerValid.method as string) ?? "holdout";
   useEffect(() => {
+    // Same guard as the objective/metric effect below: avoid partial-PUT
+    // races while the config is still being seeded by useDataPanel.
+    if (!config.config_version) return;
     if (
       filteredInnerValidOptions.length > 0 &&
       !filteredInnerValidOptions.includes(currentInnerValid)
     ) {
       handleFieldChange(["training", "inner_valid", "method"], "holdout");
     }
-  }, [filteredInnerValidOptions, currentInnerValid, handleFieldChange]);
+  }, [
+    filteredInnerValidOptions,
+    currentInnerValid,
+    handleFieldChange,
+    config.config_version,
+  ]);
 
   // Calibration
   const calibration =
@@ -211,6 +219,14 @@ export function ConfigForm({
   // LGBM rejects a multiclass objective on a binary target.
   useEffect(() => {
     if (!task || !uiSchema?.option_sets) return;
+    // Issue #107 regression guard: skip auto-select while the config is
+    // still empty or only partially seeded. Writing to an empty config
+    // here produces a partial-only PUT like {model:{params:{objective}}}
+    // that overwrites the server-side config via the router's assignment
+    // semantics, re-surfacing 'config_version / task / split: Field
+    // required' validation errors. Wait until useDataPanel has seeded a
+    // full config (recognised by config_version being set).
+    if (!config.config_version) return;
 
     // Objective: single-select. Reset when empty OR when current value
     // is not in the list of objectives valid for the current task.
@@ -258,7 +274,7 @@ export function ConfigForm({
         );
       }
     }
-  }, [task, uiSchema, modelParams, handleFieldChange]);
+  }, [task, uiSchema, modelParams, handleFieldChange, config.config_version]);
 
   if (!rawProperties) return null;
 

--- a/frontend/src/hooks/useConfigSync.ts
+++ b/frontend/src/hooks/useConfigSync.ts
@@ -110,13 +110,8 @@ export function useConfigSync({
     syncConfig();
   }, [target, task, overrides, cv, blocked, syncConfig]);
 
-  const suppressSync = useCallback(async (fn: () => Promise<void>) => {
-    skipNextSyncRef.current = true;
-    try {
-      await fn();
-    } finally {
-      skipNextSyncRef.current = false;
-    }
+  const setSyncSuppressed = useCallback((flag: boolean) => {
+    skipNextSyncRef.current = flag;
   }, []);
 
   const preseedSyncKey = useCallback((key: string) => {
@@ -125,7 +120,7 @@ export function useConfigSync({
 
   return {
     syncConfig,
-    suppressSync,
+    setSyncSuppressed,
     preseedSyncKey,
   };
 }

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -89,50 +89,64 @@ export function useDataPanel({
 
   const handleTargetChange = useCallback(
     async (value: string) => {
-      await configSync.suppressSync(async () => {
-        setTarget(value);
-        try {
-          const cols = await fetchColumns(value);
-          setColumns(cols.columns);
+      configSync.setSyncSuppressed(true);
+      setTarget(value);
+      try {
+        const cols = await fetchColumns(value);
+        setColumns(cols.columns);
 
-          let detectedTask: TaskType | null = task;
-          let detectedStrategy = cv.strategy;
-          let nextCv = cv;
-          if (cols.suggested_task) {
-            const t = cols.suggested_task as TaskType;
-            detectedTask = t;
-            setTask(t);
-            onTaskChanged?.(t);
-            detectedStrategy = getDefaultCvStrategy(t);
-            nextCv = resetCvState(detectedStrategy);
-            setCv(nextCv);
-          }
-
-          const newOverrides = buildOverridesFromColumns(cols.columns);
-          columnOverrides.setOverrides(newOverrides);
-
-          if (detectedTask) {
-            const defaults = await fetchConfigDefaults(detectedTask, value);
-            const merged = buildMergedConfig({
-              defaults,
-              task: detectedTask,
-              strategy: detectedStrategy,
-              folds: cv.folds,
-              dataPath: dataLoad.dataPath,
-              target: value,
-              overrides: newOverrides,
-            });
-            await updateConfig(merged);
-            queryClient.setQueryData(["config"], merged);
-            configSync.preseedSyncKey(
-              buildSyncKey(value, detectedTask, newOverrides, nextCv, blocked),
-            );
-            onDataChanged();
-          }
-        } catch (err) {
-          toast.error(`Column detection failed: ${getErrorMessage(err)}`);
+        let detectedTask: TaskType | null = task;
+        let detectedStrategy = cv.strategy;
+        let nextCv = cv;
+        if (cols.suggested_task) {
+          const t = cols.suggested_task as TaskType;
+          detectedTask = t;
+          setTask(t);
+          onTaskChanged?.(t);
+          detectedStrategy = getDefaultCvStrategy(t);
+          nextCv = resetCvState(detectedStrategy);
+          setCv(nextCv);
         }
-      });
+
+        const newOverrides = buildOverridesFromColumns(cols.columns);
+        columnOverrides.setOverrides(newOverrides);
+
+        if (detectedTask) {
+          const defaults = await fetchConfigDefaults(detectedTask, value);
+          const merged = buildMergedConfig({
+            defaults,
+            task: detectedTask,
+            strategy: detectedStrategy,
+            // Use nextCv.folds (post-reset) so the merged split config
+            // matches the cv state the sync effect will observe next;
+            // otherwise the pre-reset cv.folds could leak into the PUT
+            // while preseedSyncKey uses nextCv.
+            folds: nextCv.folds,
+            dataPath: dataLoad.dataPath,
+            target: value,
+            overrides: newOverrides,
+          });
+          await updateConfig(merged);
+          queryClient.setQueryData(["config"], merged);
+          configSync.preseedSyncKey(
+            buildSyncKey(value, detectedTask, newOverrides, nextCv, blocked),
+          );
+          onDataChanged();
+        }
+      } catch (err) {
+        toast.error(`Column detection failed: ${getErrorMessage(err)}`);
+      } finally {
+        configSync.setSyncSuppressed(false);
+        // Radix Select returns focus to the trigger on close via
+        // `onCloseAutoFocus`, which runs AFTER our finally block. Defer
+        // the blur to the next animation frame so it fires after Radix
+        // has restored focus, otherwise `:focus-visible` matches and the
+        // 3px focus ring combined with the 1px border reads as a doubled
+        // outline. Keyboard users regain the ring on subsequent Tab.
+        requestAnimationFrame(() => {
+          (document.activeElement as HTMLElement | null)?.blur();
+        });
+      }
     },
     [
       task,
@@ -143,7 +157,7 @@ export function useDataPanel({
       onTaskChanged,
       queryClient,
       columnOverrides.setOverrides,
-      configSync.suppressSync,
+      configSync.setSyncSuppressed,
       configSync.preseedSyncKey,
     ],
   );


### PR DESCRIPTION
## Summary

Fixes four regressions introduced or surfaced by PR #141 (Tier 4 batch refactor):

1. **Issue #107 regression** — Target selection transiently showed validation errors (`config_version / task / split / model: Field required`). The `suppressSync` async wrapper introduced in useConfigSync split released `skipNextSyncRef` in its `finally` block, allowing React batched state updates to fire syncConfig() before release. Reverted to direct `setSyncSuppressed(true/false)` calls.

2. **Pre-existing partial-PUT bug** — ConfigForm's `useEffect` for objective/metric auto-select fires when `task` changes, before useDataPanel.handleTargetChange has seeded the full config. Writing to an empty config via `setNestedValue` produces partial PUTs like `{model:{params:{objective:"binary"}}}` that overwrite the backend config. Added `config.config_version` guard to both auto-select effects.

3. **Tailwind v3/v4 syntax regression** — shadcn/ui components used v4 paren syntax `origin-(--radix-var)` and `max-h-(--var)` which Tailwind v3 cannot parse. Converted to bracket syntax `origin-[var(--var)]` and added inline comments to prevent re-regression on future shadcn/ui updates.

4. **Focus ring double-line** — Radix Select returns focus to the trigger via `onCloseAutoFocus` after selection, triggering `:focus-visible` with 1px border + 3px box-shadow ring that reads as a doubled outline. Added `requestAnimationFrame(() => activeElement.blur())` in handleTargetChange.

**Bonus fix** — `buildMergedConfig` now uses `nextCv.folds` (post-reset) instead of `cv.folds` (pre-reset closure) to match the cv state the sync effect will observe.

## Quality Gates

| Gate | Status |
|------|--------|
| Frontend tests | 1432 pass |
| Biome | 0 errors |
| Build | OK |
| Manual browser verification | Target selection no longer shows validation errors |

## Test plan

- [x] Load CSV via Path → select Target → verify no "Field required" errors appear in ModelPanel
- [x] Select different targets in succession → config updates correctly each time
- [x] Verify Target select dropdown has no double-line after selection (focus ring cleared)
- [x] Verify Popover (ConfigDiffBadge) and Tooltip still render correctly
- [x] `pnpm test` — 1432 tests pass
- [x] `pnpm build` — build succeeds

## Regression audit follow-up

Agent-reviewed PRs #135-#141 for similar risks. MEDIUM findings addressed in this PR. Two LOW findings deferred:
- `onDataChanged` ref stabilization in useConfigSync (requires wider refactor)
- ConfigDiffBadge `onCloseAutoFocus` blur (no user-visible issue)