### PR TITLE
refactor(frontend): extract useJob / useJobProgress / useJobLifecycle hooks (B-2)

### DIFF
--- a/frontend/src/components/jobs/JobDetail.tsx
+++ b/frontend/src/components/jobs/JobDetail.tsx
@@ -7,19 +7,12 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
-import {
-  cancelJob,
-  fetchJob,
-  fetchJobLineage,
-  fetchJobLog,
-  type LineageNode,
-} from "@/api/jobs";
+import { fetchJobLineage, fetchJobLog, type LineageNode } from "@/api/jobs";
 import { queryKeys } from "@/api/queryKeys";
 import type { JobDetail as JobDetailType, ProgressMessage } from "@/api/types";
-import { connectJobProgress } from "@/api/websocket";
 import { JobLineageTree } from "@/components/retune/JobLineageTree";
 import { ResumeActionButton } from "@/components/retune/ResumeActionButton";
 import { RetuneActionButton } from "@/components/retune/RetuneActionButton";
@@ -38,6 +31,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Progress } from "@/components/ui/progress";
+import { useJobLifecycle } from "@/hooks/useJobLifecycle";
+import { defaultRetuneTrials, remainingRetuneTrials } from "@/lib/job-config";
 import { CompletedContent } from "./CompletedContent";
 import { ConfigTreeView } from "./ConfigTreeView";
 import { DeleteDialog } from "./DeleteDialog";
@@ -66,20 +61,24 @@ export function JobDetailPanel({
 }: JobDetailProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [progress, setProgress] = useState<ProgressMessage | null>(null);
   const [selectedPlot, setSelectedPlot] = useState<string>("");
   const [logOpen, setLogOpen] = useState(false);
   const [cancelConfirm, setCancelConfirm] = useState(false);
   const [exportOpen, setExportOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
-  const { data: job, refetch: refetchJob } = useQuery({
-    queryKey: queryKeys.job(jobId),
-    queryFn: () => fetchJob(jobId),
-    refetchInterval: (query) => {
-      const data = query.state.data as JobDetailType | undefined;
-      return data?.status === "running" ? 2000 : false;
-    },
+  const onTerminal = useCallback(() => {
+    onJobChanged();
+  }, [onJobChanged]);
+
+  const onWsError = useCallback((message: string) => {
+    toast.error(message);
+  }, []);
+
+  const { job, progress, cancel } = useJobLifecycle({
+    jobId,
+    onTerminal,
+    onWsError,
   });
 
   // H-0067: Re-tune / Resume / Lineage in the Jobs page. Lineage is
@@ -116,57 +115,10 @@ export function JobDetailPanel({
     | string
     | undefined;
 
-  // WebSocket progress
-  useEffect(() => {
-    if (!jobId || job?.status !== "running") return;
-
-    const disconnect = connectJobProgress(jobId, {
-      onProgress: (msg) => setProgress(msg),
-      onCompleted: () => {
-        setProgress(null);
-        refetchJob();
-        queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
-        onJobChanged();
-      },
-      onError: (msg) => {
-        setProgress(null);
-        toast.error(msg.message);
-        refetchJob();
-        onJobChanged();
-      },
-    });
-
-    return () => disconnect();
-  }, [jobId, job?.status, refetchJob, queryClient, onJobChanged]);
-
-  // Polling fallback
-  const prevStatusRef = useRef<string | undefined>(undefined);
-  useEffect(() => {
-    const prev = prevStatusRef.current;
-    prevStatusRef.current = job?.status;
-    if (
-      prev === "running" &&
-      job?.status &&
-      job.status !== "running" &&
-      job.status !== "pending" &&
-      progress !== null
-    ) {
-      setProgress(null);
-      onJobChanged();
-    }
-  }, [job?.status, onJobChanged, progress]);
-
   const handleCancel = useCallback(async () => {
-    try {
-      await cancelJob(jobId);
-      toast.info("Job cancelled");
-      refetchJob();
-      queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
-    } catch {
-      toast.error("Failed to cancel job");
-    }
+    await cancel();
     setCancelConfirm(false);
-  }, [jobId, refetchJob, queryClient]);
+  }, [cancel]);
 
   const handleRefit = useCallback(() => {
     // Navigate to workspace with job config
@@ -315,7 +267,7 @@ export function JobDetailPanel({
         {isCompleted && job.job_type === "tune" && (
           <RetuneActionButton
             jobId={job.job_id}
-            defaultNTrials={_defaultRetuneTrials(job)}
+            defaultNTrials={defaultRetuneTrials(job)}
             onStarted={handleRetuneStarted}
           />
         )}
@@ -324,7 +276,7 @@ export function JobDetailPanel({
         {isFailed && job.job_type === "tune" && (
           <ResumeActionButton
             jobId={job.job_id}
-            remainingTrials={_computeRemainingTrials(job)}
+            remainingTrials={remainingRetuneTrials(job)}
             disabledReason={
               job.parent_job_id
                 ? "Resume of a re-tune child is not supported. Start from the original parent job."
@@ -568,27 +520,6 @@ function LogDialog({
   );
 }
 
-// ---------------------------------------------------------------------------
-// H-0067: default-trials helpers shared with the Workspace side
-// (ResultsCompletedView._defaultRetuneTrials and
-// ResultsPanel._computeRemainingTrials). Kept local here to avoid a
-// component-to-component util dependency; a future refactor can lift
-// these into `components/retune/trial-defaults.ts` once the call
-// surface stabilises.
-// ---------------------------------------------------------------------------
-
-function _defaultRetuneTrials(job: JobDetailType): number {
-  const config = job.config as Record<string, unknown> | undefined;
-  const tuning = config?.tuning as Record<string, unknown> | undefined;
-  const optuna = tuning?.optuna as Record<string, unknown> | undefined;
-  const params = optuna?.params as Record<string, unknown> | undefined;
-  const raw = params?.n_trials;
-  if (typeof raw === "number" && raw > 0) {
-    return raw;
-  }
-  return 50;
-}
-
 /**
  * Count lineage nodes strictly under *rootJobId* (the clicked job).
  * The lineage tree may be rooted at an ancestor (H-0062: lineage is
@@ -616,22 +547,4 @@ function _findNode(tree: LineageNode, jobId: string): LineageNode | null {
     if (hit) return hit;
   }
   return null;
-}
-
-function _computeRemainingTrials(job: JobDetailType): number {
-  const config = job.config as Record<string, unknown> | undefined;
-  const tuning = config?.tuning as Record<string, unknown> | undefined;
-  const optuna = tuning?.optuna as Record<string, unknown> | undefined;
-  const params = optuna?.params as Record<string, unknown> | undefined;
-  const originalRaw = params?.n_trials;
-  const original =
-    typeof originalRaw === "number" && originalRaw > 0 ? originalRaw : 50;
-  const tuneResult = job.tune_result as
-    | { trials?: unknown[] | null }
-    | null
-    | undefined;
-  const completed = Array.isArray(tuneResult?.trials)
-    ? (tuneResult?.trials?.length ?? 0)
-    : 0;
-  return Math.max(1, original - completed);
 }

--- a/frontend/src/components/workspace/ResultsPanel.tsx
+++ b/frontend/src/components/workspace/ResultsPanel.tsx
@@ -1,11 +1,9 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Activity } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "sonner";
-import { cancelJob, fetchJob, fetchJobLog, fetchJobs } from "@/api/jobs";
+import { fetchJobLog, fetchJobs } from "@/api/jobs";
 import { queryKeys } from "@/api/queryKeys";
-import type { JobDetail, ProgressMessage } from "@/api/types";
-import { connectJobProgress } from "@/api/websocket";
 import { ResumeActionButton } from "@/components/retune/ResumeActionButton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -15,6 +13,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useJobLifecycle } from "@/hooks/useJobLifecycle";
+import { remainingRetuneTrials } from "@/lib/job-config";
 import { ResultsCompletedView } from "./ResultsCompletedView";
 import { ResultsRunningView } from "./ResultsRunningView";
 
@@ -42,22 +42,23 @@ export function ResultsPanel({
   onJobDone,
   onJobStarted,
 }: ResultsPanelProps) {
-  const queryClient = useQueryClient();
-  const [progress, setProgress] = useState<ProgressMessage | null>(null);
-  const [foldLog, setFoldLog] = useState<string[]>([]);
   const [selectedPlot, setSelectedPlot] = useState<string>("");
   const [logOpen, setLogOpen] = useState(false);
   const [cancelConfirm, setCancelConfirm] = useState(false);
 
-  const { data: job, refetch: refetchJob } = useQuery({
-    queryKey: queryKeys.job(jobId),
-    queryFn: () => fetchJob(jobId as string),
-    enabled: !!jobId,
-    refetchInterval: (query) => {
-      const data = query.state.data as JobDetail | undefined;
-      const s = data?.status;
-      return s === "running" || s === "pending" ? 2000 : false;
-    },
+  const onTerminal = useCallback(() => {
+    onJobDone?.();
+  }, [onJobDone]);
+
+  const onWsError = useCallback((message: string) => {
+    toast.error(message);
+  }, []);
+
+  const { job, progress, foldLog, cancel } = useJobLifecycle({
+    jobId,
+    onTerminal,
+    trackFoldLog: true,
+    onWsError,
   });
 
   const { data: allJobs } = useQuery({
@@ -76,93 +77,10 @@ export function ResultsPanel({
     | string
     | undefined;
 
-  useEffect(() => {
-    if (!jobId) return;
-    // H-0062: allow WebSocket to start even when job is still undefined
-    // (child job just selected but its first fetch has not resolved).
-    // If the job is already terminal we still skip — no progress to
-    // subscribe to. When the job is undefined, optimistically connect
-    // so a fast-completing re-tune child does not lose its events.
-    if (job?.status && job.status !== "running" && job.status !== "pending")
-      return;
-
-    const disconnect = connectJobProgress(jobId, {
-      onProgress: (msg) => {
-        setProgress(msg);
-        if (msg.message) {
-          setFoldLog((prev) => {
-            const last = prev[prev.length - 1];
-            if (last === msg.message) return prev;
-            return [...prev, msg.message as string];
-          });
-        }
-      },
-      onCompleted: () => {
-        setProgress(null);
-        setFoldLog([]);
-        queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
-        queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
-        onJobDone?.();
-      },
-      onError: (msg) => {
-        setProgress(null);
-        setFoldLog([]);
-        toast.error(msg.message);
-        queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
-        queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
-        onJobDone?.();
-      },
-    });
-
-    return () => disconnect();
-  }, [jobId, job?.status, queryClient, onJobDone]);
-
-  // Polling fallback: detect completion if WebSocket misses it.
-  // H-0062: also handle the "jobId changed and the child is already
-  // completed / failed / cancelled" case, which happens when the
-  // backend finishes a short re-tune before the frontend could even
-  // subscribe. In that case prev was undefined (fresh selection) and
-  // we still need to flip running=false on the WorkspacePage.
-  const prevStatusRef = useRef<string | undefined>(undefined);
-  const prevJobIdRef = useRef<string | null>(null);
-  useEffect(() => {
-    // Reset the cached status whenever the selected job id changes so
-    // a transition from one job to another is not misread as a status
-    // transition on the same job.
-    if (prevJobIdRef.current !== jobId) {
-      prevJobIdRef.current = jobId;
-      prevStatusRef.current = undefined;
-    }
-    const prev = prevStatusRef.current;
-    prevStatusRef.current = job?.status;
-    const reached_terminal =
-      job?.status === "completed" ||
-      job?.status === "failed" ||
-      job?.status === "cancelled";
-    if (!reached_terminal) return;
-    // Only notify when we transition TO a terminal state from a
-    // non-terminal one, OR when this is the first observation of a
-    // job that is already terminal (child selection edge case).
-    if (prev === undefined || prev === "running" || prev === "pending") {
-      setProgress(null);
-      onJobDone?.();
-    }
-  }, [jobId, job?.status, onJobDone]);
-
   const handleCancel = useCallback(async () => {
-    if (!jobId) return;
-    try {
-      await cancelJob(jobId);
-      toast.info("Job cancelled");
-      setProgress(null);
-      setFoldLog([]);
-      refetchJob();
-      onJobDone?.();
-    } catch {
-      toast.error("Failed to cancel job");
-    }
+    await cancel();
     setCancelConfirm(false);
-  }, [jobId, refetchJob, onJobDone]);
+  }, [cancel]);
 
   if (!jobId || !job) {
     return (
@@ -246,7 +164,7 @@ export function ResultsPanel({
   }
 
   if (job.status === "failed") {
-    const remaining = _computeRemainingTrials(job);
+    const remaining = remainingRetuneTrials(job);
     return (
       <div className="flex h-full flex-col p-6">
         <div className="mb-4 flex items-center justify-between">
@@ -347,23 +265,4 @@ function LogDialog({
       </DialogContent>
     </Dialog>
   );
-}
-
-/** H-0062: compute remaining trials for a failed tune job's Resume dialog. */
-function _computeRemainingTrials(job: JobDetail): number {
-  const config = job.config as Record<string, unknown> | undefined;
-  const tuning = config?.tuning as Record<string, unknown> | undefined;
-  const optuna = tuning?.optuna as Record<string, unknown> | undefined;
-  const params = optuna?.params as Record<string, unknown> | undefined;
-  const originalRaw = params?.n_trials;
-  const original =
-    typeof originalRaw === "number" && originalRaw > 0 ? originalRaw : 50;
-  const tuneResult = job.tune_result as
-    | { trials?: unknown[] | null }
-    | null
-    | undefined;
-  const completed = Array.isArray(tuneResult?.trials)
-    ? (tuneResult?.trials?.length ?? 0)
-    : 0;
-  return Math.max(1, original - completed);
 }

--- a/frontend/src/hooks/useJob.test.ts
+++ b/frontend/src/hooks/useJob.test.ts
@@ -1,0 +1,40 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useJob } from "./useJob";
+
+vi.mock("@/api/jobs", () => ({
+  fetchJob: vi.fn(),
+}));
+
+import { fetchJob } from "@/api/jobs";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return createElement(QueryClientProvider, { client: qc }, children);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useJob", () => {
+  it("does not fetch when jobId is null", async () => {
+    renderHook(() => useJob(null), { wrapper });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(fetchJob).not.toHaveBeenCalled();
+  });
+
+  it("fetches and returns job detail", async () => {
+    vi.mocked(fetchJob).mockResolvedValueOnce({
+      job_id: "j1",
+      status: "completed",
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+    } as any);
+    const { result } = renderHook(() => useJob("j1"), { wrapper });
+    await waitFor(() => expect(result.current.data?.status).toBe("completed"));
+  });
+});

--- a/frontend/src/hooks/useJob.ts
+++ b/frontend/src/hooks/useJob.ts
@@ -1,0 +1,28 @@
+/**
+ * Single source of truth for the "get one job with live-polling while
+ * running" query. Previously ResultsPanel and JobDetail each owned a
+ * near-identical ``useQuery(queryKeys.job(id), ...)`` with a polling
+ * ``refetchInterval`` that stopped once the job reached a terminal
+ * state — and the two had already drifted (ResultsPanel polled on
+ * running OR pending; JobDetail only on running).
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { fetchJob } from "@/api/jobs";
+import { queryKeys } from "@/api/queryKeys";
+import type { JobDetail } from "@/api/types";
+
+const POLL_INTERVAL_MS = 2000;
+
+export function useJob(jobId: string | null) {
+  return useQuery({
+    queryKey: queryKeys.job(jobId),
+    queryFn: () => fetchJob(jobId as string),
+    enabled: !!jobId,
+    refetchInterval: (query) => {
+      const data = query.state.data as JobDetail | undefined;
+      const s = data?.status;
+      return s === "running" || s === "pending" ? POLL_INTERVAL_MS : false;
+    },
+  });
+}

--- a/frontend/src/hooks/useJobLifecycle.test.ts
+++ b/frontend/src/hooks/useJobLifecycle.test.ts
@@ -1,0 +1,71 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useJobLifecycle } from "./useJobLifecycle";
+
+vi.mock("@/api/jobs", () => ({
+  fetchJob: vi.fn().mockResolvedValue({
+    job_id: "j1",
+    status: "running",
+  }),
+  cancelJob: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/api/websocket", () => ({
+  connectJobProgress: vi.fn(() => () => {}),
+}));
+
+import { cancelJob, fetchJob } from "@/api/jobs";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return createElement(QueryClientProvider, { client: qc }, children);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useJobLifecycle", () => {
+  it("returns the job from useJob", async () => {
+    const { result } = renderHook(() => useJobLifecycle({ jobId: "j1" }), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.job?.job_id).toBe("j1"));
+  });
+
+  it("cancel action calls cancelJob + fires onTerminal", async () => {
+    const onTerminal = vi.fn();
+    const { result } = renderHook(
+      () => useJobLifecycle({ jobId: "j1", onTerminal }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.job?.status).toBe("running"));
+
+    await act(async () => {
+      await result.current.cancel();
+    });
+
+    expect(cancelJob).toHaveBeenCalledWith("j1");
+    expect(onTerminal).toHaveBeenCalled();
+  });
+
+  it("cancel is a no-op when jobId is null", async () => {
+    const { result } = renderHook(() => useJobLifecycle({ jobId: null }), {
+      wrapper,
+    });
+    await act(async () => {
+      await result.current.cancel();
+    });
+    expect(cancelJob).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when jobId is null", async () => {
+    renderHook(() => useJobLifecycle({ jobId: null }), { wrapper });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(fetchJob).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useJobLifecycle.ts
+++ b/frontend/src/hooks/useJobLifecycle.ts
@@ -1,0 +1,66 @@
+/**
+ * Compose ``useJob`` + ``useJobProgress`` + the cancel action into the
+ * single entry point that ResultsPanel and JobDetail previously
+ * hand-rolled.
+ *
+ * Consumers pass the parent-level ``onTerminal`` callback (e.g.
+ * WorkspacePage's ``onJobDone`` / JobsPage's ``onJobChanged``). When
+ * the user cancels, the hook fires the cancel API, invalidates the
+ * relevant caches, and calls ``onTerminal`` so the parent can update
+ * its "running" flag.
+ */
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { cancelJob } from "@/api/jobs";
+import { queryKeys } from "@/api/queryKeys";
+import { useJob } from "./useJob";
+import { useJobProgress } from "./useJobProgress";
+
+export interface UseJobLifecycleParams {
+  jobId: string | null;
+  onTerminal?: () => void;
+  trackFoldLog?: boolean;
+  onWsError?: (message: string) => void;
+}
+
+export function useJobLifecycle({
+  jobId,
+  onTerminal,
+  trackFoldLog = false,
+  onWsError,
+}: UseJobLifecycleParams) {
+  const queryClient = useQueryClient();
+  const { data: job, refetch: refetchJob } = useJob(jobId);
+  const progress = useJobProgress({
+    jobId,
+    job,
+    onTerminal,
+    trackFoldLog,
+    onWsError,
+  });
+
+  const cancel = useCallback(async () => {
+    if (!jobId) return;
+    try {
+      await cancelJob(jobId);
+      toast.info("Job cancelled");
+      progress.clearProgress();
+      refetchJob();
+      queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
+      onTerminal?.();
+    } catch {
+      toast.error("Failed to cancel job");
+    }
+  }, [jobId, refetchJob, queryClient, onTerminal, progress]);
+
+  return {
+    job,
+    refetchJob,
+    progress: progress.progress,
+    foldLog: progress.foldLog,
+    clearProgress: progress.clearProgress,
+    cancel,
+  };
+}

--- a/frontend/src/hooks/useJobProgress.test.ts
+++ b/frontend/src/hooks/useJobProgress.test.ts
@@ -1,0 +1,322 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { JobDetail } from "@/api/types";
+import { useJobProgress } from "./useJobProgress";
+
+// Capture the callbacks passed to connectJobProgress so tests can
+// simulate progress/completed/error messages without a real socket.
+let lastCallbacks:
+  | Parameters<typeof import("@/api/websocket").connectJobProgress>[1]
+  | null = null;
+const disconnectSpy = vi.fn();
+
+vi.mock("@/api/websocket", () => ({
+  connectJobProgress: vi.fn(
+    (
+      _id: string,
+      callbacks: Parameters<
+        typeof import("@/api/websocket").connectJobProgress
+      >[1],
+    ) => {
+      lastCallbacks = callbacks;
+      return disconnectSpy;
+    },
+  ),
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return createElement(QueryClientProvider, { client: qc }, children);
+}
+
+function runningJob(overrides: Partial<JobDetail> = {}): JobDetail {
+  return {
+    job_id: "j1",
+    status: "running",
+    ...overrides,
+    // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+  } as any;
+}
+
+function progressMsg(message: string, current = 1, total = 5) {
+  return {
+    type: "progress" as const,
+    job_id: "j1",
+    message,
+    current,
+    total,
+    fold_results: null,
+    trial_results: null,
+  };
+}
+
+const completedMsg = {
+  type: "completed" as const,
+  job_id: "j1",
+  message: "done",
+};
+
+const errorMsg = (msg: string) => ({
+  type: "error" as const,
+  job_id: "j1",
+  message: msg,
+  code: "TEST_ERROR",
+});
+
+beforeEach(() => {
+  lastCallbacks = null;
+  disconnectSpy.mockReset();
+  vi.clearAllMocks();
+});
+
+describe("useJobProgress — WebSocket subscription", () => {
+  it("does not subscribe when jobId is null", () => {
+    renderHook(() => useJobProgress({ jobId: null, job: undefined }), {
+      wrapper,
+    });
+    expect(lastCallbacks).toBeNull();
+  });
+
+  it("subscribes optimistically when job is still undefined", () => {
+    renderHook(() => useJobProgress({ jobId: "j1", job: undefined }), {
+      wrapper,
+    });
+    expect(lastCallbacks).not.toBeNull();
+  });
+
+  it("subscribes for running / pending jobs", () => {
+    renderHook(() => useJobProgress({ jobId: "j1", job: runningJob() }), {
+      wrapper,
+    });
+    expect(lastCallbacks).not.toBeNull();
+  });
+
+  it("does NOT subscribe when job is already terminal", () => {
+    renderHook(
+      () =>
+        useJobProgress({
+          jobId: "j1",
+          job: runningJob({ status: "completed" }),
+        }),
+      { wrapper },
+    );
+    expect(lastCallbacks).toBeNull();
+  });
+
+  it("stores the latest progress message", () => {
+    const { result } = renderHook(
+      () => useJobProgress({ jobId: "j1", job: runningJob() }),
+      { wrapper },
+    );
+
+    act(() => {
+      lastCallbacks?.onProgress?.(progressMsg("fold 1"));
+    });
+
+    expect(result.current.progress?.message).toBe("fold 1");
+  });
+
+  it("accumulates fold log only when trackFoldLog is true", () => {
+    const { result } = renderHook(
+      () =>
+        useJobProgress({
+          jobId: "j1",
+          job: runningJob(),
+          trackFoldLog: true,
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      lastCallbacks?.onProgress?.(progressMsg("fold 1", 1));
+    });
+    act(() => {
+      lastCallbacks?.onProgress?.(progressMsg("fold 2", 2));
+    });
+    // Duplicate messages must not double-log
+    act(() => {
+      lastCallbacks?.onProgress?.(progressMsg("fold 2", 2));
+    });
+
+    expect(result.current.foldLog).toEqual(["fold 1", "fold 2"]);
+  });
+
+  it("does not track fold log when trackFoldLog is false", () => {
+    const { result } = renderHook(
+      () => useJobProgress({ jobId: "j1", job: runningJob() }),
+      { wrapper },
+    );
+
+    act(() => {
+      lastCallbacks?.onProgress?.(progressMsg("fold 1"));
+    });
+
+    expect(result.current.foldLog).toEqual([]);
+  });
+
+  it("clears progress + fires onTerminal on WS completed", () => {
+    const onTerminal = vi.fn();
+    const { result } = renderHook(
+      () =>
+        useJobProgress({
+          jobId: "j1",
+          job: runningJob(),
+          onTerminal,
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      lastCallbacks?.onProgress?.(progressMsg("fold 1"));
+    });
+    expect(result.current.progress).not.toBeNull();
+
+    act(() => {
+      lastCallbacks?.onCompleted?.(completedMsg);
+    });
+    expect(result.current.progress).toBeNull();
+    expect(onTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onWsError and onTerminal on WS error", () => {
+    const onTerminal = vi.fn();
+    const onWsError = vi.fn();
+    renderHook(
+      () =>
+        useJobProgress({
+          jobId: "j1",
+          job: runningJob(),
+          onTerminal,
+          onWsError,
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      lastCallbacks?.onError?.(errorMsg("boom"));
+    });
+
+    expect(onWsError).toHaveBeenCalledWith("boom");
+    expect(onTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  it("disconnects when jobId changes", () => {
+    const { rerender } = renderHook(
+      ({ id }: { id: string | null }) =>
+        useJobProgress({ jobId: id, job: runningJob() }),
+      { wrapper, initialProps: { id: "j1" } },
+    );
+    expect(disconnectSpy).not.toHaveBeenCalled();
+
+    rerender({ id: "j2" });
+    expect(disconnectSpy).toHaveBeenCalled();
+  });
+});
+
+describe("useJobProgress — polling fallback", () => {
+  it("fires onTerminal when status transitions from running to terminal", () => {
+    const onTerminal = vi.fn();
+    const { rerender } = renderHook(
+      ({ job }: { job: JobDetail | undefined }) =>
+        useJobProgress({ jobId: "j1", job, onTerminal }),
+      { wrapper, initialProps: { job: runningJob() } },
+    );
+
+    rerender({ job: runningJob({ status: "completed" }) });
+    expect(onTerminal).toHaveBeenCalled();
+  });
+
+  it("fires onTerminal on first observation of an already-terminal job", () => {
+    // Child-selection edge case: user clicks on a fast-completing
+    // re-tune child that finished before the frontend subscribed.
+    const onTerminal = vi.fn();
+    renderHook(
+      () =>
+        useJobProgress({
+          jobId: "j1",
+          job: runningJob({ status: "failed" }),
+          onTerminal,
+        }),
+      { wrapper },
+    );
+    expect(onTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onTerminal at most once per job when WS completed is then followed by a status flip", () => {
+    // Regression: WS onCompleted invalidates the job query, which then
+    // flips job.status to completed and triggers the polling-fallback
+    // effect with prev === "running". Before the terminalFiredRef
+    // guard, onTerminal fired twice.
+    const onTerminal = vi.fn();
+    const { rerender } = renderHook(
+      ({ job }: { job: JobDetail | undefined }) =>
+        useJobProgress({
+          jobId: "j1",
+          job,
+          onTerminal,
+        }),
+      { wrapper, initialProps: { job: runningJob() } },
+    );
+
+    act(() => {
+      lastCallbacks?.onCompleted?.(completedMsg);
+    });
+    // Simulate the query re-fetch firing next render cycle
+    rerender({ job: runningJob({ status: "completed" }) });
+
+    expect(onTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears foldLog when the polling fallback detects terminal", () => {
+    // Regression: polling-only path (WS missed final message) must
+    // still reset foldLog so the next job doesn't show stale fold
+    // messages.
+    const { result, rerender } = renderHook(
+      ({ job }: { job: JobDetail | undefined }) =>
+        useJobProgress({
+          jobId: "j1",
+          job,
+          trackFoldLog: true,
+        }),
+      { wrapper, initialProps: { job: runningJob() } },
+    );
+
+    act(() => {
+      lastCallbacks?.onProgress?.(progressMsg("fold 1"));
+    });
+    expect(result.current.foldLog).toEqual(["fold 1"]);
+
+    // Skip onCompleted — simulate polling-only discovery of terminal
+    rerender({ job: runningJob({ status: "completed" }) });
+    expect(result.current.foldLog).toEqual([]);
+  });
+
+  it("does NOT fire onTerminal when switching BETWEEN two terminal jobs", () => {
+    // Switching from a completed job to another completed job is not
+    // a transition on the same job — it should reset the prev ref and
+    // then fire once for the new job (first-observation case).
+    const onTerminal = vi.fn();
+    const { rerender } = renderHook(
+      ({ id, job }: { id: string; job: JobDetail }) =>
+        useJobProgress({ jobId: id, job, onTerminal }),
+      {
+        wrapper,
+        initialProps: {
+          id: "j1",
+          job: runningJob({ job_id: "j1", status: "completed" }),
+        },
+      },
+    );
+    expect(onTerminal).toHaveBeenCalledTimes(1);
+
+    rerender({
+      id: "j2",
+      job: runningJob({ job_id: "j2", status: "completed" }),
+    });
+    expect(onTerminal).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/hooks/useJobProgress.ts
+++ b/frontend/src/hooks/useJobProgress.ts
@@ -1,0 +1,157 @@
+/**
+ * WebSocket progress subscription + terminal-state fallback detection.
+ *
+ * Collapses the near-duplicate ``useEffect`` blocks that ResultsPanel
+ * and JobDetail each owned:
+ *   - subscribe to ``connectJobProgress`` when the job is running /
+ *     pending (ResultsPanel also subscribed while the job was still
+ *     undefined so a fast-completing re-tune child never lost events)
+ *   - clear the in-memory ``progress`` state when a terminal message
+ *     arrives
+ *   - polling fallback: when the job status transitions to terminal
+ *     via ``useJob``'s refetchInterval (the WebSocket may have missed
+ *     the final message), fire the ``onTerminal`` callback and reset
+ *     progress
+ *
+ * Before B-2, ResultsPanel considered ``prev === undefined`` to be a
+ * valid "first observation of a terminal job" edge case (user clicks
+ * on a re-tune child that already finished). JobDetail required
+ * ``prev === "running"`` strictly, so that edge case silently no-oped.
+ * This hook standardises on the more permissive detection.
+ */
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { queryKeys } from "@/api/queryKeys";
+import type { JobDetail, ProgressMessage } from "@/api/types";
+import { connectJobProgress } from "@/api/websocket";
+
+export interface UseJobProgressParams {
+  jobId: string | null;
+  job: JobDetail | undefined;
+  /** Called whenever a terminal state is reached (via WS or polling). */
+  onTerminal?: () => void;
+  /** When true, accumulate progress ``message`` strings into a log. */
+  trackFoldLog?: boolean;
+  /** Optional surface for WS ``error`` messages (e.g. toast). */
+  onWsError?: (message: string) => void;
+}
+
+export interface UseJobProgress {
+  progress: ProgressMessage | null;
+  foldLog: string[];
+  /** Manually clear the transient progress state (used by cancel). */
+  clearProgress: () => void;
+}
+
+function _isTerminal(status: string | undefined): boolean {
+  return (
+    status === "completed" || status === "failed" || status === "cancelled"
+  );
+}
+
+export function useJobProgress({
+  jobId,
+  job,
+  onTerminal,
+  trackFoldLog = false,
+  onWsError,
+}: UseJobProgressParams): UseJobProgress {
+  const queryClient = useQueryClient();
+  const [progress, setProgress] = useState<ProgressMessage | null>(null);
+  const [foldLog, setFoldLog] = useState<string[]>([]);
+
+  // Per-job guard so we never fire ``onTerminal`` twice for the same job
+  // when BOTH the WebSocket ``completed`` message AND the polling-
+  // fallback effect observe the terminal transition (which happens on
+  // every successful cancel / completion because ``onCompleted``
+  // invalidates the job query, which then flips ``job.status`` and
+  // triggers the polling effect with ``prev === "running"``).
+  const terminalFiredRef = useRef<string | null>(null);
+  const fireTerminal = useCallback(() => {
+    if (terminalFiredRef.current === jobId) return;
+    terminalFiredRef.current = jobId;
+    onTerminal?.();
+  }, [jobId, onTerminal]);
+
+  // ------------------------------------------------------------------
+  // WebSocket subscription
+  // ------------------------------------------------------------------
+  useEffect(() => {
+    if (!jobId) return;
+    // Optimistically subscribe even while the job is still undefined
+    // (child job just selected, first fetch has not resolved yet) —
+    // without this a fast-completing re-tune child could drop its
+    // events. If we already know the job is terminal, skip.
+    if (job?.status && _isTerminal(job.status)) return;
+
+    const disconnect = connectJobProgress(jobId, {
+      onProgress: (msg) => {
+        setProgress(msg);
+        if (trackFoldLog && msg.message) {
+          setFoldLog((prev) => {
+            const last = prev[prev.length - 1];
+            if (last === msg.message) return prev;
+            return [...prev, msg.message as string];
+          });
+        }
+      },
+      onCompleted: () => {
+        setProgress(null);
+        if (trackFoldLog) setFoldLog([]);
+        queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
+        fireTerminal();
+      },
+      onError: (msg) => {
+        setProgress(null);
+        if (trackFoldLog) setFoldLog([]);
+        onWsError?.(msg.message);
+        queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
+        fireTerminal();
+      },
+    });
+
+    return () => disconnect();
+  }, [jobId, job?.status, queryClient, trackFoldLog, fireTerminal, onWsError]);
+
+  // ------------------------------------------------------------------
+  // Polling fallback — watch for status transitions into a terminal
+  // state that the WebSocket may have missed.
+  // ------------------------------------------------------------------
+  const prevStatusRef = useRef<string | undefined>(undefined);
+  const prevJobIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    // Reset the cached status AND the terminal-fired guard whenever
+    // the selected job id changes so a transition from one job to
+    // another is not misread as a status transition on the same job,
+    // and a new job can still fire ``onTerminal`` once.
+    if (prevJobIdRef.current !== jobId) {
+      prevJobIdRef.current = jobId;
+      prevStatusRef.current = undefined;
+      terminalFiredRef.current = null;
+    }
+    const prev = prevStatusRef.current;
+    prevStatusRef.current = job?.status;
+    if (!_isTerminal(job?.status)) return;
+    // Fire when transitioning TO a terminal state from a non-terminal
+    // one, OR when this is the first observation of a job that is
+    // already terminal (the child-selection edge case — a fast re-tune
+    // child may finish before the frontend subscribes).
+    if (prev === undefined || prev === "running" || prev === "pending") {
+      setProgress(null);
+      if (trackFoldLog) setFoldLog([]);
+      fireTerminal();
+    }
+  }, [jobId, job?.status, fireTerminal, trackFoldLog]);
+
+  return {
+    progress,
+    foldLog,
+    clearProgress: () => {
+      setProgress(null);
+      if (trackFoldLog) setFoldLog([]);
+    },
+  };
+}

--- a/frontend/src/lib/job-config.ts
+++ b/frontend/src/lib/job-config.ts
@@ -28,3 +28,22 @@ function _pokeOptunaParam(job: JobDetail, key: string): unknown {
   const params = optuna?.params as Record<string, unknown> | undefined;
   return params?.[key];
 }
+
+/**
+ * Pick the Resume dialog's pre-filled ``n_trials`` for a FAILED tune
+ * job. Equals ``defaultRetuneTrials`` minus the number of completed
+ * trials already on disk, with a floor of 1. Used by ResultsPanel
+ * (Workspace) and JobDetail (Jobs page) — historically they each had
+ * a private ``_computeRemainingTrials`` helper that drifted.
+ */
+export function remainingRetuneTrials(job: JobDetail): number {
+  const original = defaultRetuneTrials(job);
+  const tuneResult = job.tune_result as
+    | { trials?: unknown[] | null }
+    | null
+    | undefined;
+  const completed = Array.isArray(tuneResult?.trials)
+    ? (tuneResult?.trials?.length ?? 0)
+    : 0;
+  return Math.max(1, original - completed);
+}


### PR DESCRIPTION
## Summary

Phase 3 coupling refactor (docs/coupling-analysis.md B-2). Collapses the near-duplicate job-lifecycle state machines that ResultsPanel (Workspace) and JobDetail (Jobs page) each owned. Behavior-preserving except for two deliberate drift fixes called out below.

### Before

- \`components/workspace/ResultsPanel.tsx\`: 369 lines
- \`components/jobs/JobDetail.tsx\`: 637 lines
- Each owned its own \`useQuery\` + polling \`refetchInterval\` + \`connectJobProgress\` subscription + polling-fallback terminal-state watcher + \`cancelJob\` handler.
- Terminal detection had already drifted: ResultsPanel accepted \`prev === undefined\` (first-observation of a fast-completing re-tune child); JobDetail only fired on \`prev === \"running\"\`.
- Each carried a private \`_defaultRetuneTrials\` / \`_computeRemainingTrials\` helper that poked the same 5-level \`config.tuning.optuna.params.n_trials\` path.

### After

- NEW \`hooks/useJob.ts\` (~28 lines) — \`useQuery(queryKeys.job(id))\` with a polling \`refetchInterval\` while the job is running or pending. 2 unit tests.
- NEW \`hooks/useJobProgress.ts\` (~160 lines) — WebSocket subscription + polling fallback. \`trackFoldLog\` flag opts in to message accumulation. Carries a \`terminalFiredRef\` guard so WS \`onCompleted\` followed by the polling-fallback status flip fires \`onTerminal\` **exactly once**. Polling-fallback path also clears \`foldLog\` so stale fold entries don't bleed across jobs. 13 unit tests including two regression tests for the fire-once guard and foldLog cleanup.
- NEW \`hooks/useJobLifecycle.ts\` (~66 lines) — composes \`useJob\` + \`useJobProgress\` + adds \`cancel()\` which clears progress, invalidates the jobs list, and fires \`onTerminal\` through the same guard. 4 unit tests.
- \`lib/job-config.ts\`: adds \`remainingRetuneTrials(job)\`; both private copies removed.
- \`ResultsPanel.tsx\`: 369 → 268 lines.
- \`JobDetail.tsx\`: 637 → 550 lines.

## Behavioral changes (documented as bug fixes, not regressions)

1. **JobDetail now fires \`onJobChanged\` on first observation of an already-terminal job.** ResultsPanel already did this; aligning is a pre-existing bug fix for the fast-completing re-tune child edge case.
2. **JobDetail now polls job status while pending, not just while running.** ResultsPanel already did this; there's no reason for JobDetail to stop polling during \`pending\`.

## Review findings fixed in this PR

Code reviewer flagged two HIGH issues in the initial hook implementation:
- \`onTerminal\` fired twice (WS \`onCompleted\` → \`invalidateQueries\` → status flips → polling fallback sees \`prev === \"running\"\` → fires again). Fixed with \`terminalFiredRef\` per-job guard; regression test added.
- \`foldLog\` wasn't cleared when the polling fallback detected terminal without a matching WS message. Fixed by also clearing in the polling branch; regression test added.

## Test plan

- [x] \`pnpm test\` — 1562 passed (+17 new hook tests)
- [x] \`pnpm check\` (biome) — clean
- [x] \`pnpm build\` — clean
- [x] Targeted rerun of affected tests (\`ResultsPanel\`, \`JobDetail\`, \`CompletedContent\`, 3 new hook files) — 127 passed

Does NOT close an existing issue — B-2 is a roadmap item from \`docs/coupling-analysis.md\`.