### PR TITLE
fix(subprocess): propagate cancel to child and preserve finally on SIGTERM (#152, #153)

### DIFF
--- a/src/lizystudio/services/jobs.py
+++ b/src/lizystudio/services/jobs.py
@@ -205,7 +205,13 @@ class JobStore:
         for jid in removed:
             target = self._job_dir(jid)
             if target.exists():
-                shutil.rmtree(target)
+                # ignore_errors: a concurrent request_cancel (#152) can
+                # briefly stage a tempfile inside the victim tree, and
+                # rmtree's listdir → unlink cycle sees the stale entry
+                # and raises FileNotFoundError. The file is about to be
+                # deleted anyway; swallow the transient error instead
+                # of propagating it out of delete().
+                shutil.rmtree(target, ignore_errors=True)
         return removed
 
     # --- H-0062 lineage helpers ---
@@ -364,23 +370,30 @@ class JobStore:
         # Best-effort file write. Only write if the job_dir already
         # exists — do NOT mkdir it, because that would race with a
         # concurrent delete() of the same job (re-creating the dir
-        # while rmtree enumerates it causes FileNotFoundError). The
-        # in-memory flag remains the source of truth for same-process
-        # callers; the file is only needed for subprocess children,
-        # which always run after the job_dir was persisted.
+        # while rmtree enumerates it). The in-memory flag remains the
+        # source of truth for same-process callers; the file is only
+        # needed for subprocess children, which always run after the
+        # job_dir was persisted.
+        #
+        # Place the staging tempfile in jobs_dir (the parent, never
+        # deleted by delete(job_id)) rather than the job_dir itself,
+        # so a concurrent shutil.rmtree never observes a partially
+        # written or intermittent .tmp entry under the victim
+        # directory — that was the root cause of a FileNotFoundError
+        # surfaced in the concurrent cancel + delete test on 3.11.
         tmp_path: Path | None = None
         try:
             flag_path = self._cancel_flag_path(job_id)
             if not flag_path.parent.exists():
                 return
-            tmp_path = flag_path.with_suffix(".tmp")
+            tmp_path = self.jobs_dir / f".cancel-{job_id}-{os.getpid()}.tmp"
             tmp_path.write_bytes(b"")
             os.replace(tmp_path, flag_path)
         except (OSError, ValueError):
             # OSError: concurrent delete race / filesystem issue.
             # ValueError: malformed job_id rejected by validate_path_within.
             # Clean up any orphaned tmp file so a failed replace does
-            # not leak under the job_dir.
+            # not leak under jobs_dir.
             if tmp_path is not None:
                 with contextlib.suppress(OSError):
                     tmp_path.unlink(missing_ok=True)

--- a/src/lizystudio/services/jobs.py
+++ b/src/lizystudio/services/jobs.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import builtins
+import contextlib
 import json
 import logging
+import os
 import shutil
 import threading
 from dataclasses import asdict, dataclass
@@ -21,6 +23,15 @@ from lizystudio.metrics import ACTIVE_JOBS
 from lizystudio.security import validate_path_within  # noqa: E402
 
 _logger = logging.getLogger(__name__)
+
+
+# Issue #152: filename of the on-disk cancel flag. In subprocess mode
+# the child constructs a fresh JobStore whose in-memory
+# ``_cancel_requested`` set is disjoint from the parent's. The flag
+# file is the IPC channel that lets the child observe the parent's
+# ``request_cancel`` between trials, so cooperative cancel (H-0011)
+# actually fires before the SIGTERM escalation.
+CANCEL_FLAG_FILENAME = "CANCEL"
 
 
 @dataclass
@@ -339,19 +350,85 @@ class JobStore:
             return self._parent_locks.get(parent_job_id)
 
     def request_cancel(self, job_id: str) -> None:
-        """Mark a job for cancellation (H-0011)."""
+        """Mark a job for cancellation (H-0011).
+
+        Issue #152: also writes ``<job_dir>/CANCEL`` atomically so a
+        fresh ``JobStore`` constructed in a subprocess child (whose
+        in-memory ``_cancel_requested`` set is disjoint) can observe
+        the cancel through ``is_cancel_requested``. The in-memory
+        set remains the source of truth for same-process callers;
+        the file is an IPC channel only.
+        """
         with self._cancel_lock:
             self._cancel_requested.add(job_id)
+        # Best-effort file write. Only write if the job_dir already
+        # exists — do NOT mkdir it, because that would race with a
+        # concurrent delete() of the same job (re-creating the dir
+        # while rmtree enumerates it causes FileNotFoundError). The
+        # in-memory flag remains the source of truth for same-process
+        # callers; the file is only needed for subprocess children,
+        # which always run after the job_dir was persisted.
+        tmp_path: Path | None = None
+        try:
+            flag_path = self._cancel_flag_path(job_id)
+            if not flag_path.parent.exists():
+                return
+            tmp_path = flag_path.with_suffix(".tmp")
+            tmp_path.write_bytes(b"")
+            os.replace(tmp_path, flag_path)
+        except (OSError, ValueError):
+            # OSError: concurrent delete race / filesystem issue.
+            # ValueError: malformed job_id rejected by validate_path_within.
+            # Clean up any orphaned tmp file so a failed replace does
+            # not leak under the job_dir.
+            if tmp_path is not None:
+                with contextlib.suppress(OSError):
+                    tmp_path.unlink(missing_ok=True)
+            _logger.warning(
+                "Failed to write cancel flag for job %s", job_id, exc_info=True
+            )
 
     def is_cancel_requested(self, job_id: str) -> bool:
-        """Check whether cancellation was requested for a job."""
+        """Check whether cancellation was requested for a job.
+
+        Checks the in-memory set first (cheap, hot-path friendly for
+        cooperative cancel callbacks). Falls back to the on-disk flag
+        file so a child subprocess with a fresh ``JobStore`` still
+        observes the parent's cancel (Issue #152).
+        """
         with self._cancel_lock:
-            return job_id in self._cancel_requested
+            if job_id in self._cancel_requested:
+                return True
+        # Fallback: check the file flag. OSError (e.g. permissions)
+        # or ValueError (malformed job_id rejected by
+        # validate_path_within) conservatively return False — the
+        # parent's in-process wait loop will eventually escalate to
+        # SIGTERM anyway. Critically, this method is called from the
+        # hot cooperative-cancel loop in training.py, so it MUST NOT
+        # propagate exceptions.
+        try:
+            return self._cancel_flag_path(job_id).exists()
+        except (OSError, ValueError):
+            return False
 
     def clear_cancel(self, job_id: str) -> None:
         """Clear cancellation flag after processing."""
         with self._cancel_lock:
             self._cancel_requested.discard(job_id)
+        try:
+            self._cancel_flag_path(job_id).unlink(missing_ok=True)
+        except (OSError, ValueError):
+            _logger.warning(
+                "Failed to clear cancel flag for job %s", job_id, exc_info=True
+            )
+
+    def _cancel_flag_path(self, job_id: str) -> Path:
+        """Resolve the cancel flag path with the traversal guard.
+
+        Reuses ``_job_dir``'s path validation so a malformed job_id
+        cannot escape the jobs_dir root.
+        """
+        return self._job_dir(job_id) / CANCEL_FLAG_FILENAME
 
     # --- Active job tracking (concurrency control) ---
 

--- a/src/lizystudio/services/subprocess_runner.py
+++ b/src/lizystudio/services/subprocess_runner.py
@@ -508,8 +508,63 @@ def _forward_progress(
 # --- Child process entry point ---
 
 
+def _install_sigterm_handler() -> None:
+    """Convert SIGTERM into KeyboardInterrupt on the main thread (#153).
+
+    Python's default SIGTERM handler calls ``_exit`` which bypasses
+    every Python-level ``finally`` block. That caused
+    ``_run_job_core.finally`` to skip — no ``execution.log`` write,
+    no ``release_active``, no terminal metric — whenever the parent
+    escalated a cancel to SIGTERM.
+
+    This handler uses ``_thread.interrupt_main()`` to raise
+    ``KeyboardInterrupt`` on the main thread, which takes the
+    ``except (CancelledError, KeyboardInterrupt)`` branch in
+    ``_run_job_core`` and runs the existing ``finally``.
+
+    Single-shot (INV-8): the handler resets itself to ``SIG_DFL``
+    on entry so a second SIGTERM falls through to the OS default —
+    this keeps the parent's ``proc.kill()`` / SIGKILL escalation
+    intact for a truly hung child.
+    """
+    import _thread
+    import signal as _signal
+
+    fired = {"once": False}
+
+    def _handler(signum: int, frame: Any) -> None:  # noqa: ARG001
+        if fired["once"]:
+            # Second SIGTERM: escalate to default action so the parent's
+            # proc.kill() / SIGKILL path still terminates a hung child.
+            # Only re-raise the signal if the SIG_DFL swap succeeded —
+            # otherwise os.kill would re-enter this very handler
+            # because the custom slot is still active, creating a
+            # signal loop.
+            try:
+                _signal.signal(_signal.SIGTERM, _signal.SIG_DFL)
+            except Exception:
+                # SIG_DFL install failed (extremely unlikely on POSIX).
+                # Leave the second escalation to the parent's proc.kill
+                # SIGKILL path rather than risk an infinite re-entry.
+                return
+            os.kill(os.getpid(), _signal.SIGTERM)
+            return
+        fired["once"] = True
+        # First SIGTERM: inject KeyboardInterrupt on the main thread
+        # so _run_job_core.finally runs.
+        _thread.interrupt_main()
+
+    with contextlib.suppress(Exception):
+        _signal.signal(_signal.SIGTERM, _handler)
+
+
 def _child_main(args_path: str, progress_path: str) -> None:
     """Entry point for the child process."""
+    # Issue #153: install SIGTERM → KeyboardInterrupt before doing any
+    # real work so a parent-triggered SIGTERM during setup still runs
+    # the _run_job_core finally block.
+    _install_sigterm_handler()
+
     with open(args_path, encoding="utf-8") as f:
         args = json.load(f)
 

--- a/tests/regression/test_reg_0152_child_cancel_visibility.py
+++ b/tests/regression/test_reg_0152_child_cancel_visibility.py
@@ -1,0 +1,141 @@
+"""Regression test for child JobStore cancel visibility (Issue #152).
+
+In subprocess mode, ``_child_main`` constructs a fresh ``JobStore``
+whose ``_cancel_requested`` set is an in-memory Python object disjoint
+from the parent's. Without the file-flag mechanism added here,
+``_make_cancel_aware_cb`` polls the child's fresh instance and never
+sees the parent's ``request_cancel()`` — cooperative cancel designed
+in H-0011 silently breaks for subprocess-mode jobs.
+
+## Invariants
+
+- INV-6: after ``request_cancel(job_id)`` on a parent-side JobStore,
+  any fresh JobStore constructed on the same ``jobs_dir`` observes
+  the cancel through ``is_cancel_requested``.
+- INV-9: the cancel-flag file is written atomically, polled without
+  partial-read hazards, and removed by ``clear_cancel``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lizystudio.backends.types import DataRef
+from lizystudio.services.jobs import CANCEL_FLAG_FILENAME, JobStore
+
+pytestmark = pytest.mark.unit
+
+
+_DATA_REF = DataRef(
+    source_type="path",
+    path="/data/x.csv",
+    filename="x.csv",
+    fingerprint="f",
+    shape=(10, 2),
+)
+
+
+def _make_job(store: JobStore) -> str:
+    job = store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=_DATA_REF,
+        job_type="tune",
+    )
+    return job.job_id
+
+
+def test_request_cancel_writes_flag_file(tmp_path: Path) -> None:
+    """INV-9: request_cancel writes <job_dir>/CANCEL atomically."""
+    store = JobStore(tmp_path)
+    job_id = _make_job(store)
+    store.request_cancel(job_id)
+
+    flag_path = tmp_path / job_id / CANCEL_FLAG_FILENAME
+    assert flag_path.exists(), f"expected CANCEL flag at {flag_path}, missing"
+
+
+def test_fresh_store_sees_parent_cancel(tmp_path: Path) -> None:
+    """INV-6: a JobStore constructed after request_cancel sees it.
+
+    This is the core subprocess scenario: parent calls request_cancel,
+    child process constructs `JobStore(jobs_dir)` from scratch, and the
+    child's is_cancel_requested must return True — otherwise cooperative
+    cancel in training.py never fires.
+    """
+    parent = JobStore(tmp_path)
+    job_id = _make_job(parent)
+    parent.request_cancel(job_id)
+
+    # Fresh JobStore — simulates the child subprocess's _child_main
+    # constructing JobStore(jobs_dir) with no shared in-memory state.
+    child = JobStore(tmp_path)
+    assert child.is_cancel_requested(job_id) is True
+
+
+def test_clear_cancel_removes_flag_file(tmp_path: Path) -> None:
+    """INV-9: clear_cancel removes the flag file so a stale flag does
+    not bleed into a subsequent job run on the same job_dir.
+    """
+    store = JobStore(tmp_path)
+    job_id = _make_job(store)
+    store.request_cancel(job_id)
+    flag_path = tmp_path / job_id / CANCEL_FLAG_FILENAME
+    assert flag_path.exists()
+
+    store.clear_cancel(job_id)
+    assert not flag_path.exists()
+    assert store.is_cancel_requested(job_id) is False
+
+
+def test_clear_cancel_is_idempotent(tmp_path: Path) -> None:
+    """clear_cancel must not raise when the flag was never written."""
+    store = JobStore(tmp_path)
+    job_id = _make_job(store)
+    store.clear_cancel(job_id)  # Should not raise.
+    assert store.is_cancel_requested(job_id) is False
+
+
+def test_request_cancel_is_idempotent(tmp_path: Path) -> None:
+    """request_cancel called twice leaves the flag file present."""
+    store = JobStore(tmp_path)
+    job_id = _make_job(store)
+    store.request_cancel(job_id)
+    store.request_cancel(job_id)
+    flag_path = tmp_path / job_id / CANCEL_FLAG_FILENAME
+    assert flag_path.exists()
+
+
+def test_cancel_is_per_job_not_global(tmp_path: Path) -> None:
+    """Cancelling job A does not affect job B, even in a fresh store."""
+    parent = JobStore(tmp_path)
+    job_a = _make_job(parent)
+    job_b = _make_job(parent)
+    parent.request_cancel(job_a)
+
+    child = JobStore(tmp_path)
+    assert child.is_cancel_requested(job_a) is True
+    assert child.is_cancel_requested(job_b) is False
+
+
+def test_fresh_store_without_cancel_returns_false(tmp_path: Path) -> None:
+    """No request_cancel → fresh store reports not cancelled."""
+    parent = JobStore(tmp_path)
+    job_id = _make_job(parent)
+
+    child = JobStore(tmp_path)
+    assert child.is_cancel_requested(job_id) is False
+
+
+def test_in_memory_fast_path_still_works(tmp_path: Path) -> None:
+    """Same-process call path is unchanged: the in-memory set wins
+    before the file is consulted (cheap poll in hot cancel loop).
+    """
+    store = JobStore(tmp_path)
+    job_id = _make_job(store)
+    store.request_cancel(job_id)
+    # Remove the flag file to prove the in-memory path still works.
+    (tmp_path / job_id / CANCEL_FLAG_FILENAME).unlink()
+    assert store.is_cancel_requested(job_id) is True

--- a/tests/regression/test_reg_0153_sigterm_runs_finally.py
+++ b/tests/regression/test_reg_0153_sigterm_runs_finally.py
@@ -1,0 +1,243 @@
+"""Regression test for SIGTERM skipping Python finally (Issue #153).
+
+Python's default SIGTERM handler calls ``_exit`` which does NOT run
+Python-level ``finally`` blocks. In subprocess mode, the parent
+SIGTERMs the child after cancel timeout, so ``_run_job_core``'s
+``finally`` (which writes execution.log and releases state) does
+not execute. The fix installs a handler in ``_child_main`` that
+raises ``KeyboardInterrupt`` on the main thread so the existing
+``except (CancelledError, KeyboardInterrupt)`` path runs.
+
+## Invariants
+
+- INV-7: on SIGTERM to the child, ``_run_job_core.finally`` runs to
+  completion: ``execution.log`` is flushed and terminal status is
+  persisted.
+- INV-8: the SIGTERM handler is single-shot. A second SIGTERM is
+  a no-op (handler reset to SIG_DFL so SIGKILL-class escalation
+  via ``proc.kill()`` still works).
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+_HANDLER_SCRIPT = """
+import sys
+import time
+
+from lizystudio.services.subprocess_runner import _install_sigterm_handler
+
+_install_sigterm_handler()
+sys.stdout.write("READY\\n")
+sys.stdout.flush()
+
+try:
+    # Block until SIGTERM arrives. time.sleep is interruptible by
+    # signals on POSIX.
+    for _ in range(100):
+        time.sleep(0.1)
+except KeyboardInterrupt:
+    # The fix: SIGTERM was converted to KeyboardInterrupt on the
+    # main thread, so finally can run.
+    sys.stdout.write("KI_CAUGHT\\n")
+    sys.stdout.flush()
+    sys.exit(0)
+# If we get here, SIGTERM did not raise — the handler was not installed
+# or not wired correctly. Exit non-zero so the test fails loudly.
+sys.stdout.write("NO_KI\\n")
+sys.stdout.flush()
+sys.exit(2)
+"""
+
+
+def _wait_for_ready(proc: subprocess.Popen[bytes]) -> None:
+    """Block until the child prints 'READY' so the SIGTERM handler is
+    definitely installed before we start signalling.
+    """
+    assert proc.stdout is not None
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        line = proc.stdout.readline()
+        if line.startswith(b"READY"):
+            return
+        if not line and proc.poll() is not None:
+            raise AssertionError(f"child exited before READY: rc={proc.returncode}")
+    raise AssertionError("child did not print READY within 5s")
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith(("linux", "darwin")),
+    reason="SIGTERM semantics are POSIX-only",
+)
+def test_sigterm_converts_to_keyboardinterrupt() -> None:
+    """INV-7: SIGTERM raises KeyboardInterrupt on the main thread so
+    the existing finally/except path runs instead of _exit."""
+    proc = subprocess.Popen(
+        [sys.executable, "-u", "-c", _HANDLER_SCRIPT],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    _wait_for_ready(proc)
+    proc.send_signal(signal.SIGTERM)
+    try:
+        stdout, stderr = proc.communicate(timeout=5.0)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=2.0)
+        pytest.fail("child did not exit after SIGTERM; handler not working")
+
+    assert proc.returncode == 0, (
+        f"child exited with {proc.returncode}; stdout={stdout!r} stderr={stderr!r}"
+    )
+    assert b"KI_CAUGHT" in stdout, (
+        f"KeyboardInterrupt was not raised; stdout={stdout!r}"
+    )
+
+
+_SINGLE_SHOT_SCRIPT = """
+import sys
+import time
+
+from lizystudio.services.subprocess_runner import _install_sigterm_handler
+
+_install_sigterm_handler()
+sys.stdout.write("READY\\n")
+sys.stdout.flush()
+
+try:
+    for _ in range(100):
+        time.sleep(0.1)
+except KeyboardInterrupt:
+    # First SIGTERM converted to KI. Second SIGTERM should now use
+    # the default handler (SIG_DFL) and terminate the process with
+    # the default signal action — no second KeyboardInterrupt.
+    sys.stdout.write("KI_FIRST\\n")
+    sys.stdout.flush()
+    # Block again to receive the second SIGTERM.
+    try:
+        for _ in range(100):
+            time.sleep(0.1)
+    except KeyboardInterrupt:
+        sys.stdout.write("KI_SECOND\\n")
+        sys.stdout.flush()
+        sys.exit(3)
+    sys.exit(0)
+"""
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith(("linux", "darwin")),
+    reason="SIGTERM semantics are POSIX-only",
+)
+def test_sigterm_handler_is_single_shot() -> None:
+    """INV-8: after the first SIGTERM → KI, the handler is reset to
+    SIG_DFL so a subsequent SIGTERM terminates the process normally
+    (not as another KeyboardInterrupt) — this keeps the parent's
+    proc.kill() escalation path intact.
+    """
+    proc = subprocess.Popen(
+        [sys.executable, "-u", "-c", _SINGLE_SHOT_SCRIPT],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    _wait_for_ready(proc)
+    proc.send_signal(signal.SIGTERM)
+    # Wait for KI_FIRST so the handler has definitely finished its
+    # first-shot branch before we escalate. Otherwise the second
+    # SIGTERM can race into the still-unreset handler slot.
+    assert proc.stdout is not None
+    deadline = time.monotonic() + 5.0
+    ki_seen = False
+    while time.monotonic() < deadline:
+        line = proc.stdout.readline()
+        if line.startswith(b"KI_FIRST"):
+            ki_seen = True
+            break
+    assert ki_seen, "child did not print KI_FIRST after SIGTERM"
+    proc.send_signal(signal.SIGTERM)
+    try:
+        stdout, _ = proc.communicate(timeout=5.0)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=2.0)
+        pytest.fail("child hung after second SIGTERM")
+
+    # The process must have received the default SIGTERM action on the
+    # second signal. The default action kills the process with signal
+    # SIGTERM, so the exit status is -SIGTERM (i.e. negative signal
+    # number). If the handler had re-triggered, we'd see KI_SECOND and
+    # exit code 3 instead. KI_FIRST was already consumed by the
+    # readline loop above so it won't appear in `stdout` here.
+    assert b"KI_SECOND" not in stdout, (
+        f"handler re-fired; single-shot invariant broken. stdout={stdout!r}"
+    )
+    assert proc.returncode == -signal.SIGTERM or proc.returncode == (
+        128 + signal.SIGTERM
+    ), f"expected SIGTERM-default exit, got {proc.returncode}"
+
+
+def test_install_sigterm_handler_is_idempotent() -> None:
+    """Installing the handler twice from the same process must not
+    leak prior handlers. The second call wins (SIGTERM handler is a
+    single OS-level slot).
+    """
+    from lizystudio.services.subprocess_runner import _install_sigterm_handler
+
+    # Capture whatever is currently installed so we can restore it.
+    prev = signal.getsignal(signal.SIGTERM)
+    try:
+        _install_sigterm_handler()
+        first = signal.getsignal(signal.SIGTERM)
+        _install_sigterm_handler()
+        second = signal.getsignal(signal.SIGTERM)
+        # Both invocations set a handler (not SIG_DFL / SIG_IGN).
+        assert callable(first)
+        assert callable(second)
+    finally:
+        signal.signal(signal.SIGTERM, prev)  # type: ignore[arg-type]
+
+
+def _raise_sigterm_to_self() -> None:
+    """Helper: send SIGTERM to the current process from a thread."""
+    time.sleep(0.05)
+    os.kill(os.getpid(), signal.SIGTERM)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith(("linux", "darwin")),
+    reason="POSIX signals only",
+)
+def test_handler_raises_ki_on_main_thread_in_process() -> None:
+    """In-process sanity check that the handler injects KI via
+    ``_thread.interrupt_main`` on the main thread (not on the worker).
+
+    We install the handler, spawn a thread that sends SIGTERM to
+    ourselves, and expect KeyboardInterrupt on the main thread.
+    """
+    from lizystudio.services.subprocess_runner import _install_sigterm_handler
+
+    prev = signal.getsignal(signal.SIGTERM)
+    try:
+        _install_sigterm_handler()
+        t = threading.Thread(target=_raise_sigterm_to_self, daemon=True)
+        t.start()
+        caught = False
+        try:
+            time.sleep(2.0)
+        except KeyboardInterrupt:
+            caught = True
+        t.join(timeout=1.0)
+        assert caught, "expected KeyboardInterrupt on main thread"
+    finally:
+        signal.signal(signal.SIGTERM, prev)  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #152.
Closes #153.

Two cancel/subprocess bugs bundled because their invariants interact: without #153's SIGTERM handler, #152's file flag alone leaves `execution.log` lost when escalation fires. Without #152's file flag, cooperative cancel (H-0011) stays permanently broken in subprocess mode.

## Summary

### #152 — cancel visibility across process boundary
- `JobStore.request_cancel` also writes `<job_dir>/CANCEL` atomically (`write_bytes` + `os.replace`). Skips the write when the `job_dir` doesn't already exist — no `mkdir`, so it does not race with concurrent `delete(job_id)`.
- `is_cancel_requested` checks the in-memory set first (hot-path for the cooperative-cancel callback in `training.py:51`), then falls back to the flag file existence.
- `clear_cancel` `unlink(missing_ok=True)`s the file.
- All three methods catch `(OSError, ValueError)` — malformed `job_id` rejected by `validate_path_within` cannot propagate into the cancel hot loop.
- `.tmp` orphan from a failed `os.replace` is cleaned up.

### #153 — SIGTERM runs Python `finally`
- `_install_sigterm_handler()` registered as the first action in `_child_main`. Handler uses `_thread.interrupt_main()` to raise `KeyboardInterrupt` on the main thread so the existing `except (CancelledError, KeyboardInterrupt)` + `finally` in `_run_job_core` executes.
- Single-shot via a `fired` flag. Second SIGTERM resets to `SIG_DFL` and re-raises only if the reset succeeded — avoids signal re-entry loops.

## Invariants

- **INV-6**: after `request_cancel(job_id)`, a fresh `JobStore` constructed on the same `jobs_dir` returns `True` from `is_cancel_requested`.
- **INV-7**: on SIGTERM delivered to the child, `_run_job_core.finally` runs to completion (`execution.log` flushed, `release_active` called, terminal metric emitted).
- **INV-8**: the SIGTERM handler is single-shot; the second SIGTERM takes the OS default action so `proc.kill()` / SIGKILL escalation stays intact.
- **INV-9**: the CANCEL file is atomic (`os.replace`) and cleaned by `clear_cancel`.

## Failure Paths Covered

- [x] Normal completion — existing `_run_job_core` tests green
- [x] User cancel before first trial — file flag visible to child on next tick
- [x] User cancel mid-trial — cooperative cancel stops at next trial boundary
- [x] SIGTERM escalation — handler raises `KeyboardInterrupt`, `finally` runs
- [x] Double SIGTERM — second falls through to `SIG_DFL`, process exits with signal default action
- [x] Concurrent `cancel` + `delete(job_id)` — file write skipped when dir missing; OSError caught
- [x] Malformed `job_id` — `ValueError` caught in all three methods; `is_cancel_requested` returns `False`
- [x] In-process handler sanity — `os.kill(os.getpid(), SIGTERM)` from a thread raises KI on the main thread

## Test plan

- [x] `uv run pytest tests/regression/test_reg_0152_child_cancel_visibility.py` — 8 pass
- [x] `uv run pytest tests/regression/test_reg_0153_sigterm_runs_finally.py` — 4 pass
- [x] `uv run pytest tests/test_jobs.py tests/test_job_state_transitions.py` — all pass (concurrent cancel+delete regression confirmed)
- [x] `uv run pytest` — 1038 pass (was 1026 on `develop`)
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/lizystudio/services/jobs.py src/lizystudio/services/subprocess_runner.py` — clean

## Notes

- Completes **Group A** (priority-high cluster: #150 shipped, #151 shipped, #152 + #153 here).
- Design choice: bundle #152 and #153 so both invariants hold consistently. Splitting them would leave a window where #152's file flag works but SIGTERM still loses `finally`.