### PR TITLE
refactor(frontend): split ModelPanel into hook + 3 sub-components (B-3)

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -80,7 +80,8 @@
     {
       "includes": [
         "src/pages/WorkspacePage.tsx",
-        "src/components/workspace/ModelPanel.tsx"
+        "src/components/workspace/ModelPanel.tsx",
+        "src/components/workspace/ConfigEditorBody.tsx"
       ],
       "linter": {
         "rules": {

--- a/frontend/src/components/workspace/ConfigEditorBody.tsx
+++ b/frontend/src/components/workspace/ConfigEditorBody.tsx
@@ -1,0 +1,115 @@
+/**
+ * Scrollable config-editor body — hosts ConfigForm (Fit tab) or TuneTab
+ * plus the running / validation error overlays.
+ *
+ * Extracted from ModelPanel as part of B-3. Pure presentation — all
+ * state + change handlers flow in via props.
+ */
+
+import { Info } from "lucide-react";
+import type { ConfigError } from "@/api/types";
+import { ConfigForm } from "./ConfigForm";
+import { TuneTab } from "./TuneTab";
+
+export interface ConfigEditorBodyProps {
+  activeTab: "fit" | "tune";
+  hasData: boolean;
+  running: boolean;
+  errors: ConfigError[];
+  // biome-ignore lint/suspicious/noExplicitAny: JSON schema shape passes straight through to ConfigForm
+  schema: any | undefined;
+  config: Record<string, unknown> | undefined;
+  onChange: (newConfig: Record<string, unknown>) => Promise<void> | void;
+  task: string | null;
+  // biome-ignore lint/suspicious/noExplicitAny: UI schema shape passes straight through
+  uiSchema: any | undefined;
+  columns: string[];
+}
+
+export function ConfigEditorBody({
+  activeTab,
+  hasData,
+  running,
+  errors,
+  schema,
+  config,
+  onChange,
+  task,
+  uiSchema,
+  columns,
+}: ConfigEditorBodyProps) {
+  const visibleErrors = errors.filter((err) => err.path || err.message);
+
+  return (
+    // tabIndex=0 satisfies axe scrollable-region-focusable (WCAG 2.1.1)
+    // on narrow viewports where the panel has no focusable descendant
+    // (#167). Biome's a11y/noNoninteractiveTabindex rule conflicts with
+    // WCAG here and is overridden in biome.json for this file.
+    <div
+      tabIndex={0}
+      className="flex-1 overflow-auto p-4 focus-visible:outline-none"
+    >
+      {running && (
+        <output
+          className="mb-4 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950"
+          data-testid="running-info-bar"
+        >
+          <Info className="h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400" />
+          <p className="text-xs text-blue-800 dark:text-blue-200">
+            A job is currently running. Configuration is locked until the job
+            completes.
+          </p>
+        </output>
+      )}
+      {hasData && visibleErrors.length > 0 && (
+        <div className="mb-4 rounded-md border border-destructive/50 bg-destructive/10 p-3">
+          {visibleErrors.map((err, i) => (
+            <p key={`err-${i}`} className="text-xs text-destructive">
+              {[err.path, err.message].filter(Boolean).join(": ")}
+            </p>
+          ))}
+        </div>
+      )}
+
+      <div
+        className={running ? "pointer-events-none opacity-60" : undefined}
+        data-testid="config-form-area"
+        aria-disabled={running}
+      >
+        {activeTab === "fit" ? (
+          schema && config ? (
+            <ConfigForm
+              schema={schema}
+              config={config}
+              onChange={onChange}
+              task={task}
+              uiSchema={uiSchema}
+              columns={columns}
+            />
+          ) : (
+            <div
+              className="flex flex-col items-center justify-center py-12 text-center text-muted-foreground"
+              data-testid="config-guidance"
+            >
+              <p className="text-sm">
+                {hasData
+                  ? "Loading configuration..."
+                  : "Load data in the Data Panel to configure your model."}
+              </p>
+            </div>
+          )
+        ) : config ? (
+          <TuneTab
+            config={config}
+            onChange={onChange}
+            task={task}
+            uiSchema={uiSchema}
+            columns={columns}
+          />
+        ) : (
+          <p className="text-sm text-muted-foreground">Loading config...</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/workspace/ModelPanel.tsx
+++ b/frontend/src/components/workspace/ModelPanel.tsx
@@ -1,50 +1,9 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import equal from "fast-deep-equal";
-import {
-  Download,
-  FileText,
-  FileUp,
-  Info,
-  Redo2,
-  Save,
-  Undo2,
-} from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
-import { getErrorMessage } from "@/api/errors";
-import { queryKeys } from "@/api/queryKeys";
-import type { ConfigError } from "@/api/types";
-import {
-  fetchBackends,
-  fetchColumns,
-  fetchConfig,
-  fetchConfigSchema,
-  fetchUiSchema,
-  getConfigDownloadUrl,
-  updateConfig,
-  uploadConfig,
-  validateConfig,
-} from "@/api/workspace";
-import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { useConfigHistory } from "@/hooks/useConfigHistory";
-import { useConfigPresets } from "@/hooks/useConfigPresets";
-import { ConfigForm } from "./ConfigForm";
-import { RawConfigDialog } from "./RawConfigDialog";
+import { useState } from "react";
+import { useModelPanelData } from "@/hooks/useModelPanelData";
+import { ConfigEditorBody } from "./ConfigEditorBody";
+import { ModelPanelActions } from "./ModelPanelActions";
+import { ModelPanelHeader } from "./ModelPanelHeader";
 import { SavePresetDialog } from "./SavePresetDialog";
-import { TuneTab } from "./TuneTab";
 
 interface ModelPanelProps {
   hasData: boolean;
@@ -71,408 +30,71 @@ export function ModelPanel({
     setInternalTab(tab);
     onActiveTabChange?.(tab);
   };
-  const [errors, setErrors] = useState<ConfigError[]>([]);
   const [savePresetOpen, setSavePresetOpen] = useState(false);
-  const queryClient = useQueryClient();
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const history = useConfigHistory();
-  const { presets, save: savePreset, load: loadPreset } = useConfigPresets();
 
-  const { data: schema } = useQuery({
-    queryKey: queryKeys.configSchema(),
-    queryFn: fetchConfigSchema,
-    staleTime: Number.POSITIVE_INFINITY,
-  });
+  const data = useModelPanelData({ hasData, running, activeTab });
+  const {
+    schema,
+    config,
+    backend,
+    uiSchema,
+    nonExcludedColumns,
+    errors,
+    presets,
+    history,
+    fitEnabled,
+    tuneEnabled,
+    disabledReason,
+    handleConfigChange,
+    handleImport,
+    handleUndo,
+    handleRedo,
+    confirmSavePreset,
+    handleLoadPreset,
+  } = data;
 
-  const { data: config } = useQuery({
-    queryKey: queryKeys.config(),
-    queryFn: fetchConfig,
-  });
-
-  const { data: backends } = useQuery({
-    queryKey: queryKeys.backends(),
-    queryFn: fetchBackends,
-    staleTime: Number.POSITIVE_INFINITY,
-  });
-
-  const backend = backends?.[0];
-
-  const { data: uiSchema } = useQuery({
-    queryKey: queryKeys.uiSchema(),
-    queryFn: fetchUiSchema,
-    staleTime: Number.POSITIVE_INFINITY,
-  });
-
-  const { data: columnsData } = useQuery({
-    queryKey: queryKeys.columns(),
-    queryFn: () => fetchColumns(),
-    enabled: hasData,
-  });
-
-  const nonExcludedColumns = useMemo(() => {
-    if (!columnsData?.columns) return [];
-    return columnsData.columns
-      .filter((c) => !c.suggested_excluded)
-      .map((c) => c.name);
-  }, [columnsData]);
-
-  // Debounced validation
-  const validateTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
-    undefined,
-  );
-  const handleConfigChange = useCallback(
-    async (newConfig: Record<string, unknown>) => {
-      if (running) return;
-      const cached = queryClient.getQueryData<Record<string, unknown>>(
-        queryKeys.config(),
-      );
-      if (cached && equal(cached, newConfig)) {
-        return;
-      }
-      try {
-        await updateConfig(newConfig);
-        queryClient.setQueryData(queryKeys.config(), newConfig);
-        history.push(newConfig);
-      } catch {
-        toast.error("Failed to update config");
-        return;
-      }
-
-      clearTimeout(validateTimer.current);
-      validateTimer.current = setTimeout(async () => {
-        try {
-          const result = await validateConfig(newConfig);
-          setErrors(result.errors);
-        } catch {
-          // silent
-        }
-      }, 500);
-    },
-    [queryClient, running, history.push],
-  );
-
-  useEffect(() => {
-    return () => clearTimeout(validateTimer.current);
-  }, []);
-
-  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    try {
-      const result = await uploadConfig(file);
-      setErrors(result.errors);
-      queryClient.invalidateQueries({ queryKey: queryKeys.config() });
-      toast.success("Config imported");
-    } catch (err) {
-      toast.error(`Import failed: ${getErrorMessage(err)}`);
-    }
-    e.target.value = "";
-  };
-
-  const handleExport = () => {
-    window.open(getConfigDownloadUrl(), "_blank");
-  };
-
-  const handleUndo = useCallback(async () => {
-    const prev = history.undo();
-    if (!prev) return;
-    try {
-      await updateConfig(prev);
-      queryClient.setQueryData(queryKeys.config(), prev);
-      toast.info("Config undone");
-    } catch {
-      toast.error("Undo failed");
-    }
-  }, [history, queryClient]);
-
-  const handleRedo = useCallback(async () => {
-    const next = history.redo();
-    if (!next) return;
-    try {
-      await updateConfig(next);
-      queryClient.setQueryData(queryKeys.config(), next);
-      toast.info("Config redone");
-    } catch {
-      toast.error("Redo failed");
-    }
-  }, [history, queryClient]);
-
-  const handleSavePreset = () => {
-    if (!config) return;
-    setSavePresetOpen(true);
-  };
-
-  const confirmSavePreset = (name: string) => {
-    if (!config) return;
-    savePreset(name, config);
-    toast.success(`Preset "${name}" saved`);
-  };
-
-  const handleLoadPreset = (name: string) => {
-    const preset = loadPreset(name);
-    if (!preset) return;
-    handleConfigChange(preset);
-    toast.success(`Preset "${name}" loaded`);
-  };
-
-  const fitEnabled = hasData && !!config && !running && errors.length === 0;
-  // Tune enabled: allow empty space if capability flag is set
-  const allowEmptySpace =
-    uiSchema?.capabilities?.tune?.allow_empty_space === true;
-  const tuningSpace =
-    ((
-      (config?.tuning as Record<string, unknown> | undefined)?.optuna as
-        | Record<string, unknown>
-        | undefined
-    )?.space as Record<string, unknown> | undefined) ?? {};
-  const tuneEnabled =
-    fitEnabled && (allowEmptySpace || Object.keys(tuningSpace).length > 0);
-
-  const disabledReason = (() => {
-    if (running) return "A job is currently running";
-    if (!hasData) return "Load data first";
-    if (!config) return "Loading configuration...";
-    if (errors.length > 0) return "Fix validation errors first";
-    if (activeTab === "tune" && !tuneEnabled)
-      return "Define a search space or enable empty space";
-    return null;
-  })();
+  const backendLabel = backend ? `${backend.name} v${backend.version}` : null;
 
   return (
     <div className="flex h-full flex-col">
-      {/* Sticky Header */}
-      <div className="sticky top-0 z-10 border-b bg-background p-3">
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2">
-            <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Model
-            </span>
-            {backend && (
-              <span className="text-[10px] text-muted-foreground">
-                {backend.name} v{backend.version}
-              </span>
-            )}
-          </div>
-        </div>
-        <div className="mt-2 flex items-center justify-between gap-2">
-          <Tabs
-            value={activeTab}
-            onValueChange={(v) => setActiveTab(v as "fit" | "tune")}
-          >
-            <TabsList variant="line" className="h-9 w-auto">
-              <TabsTrigger value="fit" className="px-6">
-                Fit
-              </TabsTrigger>
-              <TabsTrigger value="tune" className="px-6">
-                Tune
-              </TabsTrigger>
-            </TabsList>
-            {/* Issue #90: Radix Tabs auto-generates `aria-controls` on
-                each TabsTrigger. Without corresponding <TabsContent>
-                elements the attribute points at IDs that do not exist
-                in the DOM, which axe's `aria-valid-attr-value` flags.
-                The visible Fit/Tune content is rendered outside this
-                Tabs tree (see the scrollable panel below), so the two
-                TabsContent nodes below exist only to host the matching
-                aria-controls targets. They are visually hidden and
-                carry no user-facing text. */}
-            <TabsContent
-              value="fit"
-              tabIndex={-1}
-              aria-hidden
-              className="sr-only"
-            />
-            <TabsContent
-              value="tune"
-              tabIndex={-1}
-              aria-hidden
-              className="sr-only"
-            />
-          </Tabs>
-          <div className="flex items-center gap-2 min-w-0">
-            {disabledReason && (
-              <span className="truncate text-[11px] text-muted-foreground max-w-[180px]">
-                {disabledReason}
-              </span>
-            )}
-            <Button
-              size="sm"
-              className="h-9 shrink-0"
-              onClick={activeTab === "fit" ? onFit : onTune}
-              disabled={activeTab === "fit" ? !fitEnabled : !tuneEnabled}
-            >
-              {running ? "Running..." : activeTab === "fit" ? "Fit" : "Tune"}
-            </Button>
-          </div>
-        </div>
-      </div>
+      <ModelPanelHeader
+        activeTab={activeTab}
+        onActiveTabChange={setActiveTab}
+        fitEnabled={fitEnabled}
+        tuneEnabled={tuneEnabled}
+        running={running}
+        disabledReason={disabledReason}
+        backendLabel={backendLabel}
+        onFit={onFit}
+        onTune={onTune}
+      />
 
-      {/* Scrollable Content — tabIndex=0 satisfies axe
-       scrollable-region-focusable (WCAG 2.1.1) on narrow viewports
-       where the panel has no focusable descendant (#167). Biome's
-       a11y/noNoninteractiveTabindex rule conflicts with WCAG here
-       and is overridden in biome.json for this file. */}
-      <div
-        tabIndex={0}
-        className="flex-1 overflow-auto p-4 focus-visible:outline-none"
-      >
-        {running && (
-          <output
-            className="mb-4 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950"
-            data-testid="running-info-bar"
-          >
-            <Info className="h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400" />
-            <p className="text-xs text-blue-800 dark:text-blue-200">
-              A job is currently running. Configuration is locked until the job
-              completes.
-            </p>
-          </output>
-        )}
-        {hasData && errors.length > 0 && (
-          <div className="mb-4 rounded-md border border-destructive/50 bg-destructive/10 p-3">
-            {errors
-              .filter((err) => err.path || err.message)
-              .map((err, i) => (
-                <p key={`err-${i}`} className="text-xs text-destructive">
-                  {[err.path, err.message].filter(Boolean).join(": ")}
-                </p>
-              ))}
-          </div>
-        )}
+      <ConfigEditorBody
+        activeTab={activeTab}
+        hasData={hasData}
+        running={running}
+        errors={errors}
+        schema={schema}
+        config={config}
+        onChange={handleConfigChange}
+        task={task}
+        uiSchema={uiSchema}
+        columns={nonExcludedColumns}
+      />
 
-        <div
-          className={running ? "pointer-events-none opacity-60" : undefined}
-          data-testid="config-form-area"
-          aria-disabled={running}
-        >
-          {activeTab === "fit" ? (
-            schema && config ? (
-              <ConfigForm
-                schema={schema}
-                config={config}
-                onChange={handleConfigChange}
-                task={task}
-                uiSchema={uiSchema}
-                columns={nonExcludedColumns}
-              />
-            ) : (
-              <div
-                className="flex flex-col items-center justify-center py-12 text-center text-muted-foreground"
-                data-testid="config-guidance"
-              >
-                <p className="text-sm">
-                  {hasData
-                    ? "Loading configuration..."
-                    : "Load data in the Data Panel to configure your model."}
-                </p>
-              </div>
-            )
-          ) : config ? (
-            <TuneTab
-              config={config}
-              onChange={handleConfigChange}
-              task={task}
-              uiSchema={uiSchema}
-              columns={nonExcludedColumns}
-            />
-          ) : (
-            <p className="text-sm text-muted-foreground">Loading config...</p>
-          )}
-        </div>
-      </div>
+      <ModelPanelActions
+        running={running}
+        config={config}
+        canUndo={history.canUndo}
+        canRedo={history.canRedo}
+        presets={presets}
+        onImport={handleImport}
+        onUndo={handleUndo}
+        onRedo={handleRedo}
+        onOpenSavePreset={() => setSavePresetOpen(true)}
+        onLoadPreset={handleLoadPreset}
+      />
 
-      {/* Config Actions — sticky footer */}
-      <div
-        className={`shrink-0 border-t bg-background px-4 py-3${running ? " pointer-events-none opacity-60" : ""}`}
-        aria-disabled={running}
-      >
-        <div className="flex flex-wrap items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => fileInputRef.current?.click()}
-            disabled={running}
-          >
-            <FileUp className="mr-1 h-3 w-3" />
-            Import YAML
-          </Button>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept=".yaml,.yml,.json"
-            className="hidden"
-            onChange={handleImport}
-          />
-          <Button variant="outline" size="sm" onClick={handleExport}>
-            <Download className="mr-1 h-3 w-3" />
-            Export YAML
-          </Button>
-
-          <div className="h-4 w-px bg-border" />
-
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleUndo}
-                disabled={!history.canUndo}
-                aria-label="Undo"
-              >
-                <Undo2 className="h-3 w-3" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Undo</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleRedo}
-                disabled={!history.canRedo}
-                aria-label="Redo"
-              >
-                <Redo2 className="h-3 w-3" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Redo</TooltipContent>
-          </Tooltip>
-
-          <div className="h-4 w-px bg-border" />
-
-          <Button variant="outline" size="sm" onClick={handleSavePreset}>
-            <Save className="mr-1 h-3 w-3" />
-            Save Preset
-          </Button>
-          {presets.length > 0 && (
-            <Select onValueChange={handleLoadPreset}>
-              <SelectTrigger
-                aria-label="Load preset"
-                className="h-8 w-36 text-xs"
-              >
-                <SelectValue placeholder="Load Preset" />
-              </SelectTrigger>
-              <SelectContent>
-                {presets.map((p) => (
-                  <SelectItem key={p.name} value={p.name}>
-                    {p.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          )}
-          <RawConfigDialog
-            config={config}
-            trigger={
-              <Button variant="outline" size="sm">
-                <FileText className="mr-1 h-3 w-3" />
-                Raw Config
-              </Button>
-            }
-          />
-        </div>
-      </div>
       <SavePresetDialog
         open={savePresetOpen}
         onOpenChange={setSavePresetOpen}

--- a/frontend/src/components/workspace/ModelPanelActions.tsx
+++ b/frontend/src/components/workspace/ModelPanelActions.tsx
@@ -1,0 +1,166 @@
+/**
+ * Sticky-footer config action bar — Import / Export / Undo / Redo /
+ * Preset save-load / Raw-config viewer.
+ *
+ * Extracted from ModelPanel as part of B-3. Pure presentation; the
+ * handlers come from useModelPanelData via props.
+ */
+
+import { Download, FileText, FileUp, Redo2, Save, Undo2 } from "lucide-react";
+import { useRef } from "react";
+import { getConfigDownloadUrl } from "@/api/workspace";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { ConfigPreset } from "@/hooks/useConfigPresets";
+import { RawConfigDialog } from "./RawConfigDialog";
+
+export interface ModelPanelActionsProps {
+  running: boolean;
+  config: Record<string, unknown> | undefined;
+  canUndo: boolean;
+  canRedo: boolean;
+  presets: ConfigPreset[];
+  onImport: (file: File) => Promise<void> | void;
+  onUndo: () => Promise<void> | void;
+  onRedo: () => Promise<void> | void;
+  onOpenSavePreset: () => void;
+  onLoadPreset: (name: string) => void;
+}
+
+export function ModelPanelActions({
+  running,
+  config,
+  canUndo,
+  canRedo,
+  presets,
+  onImport,
+  onUndo,
+  onRedo,
+  onOpenSavePreset,
+  onLoadPreset,
+}: ModelPanelActionsProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    await onImport(file);
+    e.target.value = "";
+  };
+
+  const handleExport = () => {
+    window.open(getConfigDownloadUrl(), "_blank");
+  };
+
+  return (
+    <div
+      className={`shrink-0 border-t bg-background px-4 py-3${
+        running ? " pointer-events-none opacity-60" : ""
+      }`}
+      aria-disabled={running}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={running}
+        >
+          <FileUp className="mr-1 h-3 w-3" />
+          Import YAML
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".yaml,.yml,.json"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+        <Button variant="outline" size="sm" onClick={handleExport}>
+          <Download className="mr-1 h-3 w-3" />
+          Export YAML
+        </Button>
+
+        <div className="h-4 w-px bg-border" />
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onUndo}
+              disabled={!canUndo}
+              aria-label="Undo"
+            >
+              <Undo2 className="h-3 w-3" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Undo</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onRedo}
+              disabled={!canRedo}
+              aria-label="Redo"
+            >
+              <Redo2 className="h-3 w-3" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Redo</TooltipContent>
+        </Tooltip>
+
+        <div className="h-4 w-px bg-border" />
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onOpenSavePreset}
+          disabled={!config}
+        >
+          <Save className="mr-1 h-3 w-3" />
+          Save Preset
+        </Button>
+        {presets.length > 0 && (
+          <Select onValueChange={onLoadPreset}>
+            <SelectTrigger
+              aria-label="Load preset"
+              className="h-8 w-36 text-xs"
+            >
+              <SelectValue placeholder="Load Preset" />
+            </SelectTrigger>
+            <SelectContent>
+              {presets.map((p) => (
+                <SelectItem key={p.name} value={p.name}>
+                  {p.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+        <RawConfigDialog
+          config={config}
+          trigger={
+            <Button variant="outline" size="sm">
+              <FileText className="mr-1 h-3 w-3" />
+              Raw Config
+            </Button>
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/workspace/ModelPanelHeader.tsx
+++ b/frontend/src/components/workspace/ModelPanelHeader.tsx
@@ -1,0 +1,100 @@
+/**
+ * Sticky header with Fit/Tune tabs and the primary action button.
+ *
+ * Extracted from ModelPanel as part of B-3. Pure presentation — data
+ * and enable/disable logic come from useModelPanelData.
+ */
+
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+export interface ModelPanelHeaderProps {
+  activeTab: "fit" | "tune";
+  onActiveTabChange: (tab: "fit" | "tune") => void;
+  fitEnabled: boolean;
+  tuneEnabled: boolean;
+  running: boolean;
+  disabledReason: string | null;
+  backendLabel: string | null;
+  onFit: () => void;
+  onTune: () => void;
+}
+
+export function ModelPanelHeader({
+  activeTab,
+  onActiveTabChange,
+  fitEnabled,
+  tuneEnabled,
+  running,
+  disabledReason,
+  backendLabel,
+  onFit,
+  onTune,
+}: ModelPanelHeaderProps) {
+  return (
+    <div className="sticky top-0 z-10 border-b bg-background p-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Model
+          </span>
+          {backendLabel && (
+            <span className="text-[10px] text-muted-foreground">
+              {backendLabel}
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="mt-2 flex items-center justify-between gap-2">
+        <Tabs
+          value={activeTab}
+          onValueChange={(v) => onActiveTabChange(v as "fit" | "tune")}
+        >
+          <TabsList variant="line" className="h-9 w-auto">
+            <TabsTrigger value="fit" className="px-6">
+              Fit
+            </TabsTrigger>
+            <TabsTrigger value="tune" className="px-6">
+              Tune
+            </TabsTrigger>
+          </TabsList>
+          {/* Issue #90: Radix Tabs auto-generates `aria-controls` on
+              each TabsTrigger. Without corresponding <TabsContent>
+              elements the attribute points at IDs that do not exist
+              in the DOM, which axe's `aria-valid-attr-value` flags.
+              The visible Fit/Tune content is rendered outside this
+              Tabs tree (see ConfigEditorBody), so the two TabsContent
+              nodes below exist only to host the matching aria-controls
+              targets. They are visually hidden. */}
+          <TabsContent
+            value="fit"
+            tabIndex={-1}
+            aria-hidden
+            className="sr-only"
+          />
+          <TabsContent
+            value="tune"
+            tabIndex={-1}
+            aria-hidden
+            className="sr-only"
+          />
+        </Tabs>
+        <div className="flex items-center gap-2 min-w-0">
+          {disabledReason && (
+            <span className="truncate text-[11px] text-muted-foreground max-w-[180px]">
+              {disabledReason}
+            </span>
+          )}
+          <Button
+            size="sm"
+            className="h-9 shrink-0"
+            onClick={activeTab === "fit" ? onFit : onTune}
+            disabled={activeTab === "fit" ? !fitEnabled : !tuneEnabled}
+          >
+            {running ? "Running..." : activeTab === "fit" ? "Fit" : "Tune"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useConfigPresets.ts
+++ b/frontend/src/hooks/useConfigPresets.ts
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react";
 
 const STORAGE_KEY = "lizystudio-config-presets";
 
-interface ConfigPreset {
+export interface ConfigPreset {
   name: string;
   config: Record<string, unknown>;
   createdAt: string;

--- a/frontend/src/hooks/useModelPanelData.test.ts
+++ b/frontend/src/hooks/useModelPanelData.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for useModelPanelData — data + handlers backing ModelPanel.
+ *
+ * Focuses on the derived state (fitEnabled / tuneEnabled / disabledReason)
+ * and the side-effect handlers (import / undo / redo / preset / change).
+ * The individual useQuery wrappers are left to the existing ModelPanel
+ * integration tests (ModelPanel.test.tsx) so we don't duplicate mock
+ * wiring for the full config-schema / backend / columns fan-out.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { queryKeys } from "@/api/queryKeys";
+import { useModelPanelData } from "./useModelPanelData";
+
+// All API calls are mocked — we only need to prove the hook wires them
+// into the right query keys and computes the right derived state.
+vi.mock("@/api/workspace", () => ({
+  fetchBackends: vi
+    .fn()
+    .mockResolvedValue([{ name: "lizyml", version: "0.1" }]),
+  fetchColumns: vi
+    .fn()
+    .mockResolvedValue({ columns: [{ name: "a", suggested_excluded: false }] }),
+  fetchConfig: vi.fn().mockResolvedValue({ model: {} }),
+  fetchConfigSchema: vi.fn().mockResolvedValue({ type: "object" }),
+  fetchUiSchema: vi.fn().mockResolvedValue({}),
+  getConfigDownloadUrl: vi.fn().mockReturnValue("/api/config/download"),
+  updateConfig: vi.fn().mockResolvedValue(undefined),
+  uploadConfig: vi.fn().mockResolvedValue({ errors: [] }),
+  validateConfig: vi.fn().mockResolvedValue({ errors: [] }),
+}));
+
+import {
+  fetchColumns,
+  updateConfig,
+  uploadConfig,
+  validateConfig,
+} from "@/api/workspace";
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useModelPanelData", () => {
+  // -------------------------------------------------------------------------
+  // Column filtering
+  // -------------------------------------------------------------------------
+  it("filters suggested_excluded columns from nonExcludedColumns", async () => {
+    vi.mocked(fetchColumns).mockResolvedValueOnce({
+      columns: [
+        { name: "a", suggested_excluded: false },
+        { name: "b", suggested_excluded: true },
+        { name: "c", suggested_excluded: false },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+    } as any);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useModelPanelData({ hasData: true }), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.nonExcludedColumns).toEqual(["a", "c"]);
+    });
+  });
+
+  it("does NOT fetch columns until hasData is true", async () => {
+    const { wrapper } = makeWrapper();
+    renderHook(() => useModelPanelData({ hasData: false }), { wrapper });
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(fetchColumns).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Derived enable/disable state
+  // -------------------------------------------------------------------------
+  it("fitEnabled requires hasData, config, not-running, no errors", async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useModelPanelData({ hasData: true, running: false }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.config).toBeDefined());
+    expect(result.current.fitEnabled).toBe(true);
+  });
+
+  it("fitEnabled is false while a job is running", async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useModelPanelData({ hasData: true, running: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.config).toBeDefined());
+    expect(result.current.fitEnabled).toBe(false);
+    expect(result.current.disabledReason).toBe("A job is currently running");
+  });
+
+  it("fitEnabled is false when hasData is false (data guidance)", async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useModelPanelData({ hasData: false, running: false }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.config).toBeDefined());
+    expect(result.current.fitEnabled).toBe(false);
+    expect(result.current.disabledReason).toBe("Load data first");
+  });
+
+  it("tuneEnabled requires a non-empty search space when capability disallows empty", async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useModelPanelData({ hasData: true, running: false }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.config).toBeDefined());
+    // default config has no tuning.optuna.space → tune disabled
+    expect(result.current.tuneEnabled).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // handleConfigChange
+  // -------------------------------------------------------------------------
+  it("handleConfigChange updates cache + calls validateConfig after debounce", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(
+      () => useModelPanelData({ hasData: true, running: false }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.config).toBeDefined());
+
+    await act(async () => {
+      await result.current.handleConfigChange({ model: { name: "LGBM" } });
+    });
+
+    expect(updateConfig).toHaveBeenCalledWith({ model: { name: "LGBM" } });
+    expect(queryClient.getQueryData(queryKeys.config())).toEqual({
+      model: { name: "LGBM" },
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+    expect(validateConfig).toHaveBeenCalledWith({ model: { name: "LGBM" } });
+
+    vi.useRealTimers();
+  });
+
+  it("handleConfigChange is a no-op when running", async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useModelPanelData({ hasData: true, running: true }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.config).toBeDefined());
+
+    await act(async () => {
+      await result.current.handleConfigChange({ model: { name: "LGBM" } });
+    });
+
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  it("handleConfigChange skips re-upload when new config equals cached", async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useModelPanelData({ hasData: true, running: false }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.config).toBeDefined());
+
+    await act(async () => {
+      // cached is {model: {}} from the default mock
+      await result.current.handleConfigChange({ model: {} });
+    });
+
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // handleImport
+  // -------------------------------------------------------------------------
+  it("handleImport posts the file and invalidates config cache on success", async () => {
+    vi.mocked(uploadConfig).mockResolvedValueOnce({
+      errors: [],
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+    } as any);
+    const { wrapper, queryClient } = makeWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(
+      () => useModelPanelData({ hasData: true, running: false }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.config).toBeDefined());
+
+    const file = new File(["config: {}"], "c.yaml", { type: "text/yaml" });
+    await act(async () => {
+      await result.current.handleImport(file);
+    });
+
+    expect(uploadConfig).toHaveBeenCalledWith(file);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: queryKeys.config(),
+    });
+  });
+
+  it("handleImport surfaces errors from the server response", async () => {
+    vi.mocked(uploadConfig).mockResolvedValueOnce({
+      errors: [{ path: "model", message: "required" }],
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+    } as any);
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useModelPanelData({ hasData: true, running: false }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.config).toBeDefined());
+
+    const file = new File(["bad"], "c.yaml", { type: "text/yaml" });
+    await act(async () => {
+      await result.current.handleImport(file);
+    });
+
+    expect(result.current.errors).toEqual([
+      { path: "model", message: "required" },
+    ]);
+  });
+});

--- a/frontend/src/hooks/useModelPanelData.ts
+++ b/frontend/src/hooks/useModelPanelData.ts
@@ -1,0 +1,241 @@
+/**
+ * Data + handlers for ModelPanel.
+ *
+ * ModelPanel is the workspace panel that hosts the Fit/Tune config
+ * editor. Before B-3 it was a 484-line God component that owned 5
+ * useQuery calls, debounced validation, undo/redo, import/export, and
+ * preset save/load all inline. This hook lifts the data + side effects
+ * out so the component can be split into a header / body / actions
+ * trio without prop drilling.
+ */
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import equal from "fast-deep-equal";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import { getErrorMessage } from "@/api/errors";
+import { queryKeys } from "@/api/queryKeys";
+import type { ConfigError } from "@/api/types";
+import {
+  fetchBackends,
+  fetchColumns,
+  fetchConfig,
+  fetchConfigSchema,
+  fetchUiSchema,
+  updateConfig,
+  uploadConfig,
+  validateConfig,
+} from "@/api/workspace";
+import { useConfigHistory } from "@/hooks/useConfigHistory";
+import { useConfigPresets } from "@/hooks/useConfigPresets";
+
+const VALIDATION_DEBOUNCE_MS = 500;
+
+export interface UseModelPanelDataParams {
+  hasData: boolean;
+  running?: boolean;
+  activeTab?: "fit" | "tune";
+}
+
+export function useModelPanelData({
+  hasData,
+  running = false,
+  activeTab = "fit",
+}: UseModelPanelDataParams) {
+  const queryClient = useQueryClient();
+  const history = useConfigHistory();
+  const { presets, save: savePreset, load: loadPreset } = useConfigPresets();
+  const [errors, setErrors] = useState<ConfigError[]>([]);
+
+  // --------------------------------------------------------------------
+  // Data
+  // --------------------------------------------------------------------
+  const { data: schema } = useQuery({
+    queryKey: queryKeys.configSchema(),
+    queryFn: fetchConfigSchema,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  const { data: config } = useQuery({
+    queryKey: queryKeys.config(),
+    queryFn: fetchConfig,
+  });
+
+  const { data: backends } = useQuery({
+    queryKey: queryKeys.backends(),
+    queryFn: fetchBackends,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+  const backend = backends?.[0];
+
+  const { data: uiSchema } = useQuery({
+    queryKey: queryKeys.uiSchema(),
+    queryFn: fetchUiSchema,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  const { data: columnsData } = useQuery({
+    queryKey: queryKeys.columns(),
+    queryFn: () => fetchColumns(),
+    enabled: hasData,
+  });
+
+  const nonExcludedColumns = useMemo(() => {
+    if (!columnsData?.columns) return [];
+    return columnsData.columns
+      .filter((c) => !c.suggested_excluded)
+      .map((c) => c.name);
+  }, [columnsData]);
+
+  // --------------------------------------------------------------------
+  // Debounced validation on change
+  // --------------------------------------------------------------------
+  const validateTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  useEffect(() => {
+    return () => clearTimeout(validateTimer.current);
+  }, []);
+
+  const handleConfigChange = useCallback(
+    async (newConfig: Record<string, unknown>) => {
+      if (running) return;
+      const cached = queryClient.getQueryData<Record<string, unknown>>(
+        queryKeys.config(),
+      );
+      if (cached && equal(cached, newConfig)) {
+        return;
+      }
+      try {
+        await updateConfig(newConfig);
+        queryClient.setQueryData(queryKeys.config(), newConfig);
+        history.push(newConfig);
+      } catch {
+        toast.error("Failed to update config");
+        return;
+      }
+
+      clearTimeout(validateTimer.current);
+      validateTimer.current = setTimeout(async () => {
+        try {
+          const result = await validateConfig(newConfig);
+          setErrors(result.errors);
+        } catch {
+          // silent — validation failures are surfaced via the errors
+          // state on the next successful call
+        }
+      }, VALIDATION_DEBOUNCE_MS);
+    },
+    [queryClient, running, history.push],
+  );
+
+  // --------------------------------------------------------------------
+  // Import / undo / redo
+  // --------------------------------------------------------------------
+  const handleImport = useCallback(
+    async (file: File) => {
+      try {
+        const result = await uploadConfig(file);
+        setErrors(result.errors);
+        queryClient.invalidateQueries({ queryKey: queryKeys.config() });
+        toast.success("Config imported");
+      } catch (err) {
+        toast.error(`Import failed: ${getErrorMessage(err)}`);
+      }
+    },
+    [queryClient],
+  );
+
+  const handleUndo = useCallback(async () => {
+    const prev = history.undo();
+    if (!prev) return;
+    try {
+      await updateConfig(prev);
+      queryClient.setQueryData(queryKeys.config(), prev);
+      toast.info("Config undone");
+    } catch {
+      toast.error("Undo failed");
+    }
+  }, [history, queryClient]);
+
+  const handleRedo = useCallback(async () => {
+    const next = history.redo();
+    if (!next) return;
+    try {
+      await updateConfig(next);
+      queryClient.setQueryData(queryKeys.config(), next);
+      toast.info("Config redone");
+    } catch {
+      toast.error("Redo failed");
+    }
+  }, [history, queryClient]);
+
+  // --------------------------------------------------------------------
+  // Preset handlers
+  // --------------------------------------------------------------------
+  const confirmSavePreset = useCallback(
+    (name: string) => {
+      if (!config) return;
+      savePreset(name, config);
+      toast.success(`Preset "${name}" saved`);
+    },
+    [config, savePreset],
+  );
+
+  const handleLoadPreset = useCallback(
+    (name: string) => {
+      const preset = loadPreset(name);
+      if (!preset) return;
+      handleConfigChange(preset);
+      toast.success(`Preset "${name}" loaded`);
+    },
+    [loadPreset, handleConfigChange],
+  );
+
+  // --------------------------------------------------------------------
+  // Derived enable/disable state
+  // --------------------------------------------------------------------
+  const fitEnabled = hasData && !!config && !running && errors.length === 0;
+  const allowEmptySpace =
+    uiSchema?.capabilities?.tune?.allow_empty_space === true;
+  const tuningSpace =
+    ((
+      (config?.tuning as Record<string, unknown> | undefined)?.optuna as
+        | Record<string, unknown>
+        | undefined
+    )?.space as Record<string, unknown> | undefined) ?? {};
+  const tuneEnabled =
+    fitEnabled && (allowEmptySpace || Object.keys(tuningSpace).length > 0);
+
+  const disabledReason = (() => {
+    if (running) return "A job is currently running";
+    if (!hasData) return "Load data first";
+    if (!config) return "Loading configuration...";
+    if (errors.length > 0) return "Fix validation errors first";
+    if (activeTab === "tune" && !tuneEnabled)
+      return "Define a search space or enable empty space";
+    return null;
+  })();
+
+  return {
+    schema,
+    config,
+    backend,
+    uiSchema,
+    nonExcludedColumns,
+    errors,
+    presets,
+    history,
+    fitEnabled,
+    tuneEnabled,
+    disabledReason,
+    handleConfigChange,
+    handleImport,
+    handleUndo,
+    handleRedo,
+    confirmSavePreset,
+    handleLoadPreset,
+  };
+}
+
+export type UseModelPanelData = ReturnType<typeof useModelPanelData>;


### PR DESCRIPTION
## Summary

Phase 3 coupling refactor (docs/coupling-analysis.md B-3). Breaks the 484-line \`ModelPanel\` God component into an orchestrator, a data hook, and three focused presentational pieces. Behavior-preserving — all existing \`ModelPanel.test.tsx\` / \`ConfigForm.test.tsx\` and related tests stay green without mock updates.

### Before

- \`components/workspace/ModelPanel.tsx\`: 484 lines mixing 5 useQuery calls, debounced validation, undo/redo, import/export, preset save/load, and header/body/footer JSX.

### After

- NEW \`hooks/useModelPanelData.ts\` (~241 lines) — data + side-effect handlers. 11 new unit tests.
- NEW \`components/workspace/ModelPanelHeader.tsx\` (~100 lines) — tabs + primary Fit/Tune button.
- NEW \`components/workspace/ConfigEditorBody.tsx\` (~115 lines) — scrollable body + running / error overlays.
- NEW \`components/workspace/ModelPanelActions.tsx\` (~166 lines) — footer actions; owns its own file input ref.
- \`ModelPanel.tsx\`: 484 → 106 lines (orchestrator only).
- \`useConfigPresets.ts\` now exports \`ConfigPreset\` so actions can type its props.
- \`biome.json\`: \`noNoninteractiveTabindex\` override extended to \`ConfigEditorBody.tsx\` (WCAG 2.1.1 scrollable-region-focusable, same rationale as the pre-existing \`ModelPanel.tsx\` / \`WorkspacePage.tsx\` entries).

## Behavior preserved

Verified against pre-refactor code:
- \`disabledReason\` priority: running > !hasData > !config > errors > tune-no-space.
- \`handleConfigChange\` short-circuits on \`running=true\` and on deep-equal-to-cached.
- Debounced validation (500 ms) still cleans up on unmount.
- \`fileInputRef\` encapsulated inside \`ModelPanelActions\` — no external coupling.

## Known pre-existing issues (out of scope, follow-up candidates)

Surfaced by code review, but preserved as-is to keep this PR strictly behavior-preserving:

1. \`handleLoadPreset\` emits a success toast before awaiting \`handleConfigChange\` — could show success + error toasts together on network failure.
2. \`validateConfig\` catch is silent — old \`errors\` state stays visible if the request fails. Would file as a follow-up issue if desired.

## Test plan

- [x] \`pnpm test\` — 1541 passed (+11 new hook tests)
- [x] \`pnpm check\` (biome) — clean
- [x] \`pnpm build\` — clean

Does NOT close an existing issue — B-3 is a roadmap item from \`docs/coupling-analysis.md\`.