### PR TITLE
refactor(frontend): introduce api/queries/ hook layer (B-7 Phase 1)

### DIFF
--- a/frontend/src/api/queries/index.ts
+++ b/frontend/src/api/queries/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Thin query/mutation hooks that shield consumers from the raw
+ * ``@/api/*`` fetcher modules. See docs/coupling-analysis.md B-7.
+ */
+
+export { useJobLineage } from "./useJobLineage";
+export { useJobLog } from "./useJobLog";
+export { useJobsInvalidator } from "./useJobsInvalidator";
+export { useJobsList } from "./useJobsList";
+export { useResumeJob } from "./useResumeJob";
+export { useRetuneJob } from "./useRetuneJob";
+export { useRunInference } from "./useRunInference";

--- a/frontend/src/api/queries/queries.test.ts
+++ b/frontend/src/api/queries/queries.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Contract tests for the api/queries/ thin-wrapper hook layer (B-7).
+ *
+ * Each hook must:
+ *   - fire the expected fetcher exactly once with the expected args,
+ *   - use the canonical query key from queryKeys.ts,
+ *   - respect ``enabled`` / disabled-when-null gates.
+ *
+ * Mutation hooks must:
+ *   - invalidate the correct caches on success so list views refresh,
+ *   - surface errors through the hook state rather than swallowing.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { queryKeys } from "../queryKeys";
+import {
+  useJobLineage,
+  useJobLog,
+  useJobsInvalidator,
+  useJobsList,
+  useResumeJob,
+  useRetuneJob,
+  useRunInference,
+} from ".";
+
+vi.mock("@/api/jobs", () => ({
+  fetchJobs: vi.fn(),
+  fetchJobLog: vi.fn(),
+  fetchJobLineage: vi.fn(),
+  retuneJob: vi.fn(),
+  resumeJob: vi.fn(),
+}));
+
+vi.mock("@/api/inference", () => ({
+  runInference: vi.fn(),
+}));
+
+import { runInference } from "@/api/inference";
+import {
+  fetchJobLineage,
+  fetchJobLog,
+  fetchJobs,
+  resumeJob,
+  retuneJob,
+} from "@/api/jobs";
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return {
+    qc,
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: qc }, children),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+describe("useJobsList", () => {
+  it("fetches the list and uses queryKeys.jobs() as the cache key", async () => {
+    vi.mocked(fetchJobs).mockResolvedValueOnce([]);
+    const { wrapper, qc } = makeWrapper();
+    renderHook(() => useJobsList(), { wrapper });
+    await waitFor(() => expect(fetchJobs).toHaveBeenCalledTimes(1));
+    // The cache should be populated under the canonical key
+    expect(qc.getQueryData(queryKeys.jobs())).toEqual([]);
+  });
+});
+
+describe("useJobLog", () => {
+  it("is disabled until enabled=true flips", async () => {
+    const { wrapper } = makeWrapper();
+    const { rerender } = renderHook(
+      ({ on }: { on: boolean }) => useJobLog("j1", { enabled: on }),
+      { wrapper, initialProps: { on: false } },
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fetchJobLog).not.toHaveBeenCalled();
+
+    rerender({ on: true });
+    await waitFor(() => expect(fetchJobLog).toHaveBeenCalledWith("j1"));
+  });
+
+  it("does not fetch when jobId is null", async () => {
+    const { wrapper } = makeWrapper();
+    renderHook(() => useJobLog(null, { enabled: true }), { wrapper });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fetchJobLog).not.toHaveBeenCalled();
+  });
+});
+
+describe("useJobLineage", () => {
+  it("fetches only when enabled=true", async () => {
+    vi.mocked(fetchJobLineage).mockResolvedValue({
+      tree: { job_id: "j1", children: [] } as never,
+    });
+    const { wrapper } = makeWrapper();
+    const { rerender } = renderHook(
+      ({ on }: { on: boolean }) => useJobLineage("j1", { enabled: on }),
+      { wrapper, initialProps: { on: false } },
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fetchJobLineage).not.toHaveBeenCalled();
+
+    rerender({ on: true });
+    await waitFor(() => expect(fetchJobLineage).toHaveBeenCalledWith("j1"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invalidator helper
+// ---------------------------------------------------------------------------
+
+describe("useJobsInvalidator", () => {
+  it("invalidates queryKeys.jobs() when called", () => {
+    const { wrapper, qc } = makeWrapper();
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { result } = renderHook(() => useJobsInvalidator(), { wrapper });
+    result.current();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.jobs() });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+describe("useRetuneJob", () => {
+  it("calls retuneJob and invalidates jobs + detail cache on success", async () => {
+    vi.mocked(retuneJob).mockResolvedValueOnce({
+      job_id: "child",
+      parent_job_id: "j1",
+    });
+    const { wrapper, qc } = makeWrapper();
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { result } = renderHook(() => useRetuneJob(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        jobId: "j1",
+        body: { n_trials: 10 },
+      });
+    });
+
+    expect(retuneJob).toHaveBeenCalledWith("j1", { n_trials: 10 });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.jobs() });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: queryKeys.job("j1"),
+    });
+  });
+});
+
+describe("useResumeJob", () => {
+  it("calls resumeJob and invalidates jobs + detail cache on success", async () => {
+    vi.mocked(resumeJob).mockResolvedValueOnce({
+      job_id: "child",
+      parent_job_id: "j1",
+    });
+    const { wrapper, qc } = makeWrapper();
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { result } = renderHook(() => useResumeJob(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        jobId: "j1",
+        body: { n_trials: 5 },
+      });
+    });
+
+    expect(resumeJob).toHaveBeenCalledWith("j1", { n_trials: 5 });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.jobs() });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: queryKeys.job("j1"),
+    });
+  });
+});
+
+describe("useRunInference", () => {
+  it("calls runInference and invalidates infHistoryAll on success", async () => {
+    vi.mocked(runInference).mockResolvedValueOnce({
+      inf_id: "inf1",
+      job_id: "j1",
+    } as never);
+    const { wrapper, qc } = makeWrapper();
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { result } = renderHook(() => useRunInference(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        job_id: "j1",
+        data: { source_type: "path", path: "/data.csv" },
+        return_shap: false,
+        evaluate: true,
+      });
+    });
+
+    expect(runInference).toHaveBeenCalled();
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: queryKeys.infHistoryAll(),
+    });
+  });
+});

--- a/frontend/src/api/queries/useJobLineage.ts
+++ b/frontend/src/api/queries/useJobLineage.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchJobLineage } from "@/api/jobs";
+import { queryKeys } from "../queryKeys";
+
+/**
+ * Fetch a job's lineage tree. Lineage is auxiliary info — callers
+ * typically swallow errors silently so this hook disables retries.
+ */
+export function useJobLineage(jobId: string, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: queryKeys.jobLineage(jobId),
+    queryFn: () => fetchJobLineage(jobId),
+    enabled: options?.enabled !== false,
+    retry: false,
+  });
+}

--- a/frontend/src/api/queries/useJobLog.ts
+++ b/frontend/src/api/queries/useJobLog.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchJobLog } from "@/api/jobs";
+import { queryKeys } from "../queryKeys";
+
+/**
+ * Execution log query for a single job. Consumers typically pass
+ * ``{ enabled: logDialogOpen }`` so the log is only fetched when the
+ * user opens the dialog. Passing ``jobId: null`` also disables.
+ */
+export function useJobLog(
+  jobId: string | null,
+  options?: { enabled?: boolean },
+) {
+  return useQuery({
+    queryKey: queryKeys.jobLog(jobId),
+    queryFn: () => fetchJobLog(jobId as string),
+    enabled: !!jobId && options?.enabled !== false,
+  });
+}

--- a/frontend/src/api/queries/useJobsInvalidator.ts
+++ b/frontend/src/api/queries/useJobsInvalidator.ts
@@ -1,0 +1,16 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { queryKeys } from "../queryKeys";
+
+/**
+ * Helper for mutation callbacks that need to invalidate the job list
+ * after a write (cancel / delete / retune / resume). Encapsulates the
+ * ``queryClient.invalidateQueries({ queryKey: queryKeys.jobs() })``
+ * boilerplate that was repeated at 8+ call sites before B-7.
+ */
+export function useJobsInvalidator(): () => void {
+  const queryClient = useQueryClient();
+  return useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
+  }, [queryClient]);
+}

--- a/frontend/src/api/queries/useJobsList.ts
+++ b/frontend/src/api/queries/useJobsList.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchJobs } from "@/api/jobs";
+import { queryKeys } from "../queryKeys";
+
+/**
+ * Job list query — single source of truth for the Workspace / Jobs /
+ * Inference page job dropdowns.
+ *
+ * ``refetchInterval`` is intentionally not set here. Consumers that
+ * need a live list (JobsPage) set ``refetchInterval`` themselves via
+ * useQuery options. Most consumers rely on mutation-driven
+ * invalidation via ``useJobsInvalidator``.
+ */
+export function useJobsList(options?: { refetchInterval?: number }) {
+  return useQuery({
+    queryKey: queryKeys.jobs(),
+    queryFn: () => fetchJobs(),
+    refetchInterval: options?.refetchInterval,
+  });
+}

--- a/frontend/src/api/queries/useResumeJob.ts
+++ b/frontend/src/api/queries/useResumeJob.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { type ResumeRequestBody, resumeJob } from "@/api/jobs";
+import { queryKeys } from "../queryKeys";
+
+export interface ResumeJobVariables {
+  jobId: string;
+  body: ResumeRequestBody;
+}
+
+/**
+ * Resume a FAILED tune job. Same invalidation semantics as Re-tune.
+ */
+export function useResumeJob() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ jobId, body }: ResumeJobVariables) => resumeJob(jobId, body),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.job(variables.jobId),
+      });
+    },
+  });
+}

--- a/frontend/src/api/queries/useRetuneJob.ts
+++ b/frontend/src/api/queries/useRetuneJob.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { type RetuneRequestBody, retuneJob } from "@/api/jobs";
+import { queryKeys } from "../queryKeys";
+
+export interface RetuneJobVariables {
+  jobId: string;
+  body: RetuneRequestBody;
+}
+
+/**
+ * Start a Re-tune child job. On success, invalidates both the job
+ * list and the parent's detail cache so the child appears immediately
+ * and the parent's lineage view refreshes.
+ */
+export function useRetuneJob() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ jobId, body }: RetuneJobVariables) => retuneJob(jobId, body),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.job(variables.jobId),
+      });
+    },
+  });
+}

--- a/frontend/src/api/queries/useRunInference.ts
+++ b/frontend/src/api/queries/useRunInference.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { runInference } from "@/api/inference";
+import { queryKeys } from "../queryKeys";
+
+type RunInferenceParams = Parameters<typeof runInference>[0];
+
+/**
+ * Run inference on a completed job. Invalidates the full inference
+ * history tree so every per-job cache re-fetches its list.
+ */
+export function useRunInference() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: RunInferenceParams) => runInference(params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.infHistoryAll() });
+    },
+  });
+}

--- a/frontend/src/components/jobs/JobDetail.tsx
+++ b/frontend/src/components/jobs/JobDetail.tsx
@@ -1,4 +1,3 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowRight,
   Download,
@@ -10,8 +9,8 @@ import {
 import { useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
-import { fetchJobLineage, fetchJobLog, type LineageNode } from "@/api/jobs";
-import { queryKeys } from "@/api/queryKeys";
+import type { LineageNode } from "@/api/jobs";
+import { useJobLineage, useJobLog, useJobsInvalidator } from "@/api/queries";
 import type { JobDetail as JobDetailType, ProgressMessage } from "@/api/types";
 import { JobLineageTree } from "@/components/retune/JobLineageTree";
 import { ResumeActionButton } from "@/components/retune/ResumeActionButton";
@@ -60,7 +59,7 @@ export function JobDetailPanel({
   onJobSelect,
 }: JobDetailProps) {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
+  const invalidateJobs = useJobsInvalidator();
   const [selectedPlot, setSelectedPlot] = useState<string>("");
   const [logOpen, setLogOpen] = useState(false);
   const [cancelConfirm, setCancelConfirm] = useState(false);
@@ -84,11 +83,8 @@ export function JobDetailPanel({
   // H-0067: Re-tune / Resume / Lineage in the Jobs page. Lineage is
   // auxiliary info — swallow errors silently. Only fetch for tune
   // jobs because only tune jobs can have a lineage.
-  const { data: lineageData } = useQuery({
-    queryKey: queryKeys.jobLineage(jobId),
-    queryFn: () => fetchJobLineage(jobId),
+  const { data: lineageData } = useJobLineage(jobId, {
     enabled: job?.job_type === "tune",
-    retry: false,
   });
   const lineageRoot: LineageNode | null = lineageData?.tree ?? null;
   const showLineage =
@@ -105,10 +101,10 @@ export function JobDetailPanel({
     (childJobId: string) => {
       // Invalidate the list so the new child shows up immediately in
       // the left panel, then switch selection to it.
-      queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
+      invalidateJobs();
       onJobSelect?.(childJobId);
     },
-    [queryClient, onJobSelect],
+    [invalidateJobs, onJobSelect],
   );
 
   const modelName = (job?.config?.model as Record<string, unknown>)?.name as
@@ -479,10 +475,7 @@ function FailedView({
 }
 
 function ExecutionLogContent({ jobId }: { jobId: string }) {
-  const { data } = useQuery({
-    queryKey: queryKeys.jobLog(jobId),
-    queryFn: () => fetchJobLog(jobId),
-  });
+  const { data } = useJobLog(jobId, { enabled: true });
 
   return (
     <pre className="max-h-64 overflow-auto rounded bg-muted p-3 text-xs font-mono">
@@ -500,11 +493,7 @@ function LogDialog({
   onOpenChange: (open: boolean) => void;
   jobId: string;
 }) {
-  const { data } = useQuery({
-    queryKey: queryKeys.jobLog(jobId),
-    queryFn: () => fetchJobLog(jobId),
-    enabled: open,
-  });
+  const { data } = useJobLog(jobId, { enabled: open });
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/frontend/src/components/retune/ResumeActionButton.tsx
+++ b/frontend/src/components/retune/ResumeActionButton.tsx
@@ -1,9 +1,7 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { PlayCircle } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
-import { type ResumeRequestBody, resumeJob } from "@/api/jobs";
-import { queryKeys } from "@/api/queryKeys";
+import { useResumeJob } from "@/api/queries";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -55,7 +53,6 @@ export function ResumeActionButton({
 }: ResumeActionButtonProps) {
   const [open, setOpen] = useState(false);
   const [nTrials, setNTrials] = useState<string>(String(remainingTrials));
-  const queryClient = useQueryClient();
 
   const disabled = !hasCheckpoint || disabledReason != null;
   const tooltip =
@@ -64,19 +61,23 @@ export function ResumeActionButton({
       ? undefined
       : "This failed job has no saved checkpoint to resume from");
 
-  const mutation = useMutation({
-    mutationFn: (body: ResumeRequestBody) => resumeJob(jobId, body),
-    onSuccess: (res) => {
-      toast.success(`Resume started (${res.job_id})`);
-      queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
-      setOpen(false);
-      onStarted?.(res.job_id);
-    },
-    onError: (err: Error) => {
-      toast.error(`Resume failed: ${err.message}`);
-    },
-  });
+  const mutation = useResumeJob();
+  const handleStart = () => {
+    const body = { n_trials: parsed };
+    mutation.mutate(
+      { jobId, body },
+      {
+        onSuccess: (res) => {
+          toast.success(`Resume started (${res.job_id})`);
+          setOpen(false);
+          onStarted?.(res.job_id);
+        },
+        onError: (err: Error) => {
+          toast.error(`Resume failed: ${err.message}`);
+        },
+      },
+    );
+  };
 
   const parsed = Number.parseInt(nTrials, 10);
   const invalid = Number.isNaN(parsed) || parsed < 1 || parsed > MAX_TRIALS;
@@ -126,7 +127,7 @@ export function ResumeActionButton({
           </Button>
           <Button
             disabled={invalid || mutation.isPending}
-            onClick={() => mutation.mutate({ n_trials: parsed })}
+            onClick={handleStart}
           >
             {mutation.isPending ? "Starting..." : "Start Resume"}
           </Button>

--- a/frontend/src/components/retune/RetuneActionButton.tsx
+++ b/frontend/src/components/retune/RetuneActionButton.tsx
@@ -1,9 +1,7 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Repeat } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
-import { type RetuneRequestBody, retuneJob } from "@/api/jobs";
-import { queryKeys } from "@/api/queryKeys";
+import { useRetuneJob } from "@/api/queries";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -58,7 +56,6 @@ export function RetuneActionButton({
 }: RetuneActionButtonProps) {
   const [open, setOpen] = useState(false);
   const [nTrials, setNTrials] = useState<string>(String(defaultNTrials));
-  const queryClient = useQueryClient();
 
   const disabled = !hasCheckpoint || disabledReason != null;
   const tooltip =
@@ -67,22 +64,26 @@ export function RetuneActionButton({
       ? undefined
       : "This job has no saved checkpoint and cannot be re-tuned");
 
-  const mutation = useMutation({
-    mutationFn: (body: RetuneRequestBody) => retuneJob(jobId, body),
-    onSuccess: (res) => {
-      toast.success(`Re-tune started (${res.job_id})`);
-      queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
-      setOpen(false);
-      // Switch the workspace selection to the child so the user sees
-      // progress immediately. Without this the UI keeps showing the
-      // completed parent and the re-tune appears to do nothing.
-      onStarted?.(res.job_id);
-    },
-    onError: (err: Error) => {
-      toast.error(`Re-tune failed: ${err.message}`);
-    },
-  });
+  const mutation = useRetuneJob();
+  const handleStart = () => {
+    const body = { n_trials: parsed };
+    mutation.mutate(
+      { jobId, body },
+      {
+        onSuccess: (res) => {
+          toast.success(`Re-tune started (${res.job_id})`);
+          setOpen(false);
+          // Switch the workspace selection to the child so the user sees
+          // progress immediately. Without this the UI keeps showing the
+          // completed parent and the re-tune appears to do nothing.
+          onStarted?.(res.job_id);
+        },
+        onError: (err: Error) => {
+          toast.error(`Re-tune failed: ${err.message}`);
+        },
+      },
+    );
+  };
 
   const parsed = Number.parseInt(nTrials, 10);
   const invalid = Number.isNaN(parsed) || parsed < 1 || parsed > MAX_TRIALS;
@@ -131,7 +132,7 @@ export function RetuneActionButton({
           </Button>
           <Button
             disabled={invalid || mutation.isPending}
-            onClick={() => mutation.mutate({ n_trials: parsed })}
+            onClick={handleStart}
           >
             {mutation.isPending ? "Starting..." : "Start Re-tune"}
           </Button>

--- a/frontend/src/components/workspace/ResultsCompletedView.tsx
+++ b/frontend/src/components/workspace/ResultsCompletedView.tsx
@@ -1,8 +1,7 @@
-import { useQuery } from "@tanstack/react-query";
 import { Download } from "lucide-react";
 import { useEffect } from "react";
-import { fetchJobLineage, type LineageNode } from "@/api/jobs";
-import { queryKeys } from "@/api/queryKeys";
+import type { LineageNode } from "@/api/jobs";
+import { useJobLineage } from "@/api/queries";
 import type { JobDetail } from "@/api/types";
 import { JobLineageTree } from "@/components/retune/JobLineageTree";
 import { RetuneActionButton } from "@/components/retune/RetuneActionButton";
@@ -40,11 +39,8 @@ export function ResultsCompletedView({
 
   // H-0062 acceptance #13: lineage tree wire-in. Only fetch for tune jobs;
   // silently swallow errors because lineage is auxiliary information.
-  const { data: lineageData } = useQuery({
-    queryKey: queryKeys.jobLineage(job.job_id),
-    queryFn: () => fetchJobLineage(job.job_id),
+  const { data: lineageData } = useJobLineage(job.job_id, {
     enabled: job.job_type === "tune",
-    retry: false,
   });
   const lineageRoot: LineageNode | null = lineageData?.tree ?? null;
   const showLineage =

--- a/frontend/src/components/workspace/ResultsPanel.tsx
+++ b/frontend/src/components/workspace/ResultsPanel.tsx
@@ -1,9 +1,7 @@
-import { useQuery } from "@tanstack/react-query";
 import { Activity } from "lucide-react";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
-import { fetchJobLog, fetchJobs } from "@/api/jobs";
-import { queryKeys } from "@/api/queryKeys";
+import { useJobLog, useJobsList } from "@/api/queries";
 import { ResumeActionButton } from "@/components/retune/ResumeActionButton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -61,11 +59,7 @@ export function ResultsPanel({
     onWsError,
   });
 
-  const { data: allJobs } = useQuery({
-    queryKey: queryKeys.jobs(),
-    queryFn: () => fetchJobs(),
-    enabled: !!jobId,
-  });
+  const { data: allJobs } = useJobsList();
 
   // Compute #N
   const jobNumber =
@@ -247,11 +241,7 @@ function LogDialog({
   onOpenChange: (open: boolean) => void;
   jobId: string;
 }) {
-  const { data } = useQuery({
-    queryKey: queryKeys.jobLog(jobId),
-    queryFn: () => fetchJobLog(jobId),
-    enabled: open,
-  });
+  const { data } = useJobLog(jobId, { enabled: open });
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/frontend/src/pages/InferencePage.tsx
+++ b/frontend/src/pages/InferencePage.tsx
@@ -1,21 +1,17 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import { getErrorMessage } from "@/api/errors";
-import {
-  fetchInferenceHistory,
-  fetchInferenceRecord,
-  runInference,
-} from "@/api/inference";
-import { fetchJob, fetchJobs } from "@/api/jobs";
+import { fetchInferenceHistory, fetchInferenceRecord } from "@/api/inference";
+import { fetchJob } from "@/api/jobs";
+import { useJobsList, useRunInference } from "@/api/queries";
 import { queryKeys } from "@/api/queryKeys";
 import { ResultsPredOnly } from "@/components/inference/ResultsPredOnly";
 import { ResultsWithGT } from "@/components/inference/ResultsWithGT";
 import { SetupPanel } from "@/components/inference/SetupPanel";
 
 export function InferencePage() {
-  const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [selectedJobId, setSelectedJobId] = useState<string | null>(() =>
@@ -24,10 +20,7 @@ export function InferencePage() {
   const [selectedInfId, setSelectedInfId] = useState<string | null>(null);
 
   // Fetch completed jobs
-  const { data: allJobs = [] } = useQuery({
-    queryKey: queryKeys.jobs(),
-    queryFn: () => fetchJobs(),
-  });
+  const { data: allJobs = [] } = useJobsList();
 
   const completedJobs = useMemo(
     () => allJobs.filter((j) => j.status === "completed"),
@@ -70,31 +63,30 @@ export function InferencePage() {
   });
 
   // Run inference mutation
-  const mutation = useMutation({
-    mutationFn: (params: {
-      dataPath: string;
-      evaluate: boolean;
-      returnShap: boolean;
-    }) => {
-      if (!selectedJobId) {
-        return Promise.reject(new Error("No job selected"));
-      }
-      return runInference({
-        job_id: selectedJobId,
-        data: { source_type: "path", path: params.dataPath },
-        return_shap: params.returnShap,
-        evaluate: params.evaluate,
-      });
+  const mutation = useRunInference();
+  const runInferenceAction = useCallback(
+    (params: { dataPath: string; evaluate: boolean; returnShap: boolean }) => {
+      if (!selectedJobId) return;
+      mutation.mutate(
+        {
+          job_id: selectedJobId,
+          data: { source_type: "path", path: params.dataPath },
+          return_shap: params.returnShap,
+          evaluate: params.evaluate,
+        },
+        {
+          onSuccess: (result) => {
+            toast.success("Inference completed");
+            setSelectedInfId(result.inf_id);
+          },
+          onError: (err) => {
+            toast.error(`Inference failed: ${getErrorMessage(err)}`);
+          },
+        },
+      );
     },
-    onSuccess: (result) => {
-      toast.success("Inference completed");
-      queryClient.invalidateQueries({ queryKey: queryKeys.infHistoryAll() });
-      setSelectedInfId(result.inf_id);
-    },
-    onError: (err) => {
-      toast.error(`Inference failed: ${getErrorMessage(err)}`);
-    },
-  });
+    [mutation, selectedJobId],
+  );
 
   const handleSelectJob = useCallback(
     (jobId: string) => {
@@ -108,13 +100,6 @@ export function InferencePage() {
   const handleSelectInf = useCallback((infId: string) => {
     setSelectedInfId(infId);
   }, []);
-
-  const handleRunInference = useCallback(
-    (params: { dataPath: string; evaluate: boolean; returnShap: boolean }) => {
-      mutation.mutate(params);
-    },
-    [mutation.mutate],
-  );
 
   // Auto-select latest inference when history loads
   useEffect(() => {
@@ -162,7 +147,7 @@ export function InferencePage() {
           history={history}
           selectedInfId={selectedInfId}
           onSelectInf={handleSelectInf}
-          onRunInference={handleRunInference}
+          onRunInference={runInferenceAction}
           isRunning={mutation.isPending}
           targetCol={targetCol}
         />

--- a/frontend/src/pages/JobsPage.tsx
+++ b/frontend/src/pages/JobsPage.tsx
@@ -1,19 +1,13 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useState } from "react";
-import { fetchJobs } from "@/api/jobs";
-import { queryKeys } from "@/api/queryKeys";
+import { useJobsInvalidator, useJobsList } from "@/api/queries";
 import { JobDetailPanel } from "@/components/jobs/JobDetail";
 import { JobList } from "@/components/jobs/JobList";
 
 export function JobsPage() {
-  const queryClient = useQueryClient();
+  const invalidateJobs = useJobsInvalidator();
   const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
 
-  const { data: jobs = [] } = useQuery({
-    queryKey: queryKeys.jobs(),
-    queryFn: () => fetchJobs(),
-    refetchInterval: 5000,
-  });
+  const { data: jobs = [] } = useJobsList({ refetchInterval: 5000 });
 
   // Auto-select latest job on first load
   useEffect(() => {
@@ -33,12 +27,12 @@ export function JobsPage() {
 
   const handleJobDeleted = useCallback(() => {
     setSelectedJobId(null);
-    queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
-  }, [queryClient]);
+    invalidateJobs();
+  }, [invalidateJobs]);
 
   const handleJobChanged = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
-  }, [queryClient]);
+    invalidateJobs();
+  }, [invalidateJobs]);
 
   return (
     <div className="flex h-full">


### PR DESCRIPTION
## Summary

Phase 1 of \`docs/coupling-analysis.md\` B-7. Introduces a thin query/mutation hook layer in \`src/api/queries/\` to shield consumers from the raw \`@/api/*\` fetcher modules. Scope intentionally limited to the jobs family + three mutations so one PR stays reviewable; the inference family (7 more hooks across ResultsPredOnly / ResultsWithGT / PredictionsTable) is deferred to Phase 2.

## New \`src/api/queries/\` package

Seven hooks + barrel \`index.ts\` + 8 contract tests.

| Hook | What it is |
|---|---|
| \`useJobsList\` | job list query. \`refetchInterval\` optional for JobsPage live view. |
| \`useJobLog\` | per-job execution log. \`enabled\` gates the fetch until the dialog opens. |
| \`useJobLineage\` | per-job lineage tree. \`retry=false\` because lineage is aux info. |
| \`useJobsInvalidator\` | returns a stable callback that invalidates \`queryKeys.jobs()\`. Encapsulates the boilerplate repeated at 8+ previous call sites. |
| \`useRetuneJob\` | mutation. Invalidates jobs + parent job detail on success. |
| \`useResumeJob\` | mutation. Same invalidation semantics. |
| \`useRunInference\` | mutation. Invalidates \`infHistoryAll\` so every per-job inference history cache re-fetches. |

## Migrated consumers (7 files, net −44 lines)

- **\`pages/JobsPage.tsx\`** — \`useQuery(queryKeys.jobs)\` + invalidate pair → \`useJobsList\` + \`useJobsInvalidator\`.
- **\`pages/InferencePage.tsx\`** — jobs list and runInference mutation migrated. Per-call \`onSuccess\` / \`onError\` hooks preserve the existing toast / \`setSelectedInfId\` behaviour.
- **\`components/retune/ResumeActionButton.tsx\`** & **\`RetuneActionButton.tsx\`** — manual \`useMutation\` + \`invalidateQueries\` → \`useResumeJob\` / \`useRetuneJob\`. Dialog close + \`onStarted\` callback preserved via per-call handlers.
- **\`components/jobs/JobDetail.tsx\`** — lineage \`useQuery\` + two log \`useQuery\` (ExecutionLogContent + LogDialog) + \`handleRetuneStarted\` invalidate → \`useJobLineage\` + \`useJobLog\` + \`useJobsInvalidator\`. \`queryClient\` / \`queryKeys\` imports dropped entirely.
- **\`components/workspace/ResultsPanel.tsx\`** — allJobs \`useQuery\` + LogDialog \`useQuery\` → \`useJobsList\` + \`useJobLog\`. \`queryClient\` / \`queryKeys\` imports dropped.
- **\`components/workspace/ResultsCompletedView.tsx\`** — lineage \`useQuery\` → \`useJobLineage\`.

After this PR only 3 files in the jobs family still touch react-query directly (down from 12). The inference components (ResultsPredOnly, ResultsWithGT, PredictionsTable) and FileBrowser still inline their queries — deliberately out of scope for Phase 1.

## Test plan

- [x] \`pnpm test\` — 1570 passed (+8 new contract tests)
- [x] \`pnpm check\` (biome) — clean
- [x] \`pnpm build\` — clean

Does NOT close an existing issue — B-7 is a roadmap item from \`docs/coupling-analysis.md\`. Phase 2 (inference family) will land as a separate PR.