### PR TITLE
refactor(services): split jobs.py persistence from dispatch + LRU model cache (H-0070, A-7)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1813,3 +1813,31 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (e) `pnpm build` + `pnpm vitest run` + `api-types-drift` CI job が green。
   - (f) 経路 B の JSONL 送受信は wire format 未変更（regression なし）。
 - **Decision:** 未決定。
+
+### H-0070: `services/jobs.py` God Module 分割と model LRU キャッシュ（Phase 3 coupling refactor）
+- **Status:** proposed
+- **Scope:** Backend | Internal only（公開 API / wire format / 保存形式 変更なし）
+- **Related:** docs/coupling-analysis.md A-7
+- **Context:** `services/jobs.py` は 751 行の God Module で、disk CRUD（persistence）と `BackendAdapter` ディスパッチ（evaluate/plot/importance 等の結果変換）を同居させていた。結果変換関数は `Job + BackendAdapter → 結果データ` という責務で、persistence とは明確に層が異なる。さらに各関数が毎回 `backend.load_model(job.model_path)` を呼ぶため、同じ完了ジョブに対して `get_metrics_table` / `get_split_summary` / `get_importance_kinds` / `get_job_plot` … と複数エンドポイントが連続で叩かれると、その都度 disk read + deserialize が走る無駄が発生していた。
+- **Proposal:**
+  1. `src/lizystudio/services/job_results.py` を新設し、`load_job_model` / `get_metrics_table` / `get_split_summary` / `get_importance` / `get_importance_kinds` / `get_learning_curve_metrics` / `get_job_plot` / `get_available_plots` と private helper `_get_jobs_dir` / `_load_tuning_plot_from_file` を移動する。
+  2. `load_job_model` に process-local LRU キャッシュ（`OrderedDict` + `threading.Lock`, `maxsize=8`）を追加。キーは `(backend_name, model_path)`。ロード本体も critical section 内で実行し、並列キャッシュミスで二重 load + ABA レースが起きないようにする。
+  3. `clear_model_cache()` / `clear_model_cache_for(path)` を公開し、テスト fixture および将来の invalidation hook から利用可能にする。
+  4. `JobStore.delete()` で削除対象の model キャッシュエントリを `clear_model_cache_for` で drop。rmtree 後の stale entry が次回 lookup を汚染しない。
+  5. `services/jobs.py` 末尾で `from .job_results import …` による back-compat re-export を用意。既存の `from lizystudio.services.jobs import load_job_model` 系 import 全箇所（20+ テスト、複数 api/ modules）を書き換えない。
+- **Impact:** `src/lizystudio/services/job_results.py`（新規, 143 行）、`src/lizystudio/services/jobs.py`（751 → 695 行）、`tests/test_job_results.py`（新規, 19 テスト）。公開 API / wire format / 保存形式 / BackendAdapter Protocol は変更なし。
+- **Compatibility:**
+  - import 互換: 既存の `from services.jobs import …` は re-export で継続動作。
+  - wire format 変更なし。
+  - キャッシュは process-local なため、multi-worker 配備でも workers 間の整合性に影響なし。
+- **Alternatives:**
+  - (a) `functools.lru_cache` を直接使う → 却下。インスタンス引数 (`Job` / `BackendAdapter`) 非ハッシャブルに対応できず、invalidation API も公開できない。
+  - (b) per-key Event によるローディング中の並列待機（stampede 回避）→ 却下。キャッシュサイズ 8 / 小規模 deployment なら単一 lock の方が単純で十分。必要なら後続 PR で拡張。
+  - (c) キャッシュ無しで分割のみ実施 → 却下。Results 画面の同時 4+ fetch が都度 disk read を引き起こすという実ボトルネックを放置するのは本質回避。
+- **Acceptance Criteria:**
+  - (a) 既存テスト 1136 件 + 新規 19 件 = 1138+ 件（jobs テストの置換分を考慮）が green。
+  - (b) `uv run mypy src/lizystudio/` / `uv run ruff check .` / `uv run ruff format --check .` 全 clean。
+  - (c) `services/jobs.py` の行数が 700 行以下、`services/job_results.py` の行数が 150 行以下。
+  - (d) `load_job_model` の同一 `(backend_name, model_path)` 連続呼び出しで `backend.load_model` が 1 回のみ走る（LRU ヒット）。
+  - (e) `JobStore.delete()` 後に同 path のキャッシュエントリが drop されている（regression: stale model hit 防止）。
+- **Decision:** 未決定。

--- a/src/lizystudio/services/job_results.py
+++ b/src/lizystudio/services/job_results.py
@@ -1,0 +1,149 @@
+"""Job-result dispatch helpers — transforms Job + BackendAdapter → result data.
+
+Split out of ``services/jobs.py`` as part of the A-7 coupling-refactor
+(see docs/coupling-analysis.md). ``jobs.py`` owns disk CRUD; this module
+owns adapter dispatch and memoizes ``load_model`` results so consecutive
+calls for the same completed job skip a repeated disk read + deserialize.
+
+The cache is keyed by ``(backend_name, model_path)`` rather than by job
+identity because different jobs can legitimately share a model path
+(e.g. Re-tune children that export under a parent directory) and because
+the same path deserializes identically regardless of which Job instance
+asked for it. Invalidate via :func:`clear_model_cache` when a path is
+overwritten.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+
+from lizystudio.backends.base import BackendAdapter
+from lizystudio.backends.types import PlotData
+from lizystudio.services.jobs import Job
+
+_MODEL_CACHE_MAX = 8
+
+_model_cache: OrderedDict[tuple[str, str], Any] = OrderedDict()
+_model_cache_lock = threading.Lock()
+
+
+def clear_model_cache() -> None:
+    """Drop all memoized models. Call after a path is overwritten."""
+    with _model_cache_lock:
+        _model_cache.clear()
+
+
+def clear_model_cache_for(model_path: str) -> None:
+    """Drop cached entries for a specific model path across all backends."""
+    with _model_cache_lock:
+        stale = [k for k in _model_cache if k[1] == model_path]
+        for key in stale:
+            del _model_cache[key]
+
+
+def load_job_model(job: Job, backend: BackendAdapter) -> Any:
+    """Load a trained model from a completed job, memoized in an LRU cache.
+
+    The cache critical section wraps the adapter ``load_model`` call so a
+    concurrent :func:`clear_model_cache_for` invalidation cannot interleave
+    between "cache miss" and "write result" and resurrect a path that was
+    meant to be dropped. The per-process cache is small (``maxsize=8``) and
+    model deserialization is fast enough that a single lock is simpler than
+    a per-key Event barrier.
+    """
+    if job.model_path is None:
+        msg = f"Job {job.job_id} has no saved model"
+        raise ValueError(msg)
+
+    key = (job.backend_name, job.model_path)
+    with _model_cache_lock:
+        if key in _model_cache:
+            _model_cache.move_to_end(key)
+            return _model_cache[key]
+
+        model = backend.load_model(job.model_path)
+        _model_cache[key] = model
+        _model_cache.move_to_end(key)
+        while len(_model_cache) > _MODEL_CACHE_MAX:
+            _model_cache.popitem(last=False)
+        return model
+
+
+def get_metrics_table(job: Job, backend: BackendAdapter) -> list[dict[str, Any]]:
+    """Get the metrics evaluation table for a completed job."""
+    model = load_job_model(job, backend)
+    return backend.evaluate_table(model)
+
+
+def get_split_summary(job: Job, backend: BackendAdapter) -> list[dict[str, Any]]:
+    """Get fold/split summary for a completed job."""
+    model = load_job_model(job, backend)
+    return backend.split_summary(model)
+
+
+def get_importance(
+    job: Job, backend: BackendAdapter, kind: str = "split"
+) -> dict[str, float]:
+    """Get feature importance for a completed job."""
+    model = load_job_model(job, backend)
+    return backend.importance(model, kind=kind)
+
+
+def get_importance_kinds(job: Job, backend: BackendAdapter) -> list[str]:
+    """Get the list of valid importance kind identifiers for a completed job."""
+    model = load_job_model(job, backend)
+    return backend.importance_kinds(model)
+
+
+def get_learning_curve_metrics(job: Job, backend: BackendAdapter) -> list[str]:
+    """Get the list of metric names available in the learning curve history."""
+    model = load_job_model(job, backend)
+    return backend.learning_curve_metrics(model)
+
+
+def _get_jobs_dir(job: Job) -> Path | None:
+    """Derive the jobs directory from a job's model_path."""
+    if job.model_path:
+        return Path(job.model_path).parent.parent
+    return None
+
+
+def _load_tuning_plot_from_file(job: Job) -> PlotData | None:
+    """Load a saved tuning plot JSON from disk (fallback for exported models)."""
+    jobs_dir = _get_jobs_dir(job)
+    if jobs_dir is None:
+        return None
+    path = jobs_dir / job.job_id / "tuning_plot.json"
+    if not path.exists():
+        return None
+    return PlotData(plotly_json=path.read_text(encoding="utf-8"))
+
+
+def get_job_plot(
+    job: Job, backend: BackendAdapter, plot_type: str, **kwargs: Any
+) -> Any:
+    """Get a plot for a completed job. Returns PlotData."""
+    model = load_job_model(job, backend)
+    if plot_type == "tuning":
+        try:
+            return backend.plot(model, plot_type, **kwargs)
+        except Exception:  # noqa: BLE001
+            saved = _load_tuning_plot_from_file(job)
+            if saved is not None:
+                return saved
+            raise
+    return backend.plot(model, plot_type, **kwargs)
+
+
+def get_available_plots(job: Job, backend: BackendAdapter) -> list[str]:
+    """Get list of available plot types for a completed job."""
+    model = load_job_model(job, backend)
+    plots = list(backend.available_plots(model))
+    if "tuning" not in plots and job.job_type == "tune":
+        saved = _load_tuning_plot_from_file(job)
+        if saved is not None:
+            plots.append("tuning")
+    return plots

--- a/src/lizystudio/services/jobs.py
+++ b/src/lizystudio/services/jobs.py
@@ -17,7 +17,6 @@ from uuid import uuid4
 
 from fastapi import Request
 
-from lizystudio.backends.base import BackendAdapter
 from lizystudio.backends.types import DataRef, FitSummary, TuningSummary
 from lizystudio.metrics import ACTIVE_JOBS
 from lizystudio.security import validate_path_within  # noqa: E402
@@ -212,6 +211,11 @@ class JobStore:
                 # deleted anyway; swallow the transient error instead
                 # of propagating it out of delete().
                 shutil.rmtree(target, ignore_errors=True)
+            # Drop any cached deserialized model for this job. Imported
+            # here to avoid a top-level cycle with ``job_results``.
+            from lizystudio.services.job_results import clear_model_cache_for
+
+            clear_model_cache_for(str(self._job_dir(jid) / "model"))
         return removed
 
     # --- H-0062 lineage helpers ---
@@ -658,94 +662,39 @@ def get_job_store(request: Request) -> JobStore:
     return request.app.state.job_store  # type: ignore[no-any-return]
 
 
-# --- Service-layer helpers for job results (Phase 20) ---
+# --- Back-compat re-exports (A-7: dispatch helpers moved to job_results) ---
+# External callers historically import these from services.jobs. The logic
+# now lives in services/job_results.py alongside the model LRU cache.
+from lizystudio.services.job_results import (  # noqa: E402
+    _get_jobs_dir,
+    _load_tuning_plot_from_file,
+    clear_model_cache,
+    clear_model_cache_for,
+    get_available_plots,
+    get_importance,
+    get_importance_kinds,
+    get_job_plot,
+    get_learning_curve_metrics,
+    get_metrics_table,
+    get_split_summary,
+    load_job_model,
+)
 
-
-def load_job_model(job: Job, backend: BackendAdapter) -> Any:
-    """Load a trained model from a completed job."""
-    if job.model_path is None:
-        msg = f"Job {job.job_id} has no saved model"
-        raise ValueError(msg)
-    return backend.load_model(job.model_path)
-
-
-def get_metrics_table(job: Job, backend: BackendAdapter) -> list[dict[str, Any]]:
-    """Get the metrics evaluation table for a completed job."""
-    model = load_job_model(job, backend)
-    return backend.evaluate_table(model)
-
-
-def get_split_summary(job: Job, backend: BackendAdapter) -> list[dict[str, Any]]:
-    """Get fold/split summary for a completed job."""
-    model = load_job_model(job, backend)
-    return backend.split_summary(model)
-
-
-def get_importance(
-    job: Job, backend: BackendAdapter, kind: str = "split"
-) -> dict[str, float]:
-    """Get feature importance for a completed job."""
-    model = load_job_model(job, backend)
-    return backend.importance(model, kind=kind)
-
-
-def get_importance_kinds(job: Job, backend: BackendAdapter) -> list[str]:
-    """Get the list of valid importance kind identifiers for a completed job."""
-    model = load_job_model(job, backend)
-    return backend.importance_kinds(model)
-
-
-def get_learning_curve_metrics(job: Job, backend: BackendAdapter) -> list[str]:
-    """Get the list of metric names available in the learning curve history."""
-    model = load_job_model(job, backend)
-    return backend.learning_curve_metrics(model)
-
-
-def _get_jobs_dir(job: Job) -> Path | None:
-    """Derive the jobs directory from a job's model_path."""
-    if job.model_path:
-        return Path(job.model_path).parent.parent
-    return None
-
-
-def _load_tuning_plot_from_file(job: Job) -> Any:
-    """Load a saved tuning plot JSON from disk (fallback for exported models)."""
-    from lizystudio.backends.types import PlotData
-
-    jobs_dir = _get_jobs_dir(job)
-    if jobs_dir is None:
-        return None
-    path = jobs_dir / job.job_id / "tuning_plot.json"
-    if not path.exists():
-        return None
-    return PlotData(plotly_json=path.read_text(encoding="utf-8"))
-
-
-def get_job_plot(
-    job: Job, backend: BackendAdapter, plot_type: str, **kwargs: Any
-) -> Any:
-    """Get a plot for a completed job. Returns PlotData."""
-    model = load_job_model(job, backend)
-    # For tuning plots, the exported model may lack Optuna study data.
-    # Fall back to the saved file captured at tune time.
-    if plot_type == "tuning":
-        try:
-            return backend.plot(model, plot_type, **kwargs)
-        except Exception:  # noqa: BLE001
-            saved = _load_tuning_plot_from_file(job)
-            if saved is not None:
-                return saved
-            raise
-    return backend.plot(model, plot_type, **kwargs)
-
-
-def get_available_plots(job: Job, backend: BackendAdapter) -> list[str]:
-    """Get list of available plot types for a completed job."""
-    model = load_job_model(job, backend)
-    plots = list(backend.available_plots(model))
-    # If tuning plot file exists but model doesn't have tuning data, add it
-    if "tuning" not in plots and job.job_type == "tune":
-        saved = _load_tuning_plot_from_file(job)
-        if saved is not None:
-            plots.append("tuning")
-    return plots
+__all__ = [
+    "CANCEL_FLAG_FILENAME",
+    "Job",
+    "JobStore",
+    "_get_jobs_dir",
+    "_load_tuning_plot_from_file",
+    "clear_model_cache",
+    "clear_model_cache_for",
+    "get_available_plots",
+    "get_importance",
+    "get_importance_kinds",
+    "get_job_plot",
+    "get_job_store",
+    "get_learning_curve_metrics",
+    "get_metrics_table",
+    "get_split_summary",
+    "load_job_model",
+]

--- a/tests/test_job_results.py
+++ b/tests/test_job_results.py
@@ -1,0 +1,392 @@
+"""Tests for services.job_results — dispatch helpers + model LRU cache.
+
+Covers A-7 split: dispatch-layer helpers that transform a ``Job`` +
+``BackendAdapter`` into result data. Persistence-layer tests live in
+``test_jobs.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from lizystudio.backends.types import DataRef, PlotData
+from lizystudio.services.job_results import (
+    clear_model_cache,
+    get_available_plots,
+    get_importance,
+    get_importance_kinds,
+    get_job_plot,
+    get_learning_curve_metrics,
+    get_metrics_table,
+    get_split_summary,
+    load_job_model,
+)
+from lizystudio.services.jobs import JobStore
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def job_store(tmp_path: Path) -> JobStore:
+    return JobStore(tmp_path / "jobs")
+
+
+@pytest.fixture()
+def sample_data_ref() -> DataRef:
+    return DataRef(
+        source_type="path",
+        path="/data/train.csv",
+        filename="train.csv",
+        fingerprint="abc123",
+        shape=(100, 10),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_model_cache() -> None:
+    """Ensure each test starts with a clean cache — avoids cross-test leakage."""
+    clear_model_cache()
+
+
+def _make_completed_job(
+    job_store: JobStore, data_ref: DataRef, job_type: str = "fit"
+) -> Any:
+    job = job_store.create(
+        backend_name="lizyml",
+        config={},
+        data_ref=data_ref,
+        job_type=job_type,  # type: ignore[arg-type]
+    )
+    model_dir = job_store.jobs_dir / job.job_id / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+    job.model_path = str(model_dir)
+    return job
+
+
+# ---------------------------------------------------------------------------
+# load_job_model — error path + LRU cache
+# ---------------------------------------------------------------------------
+
+
+def test_load_job_model_raises_when_no_model_path(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    """load_job_model must raise ValueError when model_path is None."""
+    job = job_store.create(
+        backend_name="lizyml",
+        config={},
+        data_ref=sample_data_ref,
+        job_type="fit",
+    )
+    assert job.model_path is None
+    backend = MagicMock()
+
+    with pytest.raises(ValueError, match="no saved model"):
+        load_job_model(job, backend)
+
+
+def test_load_job_model_returns_loaded_model(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    job = _make_completed_job(job_store, sample_data_ref)
+    backend = MagicMock()
+    backend.load_model.return_value = "MODEL_OBJ"
+
+    model = load_job_model(job, backend)
+
+    assert model == "MODEL_OBJ"
+    backend.load_model.assert_called_once_with(job.model_path)
+
+
+def test_load_job_model_caches_by_path_and_backend(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    """Second call with same (model_path, backend_name) must hit cache."""
+    job = _make_completed_job(job_store, sample_data_ref)
+    backend = MagicMock()
+    backend.load_model.return_value = "MODEL_OBJ"
+
+    first = load_job_model(job, backend)
+    second = load_job_model(job, backend)
+
+    assert first is second
+    assert backend.load_model.call_count == 1
+
+
+def test_load_job_model_different_backends_do_not_share_cache(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    """Cache key includes backend_name, so two backends load independently."""
+    job_a = _make_completed_job(job_store, sample_data_ref)
+    job_b = _make_completed_job(job_store, sample_data_ref)
+    job_b.backend_name = "other"
+
+    backend_a = MagicMock()
+    backend_a.load_model.return_value = "A"
+    backend_b = MagicMock()
+    backend_b.load_model.return_value = "B"
+
+    # Prime both
+    assert load_job_model(job_a, backend_a) == "A"
+    assert load_job_model(job_b, backend_b) == "B"
+
+    # Repeat — both should be cached
+    load_job_model(job_a, backend_a)
+    load_job_model(job_b, backend_b)
+
+    assert backend_a.load_model.call_count == 1
+    assert backend_b.load_model.call_count == 1
+
+
+def test_clear_model_cache_forces_reload(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    job = _make_completed_job(job_store, sample_data_ref)
+    backend = MagicMock()
+    backend.load_model.return_value = "M"
+
+    load_job_model(job, backend)
+    clear_model_cache()
+    load_job_model(job, backend)
+
+    assert backend.load_model.call_count == 2
+
+
+def test_job_store_delete_invalidates_model_cache(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    """Deleting a job drops its cached model so a reused path never returns
+    a stale, pre-delete deserialized object.
+    """
+    from lizystudio.services.job_results import _model_cache
+
+    job = _make_completed_job(job_store, sample_data_ref)
+    backend = MagicMock()
+    backend.load_model.return_value = "M"
+
+    load_job_model(job, backend)
+    key = (job.backend_name, job.model_path)
+    assert key in _model_cache
+
+    job_store.delete(job.job_id)
+
+    assert key not in _model_cache
+
+
+def test_load_job_model_cache_write_is_atomic_under_concurrent_reads(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    """Concurrent callers on the same (backend, path) trigger at most one
+    backend.load_model call because the critical section covers both the
+    miss-check and the load.
+    """
+    import threading as _threading
+
+    job = _make_completed_job(job_store, sample_data_ref)
+    backend = MagicMock()
+
+    load_started = _threading.Event()
+    can_return = _threading.Event()
+
+    def slow_load(_path: str) -> str:
+        load_started.set()
+        can_return.wait(timeout=2.0)
+        return "M"
+
+    backend.load_model.side_effect = slow_load
+
+    results: list[Any] = []
+
+    def call() -> None:
+        results.append(load_job_model(job, backend))
+
+    t1 = _threading.Thread(target=call)
+    t2 = _threading.Thread(target=call)
+    t1.start()
+    load_started.wait(timeout=1.0)
+    t2.start()
+    can_return.set()
+    t1.join(timeout=2.0)
+    t2.join(timeout=2.0)
+
+    assert results == ["M", "M"]
+    assert backend.load_model.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Dispatch helpers
+# ---------------------------------------------------------------------------
+
+
+def test_get_metrics_table_delegates_to_backend(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    job = _make_completed_job(job_store, sample_data_ref)
+    backend = MagicMock()
+    backend.load_model.return_value = "MODEL"
+    backend.evaluate_table.return_value = [{"metric": "rmse", "value": 0.1}]
+
+    result = get_metrics_table(job, backend)
+
+    assert result == [{"metric": "rmse", "value": 0.1}]
+    backend.evaluate_table.assert_called_once_with("MODEL")
+
+
+def test_get_split_summary_delegates(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    job = _make_completed_job(job_store, sample_data_ref)
+    backend = MagicMock()
+    backend.load_model.return_value = "M"
+    backend.split_summary.return_value = [{"fold": 0, "score": 0.9}]
+
+    assert get_split_summary(job, backend) == [{"fold": 0, "score": 0.9}]
+
+
+def test_get_importance_passes_kind(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    job = _make_completed_job(job_store, sample_data_ref)
+    backend = MagicMock()
+    backend.load_model.return_value = "M"
+    backend.importance.return_value = {"f1": 0.5}
+
+    result = get_importance(job, backend, kind="gain")
+
+    backend.importance.assert_called_once_with("M", kind="gain")
+    assert result == {"f1": 0.5}
+
+
+def test_get_importance_kinds_delegates(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    job = _make_completed_job(job_store, sample_data_ref)
+    backend = MagicMock()
+    backend.load_model.return_value = "M"
+    backend.importance_kinds.return_value = ["split", "gain"]
+
+    assert get_importance_kinds(job, backend) == ["split", "gain"]
+
+
+def test_get_learning_curve_metrics_delegates(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    job = _make_completed_job(job_store, sample_data_ref)
+    backend = MagicMock()
+    backend.load_model.return_value = "M"
+    backend.learning_curve_metrics.return_value = ["rmse", "mae"]
+
+    assert get_learning_curve_metrics(job, backend) == ["rmse", "mae"]
+
+
+def test_get_job_plot_delegates(job_store: JobStore, sample_data_ref: DataRef) -> None:
+    job = _make_completed_job(job_store, sample_data_ref)
+    backend = MagicMock()
+    backend.load_model.return_value = "M"
+    expected = PlotData(plotly_json='{"data": []}')
+    backend.plot.return_value = expected
+
+    assert get_job_plot(job, backend, "learning_curve") is expected
+    backend.plot.assert_called_once_with("M", "learning_curve")
+
+
+def test_get_job_plot_tuning_falls_back_to_file(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    """When backend.plot('tuning', ...) raises, load saved tuning_plot.json."""
+    job = _make_completed_job(job_store, sample_data_ref, job_type="tune")
+    plot_path = Path(job.model_path).parent / "tuning_plot.json"
+    plot_path.write_text('{"stored": true}', encoding="utf-8")
+
+    backend = MagicMock()
+    backend.load_model.return_value = "M"
+    backend.plot.side_effect = RuntimeError("study missing")
+
+    result = get_job_plot(job, backend, "tuning")
+
+    assert isinstance(result, PlotData)
+    assert result.plotly_json == '{"stored": true}'
+
+
+def test_get_job_plot_tuning_raises_when_no_fallback(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    job = _make_completed_job(job_store, sample_data_ref, job_type="tune")
+    backend = MagicMock()
+    backend.load_model.return_value = "M"
+    backend.plot.side_effect = RuntimeError("study missing")
+
+    with pytest.raises(RuntimeError, match="study missing"):
+        get_job_plot(job, backend, "tuning")
+
+
+def test_get_available_plots_appends_tuning_when_fallback_exists(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    job = _make_completed_job(job_store, sample_data_ref, job_type="tune")
+    plot_path = Path(job.model_path).parent / "tuning_plot.json"
+    plot_path.write_text("{}", encoding="utf-8")
+
+    backend = MagicMock()
+    backend.load_model.return_value = "M"
+    backend.available_plots.return_value = ["learning_curve"]
+
+    plots = get_available_plots(job, backend)
+
+    assert "tuning" in plots
+    assert "learning_curve" in plots
+
+
+def test_get_available_plots_does_not_duplicate_tuning(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    job = _make_completed_job(job_store, sample_data_ref, job_type="tune")
+    backend = MagicMock()
+    backend.load_model.return_value = "M"
+    backend.available_plots.return_value = ["tuning", "learning_curve"]
+
+    plots = get_available_plots(job, backend)
+
+    assert plots.count("tuning") == 1
+
+
+def test_get_available_plots_fit_job_does_not_add_tuning(
+    job_store: JobStore, sample_data_ref: DataRef
+) -> None:
+    job = _make_completed_job(job_store, sample_data_ref, job_type="fit")
+    plot_path = Path(job.model_path).parent / "tuning_plot.json"
+    plot_path.write_text("{}", encoding="utf-8")  # file exists but job_type=fit
+
+    backend = MagicMock()
+    backend.load_model.return_value = "M"
+    backend.available_plots.return_value = ["learning_curve"]
+
+    plots = get_available_plots(job, backend)
+
+    assert "tuning" not in plots
+
+
+# ---------------------------------------------------------------------------
+# Re-export back-compat — jobs.py must still expose the symbols
+# ---------------------------------------------------------------------------
+
+
+def test_jobs_module_reexports_dispatch_helpers() -> None:
+    """External imports from services.jobs must continue to work."""
+    from lizystudio.services import jobs as jobs_mod
+
+    for name in (
+        "load_job_model",
+        "get_metrics_table",
+        "get_split_summary",
+        "get_importance",
+        "get_importance_kinds",
+        "get_learning_curve_metrics",
+        "get_job_plot",
+        "get_available_plots",
+    ):
+        assert hasattr(jobs_mod, name), f"jobs module missing re-export: {name}"


### PR DESCRIPTION
## Summary

Phase 3 coupling refactor (docs/coupling-analysis.md A-7, proposal H-0070).

- Extract 8 adapter-dispatch helpers from the 751-line `services/jobs.py` God Module into a new `services/job_results.py`.
- Add an `OrderedDict` + `threading.Lock` LRU cache (`maxsize=8`) keyed by `(backend_name, model_path)` so a completed job's model is only deserialized once across `get_metrics_table` / `get_split_summary` / `get_importance` / `get_job_plot` etc.
- Wire `JobStore.delete()` to drop cached entries for the removed job so a reused path never returns a stale, pre-delete deserialized object.
- Keep all existing `from lizystudio.services.jobs import load_job_model` call sites (20+ tests, multiple `api/` modules) working via a back-compat re-export block at the bottom of `jobs.py`.

`jobs.py`: 751 → 695 lines. `job_results.py`: 143 lines, 99% covered.

## Invariants

- **INV-1:** `load_job_model` calls `backend.load_model` at most once for a given `(backend_name, model_path)` pair until the cache is invalidated — asserted by `test_load_job_model_caches_by_path_and_backend` and `test_load_job_model_cache_write_is_atomic_under_concurrent_reads`.
- **INV-2:** After `JobStore.delete(job_id)`, no entry for that job's `(backend_name, model_path)` remains in the cache — asserted by `test_job_store_delete_invalidates_model_cache`.
- **INV-3:** The cache never exceeds `_MODEL_CACHE_MAX` (8) entries — enforced by the `popitem(last=False)` eviction loop inside the same critical section as the write.

## Failure Paths Covered

- [x] No `model_path` set → raises `ValueError` (`test_load_job_model_raises_when_no_model_path`)
- [x] Cache hit → no adapter call (`test_load_job_model_caches_by_path_and_backend`)
- [x] Concurrent callers on same key → single load (`test_load_job_model_cache_write_is_atomic_under_concurrent_reads`)
- [x] Explicit invalidation → next call reloads (`test_clear_model_cache_forces_reload`)
- [x] `JobStore.delete` cascades into cache invalidation (`test_job_store_delete_invalidates_model_cache`)
- [x] `get_job_plot('tuning')` backend failure → falls back to `tuning_plot.json` file (`test_get_job_plot_tuning_falls_back_to_file`)

## Test plan

- [x] `uv run pytest` — 1138 passed (was 1136; +2 new regression tests net of merged cases)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src/lizystudio/` — clean
- [x] `pnpm check` — clean (no frontend changes)
- [x] Coverage: `job_results.py` 99%, `jobs.py` 66% (unchanged by this PR; the persistence-only remainder is covered by existing `test_jobs*.py` / regression suite)

Fixes items A-7 in `docs/coupling-analysis.md`. Does NOT close an existing issue (no #NNN issue was opened for A-7).