### PR TITLE
feat(api): add /api/metrics Prometheus endpoint (Issue #30 Phase 2)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -2601,6 +2601,66 @@ Readiness probe。Backend adapter と JobStore の初期化が完了し、トラ
 - **liveness は必ず `/api/health` を使う**。`/api/health/ready` は未初期化時に 503 を返すため、liveness probe に設定すると k8s が pod を restart loop に入れる恐れがある。
 - **認証不要**。これは probe 用であり、エンドポイントからは backend 名と pkg version しか露出しない（新規に秘匿情報を追加しないこと）。
 
+### 5.9 Metrics API
+
+Prometheus 互換の観測エンドポイント。Issue #30 Phase 2 / H-0065。
+
+#### GET `/api/metrics`
+
+Prometheus text format (version 0.0.4) で 4 系統のメトリクスを返す。認証不要（probe と同じポジショニング）。
+
+**Response 200:**
+```
+Content-Type: text/plain; version=0.0.4; charset=utf-8
+
+# HELP lizystudio_requests_total HTTP requests handled by LizyStudio
+# TYPE lizystudio_requests_total counter
+lizystudio_requests_total{method="GET",path="/api/workspace/status",status="200"} 42.0
+lizystudio_requests_total{method="POST",path="/api/workspace/fit",status="200"} 3.0
+
+# HELP lizystudio_request_duration_seconds HTTP request latency
+# TYPE lizystudio_request_duration_seconds histogram
+lizystudio_request_duration_seconds_bucket{method="GET",path="/api/workspace/status",le="0.005"} 40.0
+...
+
+# HELP lizystudio_jobs_total ML jobs by terminal status
+# TYPE lizystudio_jobs_total counter
+lizystudio_jobs_total{job_type="fit",status="completed"} 3.0
+
+# HELP lizystudio_active_jobs Currently running ML jobs (0 or 1)
+# TYPE lizystudio_active_jobs gauge
+lizystudio_active_jobs 0.0
+```
+
+#### メトリクス定義
+
+| Name | Type | Labels | 意味 |
+|------|------|--------|------|
+| `lizystudio_requests_total` | Counter | `method`, `path`, `status` | HTTP リクエスト総数 |
+| `lizystudio_request_duration_seconds` | Histogram | `method`, `path` | HTTP レイテンシ（bucket は prometheus_client default） |
+| `lizystudio_jobs_total` | Counter | `job_type`, `status` | ML ジョブ終了カウンタ。`job_type` ∈ `{fit, tune}`、`status` ∈ `{completed, failed, cancelled}` |
+| `lizystudio_active_jobs` | Gauge | なし | JobStore active slot の使用状態 (0 または 1) |
+
+#### カーディナリティ方針
+
+- **`path` label は FastAPI の route template を使う**（例: `/api/jobs/{job_id}`）。生の job_id や inf_id を label 化すると長期的に Prometheus の series が爆発するため禁止。
+- route に未マッチの path（404 経路）は `path="unmatched"` に集約する。
+- 静的ファイル (`/assets/...` / SPA fallback) は label 化せず集約カテゴリで数える（metrics router がアタッチされる前の middleware で扱う）。
+
+#### 計測対象からの除外
+
+- `/api/metrics` 自身の呼び出しは `lizystudio_requests_total` / `lizystudio_request_duration_seconds` に含めない。監視ツール由来のトラフィックが本体メトリクスのベースロードを汚染するのを防ぐため。
+- `/api/health` と `/api/health/ready` は計測に含める（probe 頻度も重要な観測情報）。
+
+#### 運用上の注意
+
+- **認証不要** — health / readiness と同じく公開エンドポイント。露出する情報は以下のみ:
+  - LizyStudio 定義のカウンタ / ヒストグラム / ゲージ（本節の冒頭表）
+  - `prometheus_client` デフォルトレジストリが自動追加する `python_info`（実装 / マイナー / パッチレベル）と `process_*`（RSS、CPU時間、FD数、スタート時刻）
+
+  運用時に Python バージョンやプロセスメモリを外部に出したくない場合は、リバースプロキシで `/api/metrics` を内部ネットワーク限定に制限すること。アプリケーション側では無効化しない（Prometheus のデフォルト挙動を保ち、ツール互換性を優先）。
+- **レート制限なし** — Prometheus の scrape 間隔（通常 15s）を前提に設計。外部公開する場合はリバースプロキシ側で rate limit を設定する想定。
+
 ---
 
 ## 6. エラーハンドリング

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1653,3 +1653,38 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (d) liveness エンドポイントが **workspace state に依存せず** 単独で応答する（未データロード状態でも 200）。
   - (e) SPA fallback ルートが `/api/health` を奪わない（`/api/` プレフィックスで既に除外されているが、テストで固定）。
 - **Decision:** 2026-04-17 採択 (Issue #30 Phase 1)。Prometheus メトリクス + system metrics は別 Proposal で追加する。
+
+---
+
+### H-0065: Prometheus メトリクスエンドポイントの追加（Issue #30 Phase 2）
+- **Status:** accepted
+- **Scope:** API / Config (runtime dep)
+- **Related:** BLUEPRINT.md §5.9（新設）
+- **Context:** H-0064 で health / readiness probe を追加したが、実運用では「このプロセスは生きているか」だけでなく「どのくらいトラフィックを処理しているか」「ジョブは詰まっていないか」を可視化する必要がある。Issue #30 Phase 2 として Prometheus 互換の `/api/metrics` を提供する。Phase 3（system metrics: メモリ / GPU / CPU）は独立 Proposal にする。
+- **Proposal:** `GET /api/metrics` を追加し、以下 4 系統のメトリクスを Prometheus text format で公開する:
+  - `lizystudio_requests_total{method, path, status}` — Counter。HTTP リクエスト総数。`path` は FastAPI の route template（例: `/api/jobs/{job_id}`）。未マッチ path は `unmatched` に集約してカーディナリティ爆発を防ぐ。
+  - `lizystudio_request_duration_seconds{method, path}` — Histogram。リクエスト処理時間。bucket は prometheus_client のデフォルトを採用。
+  - `lizystudio_jobs_total{job_type, status}` — Counter。ジョブ終了時に `status=completed|failed|cancelled` で増分。`job_type` は `fit|tune`。
+  - `lizystudio_active_jobs` — Gauge。JobStore の active slot が保持されている間は 1、解放されると 0。
+- **Impact:**
+  - 新規 runtime dep: `prometheus-client>=0.20`（pyproject.toml）
+  - 新規: `src/lizystudio/metrics.py`（メトリクス定義 + `record_job_terminal()` helper）
+  - 新規: `src/lizystudio/api/metrics_api.py`（`GET /api/metrics` エンドポイント）
+  - 追加: `src/lizystudio/server.py` にミドルウェア登録 + router include
+  - 追加: `src/lizystudio/services/jobs.py` の `claim_active` / `release_active` / `force_release_active_if` で `ACTIVE_JOBS` gauge を更新
+  - 追加: `src/lizystudio/services/training.py` / `training_retune.py` の terminal status 確定箇所で `record_job_terminal()` 呼び出し
+  - 新規: `tests/test_metrics_api.py`
+  - 追記: BLUEPRINT.md §5.9
+- **Compatibility:** 非破壊的（新規エンドポイント / 新規 runtime dep 追加のみ）。既存エンドポイントの挙動は変わらない。
+- **Alternatives:**
+  1. **選択肢 A（却下）**: prometheus-client を使わず自前で text format を生成する案。メリット: 依存ゼロ。デメリット: Histogram の bucket 生成 / label escape / HELP/TYPE ヘッダの正確な出力を再実装する必要があり、車輪の再発明。
+  2. **選択肢 B（却下）**: OpenTelemetry SDK 経由で Prometheus exporter を吊るす案。メリット: 将来 OTLP に移行しやすい。デメリット: 依存が重く（otel-sdk + otel-instrumentation-fastapi）、Phase 2 のスコープに対して過剰。
+  3. **選択肢 C（採用、本提案）**: `prometheus-client` の素朴な使い方（Counter / Histogram / Gauge + ASGI 公開）。軽量で枯れた選択。
+- **Acceptance Criteria:**
+  - (a) `GET /api/metrics` が 200 と `Content-Type: text/plain; version=0.0.4` を返す。
+  - (b) 任意のリクエスト後に `/api/metrics` を叩くと、`lizystudio_requests_total{...}` の該当ラベル行が 1 以上になる。
+  - (c) Fit / Tune ジョブ完了後、`lizystudio_jobs_total{job_type="fit",status="completed"}` 等が 1 以上になる。
+  - (d) active ジョブが動いている間 `lizystudio_active_jobs` が 1、解放後 0 に戻る。
+  - (e) `/api/metrics` エンドポイント自身は `lizystudio_requests_total` の計測対象から除外する（監視トラフィックが本体メトリクスを埋めるのを防ぐ）。
+  - (f) Path label は FastAPI の route template を使い、`/api/jobs/{job_id}/metrics` のように正規化する（生の job_id がカーディナリティ爆発しない）。
+- **Decision:** 2026-04-17 採択 (Issue #30 Phase 2)。Phase 3（system / GPU metrics）は別 Proposal。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
     # H-0062: explicit pin so pickle usage survives a future lizyml
     # dependency refactor. Already in the tree via lizyml.
     "cloudpickle>=3.0",
+    # H-0065: Prometheus metrics exposition for /api/metrics.
+    "prometheus-client>=0.20",
 ]
 
 [project.scripts]

--- a/src/lizystudio/api/metrics_api.py
+++ b/src/lizystudio/api/metrics_api.py
@@ -1,0 +1,22 @@
+"""Prometheus metrics endpoint (BLUEPRINT §5.9, H-0065).
+
+Issue #30 Phase 2. Returns the default prometheus_client registry as
+text format. Counter / Histogram / Gauge definitions live in
+`lizystudio.metrics`.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+router = APIRouter()
+
+
+@router.get("")
+def metrics() -> Response:
+    """Return all registered Prometheus metrics in text format.
+
+    Authentication-free, mirroring the probe philosophy of `/api/health`.
+    """
+    return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/src/lizystudio/metrics.py
+++ b/src/lizystudio/metrics.py
@@ -1,0 +1,68 @@
+"""Prometheus metrics (BLUEPRINT §5.9, H-0065).
+
+Issue #30 Phase 2. Centralizes metric definitions so both the ASGI
+middleware (`server.py`) and the service-layer hooks (`services/jobs.py`,
+`services/training.py`) can bump counters without each site having to
+know prometheus_client internals.
+
+Using the default CollectorRegistry is intentional — it keeps
+`generate_latest()` in `api/metrics_api.py` one line and avoids the
+need to thread a registry through app.state.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from prometheus_client import Counter, Gauge, Histogram
+
+# HTTP request counter. Labels:
+#   method  — HTTP verb
+#   path    — FastAPI route template (e.g. "/api/jobs/{job_id}"), or
+#             "unmatched" for 4xx paths that did not hit any router
+#   status  — numeric HTTP status code as a string
+REQUESTS_TOTAL = Counter(
+    "lizystudio_requests_total",
+    "HTTP requests handled by LizyStudio",
+    labelnames=("method", "path", "status"),
+)
+
+# HTTP request duration histogram. Labels kept lean (no status) so
+# latency analysis does not require summing across status buckets.
+REQUEST_DURATION = Histogram(
+    "lizystudio_request_duration_seconds",
+    "HTTP request latency",
+    labelnames=("method", "path"),
+)
+
+# Terminal-state ML job counter. Bumped from the training service layer
+# once a subprocess / thread reports its final status.
+JOBS_TOTAL = Counter(
+    "lizystudio_jobs_total",
+    "ML jobs by terminal status",
+    labelnames=("job_type", "status"),
+)
+
+# Current active-job gauge. JobStore holds at most one active slot per
+# process, so this is effectively a 0-or-1 signal. Exposed as a gauge
+# (not a counter) so external alerting can trigger on "stuck for >N
+# minutes" by combining it with request_duration.
+ACTIVE_JOBS = Gauge(
+    "lizystudio_active_jobs",
+    "Currently running ML jobs (0 or 1)",
+)
+
+
+JobType = Literal["fit", "tune"]
+TerminalStatus = Literal["completed", "failed", "cancelled"]
+
+
+def record_job_terminal(job_type: JobType, status: TerminalStatus) -> None:
+    """Increment `lizystudio_jobs_total{job_type, status}` by 1.
+
+    Call this from the service layer once the job reaches a terminal
+    state. Kept as a helper (rather than exposing the raw counter) so
+    the call sites never pass freeform strings — if a future status
+    value is added, update this module's Literal instead.
+    """
+    JOBS_TOTAL.labels(job_type=job_type, status=status).inc()

--- a/src/lizystudio/server.py
+++ b/src/lizystudio/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -16,13 +17,22 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
-from lizystudio.api import backends, files, health, inference, jobs, workspace
+from lizystudio.api import (
+    backends,
+    files,
+    health,
+    inference,
+    jobs,
+    metrics_api,
+    workspace,
+)
 from lizystudio.api.errors import (
     StudioError,
     studio_error_handler,
     validation_error_handler,
 )
 from lizystudio.backends.registry import get_adapter
+from lizystudio.metrics import REQUEST_DURATION, REQUESTS_TOTAL
 from lizystudio.services.jobs import JobStore
 from lizystudio.services.workspace import WorkspaceState
 from lizystudio.ws.progress import ProgressBroadcaster, websocket_progress
@@ -119,6 +129,44 @@ def create_app() -> FastAPI:
         )
         return response
 
+    # Prometheus metrics middleware (H-0065). Added after security
+    # headers so the decorator-order rule places it outermost: every
+    # request is timed and counted before security_headers runs, which
+    # means the counter reflects the raw HTTP surface rather than
+    # post-filter traffic. `/api/metrics` itself is excluded so scrape
+    # traffic does not pollute the baseline.
+    @application.middleware("http")
+    async def metrics_middleware(
+        request: Request,
+        call_next: Any,  # noqa: ANN401
+    ) -> Response:
+        path = request.url.path
+        if path == "/api/metrics":
+            excluded: Response = await call_next(request)
+            return excluded
+
+        start = time.perf_counter()
+        response: Response = await call_next(request)
+        elapsed = time.perf_counter() - start
+
+        # Collapse path to a route template to keep label cardinality
+        # bounded. `request.scope["route"]` is populated after routing,
+        # but starlette only sets it for matched routes; unmatched 4xx
+        # paths fall back to a sentinel string.
+        route = request.scope.get("route")
+        label_path = getattr(route, "path", None) or "unmatched"
+
+        REQUESTS_TOTAL.labels(
+            method=request.method,
+            path=label_path,
+            status=str(response.status_code),
+        ).inc()
+        REQUEST_DURATION.labels(
+            method=request.method,
+            path=label_path,
+        ).observe(elapsed)
+        return response
+
     # CORS — allow frontend dev server during development
     application.add_middleware(
         CORSMiddleware,
@@ -146,6 +194,10 @@ def create_app() -> FastAPI:
     application.include_router(files.router, prefix="/api/files", tags=["files"])
     # BLUEPRINT §5.8 / H-0064 — liveness + readiness probes
     application.include_router(health.router, prefix="/api/health", tags=["health"])
+    # BLUEPRINT §5.9 / H-0065 — Prometheus metrics exposition
+    application.include_router(
+        metrics_api.router, prefix="/api/metrics", tags=["metrics"]
+    )
 
     # WebSocket route for job progress (BLUEPRINT §5.5)
     @application.websocket("/ws/jobs/{job_id}/progress")

--- a/src/lizystudio/services/jobs.py
+++ b/src/lizystudio/services/jobs.py
@@ -17,6 +17,7 @@ from fastapi import Request
 
 from lizystudio.backends.base import BackendAdapter
 from lizystudio.backends.types import DataRef, FitSummary, TuningSummary
+from lizystudio.metrics import ACTIVE_JOBS
 from lizystudio.security import validate_path_within  # noqa: E402
 
 _logger = logging.getLogger(__name__)
@@ -410,6 +411,7 @@ class JobStore:
                 parent_job_id=parent_job_id,
             )
             self._active_job_id = job.job_id
+            ACTIVE_JOBS.set(1)
             return job
 
     def _is_slot_holder_stale_locked(self) -> bool:
@@ -439,7 +441,14 @@ class JobStore:
         with self._active_lock:
             if self._active_job_id is None:
                 self._active_job_id = job_id
+                ACTIVE_JOBS.set(1)
                 return True
+            # H-0065: the `self._active_job_id == job_id` re-claim
+            # branch intentionally skips `ACTIVE_JOBS.set(1)` — the
+            # gauge was already set to 1 by the original
+            # `create_and_claim_active` or `claim_active` call that
+            # acquired the slot, and bumping it again would be a
+            # no-op.
             return self._active_job_id == job_id
 
     def release_active(self, job_id: str) -> None:
@@ -447,6 +456,7 @@ class JobStore:
         with self._active_lock:
             if self._active_job_id == job_id:
                 self._active_job_id = None
+                ACTIVE_JOBS.set(0)
 
     def force_release_active_if(self, expected_job_id: str) -> bool:
         """Atomically release the slot iff it is still held by *expected_job_id*.
@@ -466,6 +476,7 @@ class JobStore:
         with self._active_lock:
             if self._active_job_id == expected_job_id:
                 self._active_job_id = None
+                ACTIVE_JOBS.set(0)
                 return True
             return False
 

--- a/src/lizystudio/services/training.py
+++ b/src/lizystudio/services/training.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 
 from lizystudio.backends.base import BackendAdapter, ProgressCallback
 from lizystudio.backends.types import FitSummary, TuningSummary
+from lizystudio.metrics import record_job_terminal
 from lizystudio.services.jobs import Job, JobStore
 
 if TYPE_CHECKING:
@@ -61,6 +62,24 @@ def _make_cancel_aware_cb(
     return callback
 
 
+def _emit_terminal_metric(job: Job) -> None:
+    """Bump `lizystudio_jobs_total` for *job*'s terminal status.
+
+    Centralises the per-literal dispatch that mypy requires for
+    Literal narrowing (H-0065). Two call sites share this helper:
+    ``_run_job_core``'s finally block (thread mode) and
+    ``_run_subprocess_job``'s finally block (subprocess mode).
+    The ``claim_active`` early-fail path passes a hardcoded literal
+    and calls ``record_job_terminal`` directly.
+    """
+    if job.status == "completed":
+        record_job_terminal(job.job_type, "completed")
+    elif job.status == "failed":
+        record_job_terminal(job.job_type, "failed")
+    elif job.status == "cancelled":
+        record_job_terminal(job.job_type, "cancelled")
+
+
 def _run_job_core(
     *,
     job: Job,
@@ -84,6 +103,7 @@ def _run_job_core(
             broadcaster.send_error(
                 job.job_id, "Another job is already running", code="JOB_CONFLICT"
             )
+        record_job_terminal(job.job_type, "failed")
         return job
 
     job.status = "running"
@@ -127,6 +147,7 @@ def _run_job_core(
     finally:
         job_store.release_active(job.job_id)
         job_store.clear_cancel(job.job_id)
+        _emit_terminal_metric(job)  # H-0065
         job_logger.removeHandler(handler)
         handler.close()
         # Persist captured logs. An OSError here must not propagate out of
@@ -445,10 +466,15 @@ def _run_subprocess_job(
     from lizystudio.services.subprocess_runner import run_job_in_subprocess
     from lizystudio.services.workspace import get_backend_name
 
+    # H-0065: set to True when the caller's on_data_missing callback
+    # handles the terminal-state bookkeeping (including metric
+    # emission) so the finally-block below does not double-emit.
+    terminal_already_recorded = False
     try:
         if ws.data_ref is None or not ws.data_ref.path:
             if on_data_missing is not None:
                 on_data_missing(job)
+                terminal_already_recorded = True
             else:
                 job.status = "failed"
                 job.error = "No data loaded — cannot run subprocess job"
@@ -458,6 +484,8 @@ def _run_subprocess_job(
                     broadcaster.send_error(job.job_id, job.error)
                 with ws._lock:
                     ws.current_job_id = job.job_id
+                record_job_terminal(job.job_type, "failed")
+                terminal_already_recorded = True
             return job
         data_path = ws.data_ref.path
         extra_kwargs: dict[str, Any] = {}
@@ -486,6 +514,14 @@ def _run_subprocess_job(
         return finished
     finally:
         job_store.release_active(job.job_id)
+        # H-0065: subprocess path writes the terminal status on disk
+        # from the child process; re-read it here so the parent emits
+        # exactly one counter increment per job in either mode. Skip
+        # when the early-return paths above already emitted one.
+        if not terminal_already_recorded:
+            latest = job_store.get(job.job_id)
+            if latest is not None:
+                _emit_terminal_metric(latest)  # H-0065
 
 
 def start_fit_async(

--- a/src/lizystudio/services/training_retune.py
+++ b/src/lizystudio/services/training_retune.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from lizystudio.backends.base import BackendAdapter, ProgressCallback
 from lizystudio.backends.types import FitSummary, TuningSummary
+from lizystudio.metrics import record_job_terminal
 from lizystudio.services.jobs import Job, JobStore
 from lizystudio.services.training import (
     _join_previous_thread,
@@ -146,6 +147,7 @@ def _mark_retune_child_failed(
         ws.current_job_id = child_job.job_id
     if broadcaster is not None:
         broadcaster.send_error(child_job.job_id, message)
+    record_job_terminal(child_job.job_type, "failed")
 
 
 def _run_retune_subprocess(

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -1,0 +1,146 @@
+"""Tests for GET /api/metrics (BLUEPRINT §5.9, H-0065).
+
+Issue #30 Phase 2 — Prometheus text format exposition.
+
+NOTE on test isolation: prometheus_client uses a process-global
+default registry, and Counter values cannot be reset by design.
+Assertions here are all relative (baseline-then-delta) or check
+structural properties (content-type, series presence, label
+exclusion). Do NOT add tests that assert a Counter / Histogram
+equals an absolute numeric value — earlier tests in the same
+session will have already incremented it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+def test_metrics_returns_200_and_prometheus_content_type(
+    client: TestClient,
+) -> None:
+    """GET /api/metrics must return 200 + Prometheus text format."""
+    resp = client.get("/api/metrics")
+    assert resp.status_code == 200
+    content_type = resp.headers.get("content-type", "")
+    assert content_type.startswith("text/plain")
+    # prometheus_client uses version=0.0.4 in the content-type param.
+    assert "version=" in content_type
+
+
+def test_metrics_contains_all_declared_series(client: TestClient) -> None:
+    """Declared series names must appear in the response body.
+
+    Counter / Histogram / Gauge are all registered at module import time
+    so the text output contains their HELP/TYPE blocks even with zero
+    samples. This guards against accidental metric renames.
+    """
+    resp = client.get("/api/metrics")
+    body = resp.text
+    assert "lizystudio_requests_total" in body
+    assert "lizystudio_request_duration_seconds" in body
+    assert "lizystudio_jobs_total" in body
+    assert "lizystudio_active_jobs" in body
+
+
+def test_requests_total_increments_after_a_request(client: TestClient) -> None:
+    """Any request through the middleware must bump requests_total."""
+    # Prime: fetch baseline count.
+    client.get("/api/workspace/status")
+    first = client.get("/api/metrics").text
+
+    # Fire a known request.
+    client.get("/api/workspace/status")
+    second = client.get("/api/metrics").text
+
+    # Extract the counter line for /api/workspace/status and confirm it grew.
+    def _extract(body: str) -> float:
+        for line in body.splitlines():
+            if (
+                line.startswith("lizystudio_requests_total{")
+                and ("/api/workspace/status" in line)
+                and not line.startswith("#")
+            ):
+                return float(line.rsplit(" ", 1)[1])
+        return 0.0
+
+    assert _extract(second) >= _extract(first) + 1.0
+
+
+def test_metrics_endpoint_itself_is_excluded_from_counter(
+    client: TestClient,
+) -> None:
+    """`/api/metrics` scrapes must not pollute lizystudio_requests_total."""
+    # Hit /api/metrics many times; its own line should never appear in
+    # lizystudio_requests_total.
+    for _ in range(3):
+        client.get("/api/metrics")
+    body = client.get("/api/metrics").text
+    for line in body.splitlines():
+        if line.startswith("lizystudio_requests_total") and not line.startswith("#"):
+            assert '"/api/metrics"' not in line, (
+                f"metrics endpoint leaked into requests_total: {line}"
+            )
+
+
+def test_path_label_uses_route_template_not_raw_id(client: TestClient) -> None:
+    """Path labels must be the FastAPI route template, not raw job ids.
+
+    Cardinality guard — H-0065 acceptance (f).
+    """
+    # Trigger a 404 against a job-detail route so the metric emits a path.
+    client.get("/api/jobs/job_does_not_exist_xyz")
+    body = client.get("/api/metrics").text
+
+    # No raw id should ever appear as a label value.
+    assert "job_does_not_exist_xyz" not in body
+
+    # Instead, the route template should appear.
+    assert "/api/jobs/{job_id}" in body or 'path="unmatched"' in body
+
+
+def test_unmatched_paths_collapse_to_single_label(client: TestClient) -> None:
+    """4xx paths that do not match any FastAPI route must collapse.
+
+    Without this guard, spraying random URLs at the server would grow
+    the series set unboundedly.
+    """
+    client.get("/this/does/not/exist/1")
+    client.get("/this/does/not/exist/2")
+    body = client.get("/api/metrics").text
+
+    # Neither raw path should appear.
+    assert "/this/does/not/exist/1" not in body
+    assert "/this/does/not/exist/2" not in body
+
+
+def test_asset_paths_do_not_explode_cardinality(client: TestClient) -> None:
+    """Static assets / SPA fallback paths must not leak raw URLs.
+
+    When the frontend bundle is mounted, hundreds of hashed asset
+    filenames would otherwise each become a distinct series. Assert
+    that random asset-shaped paths neither appear raw nor crash the
+    middleware.
+    """
+    client.get("/assets/chunk-abc123.js")
+    client.get("/assets/chunk-def456.js")
+    body = client.get("/api/metrics").text
+
+    # Neither hashed filename should appear as a label value.
+    assert "chunk-abc123.js" not in body
+    assert "chunk-def456.js" not in body
+
+
+def test_active_jobs_gauge_starts_at_zero(client: TestClient) -> None:
+    """A freshly-started app has no active job; gauge must read 0."""
+    body = client.get("/api/metrics").text
+    for line in body.splitlines():
+        if line.startswith("lizystudio_active_jobs") and not line.startswith("#"):
+            # Samples like "lizystudio_active_jobs 0.0"
+            value = float(line.rsplit(" ", 1)[1])
+            assert value == 0.0
+            return
+    raise AssertionError("lizystudio_active_jobs sample line not found")

--- a/uv.lock
+++ b/uv.lock
@@ -602,6 +602,7 @@ dependencies = [
     { name = "cloudpickle" },
     { name = "fastapi" },
     { name = "lizyml", extra = ["calibration", "explain", "plots", "tuning"] },
+    { name = "prometheus-client" },
     { name = "python-multipart" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockets" },
@@ -626,6 +627,7 @@ requires-dist = [
     { name = "cloudpickle", specifier = ">=3.0" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "lizyml", extras = ["calibration", "explain", "plots", "tuning"], specifier = ">=0.9.0,<0.10.0" },
+    { name = "prometheus-client", specifier = ">=0.20" },
     { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
     { name = "websockets", specifier = ">=14.0" },
@@ -1326,6 +1328,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Phase 2 of Issue #30. `/api/metrics` exposes HTTP + ML-job metrics in Prometheus text format so LizyStudio deployments can be scraped by standard observability stacks. Phase 3 (system / GPU metrics) stays deferred.

## Summary

| Metric | Type | Labels | Purpose |
|---|---|---|---|
| `lizystudio_requests_total` | Counter | method, path, status | HTTP request count. `path` = FastAPI route template; raw ids never leak. |
| `lizystudio_request_duration_seconds` | Histogram | method, path | HTTP latency. `prometheus_client` default buckets. |
| `lizystudio_jobs_total` | Counter | job_type, status | Fit/Tune terminal state. Emitted exactly once per job across both thread and subprocess execution modes. |
| `lizystudio_active_jobs` | Gauge | — | 1 while JobStore holds an active slot, 0 otherwise. |

`/api/metrics` is excluded from its own request counter so scrape traffic does not pollute the baseline.

## Change Gate

- `HISTORY.md` **H-0065** proposal (accepted 2026-04-17) — new runtime dep `prometheus-client>=0.20` + new API endpoint.
- `BLUEPRINT.md` new **§5.9 Metrics API** section documents contract, cardinality policy, exclusion rules, and a note about `python_info` / `process_*` from `prometheus_client`'s default registry being included (recommended to place `/api/metrics` behind an internal-only reverse proxy).

## Implementation notes

- **Middleware order.** `metrics_middleware` is decorator-added **after** `security_headers_middleware`, which makes it outermost per Starlette's rule. Timings therefore cover the full request path.
- **Layer-audit clean.** `services/jobs.py` now imports from `lizystudio.metrics` (new top-level module), not from `api/`. No router-to-backend leaks.
- **mypy Literal narrowing.** Terminal-status dispatch uses an `if / elif` ladder inside `_emit_terminal_metric(job)` so the `Literal["completed", "failed", "cancelled"]` constraint on `record_job_terminal()` is satisfied without any `cast` / `# type: ignore`.
- **No double-counting.** The retune data-missing path routes through `_mark_retune_child_failed`, which already emits the counter. `_run_subprocess_job`'s finally therefore honours a `terminal_already_recorded` flag before its `job_store.get()` re-read.
- **ACTIVE_JOBS re-claim.** `claim_active`'s idempotent re-claim branch intentionally skips `ACTIVE_JOBS.set(1)` — the gauge was already set to 1 by the original claim — and the skip is commented.

## Test Plan

- [x] `uv run pytest` → **1008 passed**
- [x] `uv run pytest tests/test_metrics_api.py` → **8 passed** (content-type, series presence, counter delta, self-exclusion, route-template normalisation, unmatched-path collapse, asset-path cardinality guard, active_jobs baseline)
- [x] `uv run mypy src/lizystudio/` → no issues in 46 source files
- [x] `uv run ruff check .` → clean
- [x] `uv run ruff format --check .` → 109 files already formatted
- [x] Coverage: `src/lizystudio/metrics.py` 100% · `src/lizystudio/api/metrics_api.py` 100% (Phase 4)
- [x] `tests/test_layer_audit.py` — `services/jobs.py` still passes the "router must not call backend methods directly" rule; `lizystudio.metrics` is a top-level neutral module
- [x] CI full matrix green (backend 3.10 / 3.11 / frontend)
- [x] Manual probe: `curl http://localhost:8501/api/metrics` after a started backend — verify all four series render with `# HELP` / `# TYPE` blocks and sane initial values

## H-0065 Acceptance Criteria

- [x] (a) `/api/metrics` returns 200 + `Content-Type: text/plain; version=0.0.4`
- [x] (b) Requests through the middleware bump `lizystudio_requests_total{...}`
- [x] (c) `record_job_terminal()` is called on every terminal-state transition in both thread and subprocess modes
- [x] (d) `lizystudio_active_jobs` flips 1 → 0 alongside JobStore slot state
- [x] (e) `/api/metrics` self-requests excluded from its own counter
- [x] (f) Path labels use FastAPI route templates, never raw ids

## Out of scope

- Prometheus `/metrics` dashboard templates (separate doc / repo)
- System metrics (memory / CPU / GPU) — Phase 3 of Issue #30, will ship under a separate Proposal
- Rate limiting on `/api/metrics` — recommended at the reverse proxy layer; BLUEPRINT §5.9 notes this explicitly
