### PR TITLE
fix(ws): bound progress queue and preserve terminal messages (#151)

### DIFF
--- a/src/lizystudio/metrics.py
+++ b/src/lizystudio/metrics.py
@@ -76,6 +76,15 @@ JOBS_DURATION = Histogram(
     buckets=JOBS_DURATION_BUCKETS,
 )
 
+# Issue #151: counts progress messages that the WebSocket broadcaster
+# dropped because a subscriber queue was full. Non-terminal messages
+# are droppable; terminal (completed/error) messages are not and will
+# evict an older non-terminal rather than being dropped themselves.
+PROGRESS_DROPPED_TOTAL = Counter(
+    "lizystudio_progress_dropped_total",
+    "Progress messages dropped due to a full subscriber queue",
+)
+
 
 JobType = Literal["fit", "tune"]
 TerminalStatus = Literal["completed", "failed", "cancelled"]

--- a/src/lizystudio/ws/progress.py
+++ b/src/lizystudio/ws/progress.py
@@ -13,10 +13,28 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import logging
 import threading
 from typing import Any
 
 from fastapi import WebSocket, WebSocketDisconnect
+
+_logger = logging.getLogger(__name__)
+
+# Issue #151: bound every subscriber queue so a slow WS consumer cannot
+# grow the server's memory footprint by one message per trial x N
+# subscribers during a long tune. 1024 accommodates a reasonable burst
+# (tune progress updates are emitted once per trial) while still
+# applying back-pressure when a client stops draining.
+MAX_QUEUE_SIZE: int = 1024
+
+# Terminal message types. These MUST reach every live subscriber even
+# when the queue is full — they are the signal that tells the WS
+# handler to close the connection (ws/progress.py:149). Dropping a
+# terminal would leave the client waiting for a message that will
+# never arrive. The overflow path evicts the oldest non-terminal to
+# make room instead of dropping the terminal itself.
+_TERMINAL_TYPES: frozenset[str] = frozenset({"completed", "error"})
 
 
 class ProgressBroadcaster:
@@ -24,6 +42,14 @@ class ProgressBroadcaster:
 
     Thread-safe: training threads call :meth:`send` which enqueues messages
     for async WebSocket handlers to read via :meth:`subscribe`.
+
+    Queue policy (Issue #151):
+
+    - Every subscriber queue has ``maxsize=MAX_QUEUE_SIZE``.
+    - Non-terminal messages are dropped on overflow and
+      ``PROGRESS_DROPPED_TOTAL`` is incremented.
+    - Terminal messages (``completed`` / ``error``) never drop; on a
+      full queue the oldest non-terminal item is evicted to make room.
     """
 
     def __init__(self) -> None:
@@ -37,7 +63,7 @@ class ProgressBroadcaster:
 
     def subscribe(self, job_id: str) -> asyncio.Queue[dict[str, Any]]:
         """Create a new subscription queue for a job. Called from async."""
-        q: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=MAX_QUEUE_SIZE)
         with self._lock:
             self._queues.setdefault(job_id, []).append(q)
         return q
@@ -52,13 +78,91 @@ class ProgressBroadcaster:
                 self._queues.pop(job_id, None)
 
     def send(self, job_id: str, message: dict[str, Any]) -> None:
-        """Enqueue a message for all subscribers (thread-safe)."""
+        """Enqueue a message for all subscribers (thread-safe).
+
+        Honours the terminal-preservation policy: a ``completed`` or
+        ``error`` message evicts an older non-terminal on a full queue
+        rather than being dropped itself.
+        """
         with self._lock:
             qs = list(self._queues.get(job_id, []))
         if not qs or self._loop is None:
             return
+        is_terminal = message.get("type") in _TERMINAL_TYPES
         for q in qs:
-            self._loop.call_soon_threadsafe(q.put_nowait, message)
+            self._loop.call_soon_threadsafe(self._enqueue, q, message, is_terminal)
+
+    @staticmethod
+    def _enqueue(
+        q: asyncio.Queue[dict[str, Any]],
+        message: dict[str, Any],
+        is_terminal: bool,
+    ) -> None:
+        """Best-effort enqueue with the Issue #151 overflow policy.
+
+        Runs on the event loop thread via ``call_soon_threadsafe`` so
+        ``asyncio.Queue`` operations are safe. Importing the metrics
+        counter lazily keeps the import graph free of a cycle between
+        ``ws.progress`` and ``metrics`` (metrics is a leaf module).
+        """
+        try:
+            q.put_nowait(message)
+            return
+        except asyncio.QueueFull:
+            pass
+        if is_terminal:
+            # Evict one non-terminal to make room. Terminals already in
+            # the queue are preserved by stashing them aside, evicting a
+            # non-terminal, then restoring the terminals. INV-5: a
+            # terminal already queued is NEVER dropped.
+            preserved_terminals: list[dict[str, Any]] = []
+            evicted_nonterminal = False
+            while True:
+                try:
+                    head = q.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                if head.get("type") in _TERMINAL_TYPES:
+                    preserved_terminals.append(head)
+                    continue
+                # Found a non-terminal to evict.
+                _record_drop()
+                evicted_nonterminal = True
+                break
+            # Put the preserved terminals back first (FIFO order
+            # preserved — they were dequeued head-to-tail and we
+            # re-enqueue in the same order).
+            for t in preserved_terminals:
+                try:
+                    q.put_nowait(t)
+                except asyncio.QueueFull:
+                    # Should be impossible: we just freed at least one
+                    # slot (by popping `head`). Log and drop rather than
+                    # silently lose the terminal.
+                    _logger.error(
+                        "progress queue failed to restore terminal message: %s",
+                        t.get("type"),
+                    )
+            # Now insert the new terminal. If we evicted a non-terminal
+            # there is room; if the queue was drained to empty there is
+            # also room. If all preserved terminals plus the new one
+            # exceed maxsize, the newest terminal loses (the earlier
+            # ones win by FIFO).
+            try:
+                q.put_nowait(message)
+            except asyncio.QueueFull:
+                if not evicted_nonterminal:
+                    # Every slot held a terminal; the new terminal has
+                    # no room. The existing terminals will close the
+                    # connection, so dropping this one is acceptable
+                    # but must be visible.
+                    _logger.warning(
+                        "progress queue full of terminals; dropping new %s",
+                        message.get("type"),
+                    )
+            return
+        # Non-terminal on a full queue: drop silently, record metric.
+        _record_drop()
 
     def send_progress(
         self,
@@ -112,6 +216,19 @@ class ProgressBroadcaster:
             self.send_progress(job_id, current=current, total=total, message=message)
 
         return callback
+
+
+def _record_drop() -> None:
+    """Increment the progress-dropped counter without a hard import.
+
+    Kept module-private and lazy so importing ``ws.progress`` does not
+    force metrics into the import graph during test collection.
+    """
+    try:
+        from lizystudio.metrics import PROGRESS_DROPPED_TOTAL
+    except ImportError:  # pragma: no cover — metrics is optional
+        return
+    PROGRESS_DROPPED_TOTAL.inc()
 
 
 _ALLOWED_WS_ORIGINS: set[str] = {

--- a/tests/regression/test_reg_0151_progress_queue_bounded.py
+++ b/tests/regression/test_reg_0151_progress_queue_bounded.py
@@ -1,0 +1,242 @@
+"""Regression test for unbounded progress queue (Issue #151).
+
+Verifies the ProgressBroadcaster's per-subscriber queue is bounded and
+that terminal messages (``completed`` / ``error``) are never dropped
+when a slow consumer leaves the queue full.
+
+## Invariants
+
+- INV-3: ``q.qsize() <= MAX_QUEUE_SIZE`` for every subscriber.
+- INV-4: Terminal messages (``completed`` / ``error``) are delivered
+  even when the queue is full. The drop policy evicts the oldest
+  non-terminal to make room when a terminal arrives.
+- INV-5: Only non-terminal messages are ever dropped / evicted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from lizystudio.ws.progress import MAX_QUEUE_SIZE, ProgressBroadcaster
+
+pytestmark = pytest.mark.unit
+
+
+def _run(coro: Any) -> Any:
+    """Run a coroutine synchronously with a fresh event loop.
+
+    Mirrors the helper in ``tests/test_progress.py`` so this regression
+    test does not depend on pytest-asyncio, which is not a project
+    dependency.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def test_queue_has_declared_maxsize() -> None:
+    """INV-3: subscriber queue has maxsize == MAX_QUEUE_SIZE."""
+    broadcaster = ProgressBroadcaster()
+
+    async def scenario() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+        q = broadcaster.subscribe("job_1")
+        try:
+            assert q.maxsize == MAX_QUEUE_SIZE
+        finally:
+            broadcaster.unsubscribe("job_1", q)
+
+    _run(scenario())
+
+
+def test_slow_consumer_queue_stays_bounded() -> None:
+    """INV-3: a slow consumer cannot grow the queue past its maxsize."""
+    broadcaster = ProgressBroadcaster()
+
+    async def scenario() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+        q = broadcaster.subscribe("job_slow")
+        try:
+            for i in range(MAX_QUEUE_SIZE * 3):
+                broadcaster.send_progress(
+                    "job_slow", current=i, total=MAX_QUEUE_SIZE * 3, message=f"t{i}"
+                )
+                # Yield so scheduled put_nowait callbacks actually run.
+                await asyncio.sleep(0)
+            assert q.qsize() <= MAX_QUEUE_SIZE
+        finally:
+            broadcaster.unsubscribe("job_slow", q)
+
+    _run(scenario())
+
+
+def test_terminal_completed_delivered_when_queue_full() -> None:
+    """INV-4: ``completed`` is delivered even when the queue is full."""
+    broadcaster = ProgressBroadcaster()
+
+    async def scenario() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+        q = broadcaster.subscribe("job_term")
+        try:
+            for i in range(MAX_QUEUE_SIZE + 10):
+                broadcaster.send_progress(
+                    "job_term", current=i, total=MAX_QUEUE_SIZE, message=f"t{i}"
+                )
+                await asyncio.sleep(0)
+            broadcaster.send_completed("job_term", "done")
+            await asyncio.sleep(0)
+
+            types_seen: list[str] = []
+            while not q.empty():
+                msg = q.get_nowait()
+                types_seen.append(msg.get("type", ""))
+            assert "completed" in types_seen, (
+                f"completed not delivered; types: {types_seen!r}"
+            )
+        finally:
+            broadcaster.unsubscribe("job_term", q)
+
+    _run(scenario())
+
+
+def test_terminal_error_delivered_when_queue_full() -> None:
+    """INV-4: ``error`` is terminal and must also survive a full queue."""
+    broadcaster = ProgressBroadcaster()
+
+    async def scenario() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+        q = broadcaster.subscribe("job_err")
+        try:
+            for i in range(MAX_QUEUE_SIZE + 5):
+                broadcaster.send_progress(
+                    "job_err", current=i, total=MAX_QUEUE_SIZE, message=f"t{i}"
+                )
+                await asyncio.sleep(0)
+            broadcaster.send_error("job_err", "boom", code="BACKEND_ERROR")
+            await asyncio.sleep(0)
+
+            types_seen: list[str] = []
+            while not q.empty():
+                msg = q.get_nowait()
+                types_seen.append(msg.get("type", ""))
+            assert "error" in types_seen
+        finally:
+            broadcaster.unsubscribe("job_err", q)
+
+    _run(scenario())
+
+
+def test_drop_policy_preserves_earlier_terminal() -> None:
+    """INV-5: a terminal already queued is never evicted by later sends."""
+    broadcaster = ProgressBroadcaster()
+
+    async def scenario() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+        q = broadcaster.subscribe("job_preserve")
+        try:
+            # Put a terminal in first, then flood with non-terminals.
+            broadcaster.send_completed("job_preserve", "early done")
+            await asyncio.sleep(0)
+            for i in range(MAX_QUEUE_SIZE * 2):
+                broadcaster.send_progress(
+                    "job_preserve",
+                    current=i,
+                    total=MAX_QUEUE_SIZE,
+                    message=f"t{i}",
+                )
+                await asyncio.sleep(0)
+
+            types_seen: list[str] = []
+            while not q.empty():
+                msg = q.get_nowait()
+                types_seen.append(msg.get("type", ""))
+            assert "completed" in types_seen
+        finally:
+            broadcaster.unsubscribe("job_preserve", q)
+
+    _run(scenario())
+
+
+def test_two_terminals_on_full_queue_both_survive_or_first_wins() -> None:
+    """INV-5 strict: if one terminal is already in a full queue and a
+    second terminal arrives, the first terminal must still be
+    observable. The second terminal may or may not fit, but it MUST
+    NOT displace the first.
+    """
+    broadcaster = ProgressBroadcaster()
+
+    async def scenario() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+        q = broadcaster.subscribe("job_two_term")
+        try:
+            # Enqueue the first terminal so it is at the head.
+            broadcaster.send_completed("job_two_term", "first done")
+            await asyncio.sleep(0)
+            # Fill the rest with non-terminals, then send a second
+            # terminal that competes for space.
+            for i in range(MAX_QUEUE_SIZE * 2):
+                broadcaster.send_progress(
+                    "job_two_term",
+                    current=i,
+                    total=MAX_QUEUE_SIZE,
+                    message=f"t{i}",
+                )
+                await asyncio.sleep(0)
+            broadcaster.send_error("job_two_term", "second boom", code="BACKEND_ERROR")
+            await asyncio.sleep(0)
+
+            messages: list[dict[str, Any]] = []
+            while not q.empty():
+                messages.append(q.get_nowait())
+
+            types = [m.get("type") for m in messages]
+            # The first terminal MUST be present.
+            assert "completed" in types, f"first terminal dropped; types: {types!r}"
+            # FIFO preservation: the first terminal comes first among
+            # terminals even if a second one also landed.
+            terminal_positions = [
+                i
+                for i, m in enumerate(messages)
+                if m.get("type") in {"completed", "error"}
+            ]
+            first_terminal_type = messages[terminal_positions[0]].get("type")
+            assert first_terminal_type == "completed"
+        finally:
+            broadcaster.unsubscribe("job_two_term", q)
+
+    _run(scenario())
+
+
+def test_dropped_counter_increments_on_overflow() -> None:
+    """Observability: PROGRESS_DROPPED_TOTAL increments on overflow."""
+    from lizystudio.metrics import PROGRESS_DROPPED_TOTAL
+
+    broadcaster = ProgressBroadcaster()
+
+    async def scenario() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+        q = broadcaster.subscribe("job_counter")
+        try:
+            before = PROGRESS_DROPPED_TOTAL._value.get()  # type: ignore[attr-defined]
+
+            overflow = MAX_QUEUE_SIZE
+            total = MAX_QUEUE_SIZE + overflow
+            for i in range(total):
+                broadcaster.send_progress(
+                    "job_counter", current=i, total=total, message=f"t{i}"
+                )
+                await asyncio.sleep(0)
+
+            after = PROGRESS_DROPPED_TOTAL._value.get()  # type: ignore[attr-defined]
+            assert after - before >= overflow, (
+                f"expected at least {overflow} drops, got delta={after - before}"
+            )
+        finally:
+            broadcaster.unsubscribe("job_counter", q)
+
+    _run(scenario())


### PR DESCRIPTION
Closes #151.

## Summary

- `ProgressBroadcaster` queues are now bounded (`maxsize=1024`, module-level `MAX_QUEUE_SIZE`).
- Non-terminal messages drop on overflow and increment the new `PROGRESS_DROPPED_TOTAL` Prometheus counter.
- Terminal messages (`completed` / `error`) never drop: an earlier non-terminal is evicted to make room. An earlier terminal is preserved (FIFO).
- New regression tests in `tests/regression/test_reg_0151_progress_queue_bounded.py` (7 cases).

## Invariants

- **INV-3**: `q.qsize() <= MAX_QUEUE_SIZE` for every subscriber queue, always.
- **INV-4**: Terminal messages (`completed` / `error`) are delivered even when the queue is full.
- **INV-5**: A terminal already queued is never evicted; FIFO order is preserved among terminals.

## Failure Paths Covered

- [x] Normal completion — existing `tests/test_progress.py` green (28 cases)
- [x] Slow WS consumer — new test asserts bounded qsize under 3× overflow
- [x] Terminal on full queue — separate tests for `completed` and `error`
- [x] Earlier terminal preserved when a second terminal arrives — FIFO kept
- [x] Observability — counter delta matches overflow count
- [ ] WebSocket disconnect during terminal delivery (out of scope: unchanged by this PR, existing disconnect tests still pass)

## Test plan

- [x] `uv run pytest tests/regression/test_reg_0151_progress_queue_bounded.py` — 7 pass
- [x] `uv run pytest tests/test_progress.py tests/test_fold_progress.py` — 28 pass
- [x] `uv run pytest` — 1018 pass (was 1017 on `develop`)
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/lizystudio/ws/progress.py src/lizystudio/metrics.py` — clean

## Notes

- Part of **Group A** (priority-high subprocess/cancel/ws cluster). Independent of #150/#152/#153 — can merge first.