### PR TITLE
test(ci): introduce flaky-test management (#29)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,37 @@ jobs:
       - run: uv run ruff check .
       - run: uv run ruff format --check .
       - run: uv run mypy src/lizystudio/
-      - run: uv run pytest --cov=src/lizystudio --cov-report=term-missing --cov-fail-under=80 -q
+      # Flaky-test strategy (Issue #29): CI reruns failures twice.
+      # Local runs do NOT retry so flakiness stays visible. Quarantined
+      # tests are excluded from this blocking job (default addopts in
+      # pyproject.toml) and run separately in `backend-quarantine`.
+      - run: uv run pytest --cov=src/lizystudio --cov-report=term-missing --cov-fail-under=80 --reruns 2 --reruns-delay 1 -q
+
+  # Non-blocking quarantine job — captures signal on tests marked
+  # `@pytest.mark.quarantine` without failing the PR. Skip cleanly when
+  # no tests carry the marker.
+  backend-quarantine:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - run: uv sync
+      - name: Run quarantined tests (non-blocking)
+        run: |
+          set +e
+          COUNT=$(uv run pytest -m quarantine --collect-only -q 2>/dev/null | grep -c "::" || true)
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::notice::No quarantined tests found — skipping."
+            exit 0
+          fi
+          echo "::notice::Running $COUNT quarantined test(s)."
+          uv run pytest -m quarantine --reruns 2 --reruns-delay 1 -q
+          # Intentionally swallow non-zero exit — continue-on-error
+          # already tolerates failure, but the job status will still be
+          # marked green in GitHub UI via continue-on-error.
 
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,8 @@ jobs:
       - run: uv run ruff check .
       - run: uv run ruff format --check .
       - run: uv run mypy src/lizystudio/
-      - run: uv run pytest --cov=src/lizystudio --cov-report=term-missing --cov-fail-under=80 -q
+      # Nightly uses the same flaky-retry policy as CI (Issue #29).
+      - run: uv run pytest --cov=src/lizystudio --cov-report=term-missing --cov-fail-under=80 --reruns 2 --reruns-delay 1 -q
 
   plotly-cdn:
     name: Plotly CDN reachability & SRI freshness

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -2825,6 +2825,33 @@ H-0019 で以下のテストインフラを導入済み:
 
 カバレッジの維持目標は backend と揃え 80% を下限とする（`vitest.config.ts` で CI 強制）。
 
+### 8.3 Flaky テスト運用（Issue #29）
+
+CI の red を抑えつつ本物の regression を見逃さないため、以下のマーカー／仕組みを使う。
+
+#### マーカー
+
+| marker | 用途 | 定義場所 |
+|--------|------|----------|
+| `@pytest.mark.flaky` | 既知の不安定テスト（タイミング依存など）。`pytest-rerunfailures` が CI 時に rerun | `pyproject.toml` |
+| `@pytest.mark.quarantine` | 失敗頻度が高く一時隔離。default run 対象外、CI は non-blocking job で実行 | `pyproject.toml` |
+| `@pytest.mark.slow` | 実モデルを学習する高コストテスト | 既存 |
+
+Playwright 側はテストごとの marker 機構がないため、`playwright.config.ts` の `retries` 設定で一括制御する（CI 時のみ chromium=2, tablet/mobile=1）。
+
+#### 運用ルール
+
+1. **ローカルは retry なし** — `uv run pytest` / `pnpm test:e2e` は retry せず、flaky を見える化する。
+2. **CI の自動 rerun** — backend は `pytest --reruns 2 --reruns-delay 1`、frontend E2E は Playwright の `retries`。rerun で救われた場合も CI ログ / JUnit に警告が残る。
+3. **quarantine の追加** — `pytest.mark.quarantine` を付与するだけで default run から除外される。CI は `backend-quarantine` ジョブ（`continue-on-error: true`）で実行され、失敗しても PR を block しない。
+4. **quarantine からの復帰** — 連続 10 回 green の実績を confirm してから marker 削除、対応 PR に根拠を明記する。
+5. **追跡の義務** — `flaky` / `quarantine` を付けるときは同時に追跡 Issue を起票する。塩漬けを許容しない。
+
+#### 禁止事項
+
+- 真の regression を flaky 扱いして隠蔽しない。rerun で救われた失敗は必ず原因調査する。
+- Playwright の `retries` を test 単位で上書きして特定テストを無制限に retry しない。恒常的に失敗するテストは quarantine もしくは修正する。
+
 ---
 
 ## 9. ビルドと配布

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,11 +1,21 @@
 import { defineConfig } from "@playwright/test";
 
+// Flaky-test strategy (Issue #29):
+// - CI retries failing tests twice before reporting red. Local runs do
+//   NOT retry so flakiness is visible during development.
+// - Chromium (primary) retries 2×; tablet/mobile retry 1× to cap CI
+//   walltime. Override per-project via `projects[].retries` below.
+// - `trace`/`video` are retained only on retry to keep artifact size
+//   bounded while still providing debug context.
+const CI = !!process.env.CI;
+
 export default defineConfig({
   testDir: "tests/e2e",
   outputDir: "test-results",
-  forbidOnly: !!process.env.CI,
+  forbidOnly: CI,
   workers: 1,
   timeout: 120_000,
+  retries: CI ? 2 : 0,
   snapshotPathTemplate:
     "{testDir}/__screenshots__/{projectName}/{testFilePath}/{arg}{ext}",
   expect: {
@@ -31,6 +41,8 @@ export default defineConfig({
   use: {
     baseURL: "http://localhost:5173",
     screenshot: "on",
+    trace: CI ? "retain-on-failure" : "off",
+    video: CI ? "retain-on-failure" : "off",
     viewport: { width: 1440, height: 900 },
     // Dismiss onboarding dialog for all E2E tests
     storageState: {
@@ -52,6 +64,7 @@ export default defineConfig({
     },
     {
       name: "chromium-tablet",
+      retries: CI ? 1 : 0,
       use: {
         browserName: "chromium",
         viewport: { width: 768, height: 1024 },
@@ -59,6 +72,7 @@ export default defineConfig({
     },
     {
       name: "chromium-mobile",
+      retries: CI ? 1 : 0,
       use: {
         browserName: "chromium",
         viewport: { width: 375, height: 812 },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "mypy>=1.10",
     "pytest>=8.0",
     "pytest-cov>=5.0",
+    "pytest-rerunfailures>=14.0",
     "httpx>=0.28",
     "pandas-stubs>=2.3.3.260113",
     "types-pyyaml>=6.0.12.20250915",
@@ -102,8 +103,14 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# Default run excludes quarantined tests; CI runs them in a non-blocking
+# job (see .github/workflows/ci.yml). Local runs stay retry-free so
+# flaky tests remain visible during development — see CLAUDE.md §8.
+addopts = "-m 'not quarantine'"
 markers = [
     "unit: Unit tests (fast, no external dependencies)",
     "integration: Integration tests (require TestClient/server)",
     "slow: Slow tests that actually train a real model (deselect with -m 'not slow')",
+    "flaky: Known-flaky tests — CI reruns via pytest-rerunfailures; local runs do not retry",
+    "quarantine: Isolated tests — excluded from default runs, executed in a non-blocking CI job",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -618,6 +618,7 @@ dev = [
     { name = "pyarrow" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-rerunfailures" },
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
@@ -642,6 +643,7 @@ dev = [
     { name = "pyarrow", specifier = ">=23.0.1" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
+    { name = "pytest-rerunfailures", specifier = ">=14.0" },
     { name = "ruff", specifier = ">=0.8" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
@@ -1568,6 +1570,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/04/71e9520551fc8fe2cf5c1a1842e4e600265b0815f2016b7c27ec85688682/pytest_rerunfailures-16.1.tar.gz", hash = "sha256:c38b266db8a808953ebd71ac25c381cb1981a78ff9340a14bcb9f1b9bff1899e", size = 30889, upload-time = "2025-10-10T07:06:01.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/54/60eabb34445e3db3d3d874dc1dfa72751bfec3265bd611cb13c8b290adea/pytest_rerunfailures-16.1-py3-none-any.whl", hash = "sha256:5d11b12c0ca9a1665b5054052fcc1084f8deadd9328962745ef6b04e26382e86", size = 14093, upload-time = "2025-10-10T07:06:00.019Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #29. Adds a minimal flaky-test management baseline — markers + CI retries + a non-blocking quarantine job — so known-flaky tests stop blocking PRs while real regressions stay visible. Operating principles documented in BLUEPRINT.md §8.3.

### Backend (pytest)
- `pytest-rerunfailures>=14.0` added as a dev dep
- Markers registered: `flaky` (CI auto-retries), `quarantine` (isolated, non-blocking)
- Default `addopts = -m 'not quarantine'` so local `uv run pytest` excludes quarantined tests and **retries are off locally** — flakiness remains visible during development
- `ci.yml`: main backend job gains `--reruns 2 --reruns-delay 1`; new `backend-quarantine` job with `continue-on-error: true` runs `-m quarantine` and no-ops cleanly when no tests carry the marker
- `nightly.yml`: mirrors the rerun policy

### Frontend E2E (Playwright)
- Top-level `retries: CI ? 2 : 0`; per-project override reduces tablet/mobile to 1 retry to cap CI walltime
- `trace` / `video: "retain-on-failure"` enabled in CI only, keeping artifact size bounded while preserving post-mortem context

### Docs
- `BLUEPRINT.md` §8.3 — marker table, operating rules, quarantine lifecycle, and prohibitions against silent regression hiding

## Rationale

The #184 PR (merged) ran into `session-restore.spec.ts:32` failing once and passing on re-run — a genuine race between `waitForJobDone` and the backend's post-hook write to `ws.current_job_id`. Today that flake would block the PR; after this change CI auto-retries and we track the underlying cause separately. The `flaky` marker is **available but not yet applied anywhere** — we'll tag tests per-PR as concrete cases surface, rather than preemptively labeling.

## Acceptance Criteria

- [x] `pytest-rerunfailures` in dev deps
- [x] `flaky` + `quarantine` markers registered in `pyproject.toml`
- [x] `playwright.config.ts` configures CI-only retries and trace/video
- [x] CI workflow runs flaky retry and non-blocking quarantine job
- [x] BLUEPRINT.md §8.3 documents the operating model
- [x] Existing tests all pass (markers added zero tests; proves the scaffolding is inert until used)
- [x] No HISTORY.md Proposal needed (CI + test infra only; public API / contract untouched)

## Out of Scope (tracked as follow-ups)

- Pre-emptively tagging existing backend tests with `@pytest.mark.flaky` — add as concrete flakes appear
- Frontend Vitest retry support — deferred to avoid masking unit regressions
- Monitoring / auto-quarantine after N CI failures — needs real data from this baseline first

## Test plan

- [x] `uv run pytest --reruns 2 --reruns-delay 1 -q` — 1074 passed locally
- [x] `uv run pytest -m quarantine --collect-only -q` — 0 collected (confirms the quarantine job no-op branch works)
- [x] `uv run ruff check . && ruff format --check . && mypy src/lizystudio/` — clean
- [x] `pnpm check` — clean
- [x] CI: full lint + unit run with new `--reruns` flag; `backend-quarantine` job reports notice-level skip
