### PR TITLE
fix(subprocess): drain child stderr to prevent pipe deadlock (#150)

### DIFF
--- a/src/lizystudio/services/subprocess_runner.py
+++ b/src/lizystudio/services/subprocess_runner.py
@@ -21,10 +21,12 @@ import os
 import subprocess
 import sys
 import tempfile
+import threading
 import time
+from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any
 
 from lizystudio.services.jobs import Job, JobStore
 
@@ -47,6 +49,100 @@ _WAIT_TIMEOUT = 10.0
 # where the flush->visibility delay is occasionally above that budget.
 _FINAL_FLUSH_RETRIES = 5
 _FINAL_FLUSH_INTERVAL = 0.05
+
+# Issue #150: the child's stderr pipe must be drained concurrently or
+# the child blocks on write(2) once it exceeds the OS pipe buffer
+# (~64 KiB on Linux). We retain only the last _STDERR_TAIL_CHUNKS *
+# _STDERR_READ_SIZE bytes so a chatty child does not grow the parent's
+# memory unboundedly; this tail is what the error-logging path at
+# run_job_in_subprocess reports when the child exits non-zero.
+_STDERR_READ_SIZE = 4096  # bytes per read(2)
+_STDERR_TAIL_CHUNKS = 16  # retain the most recent chunks (~64 KiB)
+
+
+class _StderrDrainer:
+    """Concurrently drain a subprocess stderr pipe on a daemon thread.
+
+    The parent no longer blocks on ``proc.stderr.read()`` only after
+    ``proc.wait()`` — which would deadlock any child that writes more
+    than the OS pipe buffer. Instead, a dedicated daemon thread reads
+    chunks until EOF (or the pipe is closed) and keeps the most
+    recent chunks in a bounded ring for post-mortem logging.
+
+    The drainer does NOT own the ``Popen`` object; callers are
+    expected to ``start()`` right after ``Popen`` and ``join(timeout)``
+    after ``proc.wait()``. ``tail_bytes()`` is safe to call after
+    ``join()`` completes.
+    """
+
+    def __init__(self, stream: IO[bytes]) -> None:
+        self._stream = stream
+        self._buffer: deque[bytes] = deque(maxlen=_STDERR_TAIL_CHUNKS)
+        self._thread = threading.Thread(
+            target=self._run, name="lizystudio-stderr-drain", daemon=True
+        )
+
+    def _run(self) -> None:
+        try:
+            while True:
+                chunk = self._stream.read(_STDERR_READ_SIZE)
+                if not chunk:
+                    # EOF or pipe closed by child exit.
+                    break
+                self._buffer.append(chunk)
+        except (OSError, ValueError):
+            # Stream closed out from under us; nothing to do.
+            return
+        except Exception:
+            # Any other exception would otherwise be silently logged by
+            # threading.excepthook and leave the pipe undrained, which
+            # in turn can re-introduce the #150 deadlock. Log with the
+            # stack trace so diagnosis is possible post-mortem.
+            _logger.exception("stderr drainer thread crashed")
+            return
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def join(self, timeout: float | None = None) -> None:
+        """Wait for the drainer to reach EOF, then close the stream.
+
+        Safe to call multiple times — the second call is a no-op on a
+        terminated thread and an already-closed stream. Callers should
+        invoke ``join`` before ``tail_bytes`` to ensure the drainer has
+        finished writing to the buffer.
+
+        If the drainer does not finish within *timeout*, close the
+        stream anyway — ``read(4096)`` on a closed stream returns
+        ``b""`` or raises, both of which terminate the loop above.
+        """
+        self._thread.join(timeout=timeout)
+        with contextlib.suppress(Exception):
+            self._stream.close()
+        # If the thread was still mid-read when the stream closed,
+        # give it a brief moment to unwind. This is a best-effort
+        # cleanup — daemon=True prevents it from blocking interpreter
+        # shutdown either way.
+        if self._thread.is_alive():
+            self._thread.join(timeout=0.5)
+            if self._thread.is_alive():
+                _logger.warning(
+                    "stderr drainer thread did not exit after join + close; "
+                    "leaving as daemon"
+                )
+
+    def tail_bytes(self) -> bytes:
+        """Return the retained tail of stderr output.
+
+        MUST be called after :meth:`join` returns so the drainer thread
+        is no longer appending to the buffer. Reading earlier is
+        technically memory-safe under CPython's GIL but may return a
+        truncated tail.
+
+        Bounded by the ring's capacity — a chatty child only gets
+        its final chunks logged, not the entire history.
+        """
+        return b"".join(self._buffer)
 
 
 def run_job_in_subprocess(
@@ -108,6 +204,7 @@ def run_job_in_subprocess(
     args_p = Path(args_path)
     progress_path = str(args_p.parent / (args_p.stem + "_progress.jsonl"))
 
+    drainer: _StderrDrainer | None = None
     try:
         proc = subprocess.Popen(
             [
@@ -120,6 +217,13 @@ def run_job_in_subprocess(
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
         )
+
+        # Issue #150: drain stderr concurrently so the child cannot
+        # block on write(2) once it exceeds the OS pipe buffer. The
+        # drainer keeps a bounded tail for post-mortem logging below.
+        if proc.stderr is not None:
+            drainer = _StderrDrainer(proc.stderr)
+            drainer.start()
 
         # H-0062 Bugfix 2026-04-14 (5): pass job_store so _poll_progress
         # can honour cancel requests and terminate a hung subprocess.
@@ -142,15 +246,25 @@ def run_job_in_subprocess(
             with contextlib.suppress(subprocess.TimeoutExpired):
                 proc.wait(timeout=_WAIT_TIMEOUT)
 
+        # Wait for the drainer to finish consuming stderr BEFORE reading
+        # the retained tail. Otherwise tail_bytes() can race with the
+        # final appends and return a truncated buffer. join() is safe
+        # to call twice — the finally below is idempotent insurance
+        # against any exception between here and there.
+        if drainer is not None:
+            drainer.join(timeout=2.0)
+
         if proc.returncode not in (0, None):
-            raw = proc.stderr.read() if proc.stderr else b""
-            stderr = (raw or b"").decode(errors="replace")
+            tail = drainer.tail_bytes() if drainer is not None else b""
+            stderr = tail.decode(errors="replace")
             _logger.error(
                 "Subprocess exited with code %d: %s",
                 proc.returncode,
-                stderr[:500],
+                stderr[-500:],
             )
     finally:
+        if drainer is not None:
+            drainer.join(timeout=2.0)
         Path(args_path).unlink(missing_ok=True)
         Path(progress_path).unlink(missing_ok=True)
 

--- a/tests/regression/test_reg_0150_stderr_deadlock.py
+++ b/tests/regression/test_reg_0150_stderr_deadlock.py
@@ -1,0 +1,164 @@
+"""Regression test for subprocess stderr pipe deadlock (Issue #150).
+
+The parent previously set ``stderr=subprocess.PIPE`` on the child
+subprocess but never drained it concurrently. Once the child wrote
+more than the OS pipe buffer (~64 KiB on Linux), ``write(2)`` in the
+child blocked forever and the subprocess poll loop stalled.
+
+## Invariants
+
+- INV-1: The child MUST never block on write(stderr) regardless of how
+  many bytes it emits. Verified by running a child that writes a
+  large, fixed amount of stderr in one burst and asserting clean exit
+  within a generous timeout.
+- INV-2: For every ``subprocess.Popen`` created by
+  ``run_job_in_subprocess``, ``proc.stderr`` (if present) is closed
+  exactly once before the function returns. Verified indirectly by
+  the drainer's own ``close`` contract — no FD leak across N runs.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+import pytest
+
+from lizystudio.services.subprocess_runner import _StderrDrainer
+
+pytestmark = pytest.mark.unit
+
+
+def _spawn_writer(n_bytes: int) -> subprocess.Popen[bytes]:
+    """Launch a minimal Python child that writes *n_bytes* of stderr."""
+    script = (
+        "import sys; "
+        f"sys.stderr.buffer.write(b'x' * {n_bytes}); "
+        "sys.stderr.flush(); "
+        "sys.exit(0)"
+    )
+    return subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+
+
+def test_large_stderr_does_not_deadlock_child() -> None:
+    """INV-1: child writing 500 KiB exits cleanly when stderr is drained.
+
+    Without draining, the child blocks on write(2) after ~64 KiB on
+    Linux (the pipe buffer is full and the parent never reads).
+    """
+    n_bytes = 500_000
+    proc = _spawn_writer(n_bytes)
+    assert proc.stderr is not None
+    drainer = _StderrDrainer(proc.stderr)
+    drainer.start()
+    try:
+        try:
+            proc.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2.0)
+            pytest.fail(
+                f"child blocked on stderr write of {n_bytes} bytes "
+                "(drainer did not drain the pipe)"
+            )
+        assert proc.returncode == 0
+    finally:
+        drainer.join(timeout=2.0)
+
+
+@pytest.mark.parametrize("n_bytes", [64 * 1024, 256 * 1024, 1_024 * 1024])
+def test_parametrized_stderr_sizes(n_bytes: int) -> None:
+    """INV-1: holds across pipe-buffer, 4x, 16x capacity."""
+    proc = _spawn_writer(n_bytes)
+    assert proc.stderr is not None
+    drainer = _StderrDrainer(proc.stderr)
+    drainer.start()
+    try:
+        proc.wait(timeout=5.0)
+        assert proc.returncode == 0
+    finally:
+        drainer.join(timeout=2.0)
+
+
+def test_drainer_captures_tail_bytes() -> None:
+    """The drainer retains the trailing bytes so error reporting
+    preserves the final diagnostic lines of a verbose child.
+    """
+    n_bytes = 200_000
+    proc = _spawn_writer(n_bytes)
+    assert proc.stderr is not None
+    drainer = _StderrDrainer(proc.stderr)
+    drainer.start()
+    try:
+        proc.wait(timeout=5.0)
+    finally:
+        drainer.join(timeout=2.0)
+    tail = drainer.tail_bytes()
+    # Bounded: the drainer caps the retained buffer; exact cap is an
+    # implementation detail, but it must be non-empty and not larger
+    # than the total written.
+    assert tail, "expected non-empty tail from drainer"
+    assert len(tail) <= n_bytes
+
+
+def test_drainer_join_releases_handle() -> None:
+    """INV-2: after join(), the drainer has closed its stderr handle."""
+    proc = _spawn_writer(1024)
+    assert proc.stderr is not None
+    drainer = _StderrDrainer(proc.stderr)
+    drainer.start()
+    proc.wait(timeout=5.0)
+    drainer.join(timeout=2.0)
+    # The underlying stream should be closed; read from a closed stream
+    # raises ValueError.
+    assert proc.stderr.closed
+
+
+def test_no_fd_leak_over_sequential_runs() -> None:
+    """INV-2 (FD release): running many drained subprocesses in
+    sequence does not accumulate open FDs in the parent.
+    """
+    import os
+
+    if not sys.platform.startswith("linux"):
+        pytest.skip("FD-count assertion is Linux-only")
+
+    def count_fds() -> int:
+        return len(os.listdir(f"/proc/{os.getpid()}/fd"))
+
+    baseline = count_fds()
+    for _ in range(10):
+        proc = _spawn_writer(4096)
+        assert proc.stderr is not None
+        drainer = _StderrDrainer(proc.stderr)
+        drainer.start()
+        proc.wait(timeout=5.0)
+        drainer.join(timeout=2.0)
+    # Allow a small slack (test infrastructure may open a few FDs) but
+    # catch the old behaviour of leaking one FD per run.
+    assert count_fds() - baseline < 5, f"FD leak: baseline={baseline}, after=10 runs"
+
+
+def test_drainer_survives_child_that_writes_nothing() -> None:
+    """Child exits without writing to stderr — drainer must not hang."""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import sys; sys.exit(0)"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    assert proc.stderr is not None
+    drainer = _StderrDrainer(proc.stderr)
+    drainer.start()
+    try:
+        proc.wait(timeout=5.0)
+    finally:
+        start = time.monotonic()
+        drainer.join(timeout=2.0)
+        elapsed = time.monotonic() - start
+        assert elapsed < 2.0, f"drainer hung on empty stderr ({elapsed:.2f}s)"
+    assert drainer.tail_bytes() == b""


### PR DESCRIPTION
Closes #150.

## Summary

- Introduce `_StderrDrainer`: a daemon thread that drains the child's stderr pipe concurrently so `write(2)` never blocks once the OS pipe buffer (~64 KiB on Linux) is exceeded.
- Retain only the most recent 16 chunks × 4 KiB (~64 KiB) for post-mortem error logging, bounding memory.
- Call `drainer.join(timeout=2.0)` right after `proc.wait()` so `tail_bytes()` reads a stable buffer, with an idempotent second `join()` in the outer `finally` as insurance.
- Drainer's `_run` logs unexpected exceptions with `_logger.exception` so a crashing thread is visible instead of silently dropped by `threading.excepthook`.
- 8 new regression tests in `tests/regression/test_reg_0150_stderr_deadlock.py`.

## Invariants

- **INV-1**: the child never blocks on `write(stderr)`, regardless of emitted byte count.
- **INV-2**: `proc.stderr` is closed exactly once before `run_job_in_subprocess` returns.

## Failure Paths Covered

- [x] Normal completion — existing subprocess tests green
- [x] Verbose stderr (64 KiB / 256 KiB / 1 MiB) — parametrized regression
- [x] Child crash (non-zero exit) — tail preserved in error log
- [x] Child writes nothing — drainer does not hang on empty pipe
- [x] FD leak across 10 sequential jobs — `join()` closes the stream
- [x] Drainer thread crash — logged instead of silently dropped

## Test plan

- [x] `uv run pytest tests/regression/test_reg_0150_stderr_deadlock.py` — 8 pass
- [x] `uv run pytest tests/test_subprocess_runner.py` — 30 pass
- [x] `uv run pytest` — 1026 pass (was 1018 on `develop`)
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/lizystudio/services/subprocess_runner.py` — clean

## Notes

- Part of **Group A** (priority-high subprocess/cancel/ws cluster).
- Independent of PR #171 (already merged). PR-C (#152 + #153) will follow after this merges.
- Design choice: background-thread drain (not `stderr=DEVNULL`) preserves the existing error-tail logging for non-zero exit diagnosis.