### PR TITLE
fix(api): emit failed-metric on workspace slot-claim failures (#154)

### DIFF
--- a/src/lizystudio/api/workspace.py
+++ b/src/lizystudio/api/workspace.py
@@ -40,6 +40,7 @@ from lizystudio.api.models import (
     ValidationResponse,
     WorkspaceStatusResponse,
 )
+from lizystudio.metrics import record_job_terminal
 from lizystudio.security import (
     check_dataframe_memory,
     read_upload_checked,
@@ -551,11 +552,18 @@ def workspace_fit(
         job.error = "Previous job still running"
         job_store.update(job)
         job_store.release_active(job.job_id)
+        # Issue #154: record the terminal status so the
+        # lizystudio_jobs_total{status="failed"} counter is not under-
+        # counted on slot-claim-after-claim failures.
+        record_job_terminal(job.job_type, "failed")
         raise JobConflictError(job.job_id) from None
     except Exception:
         # Any other failure after we claimed the slot must release it,
-        # otherwise the slot stays held until server restart.
+        # otherwise the slot stays held until server restart. Emit the
+        # failed metric (#154) before re-raising so the counter
+        # reflects the true failure count.
         job_store.release_active(job.job_id)
+        record_job_terminal(job.job_type, "failed")
         raise
     return {"job_id": job_id}
 
@@ -617,8 +625,11 @@ def workspace_tune(
         job.error = "Previous job still running"
         job_store.update(job)
         job_store.release_active(job.job_id)
+        # Issue #154: record the terminal status (same fix as /fit).
+        record_job_terminal(job.job_type, "failed")
         raise JobConflictError(job.job_id) from None
     except Exception:
         job_store.release_active(job.job_id)
+        record_job_terminal(job.job_type, "failed")
         raise
     return {"job_id": job_id}

--- a/tests/regression/test_reg_0154_failed_metric_on_slot_claim.py
+++ b/tests/regression/test_reg_0154_failed_metric_on_slot_claim.py
@@ -1,0 +1,141 @@
+"""Regression test for missing failed-job metric on slot-claim failure (Issue #154).
+
+``api/workspace.py`` called ``release_active`` on a failed handoff
+(PreviousJobStillRunningError or a generic thread-start failure) but
+did NOT call ``record_job_terminal(job_type, "failed")``. The
+``lizystudio_jobs_total{status="failed"}`` counter undercounted these
+failures. ``ACTIVE_JOBS`` recovered correctly via ``release_active``;
+only the terminal counter was missing.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+def _jobs_total(labels: dict[str, str]) -> float:
+    """Read the current value of JOBS_TOTAL for the given label set."""
+    from lizystudio.metrics import JOBS_TOTAL
+
+    return JOBS_TOTAL.labels(**labels)._value.get()  # type: ignore[attr-defined]
+
+
+def _seed_workspace(client: TestClient, tmp_path: Path) -> None:
+    """Load minimal CSV + default config so /fit and /tune reach the
+    slot-claim stage (mirrors ``tests/test_workspace_api._load_data_and_config``).
+    """
+    csv_path = tmp_path / "train.csv"
+    with csv_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["id", "age", "target"])
+        for i in range(50):
+            writer.writerow([i, 20 + i, i % 2])
+
+    r = client.post("/api/workspace/data/path", json={"path": str(csv_path)})
+    assert r.status_code == 200, r.text
+
+    r = client.get("/api/workspace/config/defaults?task=binary&target=target")
+    assert r.status_code == 200, r.text
+    config = r.json()
+    r = client.put("/api/workspace/config", json=config)
+    assert r.status_code == 200 and r.json()["saved"] is True, r.text
+
+
+def test_fit_previous_job_running_emits_failed_metric(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When start_fit_async raises PreviousJobStillRunningError after
+    slot claim, the failed counter must increment by 1.
+    """
+    from lizystudio.api import workspace as ws_mod
+    from lizystudio.services.training import PreviousJobStillRunningError
+
+    _seed_workspace(client, tmp_path)
+
+    def _raise_previous(**kwargs: Any) -> str:
+        raise PreviousJobStillRunningError("already running")
+
+    monkeypatch.setattr(ws_mod, "start_fit_async", _raise_previous)
+
+    before = _jobs_total({"job_type": "fit", "status": "failed"})
+    response = client.post("/api/workspace/fit")
+    assert response.status_code == 409, response.text
+    after = _jobs_total({"job_type": "fit", "status": "failed"})
+    assert after - before == 1, (
+        f"expected 1 failed-metric emission, got delta={after - before}"
+    )
+
+
+def test_tune_previous_job_running_emits_failed_metric(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Tune counterpart of test_fit_previous_job_running_emits_failed_metric."""
+    from lizystudio.api import workspace as ws_mod
+    from lizystudio.services.training import PreviousJobStillRunningError
+
+    _seed_workspace(client, tmp_path)
+
+    def _raise_previous(**kwargs: Any) -> str:
+        raise PreviousJobStillRunningError("already running")
+
+    monkeypatch.setattr(ws_mod, "start_tune_async", _raise_previous)
+
+    before = _jobs_total({"job_type": "tune", "status": "failed"})
+    response = client.post("/api/workspace/tune")
+    assert response.status_code == 409, response.text
+    after = _jobs_total({"job_type": "tune", "status": "failed"})
+    assert after - before == 1
+
+
+def test_fit_generic_thread_start_failure_emits_failed_metric(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The broader ``except Exception`` branch also undercounted before
+    the fix. Any post-claim exception must emit the failed metric and
+    re-raise.
+
+    Starlette's TestClient propagates server exceptions directly into
+    the test (``raise_server_exceptions=True`` by default), so we
+    assert with ``pytest.raises`` instead of status-code 500.
+    """
+    from lizystudio.api import workspace as ws_mod
+
+    _seed_workspace(client, tmp_path)
+
+    def _raise_runtime(**kwargs: Any) -> str:
+        raise RuntimeError("thread start failed")
+
+    monkeypatch.setattr(ws_mod, "start_fit_async", _raise_runtime)
+
+    before = _jobs_total({"job_type": "fit", "status": "failed"})
+    with pytest.raises(RuntimeError, match="thread start failed"):
+        client.post("/api/workspace/fit")
+    after = _jobs_total({"job_type": "fit", "status": "failed"})
+    assert after - before == 1
+
+
+def test_tune_generic_thread_start_failure_emits_failed_metric(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Tune counterpart of the generic-exception regression guard."""
+    from lizystudio.api import workspace as ws_mod
+
+    _seed_workspace(client, tmp_path)
+
+    def _raise_runtime(**kwargs: Any) -> str:
+        raise RuntimeError("thread start failed")
+
+    monkeypatch.setattr(ws_mod, "start_tune_async", _raise_runtime)
+
+    before = _jobs_total({"job_type": "tune", "status": "failed"})
+    with pytest.raises(RuntimeError, match="thread start failed"):
+        client.post("/api/workspace/tune")
+    after = _jobs_total({"job_type": "tune", "status": "failed"})
+    assert after - before == 1


### PR DESCRIPTION
Closes #154.

## Summary

- `api/workspace.py` called `release_active` on a failed handoff (`PreviousJobStillRunningError` or generic thread-start failure) but did NOT call `record_job_terminal(job_type, 'failed')`. The `lizystudio_jobs_total{status='failed'}` counter undercounted these failures.
- Four affected branches now emit the failed metric before re-raising:
  - `workspace_fit` → `PreviousJobStillRunningError` branch
  - `workspace_fit` → generic `except Exception` branch
  - `workspace_tune` → `PreviousJobStillRunningError` branch
  - `workspace_tune` → generic `except Exception` branch
- `ACTIVE_JOBS` already recovered correctly via `release_active`; only the terminal counter was missing — no gauge behaviour change.

## Test plan

- [x] `uv run pytest tests/regression/test_reg_0154_failed_metric_on_slot_claim.py` — 4 pass (fit+tune × PreviousJobStillRunning+generic)
- [x] `uv run pytest` — 1059 pass (was 1055 on `develop`)
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/lizystudio/api/workspace.py` — clean

## Notes

- **Completes Group B** (priority-medium backend bugs: #156 / #155 / #157 / #154 all merged or pending).
- Tier-2 fix: two lines added in each of four branches + one import.