### PR TITLE
fix(inference): return NaN for R² on constant target (#156)

### DIFF
--- a/src/lizystudio/services/inference.py
+++ b/src/lizystudio/services/inference.py
@@ -285,7 +285,13 @@ def _compute_inf_metrics(
         metrics["rmse"] = float((residuals**2).mean() ** 0.5)
         ss_res = float((residuals**2).sum())
         ss_tot = float(((actual - actual.mean()) ** 2).sum())
-        metrics["r2"] = 1.0 - ss_res / ss_tot if ss_tot > 0 else 0.0
+        # Issue #156: R² is mathematically undefined when the target
+        # is constant (ss_tot == 0). The legacy fallback of 0.0 was
+        # misleading — a degenerate slice was indistinguishable from
+        # a genuinely mean-level fit. NaN flags the condition so the
+        # UI can render it explicitly (e.g. "—") instead of plotting
+        # a fake zero.
+        metrics["r2"] = 1.0 - ss_res / ss_tot if ss_tot > 0 else float("nan")
     else:
         # Classification
         pred_labels = pred

--- a/tests/regression/test_reg_0156_r2_constant_target.py
+++ b/tests/regression/test_reg_0156_r2_constant_target.py
@@ -1,0 +1,76 @@
+"""Regression test for R² on constant target (Issue #156).
+
+``_compute_inf_metrics`` returned ``r2 = 0.0`` when ``ss_tot == 0``
+(constant ground truth). The statistical convention is that R² is
+undefined for a constant target — returning ``NaN`` is the correct
+reporting; ``0.0`` silently misleads users on degenerate slices (e.g.
+a single-class split inside a binary regression task).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+import pytest
+
+from lizystudio.services.inference import _compute_inf_metrics
+
+pytestmark = pytest.mark.unit
+
+
+def test_r2_is_nan_when_target_is_constant() -> None:
+    """INV: r2 is NaN when ss_tot == 0 (constant actual)."""
+    pred_df = pd.DataFrame(
+        {
+            "actual": [5.0, 5.0, 5.0, 5.0],
+            "pred": [4.8, 5.1, 5.0, 4.9],
+        }
+    )
+    metrics = _compute_inf_metrics(pred_df, {"task": "regression"})
+    assert "r2" in metrics
+    assert math.isnan(metrics["r2"]), f"expected NaN, got {metrics['r2']!r}"
+
+
+def test_r2_is_nan_when_predictions_are_also_constant() -> None:
+    """Even when predictions == actual (zero residuals), a constant
+    target still has undefined R². The statistical ``1.0`` convention
+    for zero-residual + constant-target is NOT adopted here because it
+    is ambiguous — NaN flags the degenerate slice explicitly.
+    """
+    pred_df = pd.DataFrame(
+        {
+            "actual": [3.0, 3.0, 3.0],
+            "pred": [3.0, 3.0, 3.0],
+        }
+    )
+    metrics = _compute_inf_metrics(pred_df, {"task": "regression"})
+    assert math.isnan(metrics["r2"])
+
+
+def test_r2_is_finite_for_non_degenerate_target() -> None:
+    """Sanity: the fix does not regress the normal case."""
+    pred_df = pd.DataFrame(
+        {
+            "actual": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "pred": [1.1, 1.9, 3.0, 4.2, 4.8],
+        }
+    )
+    metrics = _compute_inf_metrics(pred_df, {"task": "regression"})
+    assert math.isfinite(metrics["r2"])
+    # With near-perfect predictions, r2 should be close to 1.0.
+    assert metrics["r2"] > 0.9
+
+
+def test_r2_is_negative_when_predictions_are_worse_than_mean() -> None:
+    """A model that predicts worse than the target mean yields r2 < 0 —
+    unchanged by this fix, regression guard for the happy path.
+    """
+    pred_df = pd.DataFrame(
+        {
+            "actual": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "pred": [5.0, 4.0, 3.0, 2.0, 1.0],  # inverse of actual
+        }
+    )
+    metrics = _compute_inf_metrics(pred_df, {"task": "regression"})
+    assert metrics["r2"] < 0

--- a/tests/test_inference_service.py
+++ b/tests/test_inference_service.py
@@ -320,11 +320,17 @@ def test_compute_metrics_regression_with_residuals() -> None:
 
 
 def test_compute_metrics_regression_constant_actual() -> None:
-    """_compute_inference_metrics: constant actual prevents division-by-zero (R2=0)."""
+    """_compute_inference_metrics: constant actual → R² is NaN (Issue #156).
+
+    ss_tot == 0 makes R² mathematically undefined; we now report NaN
+    instead of the legacy 0.0 fallback so degenerate slices are
+    visible in the UI rather than silently rendered as a real zero.
+    """
+    import math
+
     pred_df = pd.DataFrame({"pred": [1.0, 2.0, 3.0], "actual": [5.0, 5.0, 5.0]})
     result = _compute_inference_metrics(pred_df, {"task": "regression"})
-    # ss_tot == 0 -> R2 clamped to 0.0
-    assert result["r2"] == pytest.approx(0.0)
+    assert math.isnan(result["r2"])
 
 
 def test_compute_metrics_classification_no_proba() -> None:


### PR DESCRIPTION
Closes #156.

## Summary

- `_compute_inf_metrics` now returns `float('nan')` for R² when `ss_tot == 0` (constant target) instead of the legacy `0.0` fallback.
- Updated the pre-existing test that asserted the old behaviour.
- New regression test in `tests/regression/test_reg_0156_r2_constant_target.py` (4 cases).

## Rationale

R² is statistically undefined when the target is constant (division by zero on `ss_tot`). Returning `0.0` was indistinguishable from a genuine mean-level fit — NaN flags the degenerate slice so the UI can render it explicitly.

## Test plan

- [x] `uv run pytest tests/regression/test_reg_0156_r2_constant_target.py` — 4 pass
- [x] `uv run pytest tests/test_inference_service.py` — 35 pass (updated contract test)
- [x] `uv run pytest` — 1042 pass (was 1038 on `develop`)
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/lizystudio/services/inference.py` — clean

## Notes

- **Group B** (priority-medium backend bugs) kickoff. Next: #155 / #157 (security) → #154 (metric emission).
- Tier-1 fix: single-line change + regression test.