### PR TITLE
refactor(frontend): extract useJobResultData hook + JobResultsBody (B-1)

### DIFF
--- a/frontend/src/components/jobs/CompletedContent.tsx
+++ b/frontend/src/components/jobs/CompletedContent.tsx
@@ -1,29 +1,7 @@
-import { useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  fetchJobImportance,
-  fetchJobImportanceKinds,
-  fetchJobPlot,
-  fetchJobPlots,
-  fetchJobSplitSummary,
-} from "@/api/jobs";
-import { queryKeys } from "@/api/queryKeys";
-import type { JobDetail, MetricEntry } from "@/api/types";
-import { MetricCards } from "@/components/shared/MetricCards";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
-import { FoldDetailsSection } from "@/components/workspace/FoldDetailsSection";
-import { PlotSection } from "@/components/workspace/PlotSection";
-import { ScoreSection } from "@/components/workspace/ScoreSection";
-import {
-  TrialResultsAccordionItem,
-  TuneTrialsSection,
-} from "@/components/workspace/TuneTrialsSection";
-import { pivotMetrics } from "@/lib/metrics";
+import { useEffect } from "react";
+import type { JobDetail } from "@/api/types";
+import { JobResultsBody } from "@/components/shared/JobResultsBody";
+import { useJobResultData } from "@/hooks/useJobResultData";
 
 interface CompletedContentProps {
   job: JobDetail;
@@ -36,96 +14,9 @@ export function CompletedContent({
   selectedPlot,
   onSelectPlot,
 }: CompletedContentProps) {
-  const { data: plots } = useQuery({
-    queryKey: queryKeys.jobPlots(job.job_id),
-    queryFn: () => fetchJobPlots(job.job_id),
-  });
+  const data = useJobResultData({ job, selectedPlot });
+  const { plots } = data;
 
-  const {
-    data: plotData,
-    isLoading: isPlotLoading,
-    isError: isPlotError,
-  } = useQuery({
-    queryKey: queryKeys.jobPlot(job.job_id, selectedPlot),
-    queryFn: () => fetchJobPlot(job.job_id, selectedPlot),
-    enabled:
-      !!selectedPlot &&
-      selectedPlot !== "learning-curve" &&
-      selectedPlot !== "importance",
-    retry: false,
-  });
-
-  // Learning curve metric filter (H-0051) — single-select
-  const [lcMetric, setLcMetric] = useState<string | null>(null);
-  const lcInitialized = useRef(false);
-
-  const { data: learningCurve, isError: isLcError } = useQuery({
-    queryKey: queryKeys.jobPlotLearningCurve(job.job_id, lcMetric),
-    queryFn: () =>
-      fetchJobPlot(job.job_id, "learning-curve", {
-        metrics: lcMetric ?? undefined,
-      }),
-    enabled:
-      selectedPlot === "learning-curve" &&
-      (plots?.includes("learning-curve") ?? false),
-    retry: false,
-  });
-
-  // If LC filter fails (e.g. feval-only metric), fall back to unfiltered view
-  useEffect(() => {
-    if (isLcError && lcMetric !== null) {
-      setLcMetric(null);
-    }
-  }, [isLcError, lcMetric]);
-
-  // Importance kind selector (H-0052)
-  const importanceEnabled = plots?.includes("importance") ?? false;
-  const [importanceKind, setImportanceKind] = useState("split");
-
-  const { data: importanceKinds } = useQuery({
-    queryKey: queryKeys.jobImportanceKinds(job.job_id),
-    queryFn: () => fetchJobImportanceKinds(job.job_id),
-    enabled: importanceEnabled,
-  });
-
-  // Sync initial kind with backend response when it differs
-  useEffect(() => {
-    if (
-      importanceKinds &&
-      importanceKinds.length > 0 &&
-      !importanceKinds.includes(importanceKind)
-    ) {
-      setImportanceKind(importanceKinds[0]);
-    }
-  }, [importanceKinds, importanceKind]);
-
-  const { data: importance } = useQuery({
-    queryKey: queryKeys.jobImportance(job.job_id, importanceKind),
-    queryFn: () => fetchJobImportance(job.job_id, importanceKind),
-    enabled: importanceEnabled,
-  });
-
-  const { data: importancePlot, isLoading: isImportancePlotLoading } = useQuery(
-    {
-      queryKey: queryKeys.jobPlotImportance(job.job_id, importanceKind),
-      queryFn: () =>
-        fetchJobPlot(job.job_id, "importance", { kind: importanceKind }),
-      enabled: importanceEnabled,
-    },
-  );
-
-  const { data: splitSummary } = useQuery({
-    queryKey: queryKeys.jobSplitSummary(job.job_id),
-    queryFn: () => fetchJobSplitSummary(job.job_id),
-  });
-
-  const { data: tuningPlot } = useQuery({
-    queryKey: queryKeys.jobPlotTuning(job.job_id),
-    queryFn: () => fetchJobPlot(job.job_id, "tuning"),
-    enabled: job.job_type === "tune",
-  });
-
-  // Auto-select first plot (learning-curve first)
   useEffect(() => {
     if (plots && plots.length > 0 && !selectedPlot) {
       const first = plots.find((p) => p !== "tuning");
@@ -133,133 +24,13 @@ export function CompletedContent({
     }
   }, [plots, selectedPlot, onSelectPlot]);
 
-  const fitResult = job.fit_result;
-  const tuneResult = job.tune_result;
-  const metrics = fitResult?.metrics
-    ? pivotMetrics(fitResult.metrics as Record<string, unknown>)
-    : undefined;
-  const hasFolds = fitResult != null && fitResult.fold_count > 1;
-
-  const evalConfig = (job.config?.evaluation as Record<string, unknown>) ?? {};
-
-  // LC filter uses model.params.metric (LightGBM internal metric names)
-  // which match the subplot titles in the learning curve plot.
-  const modelConfig = (job.config?.model as Record<string, unknown>) ?? {};
-  const lcAvailableMetrics = useMemo(() => {
-    const m = (modelConfig.params as Record<string, unknown>)?.metric;
-    if (Array.isArray(m)) return m as string[];
-    if (typeof m === "string") return [m];
-    return [];
-  }, [modelConfig.params]);
-
-  // Initialize LC filter to first metric (single-select).
-  // When only 1 metric exists, lcMetric stays null (no filter needed).
-  useEffect(() => {
-    if (lcInitialized.current) return;
-    if (lcAvailableMetrics.length > 1) {
-      lcInitialized.current = true;
-      setLcMetric(lcAvailableMetrics[0]);
-    } else if (lcAvailableMetrics.length >= 1) {
-      lcInitialized.current = true;
-    }
-  }, [lcAvailableMetrics]);
-
-  const annotateMetric = (name: string): string => {
-    if (name === "precision_at_k") {
-      // Look for MetricEntry dict form in evaluation.metrics
-      const entries = Array.isArray(evalConfig.metrics)
-        ? (evalConfig.metrics as MetricEntry[])
-        : [];
-      for (const entry of entries) {
-        if (
-          typeof entry === "object" &&
-          entry !== null &&
-          "precision_at_k" in entry
-        ) {
-          const k = entry.precision_at_k?.k;
-          return typeof k === "number" ? `${name}@${k}` : name;
-        }
-      }
-      // Fallback: check evaluation config directly
-      const k = evalConfig.precision_at_k;
-      return typeof k === "number" ? `${name}@${k}` : name;
-    }
-    return name;
-  };
-
   return (
-    <>
-      {/* Tune: Optimization History + Best Params */}
-      {tuneResult && (
-        <TuneTrialsSection
-          tuneResult={tuneResult}
-          tuningPlot={tuningPlot}
-          job={job}
-        />
-      )}
-
-      {/* KPI Summary Cards (H-0050) */}
-      {metrics && (
-        <MetricCards
-          metrics={metrics}
-          hasFolds={hasFolds}
-          annotateMetric={annotateMetric}
-        />
-      )}
-
-      {/* Plots (including Learning Curve with filter H-0051, Importance with kind selector H-0052) */}
-      {plots && plots.length > 0 && (
-        <PlotSection
-          plots={plots}
-          selectedPlot={selectedPlot}
-          onSelectPlot={onSelectPlot}
-          plotData={plotData}
-          learningCurve={learningCurve}
-          isLoading={
-            selectedPlot === "importance"
-              ? isImportancePlotLoading
-              : isPlotLoading
-          }
-          isError={isPlotError}
-          lcMetric={lcMetric}
-          onLcMetricChange={setLcMetric}
-          availableEvalMetrics={lcAvailableMetrics}
-          importanceKinds={importanceKinds}
-          selectedImportanceKind={importanceKind}
-          onImportanceKindChange={setImportanceKind}
-          importanceData={importance}
-          importancePlot={importancePlot}
-        />
-      )}
-
-      {/* Accordion sections */}
-      <Accordion type="multiple">
-        {tuneResult && <TrialResultsAccordionItem tuneResult={tuneResult} />}
-
-        {/* Score table (detailed fold view) inside accordion (H-0050) */}
-        {metrics && (
-          <AccordionItem value="score-details">
-            <AccordionTrigger className="text-sm">
-              View Details
-            </AccordionTrigger>
-            <AccordionContent>
-              <ScoreSection
-                metrics={metrics}
-                hasFolds={hasFolds}
-                annotateMetric={annotateMetric}
-              />
-            </AccordionContent>
-          </AccordionItem>
-        )}
-
-        {fitResult && (
-          <FoldDetailsSection
-            fitResult={fitResult}
-            hasFolds={hasFolds}
-            splitSummary={splitSummary}
-          />
-        )}
-      </Accordion>
-    </>
+    <JobResultsBody
+      job={job}
+      selectedPlot={selectedPlot}
+      onSelectPlot={onSelectPlot}
+      data={data}
+      showScoreAccordion
+    />
   );
 }

--- a/frontend/src/components/shared/JobResultsBody.tsx
+++ b/frontend/src/components/shared/JobResultsBody.tsx
@@ -1,0 +1,146 @@
+/**
+ * Shared "completed job" results renderer used by both the Workspace
+ * ResultsCompletedView and the Jobs page CompletedContent. Renders tune
+ * results, KPI cards, plots, and the accordion. Consumers supply their
+ * own header/footer chrome and can opt in to a detailed score accordion
+ * item that is only shown on the Jobs page today.
+ *
+ * Depends on useJobResultData for the actual data — this component is
+ * pure presentation.
+ */
+
+import type { JobDetail } from "@/api/types";
+import { MetricCards } from "@/components/shared/MetricCards";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { FoldDetailsSection } from "@/components/workspace/FoldDetailsSection";
+import { PlotSection } from "@/components/workspace/PlotSection";
+import { ScoreSection } from "@/components/workspace/ScoreSection";
+import {
+  TrialResultsAccordionItem,
+  TuneTrialsSection,
+} from "@/components/workspace/TuneTrialsSection";
+import type { UseJobResultData } from "@/hooks/useJobResultData";
+
+export interface JobResultsBodyProps {
+  job: JobDetail;
+  selectedPlot: string;
+  onSelectPlot: (p: string) => void;
+  data: UseJobResultData;
+  /** When true, inserts a "View Details" accordion item with the detailed
+   * score breakdown — used by the Jobs page only. */
+  showScoreAccordion?: boolean;
+  /** Optional Apply-to-Fit hook for TuneTrialsSection (Workspace only). */
+  onApplyToFit?: (params: Record<string, unknown>) => void;
+}
+
+export function JobResultsBody({
+  job,
+  selectedPlot,
+  onSelectPlot,
+  data,
+  showScoreAccordion = false,
+  onApplyToFit,
+}: JobResultsBodyProps) {
+  const {
+    plots,
+    plotData,
+    isPlotLoading,
+    isPlotError,
+    lcMetric,
+    setLcMetric,
+    availableEvalMetrics,
+    learningCurve,
+    isLcError,
+    importanceKind,
+    setImportanceKind,
+    importanceKinds,
+    importance,
+    importancePlot,
+    isImportancePlotLoading,
+    splitSummary,
+    tuningPlot,
+    metrics,
+    hasFolds,
+    annotateMetric,
+  } = data;
+
+  const tuneResult = job.tune_result;
+  const fitResult = job.fit_result;
+
+  return (
+    <>
+      {tuneResult && (
+        <TuneTrialsSection
+          tuneResult={tuneResult}
+          tuningPlot={tuningPlot}
+          job={job}
+          onApplyToFit={onApplyToFit}
+        />
+      )}
+
+      {metrics && (
+        <MetricCards
+          metrics={metrics}
+          hasFolds={hasFolds}
+          annotateMetric={annotateMetric}
+        />
+      )}
+
+      {plots && plots.length > 0 && (
+        <PlotSection
+          plots={plots}
+          selectedPlot={selectedPlot}
+          onSelectPlot={onSelectPlot}
+          plotData={plotData}
+          learningCurve={learningCurve}
+          isLoading={
+            selectedPlot === "importance"
+              ? isImportancePlotLoading
+              : isPlotLoading
+          }
+          isError={selectedPlot === "learning-curve" ? isLcError : isPlotError}
+          lcMetric={lcMetric}
+          onLcMetricChange={setLcMetric}
+          availableEvalMetrics={availableEvalMetrics}
+          importanceKinds={importanceKinds}
+          selectedImportanceKind={importanceKind}
+          onImportanceKindChange={setImportanceKind}
+          importanceData={importance}
+          importancePlot={importancePlot}
+        />
+      )}
+
+      <Accordion type="multiple">
+        {tuneResult && <TrialResultsAccordionItem tuneResult={tuneResult} />}
+
+        {showScoreAccordion && metrics && (
+          <AccordionItem value="score-details">
+            <AccordionTrigger className="text-sm">
+              View Details
+            </AccordionTrigger>
+            <AccordionContent>
+              <ScoreSection
+                metrics={metrics}
+                hasFolds={hasFolds}
+                annotateMetric={annotateMetric}
+              />
+            </AccordionContent>
+          </AccordionItem>
+        )}
+
+        {fitResult && (
+          <FoldDetailsSection
+            fitResult={fitResult}
+            hasFolds={hasFolds}
+            splitSummary={splitSummary}
+          />
+        )}
+      </Accordion>
+    </>
+  );
+}

--- a/frontend/src/components/workspace/ResultsCompletedView.tsx
+++ b/frontend/src/components/workspace/ResultsCompletedView.tsx
@@ -1,32 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { Download } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
-import {
-  fetchJobImportance,
-  fetchJobImportanceKinds,
-  fetchJobLearningCurveMetrics,
-  fetchJobLineage,
-  fetchJobPlot,
-  fetchJobPlots,
-  fetchJobSplitSummary,
-  type LineageNode,
-} from "@/api/jobs";
+import { useEffect } from "react";
+import { fetchJobLineage, type LineageNode } from "@/api/jobs";
 import { queryKeys } from "@/api/queryKeys";
-import type { JobDetail, MetricEntry } from "@/api/types";
+import type { JobDetail } from "@/api/types";
 import { JobLineageTree } from "@/components/retune/JobLineageTree";
 import { RetuneActionButton } from "@/components/retune/RetuneActionButton";
-import { MetricCards } from "@/components/shared/MetricCards";
-import { Accordion } from "@/components/ui/accordion";
+import { JobResultsBody } from "@/components/shared/JobResultsBody";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { pivotMetrics } from "@/lib/metrics";
+import { useJobResultData } from "@/hooks/useJobResultData";
+import { defaultRetuneTrials } from "@/lib/job-config";
 import { ConfigDiffBadge } from "./ConfigDiffBadge";
-import { FoldDetailsSection } from "./FoldDetailsSection";
-import { PlotSection } from "./PlotSection";
-import {
-  TrialResultsAccordionItem,
-  TuneTrialsSection,
-} from "./TuneTrialsSection";
 
 interface ResultsCompletedViewProps {
   job: JobDetail;
@@ -50,123 +35,8 @@ export function ResultsCompletedView({
   onJobStarted,
   onApplyToFit,
 }: ResultsCompletedViewProps) {
-  const { data: plots } = useQuery({
-    queryKey: queryKeys.jobPlots(job.job_id),
-    queryFn: () => fetchJobPlots(job.job_id),
-  });
-
-  const {
-    data: plotData,
-    isLoading: isPlotLoading,
-    isError: isPlotError,
-  } = useQuery({
-    queryKey: queryKeys.jobPlot(job.job_id, selectedPlot),
-    queryFn: () => fetchJobPlot(job.job_id, selectedPlot),
-    enabled:
-      !!selectedPlot &&
-      selectedPlot !== "learning-curve" &&
-      selectedPlot !== "importance",
-    retry: false,
-  });
-
-  // Learning curve metrics filter (H-0034).
-  // The available list comes from the backend — it reflects the actual
-  // eval_history keys, not the user-requested metric config, which can
-  // diverge when lizyml routes some metrics through feval callables.
-  const [lcMetric, setLcMetric] = useState<string | null>(null);
-  const lcInitialized = useRef(false);
-  const lcEnabled =
-    selectedPlot === "learning-curve" &&
-    (plots?.includes("learning-curve") ?? false);
-
-  const { data: lcAvailableMetrics, isError: isLcMetricsError } = useQuery({
-    queryKey: queryKeys.jobLearningCurveMetrics(job.job_id),
-    queryFn: () => fetchJobLearningCurveMetrics(job.job_id),
-    enabled: lcEnabled,
-  });
-
-  const { data: learningCurve, isError: isLcPlotError } = useQuery({
-    queryKey: queryKeys.jobPlotLearningCurve(job.job_id, lcMetric),
-    queryFn: () =>
-      fetchJobPlot(job.job_id, "learning-curve", {
-        metrics: lcMetric ?? undefined,
-      }),
-    enabled: lcEnabled,
-    retry: false,
-  });
-
-  const isLcError = isLcMetricsError || isLcPlotError;
-
-  // When the user switches to a different job within the same mounted
-  // component instance, any previously selected lcMetric must be
-  // cleared before the new job's metrics list arrives — otherwise the
-  // plot query fires with a name that isn't valid for the new job.
-  const lastJobIdRef = useRef(job.job_id);
-  useEffect(() => {
-    if (lastJobIdRef.current !== job.job_id) {
-      lastJobIdRef.current = job.job_id;
-      setLcMetric(null);
-      lcInitialized.current = false;
-    }
-  }, [job.job_id]);
-
-  // If the persisted lcMetric is no longer a valid option (e.g. legacy
-  // state from a previous job), drop it so PlotSection falls back to the
-  // first available metric. LC fetch errors are left to PlotSection to
-  // surface — silently resetting state masked real bugs (H-0061).
-  useEffect(() => {
-    if (!lcAvailableMetrics) return;
-    if (lcMetric !== null && !lcAvailableMetrics.includes(lcMetric)) {
-      setLcMetric(null);
-      lcInitialized.current = false;
-    }
-  }, [lcAvailableMetrics, lcMetric]);
-
-  const [importanceKind, setImportanceKind] = useState("split");
-  const importanceEnabled = plots?.includes("importance") ?? false;
-
-  const { data: importanceKinds } = useQuery({
-    queryKey: queryKeys.jobImportanceKinds(job.job_id),
-    queryFn: () => fetchJobImportanceKinds(job.job_id),
-    enabled: importanceEnabled,
-  });
-
-  // Sync initial kind with backend response when it differs
-  useEffect(() => {
-    if (
-      importanceKinds &&
-      importanceKinds.length > 0 &&
-      !importanceKinds.includes(importanceKind)
-    ) {
-      setImportanceKind(importanceKinds[0]);
-    }
-  }, [importanceKinds, importanceKind]);
-
-  const { data: importance } = useQuery({
-    queryKey: queryKeys.jobImportance(job.job_id, importanceKind),
-    queryFn: () => fetchJobImportance(job.job_id, importanceKind),
-    enabled: importanceEnabled,
-  });
-
-  const { data: importancePlot, isLoading: isImportancePlotLoading } = useQuery(
-    {
-      queryKey: queryKeys.jobPlotImportance(job.job_id, importanceKind),
-      queryFn: () =>
-        fetchJobPlot(job.job_id, "importance", { kind: importanceKind }),
-      enabled: importanceEnabled,
-    },
-  );
-
-  const { data: splitSummary } = useQuery({
-    queryKey: queryKeys.jobSplitSummary(job.job_id),
-    queryFn: () => fetchJobSplitSummary(job.job_id),
-  });
-
-  const { data: tuningPlot } = useQuery({
-    queryKey: queryKeys.jobPlotTuning(job.job_id),
-    queryFn: () => fetchJobPlot(job.job_id, "tuning"),
-    enabled: job.job_type === "tune",
-  });
+  const data = useJobResultData({ job, selectedPlot });
+  const { plots, metrics } = data;
 
   // H-0062 acceptance #13: lineage tree wire-in. Only fetch for tune jobs;
   // silently swallow errors because lineage is auxiliary information.
@@ -188,49 +58,7 @@ export function ResultsCompletedView({
     }
   }, [plots, selectedPlot, onSelectPlot]);
 
-  const fitResult = job.fit_result;
   const tuneResult = job.tune_result;
-  const metrics = fitResult?.metrics
-    ? pivotMetrics(fitResult.metrics as Record<string, unknown>)
-    : undefined;
-
-  // evalConfig is used by annotateMetric() for precision_at_k k-value display.
-  const evalConfig = (job.config?.evaluation as Record<string, unknown>) ?? {};
-
-  // Initialize LC filter to first metric (avoid cramped subplots).
-  // When only 1 metric exists, lcMetric stays null (no filter needed).
-  useEffect(() => {
-    if (lcInitialized.current) return;
-    if (!lcAvailableMetrics) return;
-    if (lcAvailableMetrics.length > 1) {
-      lcInitialized.current = true;
-      setLcMetric(lcAvailableMetrics[0]);
-    } else if (lcAvailableMetrics.length >= 1) {
-      lcInitialized.current = true;
-    }
-  }, [lcAvailableMetrics]);
-
-  const annotateMetric = (name: string): string => {
-    if (name === "precision_at_k") {
-      // Look for MetricEntry dict form in evaluation.metrics
-      const entries = Array.isArray(evalConfig.metrics)
-        ? (evalConfig.metrics as MetricEntry[])
-        : [];
-      for (const entry of entries) {
-        if (
-          typeof entry === "object" &&
-          entry !== null &&
-          "precision_at_k" in entry
-        ) {
-          const k = entry.precision_at_k?.k;
-          return typeof k === "number" ? `${name}@${k}` : name;
-        }
-      }
-    }
-    return name;
-  };
-  const hasFolds = fitResult != null && fitResult.fold_count > 1;
-
   const primaryMetric = tuneResult
     ? `${tuneResult.metric_name}: ${Number(tuneResult.best_score ?? 0).toFixed(4)}`
     : metrics
@@ -264,7 +92,7 @@ export function ResultsCompletedView({
           {job.job_type === "tune" && tuneResult && (
             <RetuneActionButton
               jobId={job.job_id}
-              defaultNTrials={_defaultRetuneTrials(job)}
+              defaultNTrials={defaultRetuneTrials(job)}
               onStarted={onJobStarted}
             />
           )}
@@ -291,75 +119,13 @@ export function ResultsCompletedView({
         </div>
       )}
 
-      {/* Tune results first: Optimization History -> Best Params -> Apply to Fit */}
-      {tuneResult && (
-        <TuneTrialsSection
-          tuneResult={tuneResult}
-          tuningPlot={tuningPlot}
-          job={job}
-          onApplyToFit={onApplyToFit}
-        />
-      )}
-
-      {/* KPI Summary Cards (IS + OOS + Std) */}
-      {metrics && (
-        <MetricCards
-          metrics={metrics}
-          hasFolds={hasFolds}
-          annotateMetric={annotateMetric}
-        />
-      )}
-
-      {/* Learning Curve + Plot selector */}
-      {plots && plots.length > 0 && (
-        <PlotSection
-          plots={plots}
-          selectedPlot={selectedPlot}
-          onSelectPlot={onSelectPlot}
-          plotData={plotData}
-          learningCurve={learningCurve}
-          isLoading={
-            selectedPlot === "importance"
-              ? isImportancePlotLoading
-              : isPlotLoading
-          }
-          isError={selectedPlot === "learning-curve" ? isLcError : isPlotError}
-          lcMetric={lcMetric}
-          onLcMetricChange={setLcMetric}
-          availableEvalMetrics={lcAvailableMetrics ?? []}
-          importanceKinds={importanceKinds}
-          selectedImportanceKind={importanceKind}
-          onImportanceKindChange={setImportanceKind}
-          importanceData={importance}
-          importancePlot={importancePlot}
-        />
-      )}
-
-      {/* Accordion sections */}
-      <Accordion type="multiple">
-        {tuneResult && <TrialResultsAccordionItem tuneResult={tuneResult} />}
-
-        {fitResult && (
-          <FoldDetailsSection
-            fitResult={fitResult}
-            hasFolds={hasFolds}
-            splitSummary={splitSummary}
-          />
-        )}
-      </Accordion>
+      <JobResultsBody
+        job={job}
+        selectedPlot={selectedPlot}
+        onSelectPlot={onSelectPlot}
+        data={data}
+        onApplyToFit={onApplyToFit}
+      />
     </div>
   );
-}
-
-/** H-0062: pick a sensible default n_trials for the Re-tune dialog. */
-function _defaultRetuneTrials(job: JobDetail): number {
-  const config = job.config as Record<string, unknown> | undefined;
-  const tuning = config?.tuning as Record<string, unknown> | undefined;
-  const optuna = tuning?.optuna as Record<string, unknown> | undefined;
-  const params = optuna?.params as Record<string, unknown> | undefined;
-  const raw = params?.n_trials;
-  if (typeof raw === "number" && raw > 0) {
-    return raw;
-  }
-  return 50;
 }

--- a/frontend/src/hooks/useJobResultData.test.ts
+++ b/frontend/src/hooks/useJobResultData.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for useJobResultData — the shared data-fetching hook that backs
+ * both Workspace's ResultsCompletedView and Jobs page's CompletedContent.
+ *
+ * The hook must:
+ *   - Fire the 8 plot/score/importance/tuning queries in a single place
+ *     so the two call sites cannot drift.
+ *   - Fetch LC metrics from the backend endpoint (the Workspace source of
+ *     truth), not from client-side config parsing (the Jobs page shortcut).
+ *   - Expose derived data (pivoted metrics, fold count, annotateMetric)
+ *     so consumers render identically.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { JobDetail, MetricEntry } from "@/api/types";
+import { useJobResultData } from "./useJobResultData";
+
+vi.mock("@/api/jobs", () => ({
+  fetchJobPlots: vi.fn().mockResolvedValue([]),
+  fetchJobPlot: vi.fn().mockResolvedValue({ plotly_json: "{}" }),
+  fetchJobImportance: vi.fn().mockResolvedValue({}),
+  fetchJobImportanceKinds: vi.fn().mockResolvedValue([]),
+  fetchJobLearningCurveMetrics: vi.fn().mockResolvedValue([]),
+  fetchJobSplitSummary: vi.fn().mockResolvedValue([]),
+}));
+
+import {
+  fetchJobImportance,
+  fetchJobImportanceKinds,
+  fetchJobLearningCurveMetrics,
+  fetchJobPlot,
+  fetchJobPlots,
+  fetchJobSplitSummary,
+} from "@/api/jobs";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return createElement(QueryClientProvider, { client: qc }, children);
+}
+
+function makeJob(overrides: Partial<JobDetail> = {}): JobDetail {
+  return {
+    job_id: "j1",
+    job_type: "fit",
+    status: "completed",
+    backend_name: "lizyml",
+    model_name: "LightGBM",
+    config: { model: { name: "LightGBM" } },
+    data_ref: {
+      source_type: "path",
+      path: "/data.csv",
+      filename: "data.csv",
+      fingerprint: "abc",
+      shape: [10, 3],
+    },
+    created_at: "2026-01-01T00:00:00Z",
+    completed_at: "2026-01-01T00:01:00Z",
+    error: null,
+    primary_score: 0.9,
+    fit_result: null,
+    tune_result: null,
+    model_path: null,
+    parent_job_id: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useJobResultData", () => {
+  // -------------------------------------------------------------------------
+  // Basic query fan-out
+  // -------------------------------------------------------------------------
+  it("fetches plots, split summary on mount", async () => {
+    const job = makeJob();
+    renderHook(() => useJobResultData({ job, selectedPlot: "" }), { wrapper });
+
+    await waitFor(() => {
+      expect(fetchJobPlots).toHaveBeenCalledWith("j1");
+      expect(fetchJobSplitSummary).toHaveBeenCalledWith("j1");
+    });
+  });
+
+  it("does NOT fetch the generic plot when selectedPlot is empty", async () => {
+    const job = makeJob();
+    renderHook(() => useJobResultData({ job, selectedPlot: "" }), { wrapper });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fetchJobPlot).not.toHaveBeenCalledWith("j1", "", expect.anything());
+  });
+
+  it("fetches generic plot when a non-LC / non-importance plot is selected", async () => {
+    const job = makeJob();
+    renderHook(
+      () => useJobResultData({ job, selectedPlot: "confusion_matrix" }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(fetchJobPlot).toHaveBeenCalledWith("j1", "confusion_matrix");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Learning curve
+  // -------------------------------------------------------------------------
+  it("fetches LC metrics from backend when LC plot is selected and available", async () => {
+    const job = makeJob();
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["learning-curve"]);
+    vi.mocked(fetchJobLearningCurveMetrics).mockResolvedValueOnce([
+      "rmse",
+      "mae",
+    ]);
+
+    renderHook(
+      () => useJobResultData({ job, selectedPlot: "learning-curve" }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(fetchJobLearningCurveMetrics).toHaveBeenCalledWith("j1");
+    });
+  });
+
+  it("does NOT fetch LC metrics when LC plot is not available", async () => {
+    const job = makeJob();
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce([]);
+
+    renderHook(
+      () => useJobResultData({ job, selectedPlot: "learning-curve" }),
+      { wrapper },
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fetchJobLearningCurveMetrics).not.toHaveBeenCalled();
+  });
+
+  it("auto-initializes lcMetric to the first backend-reported metric", async () => {
+    const job = makeJob();
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["learning-curve"]);
+    vi.mocked(fetchJobLearningCurveMetrics).mockResolvedValueOnce([
+      "rmse",
+      "mae",
+    ]);
+
+    const { result } = renderHook(
+      () => useJobResultData({ job, selectedPlot: "learning-curve" }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.lcMetric).toBe("rmse");
+    });
+  });
+
+  it("keeps lcMetric null when only a single metric is reported", async () => {
+    const job = makeJob();
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["learning-curve"]);
+    vi.mocked(fetchJobLearningCurveMetrics).mockResolvedValueOnce(["rmse"]);
+
+    const { result } = renderHook(
+      () => useJobResultData({ job, selectedPlot: "learning-curve" }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.availableEvalMetrics).toEqual(["rmse"]);
+    });
+    // Single metric → no filter needed, stays null
+    expect(result.current.lcMetric).toBeNull();
+  });
+
+  it("resets lcMetric when job_id changes", async () => {
+    const job1 = makeJob({ job_id: "j1" });
+    const job2 = makeJob({ job_id: "j2" });
+    vi.mocked(fetchJobPlots).mockResolvedValue(["learning-curve"]);
+    vi.mocked(fetchJobLearningCurveMetrics)
+      .mockResolvedValueOnce(["rmse", "mae"])
+      .mockResolvedValueOnce(["rmse", "mae"]);
+
+    const { result, rerender } = renderHook(
+      ({ job }) => useJobResultData({ job, selectedPlot: "learning-curve" }),
+      { wrapper, initialProps: { job: job1 } },
+    );
+
+    await waitFor(() => expect(result.current.lcMetric).toBe("rmse"));
+
+    act(() => {
+      result.current.setLcMetric("mae");
+    });
+    expect(result.current.lcMetric).toBe("mae");
+
+    rerender({ job: job2 });
+
+    // After job change, lcMetric resets before new metrics arrive
+    await waitFor(() => {
+      expect(result.current.lcMetric).not.toBe("mae");
+    });
+  });
+
+  it("drops a stale lcMetric when backend list no longer contains it", async () => {
+    const job = makeJob();
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["learning-curve"]);
+    vi.mocked(fetchJobLearningCurveMetrics).mockResolvedValueOnce([
+      "rmse",
+      "mae",
+    ]);
+
+    const { result } = renderHook(
+      () => useJobResultData({ job, selectedPlot: "learning-curve" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.lcMetric).toBe("rmse"));
+
+    act(() => {
+      result.current.setLcMetric("not_a_real_metric");
+    });
+
+    await waitFor(() => {
+      expect(result.current.lcMetric).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Importance
+  // -------------------------------------------------------------------------
+  it("fetches importance kinds and plot when importance plot is available", async () => {
+    const job = makeJob();
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["importance"]);
+    vi.mocked(fetchJobImportanceKinds).mockResolvedValueOnce(["split", "gain"]);
+
+    renderHook(() => useJobResultData({ job, selectedPlot: "" }), { wrapper });
+
+    await waitFor(() => {
+      expect(fetchJobImportanceKinds).toHaveBeenCalledWith("j1");
+      expect(fetchJobImportance).toHaveBeenCalledWith("j1", "split");
+      expect(fetchJobPlot).toHaveBeenCalledWith("j1", "importance", {
+        kind: "split",
+      });
+    });
+  });
+
+  it("syncs importanceKind when backend list doesn't include current value", async () => {
+    const job = makeJob();
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["importance"]);
+    vi.mocked(fetchJobImportanceKinds).mockResolvedValueOnce(["gain", "shap"]);
+
+    const { result } = renderHook(
+      () => useJobResultData({ job, selectedPlot: "" }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.importanceKind).toBe("gain");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Tuning plot (H-0070 fallback)
+  // -------------------------------------------------------------------------
+  it("fetches tuning plot only for tune jobs", async () => {
+    const tuneJob = makeJob({ job_type: "tune" });
+    renderHook(() => useJobResultData({ job: tuneJob, selectedPlot: "" }), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(fetchJobPlot).toHaveBeenCalledWith("j1", "tuning");
+    });
+  });
+
+  it("does NOT fetch tuning plot for fit jobs", async () => {
+    const fitJob = makeJob({ job_type: "fit" });
+    renderHook(() => useJobResultData({ job: fitJob, selectedPlot: "" }), {
+      wrapper,
+    });
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(fetchJobPlot).not.toHaveBeenCalledWith("j1", "tuning");
+  });
+
+  // -------------------------------------------------------------------------
+  // Derived data
+  // -------------------------------------------------------------------------
+  it("exposes annotateMetric that injects precision_at_k from config", () => {
+    const job = makeJob({
+      config: {
+        evaluation: {
+          metrics: [{ precision_at_k: { k: 10 } } as MetricEntry],
+        },
+      },
+    });
+    const { result } = renderHook(
+      () => useJobResultData({ job, selectedPlot: "" }),
+      { wrapper },
+    );
+    expect(result.current.annotateMetric("precision_at_k")).toBe(
+      "precision_at_k@10",
+    );
+    expect(result.current.annotateMetric("rmse")).toBe("rmse");
+  });
+
+  it("exposes hasFolds derived from fit_result.fold_count", () => {
+    const job = makeJob({
+      fit_result: {
+        metrics: {},
+        fold_count: 3,
+        params: [],
+      },
+    });
+    const { result } = renderHook(
+      () => useJobResultData({ job, selectedPlot: "" }),
+      { wrapper },
+    );
+    expect(result.current.hasFolds).toBe(true);
+  });
+
+  it("hasFolds is false for single-fold jobs", () => {
+    const job = makeJob({
+      fit_result: {
+        metrics: {},
+        fold_count: 1,
+        params: [],
+      },
+    });
+    const { result } = renderHook(
+      () => useJobResultData({ job, selectedPlot: "" }),
+      { wrapper },
+    );
+    expect(result.current.hasFolds).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useJobResultData.ts
+++ b/frontend/src/hooks/useJobResultData.ts
@@ -1,0 +1,267 @@
+/**
+ * Shared data-fetching hook for the "completed job" results panel.
+ *
+ * Previously ResultsCompletedView (Workspace) and CompletedContent (Jobs)
+ * each owned 8 near-identical useQuery blocks plus the derived state
+ * (lcMetric / importanceKind auto-init, metric parsing, annotation).
+ * That duplication already drifted — the Jobs page parsed LC metrics
+ * from ``config.model.params.metric`` while Workspace hit the
+ * ``/api/jobs/{id}/learning-curve-metrics`` endpoint.
+ *
+ * This hook collapses the two into one source of truth and standardises
+ * on the backend endpoint for LC metrics. The two consumers now differ
+ * only in presentation chrome (header/lineage on Workspace, ScoreSection
+ * accordion on Jobs).
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
+import {
+  fetchJobImportance,
+  fetchJobImportanceKinds,
+  fetchJobLearningCurveMetrics,
+  fetchJobPlot,
+  fetchJobPlots,
+  fetchJobSplitSummary,
+} from "@/api/jobs";
+import { queryKeys } from "@/api/queryKeys";
+import type {
+  ImportanceResponse,
+  JobDetail,
+  MetricEntry,
+  PlotResponse,
+  SplitSummaryRow,
+} from "@/api/types";
+import { pivotMetrics } from "@/lib/metrics";
+
+export interface UseJobResultDataParams {
+  job: JobDetail;
+  selectedPlot: string;
+}
+
+export interface UseJobResultData {
+  /** Server-reported list of available plot types for this job. */
+  plots: string[] | undefined;
+  /** Generic plot data (everything except learning-curve / importance). */
+  plotData: PlotResponse | undefined;
+  isPlotLoading: boolean;
+  isPlotError: boolean;
+  /** Learning-curve metric filter state + list from backend. */
+  lcMetric: string | null;
+  setLcMetric: (m: string | null) => void;
+  availableEvalMetrics: string[];
+  learningCurve: PlotResponse | undefined;
+  isLcError: boolean;
+  /** Importance kind state + data. */
+  importanceKind: string;
+  setImportanceKind: (kind: string) => void;
+  importanceKinds: string[] | undefined;
+  importance: ImportanceResponse | undefined;
+  importancePlot: PlotResponse | undefined;
+  isImportancePlotLoading: boolean;
+  /** Fold split summary. */
+  splitSummary: SplitSummaryRow[] | undefined;
+  /** Tuning plot (only populated for tune jobs). */
+  tuningPlot: PlotResponse | undefined;
+  /** Pivoted metrics for MetricCards / ScoreSection. */
+  metrics: Record<string, Record<string, number>> | undefined;
+  hasFolds: boolean;
+  /** Injects precision_at_k k-value into metric display names. */
+  annotateMetric: (name: string) => string;
+}
+
+export function useJobResultData({
+  job,
+  selectedPlot,
+}: UseJobResultDataParams): UseJobResultData {
+  // --------------------------------------------------------------------
+  // Plot availability + generic plot
+  // --------------------------------------------------------------------
+  const { data: plots } = useQuery({
+    queryKey: queryKeys.jobPlots(job.job_id),
+    queryFn: () => fetchJobPlots(job.job_id),
+  });
+
+  const {
+    data: plotData,
+    isLoading: isPlotLoading,
+    isError: isPlotError,
+  } = useQuery({
+    queryKey: queryKeys.jobPlot(job.job_id, selectedPlot),
+    queryFn: () => fetchJobPlot(job.job_id, selectedPlot),
+    enabled:
+      !!selectedPlot &&
+      selectedPlot !== "learning-curve" &&
+      selectedPlot !== "importance",
+    retry: false,
+  });
+
+  // --------------------------------------------------------------------
+  // Learning curve — backend is the source of truth for available metrics.
+  // (The Jobs page used to parse ``config.model.params.metric``; that
+  // shortcut diverged from eval_history reality when LightGBM routed
+  // some metrics through feval callables.)
+  // --------------------------------------------------------------------
+  const [lcMetric, setLcMetric] = useState<string | null>(null);
+  const lcInitialized = useRef(false);
+  const lcEnabled =
+    selectedPlot === "learning-curve" &&
+    (plots?.includes("learning-curve") ?? false);
+
+  const { data: lcAvailableMetricsData, isError: isLcMetricsError } = useQuery({
+    queryKey: queryKeys.jobLearningCurveMetrics(job.job_id),
+    queryFn: () => fetchJobLearningCurveMetrics(job.job_id),
+    enabled: lcEnabled,
+  });
+  const availableEvalMetrics = lcAvailableMetricsData ?? [];
+
+  const { data: learningCurve, isError: isLcPlotError } = useQuery({
+    queryKey: queryKeys.jobPlotLearningCurve(job.job_id, lcMetric),
+    queryFn: () =>
+      fetchJobPlot(job.job_id, "learning-curve", {
+        metrics: lcMetric ?? undefined,
+      }),
+    enabled: lcEnabled,
+    retry: false,
+  });
+  const isLcError = isLcMetricsError || isLcPlotError;
+
+  // When the consumer hot-swaps the job prop, pre-existing lcMetric
+  // state must be cleared before the new job's metric list arrives —
+  // otherwise the plot query fires with a name that isn't valid for
+  // the new job.
+  const lastJobIdRef = useRef(job.job_id);
+  useEffect(() => {
+    if (lastJobIdRef.current !== job.job_id) {
+      lastJobIdRef.current = job.job_id;
+      setLcMetric(null);
+      lcInitialized.current = false;
+    }
+  }, [job.job_id]);
+
+  // Drop stale lcMetric when backend no longer lists it.
+  useEffect(() => {
+    if (!lcAvailableMetricsData) return;
+    if (lcMetric !== null && !lcAvailableMetricsData.includes(lcMetric)) {
+      setLcMetric(null);
+      lcInitialized.current = false;
+    }
+  }, [lcAvailableMetricsData, lcMetric]);
+
+  // First-run init: default to first metric when multiple exist.
+  useEffect(() => {
+    if (lcInitialized.current) return;
+    if (!lcAvailableMetricsData) return;
+    if (lcAvailableMetricsData.length > 1) {
+      lcInitialized.current = true;
+      setLcMetric(lcAvailableMetricsData[0]);
+    } else if (lcAvailableMetricsData.length >= 1) {
+      lcInitialized.current = true;
+    }
+  }, [lcAvailableMetricsData]);
+
+  // --------------------------------------------------------------------
+  // Importance
+  // --------------------------------------------------------------------
+  const importanceEnabled = plots?.includes("importance") ?? false;
+  const [importanceKind, setImportanceKind] = useState("split");
+
+  const { data: importanceKinds } = useQuery({
+    queryKey: queryKeys.jobImportanceKinds(job.job_id),
+    queryFn: () => fetchJobImportanceKinds(job.job_id),
+    enabled: importanceEnabled,
+  });
+
+  useEffect(() => {
+    if (
+      importanceKinds &&
+      importanceKinds.length > 0 &&
+      !importanceKinds.includes(importanceKind)
+    ) {
+      setImportanceKind(importanceKinds[0]);
+    }
+  }, [importanceKinds, importanceKind]);
+
+  const { data: importance } = useQuery({
+    queryKey: queryKeys.jobImportance(job.job_id, importanceKind),
+    queryFn: () => fetchJobImportance(job.job_id, importanceKind),
+    enabled: importanceEnabled,
+  });
+
+  const { data: importancePlot, isLoading: isImportancePlotLoading } = useQuery(
+    {
+      queryKey: queryKeys.jobPlotImportance(job.job_id, importanceKind),
+      queryFn: () =>
+        fetchJobPlot(job.job_id, "importance", { kind: importanceKind }),
+      enabled: importanceEnabled,
+    },
+  );
+
+  // --------------------------------------------------------------------
+  // Split summary + tuning plot
+  // --------------------------------------------------------------------
+  const { data: splitSummary } = useQuery({
+    queryKey: queryKeys.jobSplitSummary(job.job_id),
+    queryFn: () => fetchJobSplitSummary(job.job_id),
+  });
+
+  const { data: tuningPlot } = useQuery({
+    queryKey: queryKeys.jobPlotTuning(job.job_id),
+    queryFn: () => fetchJobPlot(job.job_id, "tuning"),
+    enabled: job.job_type === "tune",
+  });
+
+  // --------------------------------------------------------------------
+  // Derived data
+  // --------------------------------------------------------------------
+  const fitResult = job.fit_result;
+  const metrics = fitResult?.metrics
+    ? pivotMetrics(fitResult.metrics as Record<string, unknown>)
+    : undefined;
+  const hasFolds = fitResult != null && fitResult.fold_count > 1;
+
+  const evalConfig = (job.config?.evaluation as Record<string, unknown>) ?? {};
+  const annotateMetric = (name: string): string => {
+    if (name === "precision_at_k") {
+      const entries = Array.isArray(evalConfig.metrics)
+        ? (evalConfig.metrics as MetricEntry[])
+        : [];
+      for (const entry of entries) {
+        if (
+          typeof entry === "object" &&
+          entry !== null &&
+          "precision_at_k" in entry
+        ) {
+          const k = entry.precision_at_k?.k;
+          return typeof k === "number" ? `${name}@${k}` : name;
+        }
+      }
+      const k = evalConfig.precision_at_k;
+      return typeof k === "number" ? `${name}@${k}` : name;
+    }
+    return name;
+  };
+
+  return {
+    plots,
+    plotData,
+    isPlotLoading,
+    isPlotError,
+    lcMetric,
+    setLcMetric,
+    availableEvalMetrics,
+    learningCurve,
+    isLcError,
+    importanceKind,
+    setImportanceKind,
+    importanceKinds,
+    importance,
+    importancePlot,
+    isImportancePlotLoading,
+    splitSummary,
+    tuningPlot,
+    metrics,
+    hasFolds,
+    annotateMetric,
+  };
+}

--- a/frontend/src/lib/job-config.ts
+++ b/frontend/src/lib/job-config.ts
@@ -1,0 +1,30 @@
+/**
+ * Helpers for poking at the deeply-nested ``tuning.optuna.params``
+ * section of a job config. Previously each Re-tune UI site duplicated
+ * the same 5-level optional-chain (``config?.tuning?.optuna?.params?.
+ * n_trials``), which B-2 in docs/coupling-analysis.md flagged as a
+ * twin-helper drift hazard.
+ */
+
+import type { JobDetail } from "@/api/types";
+
+/** Default n_trials value shown in the Re-tune dialog. */
+const DEFAULT_N_TRIALS = 50;
+
+/**
+ * Pick a sensible default ``n_trials`` for the Re-tune dialog based on
+ * the parent job's original tuning config. Falls back to 50 when the
+ * config is missing or malformed.
+ */
+export function defaultRetuneTrials(job: JobDetail): number {
+  const raw = _pokeOptunaParam(job, "n_trials");
+  return typeof raw === "number" && raw > 0 ? raw : DEFAULT_N_TRIALS;
+}
+
+function _pokeOptunaParam(job: JobDetail, key: string): unknown {
+  const config = job.config as Record<string, unknown> | undefined;
+  const tuning = config?.tuning as Record<string, unknown> | undefined;
+  const optuna = tuning?.optuna as Record<string, unknown> | undefined;
+  const params = optuna?.params as Record<string, unknown> | undefined;
+  return params?.[key];
+}


### PR DESCRIPTION
## Summary

Phase 3 coupling refactor (docs/coupling-analysis.md B-1). Depends on PRs #194 (A-7) and #195 (B-6), both merged.

Collapses the two \"completed job results\" views that were drifting apart into one data source and one presentation layer.

### Before

- \`components/workspace/ResultsCompletedView.tsx\` — 365 lines
- \`components/jobs/CompletedContent.tsx\` — 265 lines
- Each owned 8 near-identical \`useQuery\` calls, the \`lcMetric\` / \`importanceKind\` state machines, and the \`annotateMetric\` helper.
- **Already drifted:** Workspace hit the backend LC-metrics endpoint, Jobs page parsed \`config.model.params.metric\` client-side. The two produced different filter lists whenever LightGBM routed eval metrics through feval callables.

### After

- NEW \`hooks/useJobResultData.ts\` (~230 lines) — centralised the 8 queries + derived state. Standardised on the backend LC-metrics endpoint so Jobs page automatically gets the same list as Workspace. 16 unit tests.
- NEW \`components/shared/JobResultsBody.tsx\` (~145 lines) — shared presentation. Optional \`showScoreAccordion\` prop preserves the Jobs-page-only \"View Details\" block.
- NEW \`lib/job-config.ts\` — extracted \`defaultRetuneTrials(job)\` from its private location inside \`ResultsCompletedView\`.
- \`ResultsCompletedView.tsx\`: 365 → 131 lines (header + lineage + \`<JobResultsBody />\`)
- \`CompletedContent.tsx\`: 265 → 36 lines (\`<JobResultsBody showScoreAccordion />\`)

## Behavioral changes worth noting

1. **Jobs page now gets backend-sourced LC metrics.** This is a correctness win — the client-side config parse diverged from backend reality for feval-routed metrics. No visible UX change expected.
2. **Jobs page now resets \`lcMetric\` when the user hot-swaps jobs within the same mounted view.** Previously this safeguard was only in Workspace. Prevents the plot query firing with a metric name that is invalid for the new job.
3. **\`annotateMetric\` \`precision_at_k\` fallback preserved.** Both variants are checked (dict-form in \`evaluation.metrics\` and top-level scalar in \`evaluation.precision_at_k\`).

## Known pre-existing quirk (not a regression)

The code reviewer flagged a potential race where \`lcEnabled\` depends on \`plots\` being defined, so a cold-cache first load on the \"learning-curve\" tab briefly has empty \`availableEvalMetrics\` until the \`plots\` query resolves. This is **identical to pre-refactor behavior** (verified against \`git show develop:...ResultsCompletedView.tsx\`). Leaving as-is to keep the refactor a zero-behavior-change consolidation; the fix (staleTime / explicit loading gate) is a follow-up.

## Test plan

- [x] \`pnpm test\` — 1530 passed (+16 new hook tests)
- [x] \`pnpm check\` (biome) — clean
- [x] \`pnpm build\` — clean
- [x] Existing \`CompletedContent.test.tsx\` + \`ResultsCompletedView.test.tsx\` + \`JobDetail.test.tsx\` all green (no mock updates needed; api surface unchanged)

Does NOT close an existing issue — B-1 is a roadmap item from \`docs/coupling-analysis.md\`.