### PR TITLE
refactor(server): C-mopup batch — C-8, C-10, C-12

### DIFF
--- a/src/lizystudio/server.py
+++ b/src/lizystudio/server.py
@@ -11,7 +11,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
-from fastapi import Depends, FastAPI, HTTPException, Request, Response, WebSocket
+from fastapi import Depends, FastAPI, Request, Response, WebSocket
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
@@ -216,7 +216,18 @@ def create_app() -> FastAPI:
     # real HTTP endpoint.
     _install_ws_message_schema(application)
 
-    # Serve built frontend (production)
+    # Serve built frontend (production).
+    # C-12: surface misconfigured deployments at startup instead of
+    # silently 404-ing every SPA request — an ops person now sees a
+    # single warning line at boot if the pnpm build artefacts are
+    # missing / mounted at the wrong path.
+    if not STATIC_DIR.is_dir() or not (STATIC_DIR / "index.html").exists():
+        logger.warning(
+            "Static assets directory missing or empty at %s — "
+            "SPA requests will 404. Run `pnpm build` or point "
+            "STATIC_DIR at the frontend dist/.",
+            STATIC_DIR,
+        )
     if STATIC_DIR.is_dir() and (STATIC_DIR / "index.html").exists():
         application.mount(
             "/assets", StaticFiles(directory=STATIC_DIR / "assets"), name="assets"
@@ -230,7 +241,10 @@ def create_app() -> FastAPI:
             not the frontend build artefacts exist (C-1 drift gate).
             """
             if full_path.startswith(("api/", "ws/")):
-                raise HTTPException(status_code=404, detail="Not found")
+                # C-8: use the StudioError envelope so the frontend's
+                # ``isStudioError`` path handles this uniformly instead
+                # of falling back to "API error 404".
+                raise StudioError("NOT_FOUND", f"Route not found: /{full_path}", 404)
             from lizystudio.security import validate_static_path
 
             safe = validate_static_path(STATIC_DIR / full_path, STATIC_DIR)

--- a/src/lizystudio/ws/progress.py
+++ b/src/lizystudio/ws/progress.py
@@ -235,12 +235,31 @@ def _record_drop() -> None:
     PROGRESS_DROPPED_TOTAL.inc()
 
 
-_ALLOWED_WS_ORIGINS: set[str] = {
-    "http://localhost:5173",
-    "http://localhost:8501",
-    "http://127.0.0.1:5173",
-    "http://127.0.0.1:8501",
-}
+_DEFAULT_WS_ORIGINS: frozenset[str] = frozenset(
+    {
+        "http://localhost:5173",
+        "http://localhost:8501",
+        "http://127.0.0.1:5173",
+        "http://127.0.0.1:8501",
+    }
+)
+
+
+def get_allowed_ws_origins() -> set[str]:
+    """Return the allowlist of origins accepted on the progress WebSocket.
+
+    Reads ``LIZYSTUDIO_WS_ALLOWED_ORIGINS`` (comma-separated) at call
+    time so remote deployments don't need to patch the source. Blank
+    entries are filtered — the Origin check treats an empty string as
+    "no Origin header", so a stray "" in the allowlist would accept
+    unauthenticated cross-origin WebSockets (C-10 fix).
+    """
+    import os
+
+    raw = os.environ.get("LIZYSTUDIO_WS_ALLOWED_ORIGINS")
+    if not raw:
+        return set(_DEFAULT_WS_ORIGINS)
+    return {entry.strip() for entry in raw.split(",") if entry.strip()}
 
 
 async def websocket_progress(
@@ -250,7 +269,7 @@ async def websocket_progress(
 ) -> None:
     """WebSocket handler for ``/ws/jobs/{job_id}/progress``."""
     origin = websocket.headers.get("origin", "")
-    if origin and origin not in _ALLOWED_WS_ORIGINS:
+    if origin and origin not in get_allowed_ws_origins():
         await websocket.close(code=1008)
         return
     await websocket.accept()

--- a/tests/test_c_mopup.py
+++ b/tests/test_c_mopup.py
@@ -1,0 +1,177 @@
+"""Tests for the C-8 / C-10 / C-12 mop-up batch.
+
+C-8 — SPA catch-all 404 must use the StudioError envelope so the
+frontend's ``getErrorMessage`` / ``isStudioError`` path handles it
+uniformly instead of falling through to "API error 404".
+
+C-10 — The WebSocket origin allowlist must be overridable via the
+``LIZYSTUDIO_WS_ALLOWED_ORIGINS`` environment variable so remote
+deployments don't need a source patch.
+
+C-12 — When the static-assets directory is expected but empty (no
+``index.html``), the application must log a clear warning at startup
+instead of silently serving 404s for every non-API route.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# C-8 — SPA 404 returns StudioError envelope
+# ---------------------------------------------------------------------------
+
+
+def test_c8_spa_catchall_404_returns_studio_error_envelope() -> None:
+    """GET /api/<unknown> must return the StudioError envelope, not the
+    FastAPI default ``{"detail": "Not found"}``.
+    """
+    # Ensure STATIC_DIR exists so the catch-all route is registered.
+    from lizystudio.server import STATIC_DIR, create_app
+
+    with tempfile.TemporaryDirectory() as tmp:
+        static_dir = Path(tmp)
+        (static_dir / "index.html").write_text("<html>SPA</html>")
+        (static_dir / "assets").mkdir()
+        original = os.environ.get("LIZYSTUDIO_JOBS_DIR")
+        os.environ["LIZYSTUDIO_JOBS_DIR"] = str(Path(tmp) / "jobs")
+        # Patch STATIC_DIR module-level constant via monkey-patching.
+        import lizystudio.server as server_module
+
+        original_static = server_module.STATIC_DIR
+        server_module.STATIC_DIR = static_dir
+        try:
+            app = create_app()
+            with TestClient(app) as client:
+                res = client.get("/api/definitely-not-a-real-endpoint")
+                assert res.status_code == 404
+                body = res.json()
+                # StudioError envelope shape: {error: {code, message, details}}
+                assert "error" in body, f"Expected error envelope, got: {body}"
+                assert body["error"]["code"] == "NOT_FOUND"
+        finally:
+            server_module.STATIC_DIR = original_static
+            if original is None:
+                os.environ.pop("LIZYSTUDIO_JOBS_DIR", None)
+            else:
+                os.environ["LIZYSTUDIO_JOBS_DIR"] = original
+        # Silence ruff about unused STATIC_DIR import
+        _ = STATIC_DIR
+
+
+# ---------------------------------------------------------------------------
+# C-10 — WS origin allowlist is overridable via env
+# ---------------------------------------------------------------------------
+
+
+def test_c10_ws_allowed_origins_env_var_overrides_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting ``LIZYSTUDIO_WS_ALLOWED_ORIGINS`` replaces the hard-coded
+    allowlist.
+    """
+    monkeypatch.setenv(
+        "LIZYSTUDIO_WS_ALLOWED_ORIGINS",
+        "https://studio.example.com,https://staging.example.com",
+    )
+    # Force a fresh read — the helper accepts an env lookup at call time
+    # so we don't depend on import order.
+    from lizystudio.ws.progress import get_allowed_ws_origins
+
+    origins = get_allowed_ws_origins()
+    assert "https://studio.example.com" in origins
+    assert "https://staging.example.com" in origins
+    # Env override replaces defaults entirely
+    assert "http://localhost:5173" not in origins
+
+
+def test_c10_ws_allowed_origins_default_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no env override the default localhost set is returned."""
+    monkeypatch.delenv("LIZYSTUDIO_WS_ALLOWED_ORIGINS", raising=False)
+    from lizystudio.ws.progress import get_allowed_ws_origins
+
+    origins = get_allowed_ws_origins()
+    assert "http://localhost:5173" in origins
+    assert "http://127.0.0.1:5173" in origins
+
+
+def test_c10_ws_allowed_origins_ignores_blank_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitespace / empty entries in the env list must not appear in the
+    allowlist (they would silently accept requests without an Origin
+    header otherwise).
+    """
+    monkeypatch.setenv(
+        "LIZYSTUDIO_WS_ALLOWED_ORIGINS",
+        "https://a.example.com, ,https://b.example.com",
+    )
+    from lizystudio.ws.progress import get_allowed_ws_origins
+
+    origins = get_allowed_ws_origins()
+    assert "" not in origins
+    assert "https://a.example.com" in origins
+    assert "https://b.example.com" in origins
+
+
+# ---------------------------------------------------------------------------
+# C-12 — STATIC_DIR sanity check at startup
+# ---------------------------------------------------------------------------
+
+
+def test_c12_missing_static_dir_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When STATIC_DIR is unset / missing at app creation, a startup
+    warning must be emitted so an ops person notices the misconfigured
+    deployment before every SPA request 404s.
+    """
+    import lizystudio.server as server_module
+
+    original = server_module.STATIC_DIR
+    # Point at a path that definitely does not exist
+    server_module.STATIC_DIR = Path("/tmp/lizystudio-does-not-exist-xyz")
+    try:
+        with caplog.at_level(logging.WARNING, logger="lizystudio.server"):
+            server_module.create_app()
+        # The warning should mention the static dir path or make the
+        # situation discoverable to ops.
+        assert any("static" in record.message.lower() for record in caplog.records), (
+            "Expected a startup warning about the missing STATIC_DIR"
+        )
+    finally:
+        server_module.STATIC_DIR = original
+
+
+def test_c12_valid_static_dir_does_not_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When STATIC_DIR exists with index.html, startup must be silent."""
+    import lizystudio.server as server_module
+
+    with tempfile.TemporaryDirectory() as tmp:
+        static_dir = Path(tmp)
+        (static_dir / "index.html").write_text("<html>SPA</html>")
+        (static_dir / "assets").mkdir()
+        original = server_module.STATIC_DIR
+        server_module.STATIC_DIR = static_dir
+        try:
+            with caplog.at_level(logging.WARNING, logger="lizystudio.server"):
+                server_module.create_app()
+            static_warnings = [
+                r for r in caplog.records if "static" in r.message.lower()
+            ]
+            assert static_warnings == []
+        finally:
+            server_module.STATIC_DIR = original


### PR DESCRIPTION
## Summary

Three small, independent items from \`docs/coupling-analysis.md\` bundled because they all touch server / WS startup and each would be a drive-by.

### C-8 — SPA catch-all uses the StudioError envelope
\`serve_spa\` previously raised \`HTTPException(status_code=404, detail=\"Not found\")\`, producing \`{\"detail\": \"Not found\"}\`. The frontend's \`isStudioError\` guard didn't recognise this and fell back to a generic \"API error 404\" toast. Now raises \`StudioError(\"NOT_FOUND\", ..., 404)\` which flows through the existing \`studio_error_handler\` and produces the uniform \`{error: {code, message, details}}\` envelope.

### C-10 — WS Origin allowlist via \`LIZYSTUDIO_WS_ALLOWED_ORIGINS\`
Hardcoded \`{localhost:5173, localhost:8501, 127.0.0.1:5173, 127.0.0.1:8501}\` replaced with \`get_allowed_ws_origins()\` that reads the comma-separated env var at handshake time. Blank entries are filtered so a stray empty string can't silently accept origin-less connections. Defaults unchanged when env is unset — no config change required for existing dev setups.

### C-12 — Startup sanity warning for missing STATIC_DIR
\`create_app()\` now logs a single WARNING when \`STATIC_DIR\` is missing or lacks \`index.html\`. A misconfigured production deploy is now visible at boot instead of at every SPA request. Behavior otherwise unchanged (app still boots and serves the API).

## Test plan

- [x] \`tests/test_c_mopup.py\` — 6 new unit tests (one per invariant: StudioError envelope, env override replaces defaults, env unset keeps defaults, blank-entry filtering, warning when STATIC_DIR missing, silent when valid)
- [x] \`uv run pytest\` — 1144 passed (+6 new)
- [x] \`uv run ruff check .\` / \`ruff format --check .\` — clean
- [x] \`uv run mypy src/lizystudio/\` — clean

Does NOT close an existing issue — C-8/C-10/C-12 are roadmap items from \`docs/coupling-analysis.md\`. C-11 (app_version in /api/health) was already shipped as part of H-0064/0065, so it is omitted from this batch.