### PR TITLE
fix(api/files): stop echoing server-resolved path on rejected requests (#157)

### DIFF
--- a/src/lizystudio/api/files.py
+++ b/src/lizystudio/api/files.py
@@ -31,24 +31,35 @@ class DirectoryListing(BaseModel):
 def list_directory(
     path: str = Query(default="", description="Directory path to list"),
 ) -> DirectoryListing:
-    """List directory contents, filtered to supported data file types."""
+    """List directory contents, filtered to supported data file types.
+
+    Issue #157: rejected requests (out-of-root traversal, missing
+    directory, permission denied) do NOT echo the server-side
+    resolved path back to the caller. Successful requests still
+    return the resolved path/parent so the frontend can render
+    breadcrumb navigation. The error-path response shape is kept
+    (200 + empty entries + parent=None) for backward compatibility;
+    only the leaked server path is sanitised.
+    """
     dir_path = Path(path) if path else security.ALLOWED_FILES_ROOT
     dir_path = dir_path.resolve()
 
-    # Restrict to allowed root
+    # Restrict to allowed root. Failure: do NOT leak the resolved path
+    # — return the original user-supplied form so the client can still
+    # render an error without learning anything about the server's
+    # filesystem.
     try:
         security.validate_path_within(dir_path, security.ALLOWED_FILES_ROOT)
     except ValueError:
-        return DirectoryListing(path=str(dir_path), parent=None, entries=[])
+        return DirectoryListing(path=path, parent=None, entries=[])
 
     if not dir_path.is_dir():
-        return DirectoryListing(
-            path=str(dir_path),
-            parent=str(dir_path.parent) if dir_path.parent != dir_path else None,
-            entries=[],
-        )
+        # Missing directory: same policy as out-of-root. The resolved
+        # parent would reveal where the root lives, so omit it.
+        return DirectoryListing(path=path, parent=None, entries=[])
 
     entries: list[FileEntry] = []
+    listing_failed = False
     try:
 
         def sort_key(p: Path) -> tuple[bool, str]:
@@ -75,8 +86,19 @@ def list_directory(
                         extension=item.suffix.lower(),
                     )
                 )
-    except PermissionError:
-        pass
+    except OSError:
+        # Issue #157: catch the full OSError family, not just
+        # PermissionError. iterdir/stat/is_file can also raise
+        # FileNotFoundError (race with deletion), NotADirectoryError,
+        # and generic OSError (e.g. EIO on a failing mount). Letting
+        # any of these propagate to FastAPI's 500 handler would
+        # surface dir_path in the error response under some logging
+        # configurations. The sanitised empty response mirrors the
+        # other rejected-request paths.
+        listing_failed = True
+
+    if listing_failed:
+        return DirectoryListing(path=path, parent=None, entries=[])
 
     return DirectoryListing(
         path=str(dir_path),

--- a/tests/regression/test_reg_0157_files_api_info_disclosure.py
+++ b/tests/regression/test_reg_0157_files_api_info_disclosure.py
@@ -1,0 +1,161 @@
+"""Regression test for /api/files information disclosure (Issue #157).
+
+The file browser endpoint echoed the server-side resolved path back
+in its response, even for requests that were rejected (out-of-root
+traversal, missing directory, permission denied). That leaked the
+server-side absolute path — confirming existence of directories the
+caller may not be authorized to know about.
+
+Contract preserved for this fix (Approach B):
+- Success responses still return the resolved path so the frontend
+  can render breadcrumbs / parent navigation.
+- Error paths (traversal, missing, permission) return the ORIGINAL
+  user-supplied path (or empty) and ``parent=None`` so no server
+  topology bleeds out.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+def test_traversal_echoes_user_input_not_resolved(client: TestClient) -> None:
+    """A rejected traversal must echo the user-supplied path, not the
+    server-resolved absolute path.
+
+    The legacy behaviour returned the resolved ``/etc`` style absolute
+    path, disclosing server filesystem topology. The fix returns the
+    original client input so the UI can still render an error message
+    without leaking server paths.
+    """
+    user_input = "../../etc"
+    response = client.get(f"/api/files?path={user_input}")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["entries"] == []
+    # The response MUST echo what the caller sent, not what the server
+    # resolved it to. An absolute server path would start with "/" and
+    # be longer than the user input.
+    assert body["path"] == user_input, (
+        f"expected echo of user input, got: {body['path']!r}"
+    )
+
+
+def test_absolute_outside_root_echoes_user_input_not_resolved(
+    client: TestClient,
+) -> None:
+    """Absolute paths outside ALLOWED_FILES_ROOT must echo input only."""
+    user_input = "/etc/passwd"
+    response = client.get(f"/api/files?path={user_input}")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["entries"] == []
+    # The echoed value equals the user input. The resolved absolute
+    # path would normally be the same here (since it's already
+    # absolute), but the critical invariant is that `parent` is None
+    # — see the separate test — so no server topology is disclosed.
+    assert body["path"] == user_input
+    assert body["parent"] is None
+
+
+def test_nonexistent_path_inside_root_does_not_echo_resolved_path(
+    client: TestClient,
+) -> None:
+    """Requesting a nonexistent directory INSIDE the root: the server
+    used to echo the absolute resolved path (disclosing the real root
+    location). Now we return the user-supplied form.
+    """
+    import lizystudio.security as sec
+
+    missing = sec.ALLOWED_FILES_ROOT / "no_such_dir_xyz"
+    response = client.get(f"/api/files?path={missing}")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["entries"] == []
+    # The response may be empty or the user-supplied form; it must not
+    # be the server's resolved form with additional topology data.
+    # The critical invariant: parent field must not point at an
+    # internal server directory (was `str(missing.parent.resolve())`).
+    assert body["parent"] is None, (
+        f"parent disclosed for nonexistent path: {body['parent']!r}"
+    )
+
+
+def test_valid_path_still_returns_resolved_path(
+    client: TestClient,
+) -> None:
+    """Regression guard: for AUTHORIZED requests the resolved path
+    and parent are still returned so the frontend can render
+    navigation. Only rejected requests hide the resolution.
+
+    The ``client`` fixture points ``ALLOWED_FILES_ROOT`` at ``/tmp``.
+    Create the subdirectory with a unique name and clean it up
+    afterwards so this test cannot collide with concurrent runs or
+    leave residue for subsequent invocations.
+    """
+    import shutil
+    import uuid
+
+    import lizystudio.security as sec
+
+    root = sec.ALLOWED_FILES_ROOT
+    subdir = root / f"reg_0157_{uuid.uuid4().hex}"
+    subdir.mkdir()
+    try:
+        response = client.get(f"/api/files?path={subdir}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["path"] == str(subdir)
+        assert body["parent"] == str(root)
+    finally:
+        shutil.rmtree(subdir, ignore_errors=True)
+
+
+def test_oserror_during_listing_sanitized(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An OSError during iteration (not just PermissionError) must
+    not propagate; the sanitised empty response is returned.
+
+    Simulates a failing iterdir by monkey-patching Path.iterdir to
+    raise OSError(EIO). Without the broader `except OSError` catch
+    the handler would 500 and may include ``dir_path`` in logs.
+    """
+    import shutil
+    import uuid
+
+    import lizystudio.security as sec
+
+    root = sec.ALLOWED_FILES_ROOT
+    subdir = root / f"reg_0157_io_{uuid.uuid4().hex}"
+    subdir.mkdir()
+    try:
+        real_iterdir = Path.iterdir
+
+        def failing_iterdir(self: Path) -> object:  # type: ignore[override]
+            if self == subdir:
+                raise OSError(5, "Input/output error")
+            return real_iterdir(self)
+
+        monkeypatch.setattr(Path, "iterdir", failing_iterdir)
+        response = client.get(f"/api/files?path={subdir}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["entries"] == []
+        assert body["parent"] is None
+    finally:
+        shutil.rmtree(subdir, ignore_errors=True)
+
+
+def test_traversal_response_parent_is_none(client: TestClient) -> None:
+    """parent=None on all rejected-request paths prevents disclosing
+    the server-side parent directory.
+    """
+    response = client.get("/api/files?path=../../etc")
+    assert response.status_code == 200
+    assert response.json()["parent"] is None

--- a/tests/test_files_api.py
+++ b/tests/test_files_api.py
@@ -150,28 +150,40 @@ def test_nonexistent_directory_returns_empty_entries(
     assert body["entries"] == []
 
 
-def test_nonexistent_directory_path_in_response(
+def test_nonexistent_directory_path_echoes_request(
     client: TestClient, tmp_path: Path
 ) -> None:
-    """Path field reflects requested path even if missing."""
+    """Path field echoes the REQUESTED path for missing directories.
+
+    Issue #157 removed server-side resolved-path echo from error paths
+    to avoid disclosing filesystem topology. The `path` field now
+    reflects whatever the client sent, not the server's resolution.
+    """
     import lizystudio.security as sec
 
     missing = sec.ALLOWED_FILES_ROOT / "no_such_dir"
     response = client.get(f"/api/files?path={missing}")
     assert response.status_code == 200
     body = response.json()
-    assert body["path"] == str(missing.resolve())
+    assert body["path"] == str(missing)
 
 
-def test_nonexistent_directory_has_parent(client: TestClient, tmp_path: Path) -> None:
-    """A non-existent path still reports its parent directory."""
+def test_nonexistent_directory_has_no_parent(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """A non-existent path reports parent=None (Issue #157).
+
+    The legacy behaviour disclosed the server-resolved parent
+    directory, revealing where the allowed-files root lives. The
+    sanitised response omits the parent for all rejected requests.
+    """
     import lizystudio.security as sec
 
     missing = sec.ALLOWED_FILES_ROOT / "ghost_dir"
     response = client.get(f"/api/files?path={missing}")
     assert response.status_code == 200
     body = response.json()
-    assert body["parent"] == str(missing.parent.resolve())
+    assert body["parent"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #157.

## Summary

Information-disclosure hardening for `/api/files`. Rejected requests (out-of-root traversal, missing directory, permission denied, I/O failure) no longer echo the server-resolved absolute path. Success responses are unchanged so the frontend's breadcrumb navigation keeps working.

## Approach — B (info disclosure only)

Per design decision, this PR fixes the information disclosure half of the issue. The UX half (distinct 403/404 status codes) is intentionally deferred because it requires a frontend contract change that is out of scope for a tier-2 security fix.

## Changes

- `src/lizystudio/api/files.py`:
  - All error paths return `DirectoryListing(path=<user-input>, parent=None, entries=[])` — no server-resolved path echo.
  - Broadened `except PermissionError` to `except OSError` so FileNotFoundError / EIO / NotADirectoryError during iteration also take the sanitised path instead of propagating to the 500 handler.
- `tests/regression/test_reg_0157_files_api_info_disclosure.py` (new, 6 tests) — echoes, parent=None invariant, valid-path regression guard, OSError simulation.
- `tests/test_files_api.py` — two legacy tests updated to reflect the new contract (they asserted the old leaky behaviour).

## Security properties

- **Preserved**: traversal rejection (ValueError from `validate_path_within`), symlink escape rejection (via `Path.resolve()`).
- **Improved**:
  - Server-resolved path no longer echoed on any rejected request.
  - `parent` field is `None` uniformly across all error paths (was `str(dir_path.parent)` for missing dirs — disclosed root topology).
  - Broader OSError catch prevents stack-trace leakage through unhandled I/O errors.

## Test plan

- [x] `uv run pytest tests/regression/test_reg_0157_files_api_info_disclosure.py` — 6 pass
- [x] `uv run pytest tests/test_files_api.py` — 31 pass (updated contract)
- [x] `uv run pytest` — 1055 pass (was 1049 on `develop`)
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/lizystudio/api/files.py` — clean
- [x] security-reviewer agent: 0 CRITICAL / 0 HIGH (after fixes) / 0 MEDIUM

## Notes

- **Group B** progress: #156 / #155 merged, **#157 (this) pending**, next #154 (metric emission).
- Cleanup: the regression test creates its scratch directory under `ALLOWED_FILES_ROOT` with a UUID suffix and removes it in a `finally` — avoids leaving residue in `/tmp`.