### PR TITLE
chore(github): add tech-task template and tier-aware issue fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,6 +7,23 @@ body:
       value: |
         Thanks for reporting a bug! Please fill in the details below.
 
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Tier (estimated fix effort)
+      description: |
+        Leave as Unknown if not yet investigated.
+        Tier 1: <5 min, obvious fix. Tier 2: <30 min, root cause known.
+        Tier 3: <1 hour, design judgment needed. Tier 4: >1 hour, multi-file.
+      options:
+        - "Unknown"
+        - "Tier 1: Quick fix (<5 min)"
+        - "Tier 2: Small fix (<30 min)"
+        - "Tier 3: Medium fix (<1 hour)"
+        - "Tier 4: Large fix (>1 hour)"
+    validations:
+      required: true
+
   - type: input
     id: version
     attributes:
@@ -66,6 +83,33 @@ body:
       description: What you expected to happen.
     validations:
       required: true
+
+  - type: textarea
+    id: investigation
+    attributes:
+      label: Investigation notes
+      description: |
+        What has been tried or explored so far?
+        Include failed approaches so the fixer does not repeat them.
+        Leave empty if not yet investigated.
+      placeholder: |
+        - Tried X but failed because Y
+        - Root cause appears to be ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: recommended-approach
+    attributes:
+      label: Recommended fix approach
+      description: |
+        The most promising fix strategy, if known.
+        Be specific enough that someone can start coding immediately.
+      placeholder: |
+        1. Change X in file A
+        2. Add regression test for Y
+    validations:
+      required: false
 
   - type: textarea
     id: logs

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/tech_task.yml
+++ b/.github/ISSUE_TEMPLATE/tech_task.yml
@@ -1,0 +1,113 @@
+name: Tech Task
+description: Refactoring, hardening, chore, test coverage, or other technical work
+labels: ["tech-task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for technical tasks discovered during exploration phases.
+        Fill in the investigation notes and recommended approach so execution can start immediately.
+
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Tier (estimated effort)
+      description: |
+        Tier 1: <5 min, mechanical change (chore, lint, dep cleanup)
+        Tier 2: <30 min, approach decided (hardening, small refactor)
+        Tier 3: <1 hour, design judgment needed (consolidation, test stabilization)
+        Tier 4: >1 hour, multi-file (large refactor, coverage push)
+      options:
+        - "Tier 1: Quick win (<5 min)"
+        - "Tier 2: Small task (<30 min)"
+        - "Tier 3: Medium task (<1 hour)"
+        - "Tier 4: Large task (>1 hour)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Frontend
+        - Backend / API
+        - Testing
+        - CI / Infra
+        - Cross-cutting
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Task type
+      options:
+        - Refactor
+        - Hardening
+        - Test coverage
+        - Chore / Cleanup
+        - Performance
+        - CI / Workflow
+        - Documentation
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs to be done and why.
+    validations:
+      required: true
+
+  - type: textarea
+    id: investigation
+    attributes:
+      label: Investigation notes
+      description: |
+        What has been tried or explored so far?
+        Include failed approaches so the implementer does not repeat them.
+      placeholder: |
+        - Tried X but failed because Y
+        - Confirmed Z works in isolation
+        - Root cause is ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: recommended-approach
+    attributes:
+      label: Recommended approach
+      description: |
+        The most promising implementation strategy.
+        Be specific enough that someone can start coding immediately.
+      placeholder: |
+        1. Change X in file A
+        2. Add test for Y
+        3. Verify with `uv run pytest tests/...`
+    validations:
+      required: true
+
+  - type: textarea
+    id: batch-candidates
+    attributes:
+      label: Batch candidates
+      description: |
+        Other Issues that could be grouped into the same PR.
+        Tier 1-2 tasks are good batch candidates.
+      placeholder: "Related: #NNN, #NNN"
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How do we know this is done?
+      placeholder: |
+        - [ ] Tests pass
+        - [ ] Coverage >= 80%
+        - [ ] No lint warnings
+    validations:
+      required: true


### PR DESCRIPTION
## Summary

Adds a structured intake surface so issues land closer to "executable" rather than needing a second triage pass. Mirrors the Tier 1–4 batching workflow that has been driving recent PRs (#133–#142).

## Changes

| File | Change |
| --- | --- |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Add **Tier** dropdown (1–4 / Unknown), **Investigation notes** textarea, **Recommended fix approach** textarea |
| `.github/ISSUE_TEMPLATE/tech_task.yml` | NEW template for refactor / hardening / test-coverage / chore work — Tier, Area, Type, Investigation, Recommended approach, Batch candidates, Acceptance criteria |
| `.github/ISSUE_TEMPLATE/config.yml` | NEW — disable blank issues so contributors always hit a template |

Pure metadata. No code paths affected.

## Why now

Recent batched PRs grouped issues by Tier (Tier 1–4 quickwins → multi-file refactors). Capturing Tier and prior investigation directly on the issue removes one round-trip and makes batch construction faster.

## Test Plan

- [x] `python -c 'import yaml; ...'` — all three YAML files parse cleanly
- [x] No code or workflow changes; CI footprint is zero
- [ ] Verify on GitHub UI after merge: bug template renders Tier + new textareas; "New issue" page shows two templates and no blank-issue option
