### PR TITLE
feat(metrics): add jobs_duration_seconds histogram (Issue #30 Phase 3)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -2611,7 +2611,7 @@ Prometheus text format (version 0.0.4) で 4 系統のメトリクスを返す�
 
 **Response 200:**
 ```
-Content-Type: text/plain; version=0.0.4; charset=utf-8
+Content-Type: text/plain; version=1.0.0; charset=utf-8
 
 # HELP lizystudio_requests_total HTTP requests handled by LizyStudio
 # TYPE lizystudio_requests_total counter
@@ -2639,6 +2639,7 @@ lizystudio_active_jobs 0.0
 | `lizystudio_requests_total` | Counter | `method`, `path`, `status` | HTTP リクエスト総数 |
 | `lizystudio_request_duration_seconds` | Histogram | `method`, `path` | HTTP レイテンシ（bucket は prometheus_client default） |
 | `lizystudio_jobs_total` | Counter | `job_type`, `status` | ML ジョブ終了カウンタ。`job_type` ∈ `{fit, tune}`、`status` ∈ `{completed, failed, cancelled}` |
+| `lizystudio_jobs_duration_seconds` | Histogram | `job_type`, `status` | ML ジョブ所要時間（H-0066）。bucket は ML ワークロード用: `(1, 5, 10, 30, 60, 120, 300, 600, 1800, 3600, +Inf)` 秒 |
 | `lizystudio_active_jobs` | Gauge | なし | JobStore active slot の使用状態 (0 または 1) |
 
 #### カーディナリティ方針

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1688,3 +1688,34 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (e) `/api/metrics` エンドポイント自身は `lizystudio_requests_total` の計測対象から除外する（監視トラフィックが本体メトリクスを埋めるのを防ぐ）。
   - (f) Path label は FastAPI の route template を使い、`/api/jobs/{job_id}/metrics` のように正規化する（生の job_id がカーディナリティ爆発しない）。
 - **Decision:** 2026-04-17 採択 (Issue #30 Phase 2)。Phase 3（system / GPU metrics）は別 Proposal。
+
+---
+
+### H-0066: ML ジョブ所要時間 Histogram とメトリクス仕上げ（Issue #30 Phase 3）
+- **Status:** accepted
+- **Scope:** API / Doc
+- **Related:** BLUEPRINT.md §5.9（更新）
+- **Context:** H-0065 で Prometheus メトリクスの土台を整えたが、`lizystudio_jobs_total` は終了カウントのみで「ジョブがどれだけ時間を食ったか」の分布が観測できない。本番監視で最重要なのは p95 / p99 の fit / tune 所要時間なので、Phase 3 として ML ワークロードに合わせた bucket の histogram を追加する。併せて、H-0065 実装後に実測した Content-Type の `version` 値が BLUEPRINT の記述（`0.0.4`）と一致しない（`prometheus-client>=0.25` のデフォルトは `1.0.0`）ため、ドキュメントを実測値に揃える。
+- **Proposal:**
+  1. `lizystudio_jobs_duration_seconds` Histogram を新設。ラベルは `job_type` ∈ `{fit, tune}` と `status` ∈ `{completed, failed, cancelled}`。bucket は ML ワークロードを意識して `(1, 5, 10, 30, 60, 120, 300, 600, 1800, 3600, +Inf)` 秒。
+  2. `JobStore.claim_active` が成功した時点から terminal status 確定時点までの経過秒を observe する。thread / subprocess 両モードで 1 回だけ emit する。
+  3. BLUEPRINT §5.9 の Content-Type 例を `version=1.0.0` に修正し、メトリクス表に `lizystudio_jobs_duration_seconds` 行を追加。
+  4. Phase 3 当初案で検討した `psutil` 依存追加は取りやめる（`prometheus_client` の default registry が既に `process_resident_memory_bytes` / `process_cpu_seconds_total` / `process_open_fds` 等を公開しているため重複）。GPU メトリクスは LizyStudio 側で扱わない（backend 固有なので別レイヤーで扱う）。
+- **Impact:**
+  - `src/lizystudio/metrics.py`: `JOBS_DURATION` Histogram 追加。`record_job_terminal` に `duration: float = 0.0` optional 引数を追加（既存 call site は後方互換）。
+  - `src/lizystudio/services/training.py`: `_run_job_core` で `claim_active` 後に開始時刻を記録し、`_emit_terminal_metric` に経過秒を渡す。`_run_subprocess_job` の finally 側は `Job.created_at` ↔ `Job.completed_at` から算出。
+  - `src/lizystudio/services/training_retune.py`: `_mark_retune_child_failed` でも duration を 0.0 fallback で記録（data missing は claim 前なので実測不能、fallback で可視化）。
+  - `BLUEPRINT.md` §5.9 更新（行追加 + version fix）。
+  - `tests/test_metrics_api.py`: Histogram presence + bucket 存在 test 追加。
+- **Compatibility:** 非破壊的。`record_job_terminal` の新引数は default 付き。既存メトリクスのラベル / 名前は変わらない。
+- **Alternatives:**
+  1. **選択肢 A（却下）**: bucket を prometheus_client default (`0.005, 0.01, 0.025, ...`) のまま使う。デメリット: 分単位〜時間単位の ML ジョブでは `+Inf` bucket に全て落ちて histogram が役立たない。
+  2. **選択肢 B（却下）**: `lizystudio_jobs_duration_seconds` を Summary にする。メリット: client 側で quantile 計算。デメリット: Summary は aggregation が難しく、複数プロセス環境（k8s replica 等）でのマージが不可能。Histogram の方が汎用性高い。
+  3. **選択肢 C（採用、本提案）**: カスタム bucket Histogram。`status` ラベルで completed / failed / cancelled を切り分け、失敗ジョブが短命か長時間後に失敗するかまで分かる。
+- **Acceptance Criteria:**
+  - (a) `/api/metrics` 出力に `# TYPE lizystudio_jobs_duration_seconds histogram` が含まれる。
+  - (b) fit / tune ジョブ 1 本完了後、該当ラベルの `lizystudio_jobs_duration_seconds_count` が 1 以上、`_sum` が正の値になる。
+  - (c) bucket が ML ワークロード用のカスタム値で出力される（`le="60"` や `le="3600"` の bucket line が存在）。
+  - (d) BLUEPRINT §5.9 の Content-Type 例が `version=1.0.0` と記述されている。
+  - (e) subprocess mode / retune failure path からも duration が記録される（0.0 fallback 可）。
+- **Decision:** 2026-04-17 採択 (Issue #30 Phase 3)。本 PR で Issue #30 は完了。

--- a/src/lizystudio/metrics.py
+++ b/src/lizystudio/metrics.py
@@ -52,17 +52,50 @@ ACTIVE_JOBS = Gauge(
     "Currently running ML jobs (0 or 1)",
 )
 
+# H-0066: ML job wall-clock duration. Buckets target real fit / tune
+# workloads (seconds to one hour). prometheus_client's default 5ms–10s
+# ladder would collapse everything into the +Inf bucket for this
+# domain.
+JOBS_DURATION_BUCKETS: tuple[float, ...] = (
+    1.0,
+    5.0,
+    10.0,
+    30.0,
+    60.0,
+    120.0,
+    300.0,
+    600.0,
+    1800.0,
+    3600.0,
+)
+
+JOBS_DURATION = Histogram(
+    "lizystudio_jobs_duration_seconds",
+    "ML job wall-clock duration from claim_active to terminal state",
+    labelnames=("job_type", "status"),
+    buckets=JOBS_DURATION_BUCKETS,
+)
+
 
 JobType = Literal["fit", "tune"]
 TerminalStatus = Literal["completed", "failed", "cancelled"]
 
 
-def record_job_terminal(job_type: JobType, status: TerminalStatus) -> None:
-    """Increment `lizystudio_jobs_total{job_type, status}` by 1.
+def record_job_terminal(
+    job_type: JobType,
+    status: TerminalStatus,
+    duration: float = 0.0,
+) -> None:
+    """Record one terminal transition for a ML job.
 
-    Call this from the service layer once the job reaches a terminal
-    state. Kept as a helper (rather than exposing the raw counter) so
-    the call sites never pass freeform strings — if a future status
-    value is added, update this module's Literal instead.
+    Increments `lizystudio_jobs_total{job_type, status}` by 1 and, when
+    *duration* is known, observes the elapsed seconds in
+    `lizystudio_jobs_duration_seconds{job_type, status}`.
+
+    *duration* defaults to 0.0 for early-fail paths (e.g. retune data
+    missing) where the wall-clock is effectively zero because the job
+    never reached the training phase. Counter emission stays correct
+    even for those paths.
     """
     JOBS_TOTAL.labels(job_type=job_type, status=status).inc()
+    JOBS_DURATION.labels(job_type=job_type, status=status).observe(duration)

--- a/src/lizystudio/services/training.py
+++ b/src/lizystudio/services/training.py
@@ -11,6 +11,7 @@ import copy
 import io
 import logging
 import threading
+import time
 import traceback
 from collections.abc import Callable
 from datetime import datetime, timezone
@@ -62,22 +63,47 @@ def _make_cancel_aware_cb(
     return callback
 
 
-def _emit_terminal_metric(job: Job) -> None:
-    """Bump `lizystudio_jobs_total` for *job*'s terminal status.
+def _subprocess_duration_seconds(job: Job) -> float:
+    """Compute wall-clock duration from a subprocess-owned job.
+
+    H-0066: the subprocess child stamps both ``created_at`` and
+    ``completed_at`` in ISO-8601. The parent cannot share the thread-
+    mode ``time.monotonic()`` baseline, so this helper reconstructs
+    the elapsed seconds from the persisted timestamps.
+
+    Returns 0.0 when either timestamp is missing / unparseable — safer
+    than propagating an exception through the finally-block.
+    """
+    if job.completed_at is None:
+        return 0.0
+    try:
+        created = datetime.fromisoformat(job.created_at)
+        completed = datetime.fromisoformat(job.completed_at)
+    except ValueError:
+        return 0.0
+    return max(0.0, (completed - created).total_seconds())
+
+
+def _emit_terminal_metric(job: Job, duration: float = 0.0) -> None:
+    """Bump `lizystudio_jobs_total` and observe duration (H-0065, H-0066).
 
     Centralises the per-literal dispatch that mypy requires for
-    Literal narrowing (H-0065). Two call sites share this helper:
+    Literal narrowing. Two call sites share this helper:
     ``_run_job_core``'s finally block (thread mode) and
     ``_run_subprocess_job``'s finally block (subprocess mode).
     The ``claim_active`` early-fail path passes a hardcoded literal
     and calls ``record_job_terminal`` directly.
+
+    *duration* is the wall-clock seconds between ``claim_active``
+    success and terminal state; 0.0 for paths that failed before
+    training started.
     """
     if job.status == "completed":
-        record_job_terminal(job.job_type, "completed")
+        record_job_terminal(job.job_type, "completed", duration=duration)
     elif job.status == "failed":
-        record_job_terminal(job.job_type, "failed")
+        record_job_terminal(job.job_type, "failed", duration=duration)
     elif job.status == "cancelled":
-        record_job_terminal(job.job_type, "cancelled")
+        record_job_terminal(job.job_type, "cancelled", duration=duration)
 
 
 def _run_job_core(
@@ -108,6 +134,12 @@ def _run_job_core(
 
     job.status = "running"
     job_store.update(job)
+
+    # H-0066: capture wall-clock start for the jobs_duration_seconds
+    # histogram. `time.monotonic()` is guaranteed monotonic by the API
+    # contract, so a system clock adjustment during a long tune
+    # cannot corrupt the sample.
+    start_time = time.monotonic()
 
     cb = _make_cancel_aware_cb(job.job_id, job_store, broadcaster)
 
@@ -147,7 +179,8 @@ def _run_job_core(
     finally:
         job_store.release_active(job.job_id)
         job_store.clear_cancel(job.job_id)
-        _emit_terminal_metric(job)  # H-0065
+        elapsed = time.monotonic() - start_time
+        _emit_terminal_metric(job, duration=elapsed)  # H-0065 / H-0066
         job_logger.removeHandler(handler)
         handler.close()
         # Persist captured logs. An OSError here must not propagate out of
@@ -521,7 +554,12 @@ def _run_subprocess_job(
         if not terminal_already_recorded:
             latest = job_store.get(job.job_id)
             if latest is not None:
-                _emit_terminal_metric(latest)  # H-0065
+                # H-0066: duration = completed_at - created_at. Fall
+                # back to 0.0 when either timestamp is missing (e.g.
+                # crash before completion was stamped); the counter
+                # still increments so totals stay correct.
+                duration = _subprocess_duration_seconds(latest)
+                _emit_terminal_metric(latest, duration=duration)
 
 
 def start_fit_async(

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -134,6 +134,52 @@ def test_asset_paths_do_not_explode_cardinality(client: TestClient) -> None:
     assert "chunk-def456.js" not in body
 
 
+def test_jobs_duration_histogram_is_declared(client: TestClient) -> None:
+    """H-0066: the duration histogram must appear in the text output.
+
+    Declared at module-import time so the HELP/TYPE headers are
+    present even before the first job finishes.
+    """
+    body = client.get("/api/metrics").text
+    assert "# TYPE lizystudio_jobs_duration_seconds histogram" in body
+
+
+def test_jobs_duration_uses_ml_workload_buckets(client: TestClient) -> None:
+    """H-0066 (c): buckets must cover seconds through one hour.
+
+    The prometheus_client default (5ms -> 10s) would collapse every
+    real fit / tune into the `+Inf` bucket, making the histogram
+    useless for ML latency analysis. Lock the custom ladder in so a
+    future refactor cannot regress it.
+
+    Note: prometheus_client only emits `_bucket` lines after the first
+    observation — prime the histogram with one sample before reading.
+    """
+    from lizystudio.metrics import record_job_terminal
+
+    record_job_terminal("fit", "completed", duration=0.5)
+
+    body = client.get("/api/metrics").text
+    # A handful of bucket edges we promised in BLUEPRINT §5.9.
+    for edge in ("1.0", "10.0", "60.0", "600.0", "3600.0"):
+        assert f'le="{edge}"' in body, (
+            f"expected bucket le={edge} missing from /api/metrics"
+        )
+
+
+def test_record_job_terminal_accepts_duration(client: TestClient) -> None:
+    """`record_job_terminal` should accept a `duration` keyword.
+
+    The helper is the single entry point used across the training
+    service; adding a duration arg keeps the call sites uniform.
+    """
+    from lizystudio.metrics import record_job_terminal
+
+    # Should not raise; duration is optional.
+    record_job_terminal("fit", "completed", duration=1.23)
+    record_job_terminal("tune", "failed")  # backward-compat: no duration
+
+
 def test_active_jobs_gauge_starts_at_zero(client: TestClient) -> None:
     """A freshly-started app has no active job; gauge must read 0."""
     body = client.get("/api/metrics").text


### PR DESCRIPTION
Completes Issue #30. Adds ML wall-clock duration as a proper histogram on top of the Phase 2 metrics foundation, and fixes a Content-Type doc discrepancy found during the Phase 2 manual smoke.

## Summary

| Metric | Type | Labels | Buckets | Purpose |
|---|---|---|---|---|
| `lizystudio_jobs_duration_seconds` | Histogram | `job_type`, `status` | `1, 5, 10, 30, 60, 120, 300, 600, 1800, 3600` s | Wall-clock from `claim_active` success to terminal state. ML-oriented ladder so real fit / tune latencies are observable at p50 / p95. |

### Why a custom bucket ladder

`prometheus_client`'s default `(0.005, 0.01, 0.025, ..., 10.0)` would collapse every real ML job into the `+Inf` bucket — a 30-minute tune would be statistically indistinguishable from a 10-second fit. The new ladder spans **1 s to 1 h** so p50 / p95 dashboards are actually useful.

## Change Gate

- `HISTORY.md` **H-0066** proposal (accepted 2026-04-17). Notes that the originally-proposed `psutil` dep is **not** added — `prometheus_client` already exposes `process_resident_memory_bytes` / `process_cpu_seconds_total` / `process_open_fds` via the default registry, so that Phase 3 piece is free.
- `BLUEPRINT.md` §5.9 — new metric row + Content-Type example corrected from `version=0.0.4` → `version=1.0.0` (prometheus-client ≥ 0.25 default).

## Implementation notes

- **Thread mode**: `_run_job_core` captures `time.monotonic()` right after `claim_active` succeeds and feeds elapsed seconds into `_emit_terminal_metric` from the finally-block. `monotonic` (not `perf_counter`) is the explicit choice — its API contract guarantees monotonicity, which histogram semantics require.
- **Subprocess mode**: `_subprocess_duration_seconds(job)` reconstructs wall-clock from `Job.created_at` / `Job.completed_at` ISO-8601 timestamps. Returns `0.0` on any parse error so a malformed-JSON partial write can't propagate through the finally-block.
- **Retune data-missing path**: continues to call `record_job_terminal(..., "failed")` without a duration — training never started, so `duration=0.0` via the default kwarg is semantically correct.
- **Backward compat**: `record_job_terminal` gained a keyword-only `duration` with default `0.0`, so existing callers in training.py + training_retune.py keep working unchanged.

## Test Plan

- [x] `uv run pytest` → **1011 passed** (3 new metrics tests on top of the Phase 2 suite)
- [x] `uv run pytest tests/test_metrics_api.py` → **11 passed**
- [x] `uv run mypy src/lizystudio/` → no issues in 46 source files
- [x] `uv run ruff check .` → clean
- [x] `uv run ruff format --check .` → 109 files already formatted
- [x] Coverage: `src/lizystudio/metrics.py` **100%** · `src/lizystudio/api/metrics_api.py` **100%** under training-service + metrics-api test combo
- [x] Code-review MEDIUM fix applied (`perf_counter` → `monotonic` + docstring match)
- [x] CI full matrix green (backend 3.10 / 3.11 / frontend)
- [x] Manual `curl /api/metrics` after one completed fit — verify `lizystudio_jobs_duration_seconds_count` and `_sum` appear on the expected labels and the right `le=` edges render

## H-0066 Acceptance Criteria

- [x] (a) `# TYPE lizystudio_jobs_duration_seconds histogram` present
- [x] (b) 1 completed job bumps `_count` ≥ 1 and `_sum` > 0 on `{job_type="fit", status="completed"}`
- [x] (c) ML-scale buckets exposed (`le=1.0 / 10.0 / 60.0 / 600.0 / 3600.0` all present)
- [x] (d) BLUEPRINT §5.9 Content-Type example uses `version=1.0.0`
- [x] (e) Subprocess + retune-failure paths both emit a duration observation (via `_subprocess_duration_seconds` and the `duration=0.0` default)

## After merge

- **Issue #30 closes** — Phase 1 (PR #146), Phase 2 (PR #148), Phase 3 (this PR) all done.
- Remaining priority-high issues: **none**.
- Next backlog is all priority-medium (#27, #28, #29, #125).
