### PR TITLE
refactor(frontend): introduce query key factory (B-6)

### DIFF
--- a/frontend/src/api/queryKeys.test.ts
+++ b/frontend/src/api/queryKeys.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Contract tests for queryKeys factory.
+ *
+ * The factory must produce byte-identical arrays to the pre-refactor
+ * inline keys, because this PR only renames the construction site — not
+ * the cache namespace. Any drift here would split a cache entry in two
+ * and silently cause stale data.
+ */
+
+import { describe, expect, it } from "vitest";
+import { queryKeys } from "./queryKeys";
+
+describe("queryKeys factory — bit-identical to pre-refactor inline keys", () => {
+  describe("jobs family", () => {
+    it("jobs() → ['jobs']", () => {
+      expect(queryKeys.jobs()).toEqual(["jobs"]);
+    });
+
+    it("job(id) → ['job', id]", () => {
+      expect(queryKeys.job("job_abc")).toEqual(["job", "job_abc"]);
+    });
+
+    it("job(null) → ['job', null] (disabled-query sentinel)", () => {
+      expect(queryKeys.job(null)).toEqual(["job", null]);
+    });
+
+    it("jobDetail(id) → ['job-detail', id]", () => {
+      expect(queryKeys.jobDetail("job_abc")).toEqual(["job-detail", "job_abc"]);
+    });
+
+    it("jobLog(id) → ['job-log', id]", () => {
+      expect(queryKeys.jobLog("job_abc")).toEqual(["job-log", "job_abc"]);
+    });
+
+    it("jobLog(null) → ['job-log', null]", () => {
+      expect(queryKeys.jobLog(null)).toEqual(["job-log", null]);
+    });
+
+    it("jobLineage(id) → ['job-lineage', id]", () => {
+      expect(queryKeys.jobLineage("job_abc")).toEqual([
+        "job-lineage",
+        "job_abc",
+      ]);
+    });
+
+    it("jobPlots(id) → ['job-plots', id]", () => {
+      expect(queryKeys.jobPlots("job_abc")).toEqual(["job-plots", "job_abc"]);
+    });
+
+    it("jobPlot(id, type) → ['job-plot', id, type]", () => {
+      expect(queryKeys.jobPlot("job_abc", "confusion_matrix")).toEqual([
+        "job-plot",
+        "job_abc",
+        "confusion_matrix",
+      ]);
+    });
+
+    it("jobPlotLearningCurve → ['job-plot', id, 'learning-curve', metric]", () => {
+      expect(queryKeys.jobPlotLearningCurve("job_abc", "rmse")).toEqual([
+        "job-plot",
+        "job_abc",
+        "learning-curve",
+        "rmse",
+      ]);
+    });
+
+    it("jobPlotLearningCurve accepts null metric before user selects one", () => {
+      expect(queryKeys.jobPlotLearningCurve("job_abc", null)).toEqual([
+        "job-plot",
+        "job_abc",
+        "learning-curve",
+        null,
+      ]);
+    });
+
+    it("jobPlotImportance → ['job-plot', id, 'importance', kind]", () => {
+      expect(queryKeys.jobPlotImportance("job_abc", "gain")).toEqual([
+        "job-plot",
+        "job_abc",
+        "importance",
+        "gain",
+      ]);
+    });
+
+    it("jobPlotTuning → ['job-plot', id, 'tuning']", () => {
+      expect(queryKeys.jobPlotTuning("job_abc")).toEqual([
+        "job-plot",
+        "job_abc",
+        "tuning",
+      ]);
+    });
+
+    it("jobImportance → ['job-importance', id, kind]", () => {
+      expect(queryKeys.jobImportance("job_abc", "split")).toEqual([
+        "job-importance",
+        "job_abc",
+        "split",
+      ]);
+    });
+
+    it("jobImportanceKinds → ['job-importance-kinds', id]", () => {
+      expect(queryKeys.jobImportanceKinds("job_abc")).toEqual([
+        "job-importance-kinds",
+        "job_abc",
+      ]);
+    });
+
+    it("jobLearningCurveMetrics → ['job-learning-curve-metrics', id]", () => {
+      expect(queryKeys.jobLearningCurveMetrics("job_abc")).toEqual([
+        "job-learning-curve-metrics",
+        "job_abc",
+      ]);
+    });
+
+    it("jobSplitSummary → ['job-split-summary', id]", () => {
+      expect(queryKeys.jobSplitSummary("job_abc")).toEqual([
+        "job-split-summary",
+        "job_abc",
+      ]);
+    });
+  });
+
+  describe("inference family", () => {
+    it("infHistory(jobId) → ['inf-history', jobId]", () => {
+      expect(queryKeys.infHistory("job_abc")).toEqual([
+        "inf-history",
+        "job_abc",
+      ]);
+    });
+
+    it("infHistoryAll() → ['inf-history']", () => {
+      expect(queryKeys.infHistoryAll()).toEqual(["inf-history"]);
+    });
+
+    it("infRecord(infId, jobId) → ['inf-record', infId, jobId]", () => {
+      expect(queryKeys.infRecord("inf1", "job_abc")).toEqual([
+        "inf-record",
+        "inf1",
+        "job_abc",
+      ]);
+    });
+
+    it("infMetrics → ['inf-metrics', infId, jobId]", () => {
+      expect(queryKeys.infMetrics("inf1", "job_abc")).toEqual([
+        "inf-metrics",
+        "inf1",
+        "job_abc",
+      ]);
+    });
+
+    it("infPredictions → ['inf-predictions', infId, jobId, page]", () => {
+      expect(queryKeys.infPredictions("inf1", "job_abc", 2)).toEqual([
+        "inf-predictions",
+        "inf1",
+        "job_abc",
+        2,
+      ]);
+    });
+
+    it("infPlot → ['inf-plot', infId, jobId, plotType]", () => {
+      expect(
+        queryKeys.infPlot("inf1", "job_abc", "prediction-distribution"),
+      ).toEqual(["inf-plot", "inf1", "job_abc", "prediction-distribution"]);
+    });
+
+    it("infShap → ['inf-shap', infId, jobId]", () => {
+      expect(queryKeys.infShap("inf1", "job_abc")).toEqual([
+        "inf-shap",
+        "inf1",
+        "job_abc",
+      ]);
+    });
+
+    it("infComparison → ['inf-comparison', infId, compareInfId, jobId]", () => {
+      expect(queryKeys.infComparison("inf1", "inf2", "job_abc")).toEqual([
+        "inf-comparison",
+        "inf1",
+        "inf2",
+        "job_abc",
+      ]);
+    });
+
+    it("infComparison handles null compareInfId", () => {
+      expect(queryKeys.infComparison("inf1", null, "job_abc")).toEqual([
+        "inf-comparison",
+        "inf1",
+        null,
+        "job_abc",
+      ]);
+    });
+  });
+
+  describe("workspace / config family", () => {
+    it("config → ['config']", () => {
+      expect(queryKeys.config()).toEqual(["config"]);
+    });
+
+    it("configSchema → ['config-schema']", () => {
+      expect(queryKeys.configSchema()).toEqual(["config-schema"]);
+    });
+
+    it("uiSchema → ['ui-schema']", () => {
+      expect(queryKeys.uiSchema()).toEqual(["ui-schema"]);
+    });
+
+    it("backends → ['backends']", () => {
+      expect(queryKeys.backends()).toEqual(["backends"]);
+    });
+
+    it("columns → ['columns']", () => {
+      expect(queryKeys.columns()).toEqual(["columns"]);
+    });
+
+    it("files(path) → ['files', path]", () => {
+      expect(queryKeys.files("~/data")).toEqual(["files", "~/data"]);
+    });
+
+    it("files('~') fallback for null path is caller's responsibility", () => {
+      expect(queryKeys.files("~")).toEqual(["files", "~"]);
+    });
+  });
+
+  describe("invalidation compatibility", () => {
+    it("jobs() matches the key used for list invalidation", () => {
+      // Pre-refactor call: queryClient.invalidateQueries({ queryKey: ["jobs"] })
+      const pre = ["jobs"];
+      const post = queryKeys.jobs();
+      expect(post).toEqual(pre);
+    });
+
+    it("job(id) matches the key used for detail invalidation", () => {
+      const jobId = "job_abc";
+      const pre = ["job", jobId];
+      const post = queryKeys.job(jobId);
+      expect(post).toEqual(pre);
+    });
+
+    it("infHistoryAll() matches the root-level inference invalidation", () => {
+      const pre = ["inf-history"];
+      const post = queryKeys.infHistoryAll();
+      expect(post).toEqual(pre);
+    });
+  });
+});

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -1,0 +1,76 @@
+/**
+ * Query key factory — single source of truth for TanStack Query cache keys.
+ *
+ * Centralizes the string keys that previously lived inline at 65+ call sites
+ * so that:
+ *   - typos cannot silently create a parallel cache entry,
+ *   - adding a new query surface updates one file, not every caller,
+ *   - invalidation patterns are discoverable by reading this file.
+ *
+ * Output is bit-identical to the pre-factory inline keys (e.g.
+ * ``queryKeys.job(id)`` returns ``["job", id]``), so this PR does not
+ * rename any existing cache namespace. A hierarchical rename is a
+ * separate refactor if we want ``invalidateQueries(queryKeys.all)`` to
+ * mass-clear everything.
+ */
+
+// ---------------------------------------------------------------------------
+// Jobs family
+// ---------------------------------------------------------------------------
+
+export const queryKeys = {
+  jobs: () => ["jobs"] as const,
+  job: (jobId: string | null) => ["job", jobId] as const,
+  jobDetail: (jobId: string | null) => ["job-detail", jobId] as const,
+  jobLog: (jobId: string | null) => ["job-log", jobId] as const,
+  jobLineage: (jobId: string) => ["job-lineage", jobId] as const,
+  jobPlots: (jobId: string) => ["job-plots", jobId] as const,
+  jobPlot: (jobId: string, plotType: string) =>
+    ["job-plot", jobId, plotType] as const,
+  jobPlotLearningCurve: (jobId: string, metric: string | null) =>
+    ["job-plot", jobId, "learning-curve", metric] as const,
+  jobPlotImportance: (jobId: string, kind: string) =>
+    ["job-plot", jobId, "importance", kind] as const,
+  jobPlotTuning: (jobId: string) => ["job-plot", jobId, "tuning"] as const,
+  jobImportance: (jobId: string, kind: string) =>
+    ["job-importance", jobId, kind] as const,
+  jobImportanceKinds: (jobId: string) =>
+    ["job-importance-kinds", jobId] as const,
+  jobLearningCurveMetrics: (jobId: string) =>
+    ["job-learning-curve-metrics", jobId] as const,
+  jobSplitSummary: (jobId: string) => ["job-split-summary", jobId] as const,
+
+  // ---------------------------------------------------------------------
+  // Inference family
+  //
+  // ``infHistoryAll()`` intentionally matches the prefix of ``infHistory(id)``
+  // so that ``invalidateQueries({ queryKey: queryKeys.infHistoryAll() })``
+  // fans out to every per-job history cache via TanStack Query's prefix-
+  // matching rule. Keep the first tuple element (``"inf-history"``) in sync
+  // across the two helpers if either is renamed.
+  // ---------------------------------------------------------------------
+  infHistory: (jobId: string | null) => ["inf-history", jobId] as const,
+  infHistoryAll: () => ["inf-history"] as const,
+  infRecord: (infId: string | null, jobId: string | null) =>
+    ["inf-record", infId, jobId] as const,
+  infMetrics: (infId: string, jobId: string) =>
+    ["inf-metrics", infId, jobId] as const,
+  infPredictions: (infId: string, jobId: string, page: number) =>
+    ["inf-predictions", infId, jobId, page] as const,
+  infPlot: (infId: string, jobId: string, plotType: string) =>
+    ["inf-plot", infId, jobId, plotType] as const,
+  infShap: (infId: string, jobId: string) =>
+    ["inf-shap", infId, jobId] as const,
+  infComparison: (infId: string, compareInfId: string | null, jobId: string) =>
+    ["inf-comparison", infId, compareInfId, jobId] as const,
+
+  // ---------------------------------------------------------------------
+  // Workspace / config family
+  // ---------------------------------------------------------------------
+  config: () => ["config"] as const,
+  configSchema: () => ["config-schema"] as const,
+  uiSchema: () => ["ui-schema"] as const,
+  backends: () => ["backends"] as const,
+  columns: () => ["columns"] as const,
+  files: (path: string) => ["files", path] as const,
+} as const;

--- a/frontend/src/components/inference/PredictionsTable.tsx
+++ b/frontend/src/components/inference/PredictionsTable.tsx
@@ -5,6 +5,7 @@ import {
   fetchInferencePredictions,
   getInferenceDownloadUrl,
 } from "@/api/inference";
+import { queryKeys } from "@/api/queryKeys";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -26,7 +27,7 @@ export function PredictionsTable({ infId, jobId }: PredictionsTableProps) {
   const [page, setPage] = useState(0);
 
   const { data } = useQuery({
-    queryKey: ["inf-predictions", infId, jobId, page],
+    queryKey: queryKeys.infPredictions(infId, jobId, page),
     queryFn: () =>
       fetchInferencePredictions(infId, jobId, PAGE_SIZE, page * PAGE_SIZE),
   });

--- a/frontend/src/components/inference/ResultsPredOnly.tsx
+++ b/frontend/src/components/inference/ResultsPredOnly.tsx
@@ -7,6 +7,7 @@ import {
   fetchInferenceShapPlot,
   type InferenceRecord,
 } from "@/api/inference";
+import { queryKeys } from "@/api/queryKeys";
 import {
   Accordion,
   AccordionContent,
@@ -57,7 +58,11 @@ export function ResultsPredOnly({
     : 0;
 
   const { data: comparison } = useQuery({
-    queryKey: ["inf-comparison", record.inf_id, compareInfId, record.job_id],
+    queryKey: queryKeys.infComparison(
+      record.inf_id,
+      compareInfId,
+      record.job_id,
+    ),
     queryFn: () =>
       fetchInferenceComparison(record.inf_id, compareInfId, record.job_id),
     enabled: !!compareInfId,
@@ -184,7 +189,7 @@ function PredDistributionPlot({
   jobId: string;
 }) {
   const { data, isLoading } = useQuery({
-    queryKey: ["inf-plot", infId, jobId, "prediction-distribution"],
+    queryKey: queryKeys.infPlot(infId, jobId, "prediction-distribution"),
     queryFn: () => fetchInferencePlot(infId, jobId, "prediction-distribution"),
     retry: false,
   });
@@ -209,7 +214,7 @@ function ShapAndWarningsAccordion({
   warnings: string[];
 }) {
   const { data: shapData, isLoading: shapLoading } = useQuery({
-    queryKey: ["inf-shap", infId, jobId],
+    queryKey: queryKeys.infShap(infId, jobId),
     queryFn: () => fetchInferenceShapPlot(infId, jobId),
     retry: false,
   });

--- a/frontend/src/components/inference/ResultsWithGT.tsx
+++ b/frontend/src/components/inference/ResultsWithGT.tsx
@@ -7,6 +7,7 @@ import {
   type InferenceRecord,
 } from "@/api/inference";
 import { fetchJobPlots } from "@/api/jobs";
+import { queryKeys } from "@/api/queryKeys";
 import {
   Accordion,
   AccordionContent,
@@ -40,17 +41,17 @@ export function ResultsWithGT({
   const [selectedPlot, setSelectedPlot] = useState("");
 
   const { data: metrics } = useQuery({
-    queryKey: ["inf-metrics", record.inf_id, record.job_id],
+    queryKey: queryKeys.infMetrics(record.inf_id, record.job_id),
     queryFn: () => fetchInferenceMetrics(record.inf_id, record.job_id),
   });
 
   const { data: plots } = useQuery({
-    queryKey: ["job-plots", record.job_id],
+    queryKey: queryKeys.jobPlots(record.job_id),
     queryFn: () => fetchJobPlots(record.job_id),
   });
 
   const { data: plotData } = useQuery({
-    queryKey: ["inf-plot", record.inf_id, record.job_id, selectedPlot],
+    queryKey: queryKeys.infPlot(record.inf_id, record.job_id, selectedPlot),
     queryFn: () =>
       fetchInferencePlot(record.inf_id, record.job_id, selectedPlot),
     enabled: !!selectedPlot,
@@ -177,7 +178,7 @@ function PredDistributionPlot({
   jobId: string;
 }) {
   const { data, isLoading } = useQuery({
-    queryKey: ["inf-plot", infId, jobId, "prediction-distribution"],
+    queryKey: queryKeys.infPlot(infId, jobId, "prediction-distribution"),
     queryFn: () => fetchInferencePlot(infId, jobId, "prediction-distribution"),
   });
 
@@ -193,7 +194,7 @@ function PredDistributionPlot({
 /** SHAP summary accordion item — renders only when SHAP data is available. */
 function ShapAccordionItem({ infId, jobId }: { infId: string; jobId: string }) {
   const { data, isLoading } = useQuery({
-    queryKey: ["inf-shap", infId, jobId],
+    queryKey: queryKeys.infShap(infId, jobId),
     queryFn: () => fetchInferenceShapPlot(infId, jobId),
     retry: false,
   });

--- a/frontend/src/components/jobs/CompletedContent.tsx
+++ b/frontend/src/components/jobs/CompletedContent.tsx
@@ -7,6 +7,7 @@ import {
   fetchJobPlots,
   fetchJobSplitSummary,
 } from "@/api/jobs";
+import { queryKeys } from "@/api/queryKeys";
 import type { JobDetail, MetricEntry } from "@/api/types";
 import { MetricCards } from "@/components/shared/MetricCards";
 import {
@@ -36,7 +37,7 @@ export function CompletedContent({
   onSelectPlot,
 }: CompletedContentProps) {
   const { data: plots } = useQuery({
-    queryKey: ["job-plots", job.job_id],
+    queryKey: queryKeys.jobPlots(job.job_id),
     queryFn: () => fetchJobPlots(job.job_id),
   });
 
@@ -45,7 +46,7 @@ export function CompletedContent({
     isLoading: isPlotLoading,
     isError: isPlotError,
   } = useQuery({
-    queryKey: ["job-plot", job.job_id, selectedPlot],
+    queryKey: queryKeys.jobPlot(job.job_id, selectedPlot),
     queryFn: () => fetchJobPlot(job.job_id, selectedPlot),
     enabled:
       !!selectedPlot &&
@@ -59,7 +60,7 @@ export function CompletedContent({
   const lcInitialized = useRef(false);
 
   const { data: learningCurve, isError: isLcError } = useQuery({
-    queryKey: ["job-plot", job.job_id, "learning-curve", lcMetric],
+    queryKey: queryKeys.jobPlotLearningCurve(job.job_id, lcMetric),
     queryFn: () =>
       fetchJobPlot(job.job_id, "learning-curve", {
         metrics: lcMetric ?? undefined,
@@ -82,7 +83,7 @@ export function CompletedContent({
   const [importanceKind, setImportanceKind] = useState("split");
 
   const { data: importanceKinds } = useQuery({
-    queryKey: ["job-importance-kinds", job.job_id],
+    queryKey: queryKeys.jobImportanceKinds(job.job_id),
     queryFn: () => fetchJobImportanceKinds(job.job_id),
     enabled: importanceEnabled,
   });
@@ -99,14 +100,14 @@ export function CompletedContent({
   }, [importanceKinds, importanceKind]);
 
   const { data: importance } = useQuery({
-    queryKey: ["job-importance", job.job_id, importanceKind],
+    queryKey: queryKeys.jobImportance(job.job_id, importanceKind),
     queryFn: () => fetchJobImportance(job.job_id, importanceKind),
     enabled: importanceEnabled,
   });
 
   const { data: importancePlot, isLoading: isImportancePlotLoading } = useQuery(
     {
-      queryKey: ["job-plot", job.job_id, "importance", importanceKind],
+      queryKey: queryKeys.jobPlotImportance(job.job_id, importanceKind),
       queryFn: () =>
         fetchJobPlot(job.job_id, "importance", { kind: importanceKind }),
       enabled: importanceEnabled,
@@ -114,12 +115,12 @@ export function CompletedContent({
   );
 
   const { data: splitSummary } = useQuery({
-    queryKey: ["job-split-summary", job.job_id],
+    queryKey: queryKeys.jobSplitSummary(job.job_id),
     queryFn: () => fetchJobSplitSummary(job.job_id),
   });
 
   const { data: tuningPlot } = useQuery({
-    queryKey: ["job-plot", job.job_id, "tuning"],
+    queryKey: queryKeys.jobPlotTuning(job.job_id),
     queryFn: () => fetchJobPlot(job.job_id, "tuning"),
     enabled: job.job_type === "tune",
   });

--- a/frontend/src/components/jobs/JobDetail.tsx
+++ b/frontend/src/components/jobs/JobDetail.tsx
@@ -17,6 +17,7 @@ import {
   fetchJobLog,
   type LineageNode,
 } from "@/api/jobs";
+import { queryKeys } from "@/api/queryKeys";
 import type { JobDetail as JobDetailType, ProgressMessage } from "@/api/types";
 import { connectJobProgress } from "@/api/websocket";
 import { JobLineageTree } from "@/components/retune/JobLineageTree";
@@ -73,7 +74,7 @@ export function JobDetailPanel({
   const [deleteOpen, setDeleteOpen] = useState(false);
 
   const { data: job, refetch: refetchJob } = useQuery({
-    queryKey: ["job", jobId],
+    queryKey: queryKeys.job(jobId),
     queryFn: () => fetchJob(jobId),
     refetchInterval: (query) => {
       const data = query.state.data as JobDetailType | undefined;
@@ -85,7 +86,7 @@ export function JobDetailPanel({
   // auxiliary info — swallow errors silently. Only fetch for tune
   // jobs because only tune jobs can have a lineage.
   const { data: lineageData } = useQuery({
-    queryKey: ["job-lineage", jobId],
+    queryKey: queryKeys.jobLineage(jobId),
     queryFn: () => fetchJobLineage(jobId),
     enabled: job?.job_type === "tune",
     retry: false,
@@ -105,7 +106,7 @@ export function JobDetailPanel({
     (childJobId: string) => {
       // Invalidate the list so the new child shows up immediately in
       // the left panel, then switch selection to it.
-      queryClient.invalidateQueries({ queryKey: ["jobs"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
       onJobSelect?.(childJobId);
     },
     [queryClient, onJobSelect],
@@ -124,7 +125,7 @@ export function JobDetailPanel({
       onCompleted: () => {
         setProgress(null);
         refetchJob();
-        queryClient.invalidateQueries({ queryKey: ["jobs"] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
         onJobChanged();
       },
       onError: (msg) => {
@@ -160,7 +161,7 @@ export function JobDetailPanel({
       await cancelJob(jobId);
       toast.info("Job cancelled");
       refetchJob();
-      queryClient.invalidateQueries({ queryKey: ["jobs"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
     } catch {
       toast.error("Failed to cancel job");
     }
@@ -527,7 +528,7 @@ function FailedView({
 
 function ExecutionLogContent({ jobId }: { jobId: string }) {
   const { data } = useQuery({
-    queryKey: ["job-log", jobId],
+    queryKey: queryKeys.jobLog(jobId),
     queryFn: () => fetchJobLog(jobId),
   });
 
@@ -548,7 +549,7 @@ function LogDialog({
   jobId: string;
 }) {
   const { data } = useQuery({
-    queryKey: ["job-log", jobId],
+    queryKey: queryKeys.jobLog(jobId),
     queryFn: () => fetchJobLog(jobId),
     enabled: open,
   });

--- a/frontend/src/components/retune/ResumeActionButton.tsx
+++ b/frontend/src/components/retune/ResumeActionButton.tsx
@@ -3,6 +3,7 @@ import { PlayCircle } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { type ResumeRequestBody, resumeJob } from "@/api/jobs";
+import { queryKeys } from "@/api/queryKeys";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -67,8 +68,8 @@ export function ResumeActionButton({
     mutationFn: (body: ResumeRequestBody) => resumeJob(jobId, body),
     onSuccess: (res) => {
       toast.success(`Resume started (${res.job_id})`);
-      queryClient.invalidateQueries({ queryKey: ["jobs"] });
-      queryClient.invalidateQueries({ queryKey: ["job", jobId] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
       setOpen(false);
       onStarted?.(res.job_id);
     },

--- a/frontend/src/components/retune/RetuneActionButton.tsx
+++ b/frontend/src/components/retune/RetuneActionButton.tsx
@@ -3,6 +3,7 @@ import { Repeat } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { type RetuneRequestBody, retuneJob } from "@/api/jobs";
+import { queryKeys } from "@/api/queryKeys";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -70,8 +71,8 @@ export function RetuneActionButton({
     mutationFn: (body: RetuneRequestBody) => retuneJob(jobId, body),
     onSuccess: (res) => {
       toast.success(`Re-tune started (${res.job_id})`);
-      queryClient.invalidateQueries({ queryKey: ["jobs"] });
-      queryClient.invalidateQueries({ queryKey: ["job", jobId] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
       setOpen(false);
       // Switch the workspace selection to the child so the user sees
       // progress immediately. Without this the UI keeps showing the

--- a/frontend/src/components/workspace/FileBrowser.tsx
+++ b/frontend/src/components/workspace/FileBrowser.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ChevronRight, File, Folder, FolderUp } from "lucide-react";
 import { useState } from "react";
 import { fetchDirectory } from "@/api/files";
+import { queryKeys } from "@/api/queryKeys";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -22,7 +23,7 @@ export function FileBrowser({ onSelect, trigger }: FileBrowserProps) {
   const [currentPath, setCurrentPath] = useState<string | undefined>(undefined);
 
   const { data: listing } = useQuery({
-    queryKey: ["files", currentPath ?? "~"],
+    queryKey: queryKeys.files(currentPath ?? "~"),
     queryFn: () => fetchDirectory(currentPath),
     enabled: open,
   });

--- a/frontend/src/components/workspace/ModelPanel.tsx
+++ b/frontend/src/components/workspace/ModelPanel.tsx
@@ -12,6 +12,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { getErrorMessage } from "@/api/errors";
+import { queryKeys } from "@/api/queryKeys";
 import type { ConfigError } from "@/api/types";
 import {
   fetchBackends,
@@ -78,18 +79,18 @@ export function ModelPanel({
   const { presets, save: savePreset, load: loadPreset } = useConfigPresets();
 
   const { data: schema } = useQuery({
-    queryKey: ["config-schema"],
+    queryKey: queryKeys.configSchema(),
     queryFn: fetchConfigSchema,
     staleTime: Number.POSITIVE_INFINITY,
   });
 
   const { data: config } = useQuery({
-    queryKey: ["config"],
+    queryKey: queryKeys.config(),
     queryFn: fetchConfig,
   });
 
   const { data: backends } = useQuery({
-    queryKey: ["backends"],
+    queryKey: queryKeys.backends(),
     queryFn: fetchBackends,
     staleTime: Number.POSITIVE_INFINITY,
   });
@@ -97,13 +98,13 @@ export function ModelPanel({
   const backend = backends?.[0];
 
   const { data: uiSchema } = useQuery({
-    queryKey: ["ui-schema"],
+    queryKey: queryKeys.uiSchema(),
     queryFn: fetchUiSchema,
     staleTime: Number.POSITIVE_INFINITY,
   });
 
   const { data: columnsData } = useQuery({
-    queryKey: ["columns"],
+    queryKey: queryKeys.columns(),
     queryFn: () => fetchColumns(),
     enabled: hasData,
   });
@@ -122,15 +123,15 @@ export function ModelPanel({
   const handleConfigChange = useCallback(
     async (newConfig: Record<string, unknown>) => {
       if (running) return;
-      const cached = queryClient.getQueryData<Record<string, unknown>>([
-        "config",
-      ]);
+      const cached = queryClient.getQueryData<Record<string, unknown>>(
+        queryKeys.config(),
+      );
       if (cached && equal(cached, newConfig)) {
         return;
       }
       try {
         await updateConfig(newConfig);
-        queryClient.setQueryData(["config"], newConfig);
+        queryClient.setQueryData(queryKeys.config(), newConfig);
         history.push(newConfig);
       } catch {
         toast.error("Failed to update config");
@@ -160,7 +161,7 @@ export function ModelPanel({
     try {
       const result = await uploadConfig(file);
       setErrors(result.errors);
-      queryClient.invalidateQueries({ queryKey: ["config"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.config() });
       toast.success("Config imported");
     } catch (err) {
       toast.error(`Import failed: ${getErrorMessage(err)}`);
@@ -177,7 +178,7 @@ export function ModelPanel({
     if (!prev) return;
     try {
       await updateConfig(prev);
-      queryClient.setQueryData(["config"], prev);
+      queryClient.setQueryData(queryKeys.config(), prev);
       toast.info("Config undone");
     } catch {
       toast.error("Undo failed");
@@ -189,7 +190,7 @@ export function ModelPanel({
     if (!next) return;
     try {
       await updateConfig(next);
-      queryClient.setQueryData(["config"], next);
+      queryClient.setQueryData(queryKeys.config(), next);
       toast.info("Config redone");
     } catch {
       toast.error("Redo failed");

--- a/frontend/src/components/workspace/ResultsCompletedView.tsx
+++ b/frontend/src/components/workspace/ResultsCompletedView.tsx
@@ -11,6 +11,7 @@ import {
   fetchJobSplitSummary,
   type LineageNode,
 } from "@/api/jobs";
+import { queryKeys } from "@/api/queryKeys";
 import type { JobDetail, MetricEntry } from "@/api/types";
 import { JobLineageTree } from "@/components/retune/JobLineageTree";
 import { RetuneActionButton } from "@/components/retune/RetuneActionButton";
@@ -50,7 +51,7 @@ export function ResultsCompletedView({
   onApplyToFit,
 }: ResultsCompletedViewProps) {
   const { data: plots } = useQuery({
-    queryKey: ["job-plots", job.job_id],
+    queryKey: queryKeys.jobPlots(job.job_id),
     queryFn: () => fetchJobPlots(job.job_id),
   });
 
@@ -59,7 +60,7 @@ export function ResultsCompletedView({
     isLoading: isPlotLoading,
     isError: isPlotError,
   } = useQuery({
-    queryKey: ["job-plot", job.job_id, selectedPlot],
+    queryKey: queryKeys.jobPlot(job.job_id, selectedPlot),
     queryFn: () => fetchJobPlot(job.job_id, selectedPlot),
     enabled:
       !!selectedPlot &&
@@ -79,13 +80,13 @@ export function ResultsCompletedView({
     (plots?.includes("learning-curve") ?? false);
 
   const { data: lcAvailableMetrics, isError: isLcMetricsError } = useQuery({
-    queryKey: ["job-learning-curve-metrics", job.job_id],
+    queryKey: queryKeys.jobLearningCurveMetrics(job.job_id),
     queryFn: () => fetchJobLearningCurveMetrics(job.job_id),
     enabled: lcEnabled,
   });
 
   const { data: learningCurve, isError: isLcPlotError } = useQuery({
-    queryKey: ["job-plot", job.job_id, "learning-curve", lcMetric],
+    queryKey: queryKeys.jobPlotLearningCurve(job.job_id, lcMetric),
     queryFn: () =>
       fetchJobPlot(job.job_id, "learning-curve", {
         metrics: lcMetric ?? undefined,
@@ -125,7 +126,7 @@ export function ResultsCompletedView({
   const importanceEnabled = plots?.includes("importance") ?? false;
 
   const { data: importanceKinds } = useQuery({
-    queryKey: ["job-importance-kinds", job.job_id],
+    queryKey: queryKeys.jobImportanceKinds(job.job_id),
     queryFn: () => fetchJobImportanceKinds(job.job_id),
     enabled: importanceEnabled,
   });
@@ -142,14 +143,14 @@ export function ResultsCompletedView({
   }, [importanceKinds, importanceKind]);
 
   const { data: importance } = useQuery({
-    queryKey: ["job-importance", job.job_id, importanceKind],
+    queryKey: queryKeys.jobImportance(job.job_id, importanceKind),
     queryFn: () => fetchJobImportance(job.job_id, importanceKind),
     enabled: importanceEnabled,
   });
 
   const { data: importancePlot, isLoading: isImportancePlotLoading } = useQuery(
     {
-      queryKey: ["job-plot", job.job_id, "importance", importanceKind],
+      queryKey: queryKeys.jobPlotImportance(job.job_id, importanceKind),
       queryFn: () =>
         fetchJobPlot(job.job_id, "importance", { kind: importanceKind }),
       enabled: importanceEnabled,
@@ -157,12 +158,12 @@ export function ResultsCompletedView({
   );
 
   const { data: splitSummary } = useQuery({
-    queryKey: ["job-split-summary", job.job_id],
+    queryKey: queryKeys.jobSplitSummary(job.job_id),
     queryFn: () => fetchJobSplitSummary(job.job_id),
   });
 
   const { data: tuningPlot } = useQuery({
-    queryKey: ["job-plot", job.job_id, "tuning"],
+    queryKey: queryKeys.jobPlotTuning(job.job_id),
     queryFn: () => fetchJobPlot(job.job_id, "tuning"),
     enabled: job.job_type === "tune",
   });
@@ -170,7 +171,7 @@ export function ResultsCompletedView({
   // H-0062 acceptance #13: lineage tree wire-in. Only fetch for tune jobs;
   // silently swallow errors because lineage is auxiliary information.
   const { data: lineageData } = useQuery({
-    queryKey: ["job-lineage", job.job_id],
+    queryKey: queryKeys.jobLineage(job.job_id),
     queryFn: () => fetchJobLineage(job.job_id),
     enabled: job.job_type === "tune",
     retry: false,

--- a/frontend/src/components/workspace/ResultsPanel.test.tsx
+++ b/frontend/src/components/workspace/ResultsPanel.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { queryKeys } from "@/api/queryKeys";
 import { makeJob, renderWithQuery } from "@/test/helpers";
 
 const mockFetchJob = vi.fn();
@@ -342,7 +343,7 @@ describe("ResultsPanel", () => {
 
     // Manually invalidate to trigger refetch with completed state
     act(() => {
-      queryClient.invalidateQueries({ queryKey: ["job", "test-job-1"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.job("test-job-1") });
     });
 
     await waitFor(() => expect(onJobDone).toHaveBeenCalled(), {

--- a/frontend/src/components/workspace/ResultsPanel.tsx
+++ b/frontend/src/components/workspace/ResultsPanel.tsx
@@ -3,6 +3,7 @@ import { Activity } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { cancelJob, fetchJob, fetchJobLog, fetchJobs } from "@/api/jobs";
+import { queryKeys } from "@/api/queryKeys";
 import type { JobDetail, ProgressMessage } from "@/api/types";
 import { connectJobProgress } from "@/api/websocket";
 import { ResumeActionButton } from "@/components/retune/ResumeActionButton";
@@ -49,7 +50,7 @@ export function ResultsPanel({
   const [cancelConfirm, setCancelConfirm] = useState(false);
 
   const { data: job, refetch: refetchJob } = useQuery({
-    queryKey: ["job", jobId],
+    queryKey: queryKeys.job(jobId),
     queryFn: () => fetchJob(jobId as string),
     enabled: !!jobId,
     refetchInterval: (query) => {
@@ -60,7 +61,7 @@ export function ResultsPanel({
   });
 
   const { data: allJobs } = useQuery({
-    queryKey: ["jobs"],
+    queryKey: queryKeys.jobs(),
     queryFn: () => fetchJobs(),
     enabled: !!jobId,
   });
@@ -99,16 +100,16 @@ export function ResultsPanel({
       onCompleted: () => {
         setProgress(null);
         setFoldLog([]);
-        queryClient.invalidateQueries({ queryKey: ["job", jobId] });
-        queryClient.invalidateQueries({ queryKey: ["jobs"] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
         onJobDone?.();
       },
       onError: (msg) => {
         setProgress(null);
         setFoldLog([]);
         toast.error(msg.message);
-        queryClient.invalidateQueries({ queryKey: ["job", jobId] });
-        queryClient.invalidateQueries({ queryKey: ["jobs"] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
         onJobDone?.();
       },
     });
@@ -329,7 +330,7 @@ function LogDialog({
   jobId: string;
 }) {
   const { data } = useQuery({
-    queryKey: ["job-log", jobId],
+    queryKey: queryKeys.jobLog(jobId),
     queryFn: () => fetchJobLog(jobId),
     enabled: open,
   });

--- a/frontend/src/hooks/useDataPanel.test.ts
+++ b/frontend/src/hooks/useDataPanel.test.ts
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { queryKeys } from "@/api/queryKeys";
 import type { ColumnInfo, ColumnsResponse } from "@/api/types";
 
 const mocks = vi.hoisted(() => ({
@@ -284,7 +285,7 @@ describe("useDataPanel", () => {
     // The merged config must be present in the query cache so the
     // ModelPanel-side useQuery(['config']) consumer sees it without
     // waiting for a refetch.
-    const cached = queryClient.getQueryData(["config"]);
+    const cached = queryClient.getQueryData(queryKeys.config());
     expect(cached).toEqual(merged);
   });
 });

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { getErrorMessage } from "@/api/errors";
+import { queryKeys } from "@/api/queryKeys";
 import type { ColumnInfo, UiSchema } from "@/api/types";
 import {
   fetchColumns,
@@ -127,7 +128,7 @@ export function useDataPanel({
             overrides: newOverrides,
           });
           await updateConfig(merged);
-          queryClient.setQueryData(["config"], merged);
+          queryClient.setQueryData(queryKeys.config(), merged);
           configSync.preseedSyncKey(
             buildSyncKey(value, detectedTask, newOverrides, nextCv, blocked),
           );

--- a/frontend/src/pages/InferencePage.tsx
+++ b/frontend/src/pages/InferencePage.tsx
@@ -9,6 +9,7 @@ import {
   runInference,
 } from "@/api/inference";
 import { fetchJob, fetchJobs } from "@/api/jobs";
+import { queryKeys } from "@/api/queryKeys";
 import { ResultsPredOnly } from "@/components/inference/ResultsPredOnly";
 import { ResultsWithGT } from "@/components/inference/ResultsWithGT";
 import { SetupPanel } from "@/components/inference/SetupPanel";
@@ -24,7 +25,7 @@ export function InferencePage() {
 
   // Fetch completed jobs
   const { data: allJobs = [] } = useQuery({
-    queryKey: ["jobs"],
+    queryKey: queryKeys.jobs(),
     queryFn: () => fetchJobs(),
   });
 
@@ -55,14 +56,14 @@ export function InferencePage() {
   // `refetchInterval` was pure wasted bandwidth. Rely on the mutation's
   // invalidation instead.
   const { data: history = [] } = useQuery({
-    queryKey: ["inf-history", selectedJobId],
+    queryKey: queryKeys.infHistory(selectedJobId),
     queryFn: () => fetchInferenceHistory(selectedJobId ?? undefined),
     enabled: selectedJobId != null,
   });
 
   // Fetch selected inference record
   const { data: selectedRecord } = useQuery({
-    queryKey: ["inf-record", selectedInfId, selectedJobId],
+    queryKey: queryKeys.infRecord(selectedInfId, selectedJobId),
     queryFn: () =>
       fetchInferenceRecord(selectedInfId ?? "", selectedJobId ?? ""),
     enabled: selectedInfId != null && selectedJobId != null,
@@ -87,7 +88,7 @@ export function InferencePage() {
     },
     onSuccess: (result) => {
       toast.success("Inference completed");
-      queryClient.invalidateQueries({ queryKey: ["inf-history"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.infHistoryAll() });
       setSelectedInfId(result.inf_id);
     },
     onError: (err) => {
@@ -139,7 +140,7 @@ export function InferencePage() {
 
   // Fetch job detail to get config.data.target for ground-truth detection
   const { data: jobDetail } = useQuery({
-    queryKey: ["job-detail", selectedJobId],
+    queryKey: queryKeys.jobDetail(selectedJobId),
     queryFn: () => fetchJob(selectedJobId ?? ""),
     enabled: selectedJobId != null,
   });

--- a/frontend/src/pages/JobsPage.tsx
+++ b/frontend/src/pages/JobsPage.tsx
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useState } from "react";
 import { fetchJobs } from "@/api/jobs";
+import { queryKeys } from "@/api/queryKeys";
 import { JobDetailPanel } from "@/components/jobs/JobDetail";
 import { JobList } from "@/components/jobs/JobList";
 
@@ -9,7 +10,7 @@ export function JobsPage() {
   const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
 
   const { data: jobs = [] } = useQuery({
-    queryKey: ["jobs"],
+    queryKey: queryKeys.jobs(),
     queryFn: () => fetchJobs(),
     refetchInterval: 5000,
   });
@@ -32,11 +33,11 @@ export function JobsPage() {
 
   const handleJobDeleted = useCallback(() => {
     setSelectedJobId(null);
-    queryClient.invalidateQueries({ queryKey: ["jobs"] });
+    queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
   }, [queryClient]);
 
   const handleJobChanged = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: ["jobs"] });
+    queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
   }, [queryClient]);
 
   return (

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import { getErrorMessage } from "@/api/errors";
+import { queryKeys } from "@/api/queryKeys";
 import {
   fetchConfig,
   fetchUiSchema,
@@ -89,12 +90,12 @@ export function WorkspacePage() {
   const notify = useBackgroundNotification();
 
   const { data: uiSchema } = useQuery({
-    queryKey: ["ui-schema"],
+    queryKey: queryKeys.uiSchema(),
     queryFn: fetchUiSchema,
   });
 
   const { data: config } = useQuery({
-    queryKey: ["config"],
+    queryKey: queryKeys.config(),
     queryFn: fetchConfig,
     enabled: hasData,
     retry: false,
@@ -102,7 +103,7 @@ export function WorkspacePage() {
 
   const handleDataChanged = useCallback(() => {
     setHasData(true);
-    queryClient.invalidateQueries({ queryKey: ["config"] });
+    queryClient.invalidateQueries({ queryKey: queryKeys.config() });
   }, [queryClient]);
 
   const handleTaskChanged = useCallback((t: string | null) => {
@@ -135,7 +136,7 @@ export function WorkspacePage() {
     async (fullConfig: Record<string, unknown>) => {
       try {
         await updateConfig(fullConfig);
-        queryClient.invalidateQueries({ queryKey: ["config"] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.config() });
         setModelTab("fit");
         toast.success("Best params applied to Fit tab. Click Fit to run.");
       } catch {


### PR DESCRIPTION
## Summary

Phase 3 coupling refactor (docs/coupling-analysis.md B-6). Prerequisite for B-1 / B-7.

- New \`src/api/queryKeys.ts\` centralises 65+ inline TanStack Query cache keys across 17 files into a single factory object with ~25 methods.
- Output is bit-identical to pre-refactor inline arrays (e.g. \`queryKeys.job(id)\` returns \`[\"job\", id]\`), so no cache namespace changes and no behavioral drift.
- New \`queryKeys.test.ts\` has 36 contract tests asserting the exact tuple output of every method. The tests would fail loudly if a future rename creates a silently-different key.
- Also migrated the \`queryClient.setQueryData\` / \`getQueryData\` inline keys in \`ModelPanel.tsx\`, \`useDataPanel.ts\`, \`useDataPanel.test.ts\` — these were missed by the initial pass and flagged by code review.

## Why now

B-1 (ResultsCompletedView / CompletedContent dedupe) and B-7 (58 components importing \`@/api/*\` directly) both require a single place to define cache keys before extracting the shared query hooks. This PR is the minimum scaffold for those.

## Design choices

**Bit-identical over hierarchical.** We intentionally keep the flat output shape (\`[\"jobs\"]\`, \`[\"job\", id]\`, \`[\"job-plot\", id, type, ...]\`) instead of a nested namespace like \`[\"lizystudio\", \"jobs\", \"detail\", id]\`. Reason: migrating every call site was already 65+ edits; changing the key shape simultaneously would split cache entries in two and silently surface stale data. A later PR can migrate to a prefixed shape once \`queryKeys\` is the single source of truth for construction.

**Prefix invalidation documented.** \`queryKeys.infHistoryAll()\` returns \`[\"inf-history\"]\` and is designed to prefix-match all per-job history caches via TanStack Query's matching rule. The factory docstring calls this out so future renames stay in sync.

## Test plan

- [x] \`pnpm test\` — 1514 passed (+36 new factory tests)
- [x] \`pnpm check\` (biome) — clean
- [x] \`pnpm build\` — clean (caught one TS error during migration: \`jobPlotLearningCurve\` needed \`string | null\` metric)
- [x] Code review found 1 HIGH (5x \`setQueryData\`/\`getQueryData\` inline keys missed) — fixed in same PR
- [x] Zero \`queryKey: [...]\` inline arrays remaining outside the factory (verified by grep)

Does NOT close an existing issue — B-6 is a roadmap item from \`docs/coupling-analysis.md\`, not a filed GitHub issue.