### PR TITLE
refactor(api): centralize FastAPI dependency factories (A-8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ select = ["E", "F", "I", "W", "UP", "B", "SIM"]
 
 [tool.ruff.lint.per-file-ignores]
 "src/lizystudio/api/*.py" = ["B008"]  # Depends() in defaults is standard FastAPI
+"src/lizystudio/server.py" = ["B008"]  # WebSocket handler uses Depends() (A-8)
 "src/lizystudio/_version.py" = ["UP006", "UP007", "UP035", "I001"]  # auto-generated
 
 [tool.mypy]

--- a/src/lizystudio/api/backends.py
+++ b/src/lizystudio/api/backends.py
@@ -4,23 +4,27 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends
 
+from lizystudio.api.deps import get_backend
 from lizystudio.api.models import BackendInfoResponse
+from lizystudio.backends.base import BackendAdapter
 
 router = APIRouter()
 
 
 @router.get("", response_model=list[BackendInfoResponse])
-def list_backends(request: Request) -> list[dict[str, Any]]:
+def list_backends(
+    backend: BackendAdapter = Depends(get_backend),
+) -> list[dict[str, Any]]:
     """Return available backends."""
-    backend = request.app.state.workspace.backend
     info = backend.info
     return [{"name": info.name, "version": info.version}]
 
 
 @router.get("/ui-schema")
-def get_ui_schema(request: Request) -> dict[str, Any]:
+def get_ui_schema(
+    backend: BackendAdapter = Depends(get_backend),
+) -> dict[str, Any]:
     """Return UI metadata for the current backend (H-0026)."""
-    backend = request.app.state.workspace.backend
-    return backend.get_ui_schema()  # type: ignore[no-any-return]
+    return backend.get_ui_schema()

--- a/src/lizystudio/api/deps.py
+++ b/src/lizystudio/api/deps.py
@@ -1,0 +1,51 @@
+"""Central FastAPI dependency factories (coupling-analysis A-8).
+
+Every router that needs a shared server-lifetime object obtains it
+through one of the `Depends(get_*)` helpers defined here rather than
+reaching for `request.app.state.*` directly.  This gives the test
+suite a single seam to patch, makes the router signatures self-
+documenting, and eliminates the duplicate `_get_broadcaster` helpers
+that used to live in both `api/workspace.py` and `api/retune.py`.
+
+The existing `get_workspace` / `get_job_store` helpers defined in the
+service layer are re-exported here so that routers only need to import
+from a single location.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import Request
+
+from lizystudio.services.jobs import get_job_store
+from lizystudio.services.workspace import get_workspace
+
+if TYPE_CHECKING:
+    from lizystudio.backends.base import BackendAdapter
+    from lizystudio.ws.progress import ProgressBroadcaster
+
+
+__all__ = [
+    "get_backend",
+    "get_broadcaster",
+    "get_job_store",
+    "get_workspace",
+]
+
+
+def get_broadcaster(request: Request) -> ProgressBroadcaster:
+    """Return the process-wide :class:`ProgressBroadcaster`.
+
+    Populated by the application lifespan in :func:`lizystudio.server.create_app`.
+    """
+    return request.app.state.broadcaster  # type: ignore[no-any-return]
+
+
+def get_backend(request: Request) -> BackendAdapter:
+    """Return the active :class:`BackendAdapter` bound to the workspace.
+
+    Convenience factory so endpoints that only need the adapter do not
+    have to depend on the whole :class:`WorkspaceState`.
+    """
+    return request.app.state.workspace.backend  # type: ignore[no-any-return]

--- a/src/lizystudio/api/retune.py
+++ b/src/lizystudio/api/retune.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import Depends, Request
+from fastapi import Depends
 from pydantic import BaseModel, ConfigDict
 
+from lizystudio.api.deps import get_broadcaster
 from lizystudio.api.errors import (
     JobNotCompletedError,
     JobNotFoundError,
@@ -26,6 +27,7 @@ from lizystudio.api.errors import (
 from lizystudio.api.jobs import _get_job_or_404, router
 from lizystudio.services.jobs import Job, JobStore, get_job_store
 from lizystudio.services.workspace import WorkspaceState, get_workspace
+from lizystudio.ws.progress import ProgressBroadcaster
 
 # Hard upper bound on Re-tune / Resume n_trials. Mirrors lizyml's
 # _MAX_RE_TUNE_TRIALS_PER_ROUND so a Re-tune child cannot smuggle
@@ -156,18 +158,13 @@ def _claim_retune_slot(parent_job_id: str, job_store: JobStore) -> str:
     return placeholder
 
 
-def _get_broadcaster(request: Request) -> Any:
-    """Pull the ProgressBroadcaster off the app state (H-0062)."""
-    return request.app.state.broadcaster
-
-
 @router.post("/{job_id}/retune")
 def retune_job(
     job_id: str,
     body: RetuneRequest,
-    request: Request,
     job_store: JobStore = Depends(get_job_store),
     ws: WorkspaceState = Depends(get_workspace),
+    broadcaster: ProgressBroadcaster = Depends(get_broadcaster),
 ) -> dict[str, str]:
     """Start a Re-tune child job from a completed parent Tune (H-0062)."""
     from lizystudio.services.training import start_retune_async
@@ -212,7 +209,7 @@ def retune_job(
         start_retune_async(
             ws=ws,
             job_store=job_store,
-            broadcaster=_get_broadcaster(request),
+            broadcaster=broadcaster,
             parent_job=parent,
             child_job=child,
             n_trials=body.n_trials,
@@ -231,9 +228,9 @@ def retune_job(
 def resume_job(
     job_id: str,
     body: ResumeRequest,
-    request: Request,
     job_store: JobStore = Depends(get_job_store),
     ws: WorkspaceState = Depends(get_workspace),
+    broadcaster: ProgressBroadcaster = Depends(get_broadcaster),
 ) -> dict[str, str]:
     """Resume a failed Tune Job from its last saved checkpoint (H-0062)."""
     from lizystudio.services.training import start_retune_async
@@ -272,7 +269,7 @@ def resume_job(
         start_retune_async(
             ws=ws,
             job_store=job_store,
-            broadcaster=_get_broadcaster(request),
+            broadcaster=broadcaster,
             parent_job=parent,
             child_job=child,
             n_trials=n_trials,

--- a/src/lizystudio/api/workspace.py
+++ b/src/lizystudio/api/workspace.py
@@ -19,6 +19,7 @@ from fastapi.responses import Response
 from pydantic import BaseModel  # noqa: F401
 
 import lizystudio.security as security
+from lizystudio.api.deps import get_broadcaster
 from lizystudio.api.errors import (
     ConfigImportError,
     FileInvalidError,
@@ -502,21 +503,14 @@ def config_download(
     )
 
 
-# --- Helpers ---
-
-
-def _get_broadcaster(request: Request) -> ProgressBroadcaster:
-    return request.app.state.broadcaster  # type: ignore[no-any-return]
-
-
 # --- Fit / Tune endpoints (BLUEPRINT §5.2 Fit/Tune) ---
 
 
 @router.post("/fit", response_model=JobStartResponse)
 def workspace_fit(
-    request: Request,
     ws: WorkspaceState = Depends(get_workspace),
     job_store: JobStore = Depends(get_job_store),
+    broadcaster: ProgressBroadcaster = Depends(get_broadcaster),
 ) -> dict[str, Any]:
     """Create a fit job (thread managed by Service layer)."""
     if not ws.config:
@@ -542,7 +536,7 @@ def workspace_fit(
         job_id = start_fit_async(
             ws=ws,
             job_store=job_store,
-            broadcaster=_get_broadcaster(request),
+            broadcaster=broadcaster,
             config=ws.config,
             dataframe=ws.dataframe,
             job=job,
@@ -570,9 +564,9 @@ def workspace_fit(
 
 @router.post("/tune", response_model=JobStartResponse)
 def workspace_tune(
-    request: Request,
     ws: WorkspaceState = Depends(get_workspace),
     job_store: JobStore = Depends(get_job_store),
+    broadcaster: ProgressBroadcaster = Depends(get_broadcaster),
 ) -> dict[str, Any]:
     """Create a tune job (thread managed by Service layer)."""
     if not ws.config:
@@ -615,7 +609,7 @@ def workspace_tune(
         job_id = start_tune_async(
             ws=ws,
             job_store=job_store,
-            broadcaster=_get_broadcaster(request),
+            broadcaster=broadcaster,
             config=ws.config,
             dataframe=ws.dataframe,
             job=job,

--- a/src/lizystudio/server.py
+++ b/src/lizystudio/server.py
@@ -11,7 +11,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
-from fastapi import FastAPI, HTTPException, Request, Response, WebSocket
+from fastapi import Depends, FastAPI, HTTPException, Request, Response, WebSocket
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
@@ -26,6 +26,7 @@ from lizystudio.api import (
     metrics_api,
     workspace,
 )
+from lizystudio.api.deps import get_broadcaster
 from lizystudio.api.errors import (
     StudioError,
     studio_error_handler,
@@ -201,8 +202,11 @@ def create_app() -> FastAPI:
 
     # WebSocket route for job progress (BLUEPRINT §5.5)
     @application.websocket("/ws/jobs/{job_id}/progress")
-    async def ws_job_progress(ws: WebSocket, job_id: str) -> None:
-        broadcaster: ProgressBroadcaster = application.state.broadcaster
+    async def ws_job_progress(
+        ws: WebSocket,
+        job_id: str,
+        broadcaster: ProgressBroadcaster = Depends(get_broadcaster),
+    ) -> None:
         await websocket_progress(ws, job_id, broadcaster)
 
     # Serve built frontend (production)

--- a/tests/test_api_deps.py
+++ b/tests/test_api_deps.py
@@ -1,0 +1,167 @@
+"""Tests for the centralized API dependency module (A-8).
+
+Covers:
+
+- `api/deps` exposes factories that resolve the shared app.state objects.
+- Invariant INV-DEPS-1: no router module may reach for `request.app.state.*`
+  directly — every access must be mediated by `api/deps`. The readiness
+  probe in `api/health.py` is the single allowed exception (it deliberately
+  swallows `app.state` access failures to return 503 instead of 500 when the
+  lifespan hasn't finished initializing state).
+
+RED expectations before implementation:
+
+- `lizystudio.api.deps` does not exist → imports fail.
+- Routers still access `request.app.state.broadcaster|workspace|job_store`
+  outside the readiness allowlist → AST audit fails.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_API_DIR = _REPO_ROOT / "src" / "lizystudio" / "api"
+_SERVER_PY = _REPO_ROOT / "src" / "lizystudio" / "server.py"
+
+# Files where `request.app.state.*` is still allowed.  `health.py` uses the
+# raw attribute access inside a broad try/except so the readiness probe can
+# reply 503 rather than 500 when the lifespan has not finished running yet
+# — converting that to `Depends(...)` would raise AttributeError at binding
+# time and break the contract.  Keep this allowlist tight; do not add new
+# entries without also adding a counterpart invariant test.
+_ALLOWLIST: frozenset[str] = frozenset({"health.py"})
+
+
+def test_api_deps_module_importable() -> None:
+    """`lizystudio.api.deps` exists and is a real module."""
+    import importlib
+
+    deps = importlib.import_module("lizystudio.api.deps")
+    assert hasattr(deps, "get_workspace"), "deps must re-export get_workspace"
+    assert hasattr(deps, "get_job_store"), "deps must re-export get_job_store"
+    assert hasattr(deps, "get_broadcaster"), "deps must expose get_broadcaster"
+    assert hasattr(deps, "get_backend"), "deps must expose get_backend"
+
+
+def test_get_broadcaster_returns_app_state_broadcaster(client: TestClient) -> None:
+    """`get_broadcaster` resolves to the live broadcaster on app.state."""
+    from lizystudio.api.deps import get_broadcaster
+
+    # TestClient's portal exposes the FastAPI app via .app
+    app = client.app
+    broadcaster = app.state.broadcaster  # type: ignore[union-attr]
+
+    # Build a stand-in Request with the right scope so Depends can call it
+    from starlette.requests import Request
+
+    scope = {"type": "http", "app": app}
+    req = Request(scope=scope)
+    resolved = get_broadcaster(req)
+    assert resolved is broadcaster
+
+
+def test_get_backend_returns_workspace_backend(client: TestClient) -> None:
+    """`get_backend` resolves to `workspace.backend` off app.state."""
+    from lizystudio.api.deps import get_backend
+
+    app = client.app
+    expected = app.state.workspace.backend  # type: ignore[union-attr]
+
+    from starlette.requests import Request
+
+    scope = {"type": "http", "app": app}
+    req = Request(scope=scope)
+    resolved = get_backend(req)
+    assert resolved is expected
+
+
+# --- INV-DEPS-1: no router may touch request.app.state.* outside allowlist ---
+
+
+def _accesses_app_state(tree: ast.AST) -> list[str]:
+    """Return every `*.app.state.<attr>` READ chain found in the AST.
+
+    Matches patterns like `request.app.state.broadcaster` OR
+    `application.state.foo`.  Only ``ast.Load`` contexts are flagged —
+    lifespan assignments such as ``application.state.workspace = ...``
+    use ``ast.Store`` and must not trigger the invariant.
+    """
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute):
+            continue
+        if not isinstance(node.ctx, ast.Load):
+            continue
+        inner = node.value
+        if not isinstance(inner, ast.Attribute) or inner.attr != "state":
+            continue
+        innermost = inner.value
+        if isinstance(innermost, ast.Attribute) and innermost.attr == "app":
+            hits.append(f".app.state.{node.attr}")
+        elif isinstance(innermost, ast.Name) and innermost.id in {
+            "app",
+            "application",
+        }:
+            hits.append(f"{innermost.id}.state.{node.attr}")
+    return hits
+
+
+def test_no_router_touches_app_state_directly() -> None:
+    """Every router module goes through `api/deps` (INV-DEPS-1)."""
+    offenders: list[str] = []
+    for py in _API_DIR.glob("*.py"):
+        if py.name in _ALLOWLIST or py.name == "deps.py":
+            continue
+        tree = ast.parse(py.read_text())
+        hits = _accesses_app_state(tree)
+        if hits:
+            offenders.append(f"{py.name}: {hits}")
+    assert not offenders, (
+        "Routers must use api/deps.Depends(get_*) instead of raw "
+        f"request.app.state access. Offenders: {offenders}"
+    )
+
+
+def test_server_ws_handler_uses_deps() -> None:
+    """The WebSocket handler in server.py must not read app.state directly.
+
+    The route definition in `create_app()` closes over `application`,
+    so the offending pattern is `application.state.broadcaster`.  After
+    the refactor this becomes a call into `api/deps.get_broadcaster`
+    (with a `Request` proxy) or an equivalent factory.
+    """
+    tree = ast.parse(_SERVER_PY.read_text())
+    hits = _accesses_app_state(tree)
+    # The lifespan assignments (`application.state.workspace = ...`) are
+    # *writes* and pass through ast.Assign targets — those don't count
+    # because ast.walk visits them as Attribute nodes too. Accept only
+    # reads within the WS handler body.
+    read_hits = [h for h in hits if h.endswith(".broadcaster")]
+    assert not read_hits, (
+        "server.ws_job_progress must resolve the broadcaster via "
+        f"api/deps, not app.state. Offenders: {read_hits}"
+    )
+
+
+# --- no duplicate _get_broadcaster helpers ---
+
+
+def test_no_duplicate_get_broadcaster_helpers() -> None:
+    """`_get_broadcaster` must exist in at most one place (api/deps)."""
+    offenders: list[str] = []
+    for py in _API_DIR.glob("*.py"):
+        if py.name == "deps.py":
+            continue
+        src = py.read_text()
+        if "_get_broadcaster" in src or "def get_broadcaster" in src:
+            offenders.append(py.name)
+    assert not offenders, (
+        f"Broadcaster helpers must live in api/deps only. Offenders: {offenders}"
+    )


### PR DESCRIPTION
## Summary
Phase-1 coupling refactor, item A-8 from [`docs/coupling-analysis.md`](./docs/coupling-analysis.md).

- **New** `src/lizystudio/api/deps.py` is now the single location for shared-state dependency factories. It re-exports the existing `get_workspace` / `get_job_store` and adds `get_broadcaster` and `get_backend`.
- **Deleted** duplicate `_get_broadcaster(request)` helpers in `api/workspace.py` and `api/retune.py`.
- **Replaced** every `request.app.state.*` read in routers with a `Depends(...)` parameter (`backends.py`, `workspace.py`, `retune.py`, `server.py` WebSocket handler).
- `api/health.py` is the sole allowlisted exception — the readiness probe intentionally reads `app.state` inside `try/except` so it can return 503 (not 500) when lifespan has not finished initializing.

## Invariant
**INV-DEPS-1**: every HTTP/WS handler that accesses shared server state does so through a `Depends(...)` parameter, never via `request.app.state.*` or module-level globals.

Enforced by `tests/test_api_deps.py::test_no_router_touches_app_state_directly` (AST walker, `ast.Load` context only so lifespan writes are not flagged).

## Touch list
- NEW: `src/lizystudio/api/deps.py`
- NEW: `tests/test_api_deps.py`
- MOD: `src/lizystudio/api/backends.py`, `api/workspace.py`, `api/retune.py`, `server.py`, `pyproject.toml`

## Test plan
- [x] `uv run ruff check` / `ruff format --check` — pass
- [x] `uv run mypy src/lizystudio/` — pass (also removed one now-unnecessary `type: ignore`)
- [x] `uv run pytest -m "not slow"` — **1074 / 1074 passed**, no regression
- [x] Coverage: `api/deps.py` 100%, `api/backends.py` 93%, overall 97%
- [x] `code-reviewer` agent — 0 CRITICAL/HIGH, 1 HIGH (relative test path) **fixed**
- [x] `security-reviewer` agent — 0 CRITICAL/HIGH
- [x] API smoke (curl + backend log) — fit/tune/retune/inference/WS all 200

## Out of scope
Phase-1 remaining items — next PRs:
- PR #2 C-1 + C-2: Inference `response_model` + API-type drift CI gate
- PR #3 A-3 + A-4: `_training_core.py` extraction + `WorkspaceState` encapsulation

Phase-2+ items (A-1/A-2/A-5/A-6/A-7, all B-*, C-3..C-12) are explicitly deferred.