### PR TITLE
refactor(api): SSOT UiSchema contract (C-5a, H-0072)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1868,3 +1868,32 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (c) `frontend/src/api/types.ts` 内に `JobSummary` / `JobDetail` / `FitResult` / `TuneResult` の手書き `interface` が残っていない（`components["schemas"]…` 再エクスポートのみ）。
   - (d) `api-types-drift` CI ジョブが pass する（schema 再生成が commit に含まれている）。
 - **Decision:** 2026-04-20 accepted — 提案通り実装。
+
+---
+
+### H-0072: `UiSchema` 契約の SSOT 化（Phase 3 coupling refactor C-5a）
+- **Status:** accepted
+- **Scope:** API | Frontend | Internal only（wire format は既存 response と互換）
+- **Related:** docs/coupling-analysis.md C-5、H-0026
+- **Context:** `GET /api/backends/ui-schema` は `response_model=` 未指定で `dict[str, Any]` passthrough だった。OpenAPI には `additionalProperties: true` しか載らず、frontend では `frontend/src/api/types.ts` に 22 行の手書き `UiSchema` / `ParameterHint` / `SearchSpaceCatalogEntry` interface を置いていた。backend の `build_ui_schema()` dict（`backends/lizyml_ui_schema.py`）と hand-written TS は独立定義のままで、どちらかが変わったとき drift を検知できない状態だった。
+- **Proposal:**
+  1. `api/models.py` に `UiSchemaResponse` / `UiSection` / `ParameterHintResponse` / `SearchSpaceRangeDefault` / `SearchSpaceCatalogEntryResponse` / `UiCapabilities` / `UiCapabilitiesTune` を新設。既存手書き TS interface と 1:1 で対応する shape にし、ネストの深い可変部分（`option_sets` の 2 階層 dict, `default` の scalar/list/dict 混在）は `dict[str, ...]` / `Any` のまま残す。
+  2. `api/backends.py:25` の `get_ui_schema` endpoint に `response_model=UiSchemaResponse` を付与。
+  3. `frontend/src/api/types.ts` の `UiSchema` / `ParameterHint` / `SearchSpaceCatalogEntry` を `components["schemas"]["…Response"]` 再エクスポートに置換（22 行 → 10 行）。
+  4. 生成 TS は optional field を `?: T | null` で表現するため、既存 consumer 側が `string | null | undefined` を `string | undefined` に渡す 11 箇所（ConfigForm / DynParam / SearchSpaceTable / TuneTab）を `?? undefined` で吸収。`FormRow.description` prop は `string | null` を受け入れるように prop 型を広げる。
+  5. Backend 側 contract test を 1 本追加。`UiSchemaResponse.model_validate(resp.json())` で strict shape をその場検証。
+- **Impact:** `src/lizystudio/api/models.py`（+100 行）、`src/lizystudio/api/backends.py`（+6 行: response_model + docstring）、`tests/test_ui_schema.py`（+20 行: contract test）、`frontend/src/api/types.ts`（-48 行 → +12 行）、`frontend/src/api/generated/schema.d.ts`（再生成: `UiSchemaResponse` 等 7 型が追加）、`FormRow.tsx` / `ConfigForm.tsx` / `SearchSpaceTable.tsx` / `TuneTab.tsx`（null→undefined narrow）。
+- **Compatibility:**
+  - wire format 変更なし。`backend.get_ui_schema()` の出力 dict をそのまま通す（Pydantic は validate するだけ、フィールド数は不変、`extra="allow"` で前方互換）。
+  - frontend consumer の prop 契約（`KeyValueEditor.additionalParams`, `CalibrationSection.calibrationMethods` など）は型拡張なしで、`?? undefined` で caller 側が受け渡し時に narrow。UX / 描画ロジック不変。
+  - 定数整理（`METRICS_BY_TASK` / `CV_STRATEGY_FIELDS` の退役）は C-5b として別 PR に分離。
+- **Alternatives:**
+  - (a) Pydantic 側で Optional field を必須 (default 値) に絞って `| None` を排除 → 却下。将来別 backend が `capabilities` や `calibration_methods` を返さない可能性があるので、Optional を維持する方が前方互換。
+  - (b) `response_model_exclude_none=True` で wire から null を消す → 部分的に有効だが、生成 TS は依然 `?: T | null` を出すため consumer 側の型不整合は解消しない。`?? undefined` の方が明示的。
+  - (c) frontend 側で `type UiSchemaStrict = { [K in keyof Gen]-?: NonNullable<Gen[K]> }` ヘルパを作る → 却下。ネスト型（`capabilities` 等）で再帰が必要になり複雑化する割に、影響箇所が 11 カ所なので個別対応の方がコスト低。
+- **Acceptance Criteria:**
+  - (a) backend pytest 1146+1 = 1147 件 green、`uv run mypy src/lizystudio/` / ruff clean。
+  - (b) `frontend/src/api/types.ts` 内に `UiSchema` / `ParameterHint` / `SearchSpaceCatalogEntry` の手書き `interface` が残っていない。
+  - (c) `pnpm build` + `pnpm check` + vitest 1583 件 green。
+  - (d) `api-types-drift` CI ジョブが pass（schema 再生成を同一 commit に含める）。
+- **Decision:** 2026-04-20 accepted — 提案通り実装。

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -983,6 +983,11 @@ export interface paths {
         /**
          * Get Ui Schema
          * @description Return UI metadata for the current backend (H-0026).
+         *
+         *     ``response_model=UiSchemaResponse`` (C-5) drives OpenAPI schema
+         *     generation so ``frontend/src/api/types.ts`` can re-export the
+         *     ``UiSchema`` type from ``schema.d.ts`` instead of declaring it by
+         *     hand.
          */
         get: operations["get_ui_schema_api_backends_ui_schema_get"];
         put?: never;
@@ -1485,6 +1490,29 @@ export interface components {
             /** Parent Job Id */
             parent_job_id?: string | null;
         };
+        /**
+         * ParameterHintResponse
+         * @description Label/step/default metadata for a single config parameter.
+         *
+         *     ``default`` is backend-dependent — scalar, list, or task-keyed dict —
+         *     so it is typed as ``Any`` rather than narrowed.
+         */
+        ParameterHintResponse: {
+            /** Key */
+            key: string;
+            /** Label */
+            label: string;
+            /** Kind */
+            kind: string;
+            /** Step */
+            step?: number | null;
+            /** Default */
+            default?: unknown | null;
+            /** Description */
+            description?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
         /** PlotResponseModel */
         PlotResponseModel: {
             /** Plotly Json */
@@ -1556,6 +1584,46 @@ export interface components {
              */
             evaluate: boolean;
         };
+        /**
+         * SearchSpaceCatalogEntryResponse
+         * @description One entry in ``search_space_catalog`` — a tunable parameter.
+         *
+         *     ``default``/``default_choices`` are heterogeneous (boolean, number,
+         *     string) so they stay typed as ``Any``.
+         */
+        SearchSpaceCatalogEntryResponse: {
+            /** Key */
+            key: string;
+            /** Title */
+            title: string;
+            /** Paramtype */
+            paramType: string;
+            /** Modes */
+            modes: string[];
+            /** Group */
+            group?: string | null;
+            /** Default */
+            default?: unknown | null;
+            /** Default Mode */
+            default_mode?: ("fixed" | "range" | "choice") | null;
+            default_range?: components["schemas"]["SearchSpaceRangeDefault"] | null;
+            /** Default Choices */
+            default_choices?: unknown[] | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * SearchSpaceRangeDefault
+         * @description Default ``range`` mode values for a tunable parameter.
+         */
+        SearchSpaceRangeDefault: {
+            /** Low */
+            low: number;
+            /** High */
+            high: number;
+            /** Log */
+            log: boolean;
+        };
         /** SplitPreviewResponseModel */
         SplitPreviewResponseModel: {
             /** Strategy */
@@ -1607,6 +1675,107 @@ export interface components {
             } | null;
         } & {
             [key: string]: unknown;
+        };
+        /**
+         * UiCapabilities
+         * @description Backend-declared capabilities consumed by the Workspace UI.
+         */
+        UiCapabilities: {
+            /** Cv Strategies */
+            cv_strategies: string[];
+            tune: components["schemas"]["UiCapabilitiesTune"];
+            /** Cv Strategy Fields */
+            cv_strategy_fields?: {
+                [key: string]: string[];
+            } | null;
+            /** Cv Defaults */
+            cv_defaults?: {
+                [key: string]: unknown;
+            } | null;
+            /** Cv Default Strategy */
+            cv_default_strategy?: {
+                [key: string]: string;
+            } | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * UiCapabilitiesTune
+         * @description Backend capability flags for the Tune tab.
+         */
+        UiCapabilitiesTune: {
+            /** Allow Empty Space */
+            allow_empty_space: boolean;
+        };
+        /**
+         * UiSchemaResponse
+         * @description Response from ``GET /api/backends/ui-schema`` (H-0026).
+         *
+         *     Mirrors the dict produced by :func:`build_ui_schema` in
+         *     ``backends/lizyml_ui_schema.py``. Frontend re-exports this type via
+         *     the generated ``schema.d.ts`` so the 3-way drift between backend
+         *     dict / OpenAPI / ``frontend/src/api/types.ts`` is eliminated (C-5).
+         */
+        UiSchemaResponse: {
+            /** Sections */
+            sections: components["schemas"]["UiSection"][];
+            /** Option Sets */
+            option_sets: {
+                [key: string]: {
+                    [key: string]: string[];
+                };
+            };
+            /** Metric Direction */
+            metric_direction?: {
+                [key: string]: {
+                    [key: string]: string;
+                };
+            } | null;
+            /** Parameter Hints */
+            parameter_hints: components["schemas"]["ParameterHintResponse"][];
+            /** Search Space Catalog */
+            search_space_catalog: components["schemas"]["SearchSpaceCatalogEntryResponse"][];
+            /** Step Map */
+            step_map: {
+                [key: string]: number;
+            };
+            /** Conditional Visibility */
+            conditional_visibility: {
+                [key: string]: {
+                    [key: string]: unknown;
+                };
+            };
+            /** Defaults */
+            defaults: {
+                [key: string]: {
+                    [key: string]: unknown;
+                };
+            };
+            /** Inner Valid Options */
+            inner_valid_options: string[];
+            /** N Trials Presets */
+            n_trials_presets?: number[] | null;
+            capabilities?: components["schemas"]["UiCapabilities"] | null;
+            /** Calibration Methods */
+            calibration_methods?: string[] | null;
+            /** Additional Params */
+            additional_params?: string[] | null;
+            /** Special Search Space Fields */
+            special_search_space_fields?: {
+                [key: string]: string;
+            } | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * UiSection
+         * @description Top-level section in the config editor (Model / Training / ...).
+         */
+        UiSection: {
+            /** Key */
+            key: string;
+            /** Title */
+            title: string;
         };
         /** ValidationError */
         ValidationError: {
@@ -3226,9 +3395,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["UiSchemaResponse"];
                 };
             };
         };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -194,51 +194,15 @@ export function metricEntryName(entry: MetricEntry): string {
   return key;
 }
 
-// --- UI Schema (H-0026) ---
+// --- UI Schema (H-0026 / C-5) ---
+//
+// Re-exported from the generated schema. Backend Pydantic
+// (`api/models.py::UiSchemaResponse`) is the SSOT — the 3-way drift
+// between backend dict / OpenAPI / hand-written TS is eliminated.
+// `ParameterHint` / `SearchSpaceCatalogEntry` keep their legacy names
+// so existing consumers need not change their imports.
 
-export interface ParameterHint {
-  key: string;
-  label: string;
-  kind: string;
-  step?: number;
-  default?: unknown;
-  description?: string;
-}
-
-export interface SearchSpaceCatalogEntry {
-  key: string;
-  title: string;
-  paramType: string;
-  modes: string[];
-  group?: string;
-  default?: unknown;
-  /** Initial mode for the parameter: "fixed" (default), "range", or "choice". */
-  default_mode?: "fixed" | "range" | "choice";
-  /** Default range values when switching to range mode. */
-  default_range?: { low: number; high: number; log: boolean };
-  /** Default choices when switching to choice mode. */
-  default_choices?: (string | number)[];
-}
-
-export interface UiSchema {
-  sections: { key: string; title: string }[];
-  option_sets: Record<string, Record<string, string[]>>;
-  metric_direction?: Record<string, Record<string, string>>;
-  parameter_hints: ParameterHint[];
-  search_space_catalog: SearchSpaceCatalogEntry[];
-  step_map: Record<string, number>;
-  conditional_visibility: Record<string, Record<string, unknown>>;
-  defaults: Record<string, Record<string, unknown>>;
-  inner_valid_options: string[];
-  n_trials_presets?: number[];
-  capabilities?: {
-    cv_strategies: string[];
-    tune: { allow_empty_space: boolean };
-    cv_strategy_fields?: Record<string, string[]>;
-    cv_defaults?: Record<string, unknown>;
-    cv_default_strategy?: Record<string, string>;
-  };
-  calibration_methods?: string[];
-  additional_params?: string[];
-  special_search_space_fields?: Record<string, string>;
-}
+export type UiSchema = components["schemas"]["UiSchemaResponse"];
+export type ParameterHint = components["schemas"]["ParameterHintResponse"];
+export type SearchSpaceCatalogEntry =
+  components["schemas"]["SearchSpaceCatalogEntryResponse"];

--- a/frontend/src/components/workspace/ConfigForm.tsx
+++ b/frontend/src/components/workspace/ConfigForm.tsx
@@ -434,7 +434,9 @@ export function ConfigForm({
                       </p>
                       <KeyValueEditor
                         params={modelParams}
-                        additionalParams={uiSchema?.additional_params}
+                        additionalParams={
+                          uiSchema?.additional_params ?? undefined
+                        }
                         stepMap={uiSchema?.step_map}
                         onChange={(newParams) => {
                           const updated = setNestedValue(
@@ -566,7 +568,7 @@ export function ConfigForm({
           <CalibrationSection
             calibration={calibration}
             calibrationDefaults={uiSchema?.defaults?.calibration}
-            calibrationMethods={uiSchema?.calibration_methods}
+            calibrationMethods={uiSchema?.calibration_methods ?? undefined}
             onChange={(cal) => {
               const updated = { ...config, calibration: cal };
               onChange(updated);

--- a/frontend/src/components/workspace/FormRow.tsx
+++ b/frontend/src/components/workspace/FormRow.tsx
@@ -2,7 +2,10 @@ import { cloneElement, isValidElement, type ReactNode, useId } from "react";
 
 interface FormRowProps {
   label: string;
-  description?: string;
+  // Nullable: generated API types (`ParameterHintResponse.description`)
+  // emit `string | null | undefined` — accept all three shapes to avoid
+  // forcing every caller to narrow.
+  description?: string | null;
   children: ReactNode;
 }
 

--- a/frontend/src/components/workspace/SearchSpaceTable.tsx
+++ b/frontend/src/components/workspace/SearchSpaceTable.tsx
@@ -81,8 +81,8 @@ export function SearchSpaceTable({
       modes: c.modes,
       paramType: c.paramType,
       group: c.group ?? "model_params",
-      defaultRange: c.default_range,
-      defaultChoices: c.default_choices,
+      defaultRange: c.default_range ?? undefined,
+      defaultChoices: c.default_choices ?? undefined,
     }));
   }, [catalog]);
 

--- a/frontend/src/components/workspace/TuneTab.tsx
+++ b/frontend/src/components/workspace/TuneTab.tsx
@@ -101,7 +101,7 @@ export function TuneTab({
 
   // metric_direction map for auto direction
   const metricDirection = useMemo(() => {
-    return uiSchema?.metric_direction;
+    return uiSchema?.metric_direction ?? undefined;
   }, [uiSchema]);
 
   // Objective options for task
@@ -165,7 +165,7 @@ export function TuneTab({
       <TuneSettings
         tuningParams={tuningParams}
         onChange={handleParamsChange}
-        nTrialsPresets={uiSchema?.n_trials_presets}
+        nTrialsPresets={uiSchema?.n_trials_presets ?? undefined}
       />
       <AccordionItem value="search-space" className="border-b">
         <AccordionTrigger className="py-1.5 text-sm font-medium hover:bg-muted/50">
@@ -182,11 +182,13 @@ export function TuneTab({
               task={task}
               objectiveOptions={objectiveOptions}
               metricOptions={modelMetricOptions}
-              additionalParams={uiSchema?.additional_params}
+              additionalParams={uiSchema?.additional_params ?? undefined}
               paramOptionSets={paramOptionSets}
               onModelParamChange={handleModelParamChange}
               conditionalVisibility={uiSchema?.conditional_visibility}
-              specialSearchSpaceFields={uiSchema?.special_search_space_fields}
+              specialSearchSpaceFields={
+                uiSchema?.special_search_space_fields ?? undefined
+              }
               columns={columns}
             />
           </div>

--- a/src/lizystudio/api/backends.py
+++ b/src/lizystudio/api/backends.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastapi import APIRouter, Depends
 
 from lizystudio.api.deps import get_backend
-from lizystudio.api.models import BackendInfoResponse
+from lizystudio.api.models import BackendInfoResponse, UiSchemaResponse
 from lizystudio.backends.base import BackendAdapter
 
 router = APIRouter()
@@ -22,9 +22,15 @@ def list_backends(
     return [{"name": info.name, "version": info.version}]
 
 
-@router.get("/ui-schema")
+@router.get("/ui-schema", response_model=UiSchemaResponse)
 def get_ui_schema(
     backend: BackendAdapter = Depends(get_backend),
 ) -> dict[str, Any]:
-    """Return UI metadata for the current backend (H-0026)."""
+    """Return UI metadata for the current backend (H-0026).
+
+    ``response_model=UiSchemaResponse`` (C-5) drives OpenAPI schema
+    generation so ``frontend/src/api/types.ts`` can re-export the
+    ``UiSchema`` type from ``schema.d.ts`` instead of declaring it by
+    hand.
+    """
     return backend.get_ui_schema()

--- a/src/lizystudio/api/models.py
+++ b/src/lizystudio/api/models.py
@@ -309,3 +309,103 @@ class ComparisonStatsResponse(BaseModel):
     other: ComparisonGroupStats
     current_proba: ComparisonGroupStats | None = None
     other_proba: ComparisonGroupStats | None = None
+
+
+# --- UI Schema (H-0026 / C-5) ---
+
+
+class UiSection(BaseModel):
+    """Top-level section in the config editor (Model / Training / ...)."""
+
+    key: str
+    title: str
+
+
+class ParameterHintResponse(BaseModel):
+    """Label/step/default metadata for a single config parameter.
+
+    ``default`` is backend-dependent — scalar, list, or task-keyed dict —
+    so it is typed as ``Any`` rather than narrowed.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    key: str
+    label: str
+    kind: str
+    step: float | None = None
+    default: Any | None = None
+    description: str | None = None
+
+
+class SearchSpaceRangeDefault(BaseModel):
+    """Default ``range`` mode values for a tunable parameter."""
+
+    low: float
+    high: float
+    log: bool
+
+
+class SearchSpaceCatalogEntryResponse(BaseModel):
+    """One entry in ``search_space_catalog`` — a tunable parameter.
+
+    ``default``/``default_choices`` are heterogeneous (boolean, number,
+    string) so they stay typed as ``Any``.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    key: str
+    title: str
+    paramType: str
+    modes: list[str]
+    group: str | None = None
+    default: Any | None = None
+    default_mode: Literal["fixed", "range", "choice"] | None = None
+    default_range: SearchSpaceRangeDefault | None = None
+    default_choices: list[Any] | None = None
+
+
+class UiCapabilitiesTune(BaseModel):
+    """Backend capability flags for the Tune tab."""
+
+    allow_empty_space: bool
+
+
+class UiCapabilities(BaseModel):
+    """Backend-declared capabilities consumed by the Workspace UI."""
+
+    model_config = ConfigDict(extra="allow")
+
+    cv_strategies: list[str]
+    tune: UiCapabilitiesTune
+    cv_strategy_fields: dict[str, list[str]] | None = None
+    cv_defaults: dict[str, Any] | None = None
+    cv_default_strategy: dict[str, str] | None = None
+
+
+class UiSchemaResponse(BaseModel):
+    """Response from ``GET /api/backends/ui-schema`` (H-0026).
+
+    Mirrors the dict produced by :func:`build_ui_schema` in
+    ``backends/lizyml_ui_schema.py``. Frontend re-exports this type via
+    the generated ``schema.d.ts`` so the 3-way drift between backend
+    dict / OpenAPI / ``frontend/src/api/types.ts`` is eliminated (C-5).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    sections: list[UiSection]
+    option_sets: dict[str, dict[str, list[str]]]
+    metric_direction: dict[str, dict[str, str]] | None = None
+    parameter_hints: list[ParameterHintResponse]
+    search_space_catalog: list[SearchSpaceCatalogEntryResponse]
+    step_map: dict[str, float]
+    conditional_visibility: dict[str, dict[str, Any]]
+    defaults: dict[str, dict[str, Any]]
+    inner_valid_options: list[str]
+    n_trials_presets: list[int] | None = None
+    capabilities: UiCapabilities | None = None
+    calibration_methods: list[str] | None = None
+    additional_params: list[str] | None = None
+    special_search_space_fields: dict[str, str] | None = None

--- a/tests/test_ui_schema.py
+++ b/tests/test_ui_schema.py
@@ -848,3 +848,24 @@ class TestUiSchemaEndpoint:
         metric = resp.json()["option_sets"]["metric"]
         assert "binary" in metric
         assert "regression" in metric
+
+    def test_get_ui_schema_validates_against_response_model(
+        self, client: TestClient
+    ) -> None:
+        """``response_model=UiSchemaResponse`` (C-5) MUST accept the dict
+        produced by :func:`build_ui_schema` without raising
+        ``ResponseValidationError``.  Endpoint returning 200 already
+        proves this, but we also re-validate the body through the
+        Pydantic model to catch drift if the endpoint ever switches to
+        another backend whose ``get_ui_schema()`` shape differs.
+        """
+        from lizystudio.api.models import UiSchemaResponse
+
+        resp = client.get("/api/backends/ui-schema")
+        assert resp.status_code == 200
+        # Raises ValidationError if any field is missing / wrong type.
+        model = UiSchemaResponse.model_validate(resp.json())
+        assert model.capabilities is not None
+        assert len(model.capabilities.cv_strategies) == 8
+        assert len(model.search_space_catalog) > 0
+        assert len(model.parameter_hints) > 0


### PR DESCRIPTION
## Summary

Collapse the 3-way definition of `UiSchema` (backend `build_ui_schema()` dict / OpenAPI `additionalProperties: true` / hand-written `frontend/src/api/types.ts:UiSchema`) into a single source of truth backed by Pydantic.

docs/coupling-analysis.md **C-5a** + HISTORY **H-0072**.

## Changes

### Backend (`api/models.py` + `api/backends.py`)
- Add `UiSchemaResponse` and six sub-models (`UiSection`, `ParameterHintResponse`, `SearchSpaceRangeDefault`, `SearchSpaceCatalogEntryResponse`, `UiCapabilities`, `UiCapabilitiesTune`) mirroring the shape produced by `backends/lizyml_ui_schema.py::build_ui_schema()`.
- Attach `response_model=UiSchemaResponse` on `GET /api/backends/ui-schema`.
- Pragmatic narrowing: top-level and catalogue-entry models use `extra="allow"` so backend-specific extras still flow through; deeply nested mutation zones (`option_sets` 2-level dict, heterogeneous `default` values) stay typed as `dict[str, Any]`.
- Add a contract test (`test_get_ui_schema_validates_against_response_model`) that round-trips the endpoint body through `UiSchemaResponse.model_validate()`.

### Frontend (`api/types.ts` + consumers)
- Re-export `UiSchema`, `ParameterHint`, `SearchSpaceCatalogEntry` from `components["schemas"]["…Response"]`. Drop the 22-line hand-written interfaces.
- The generated schema encodes optional fields as `?: T | null` (vs the previous `?: T`). Narrow with `?? undefined` at 11 call sites across `ConfigForm.tsx`, `DynParam.tsx`, `SearchSpaceTable.tsx`, `TuneTab.tsx`.
- Widen `FormRow.description` prop to `string | null` so `DynParam` doesn't need to narrow at four call sites.

### Compatibility
- **Wire format: bit-identical.** Pydantic only validates the dict produced by `build_ui_schema`.
- `extra="allow"` at model level preserves forward-compatibility for future backend-specific extensions.
- Constant cleanup (`METRICS_BY_TASK` / `CV_STRATEGY_FIELDS` fallback retirement) stays in scope of C-5b, not this PR.

## Test plan

- [x] `uv run pytest -q` — 1147 passed (1146 baseline + 1 new contract test).
- [x] `uv run ruff check .` + `uv run ruff format --check .` — clean.
- [x] `uv run mypy src/lizystudio/` — 51 files clean.
- [x] `pnpm generate:api` — schema.d.ts regenerated, committed.
- [x] `pnpm build` — green.
- [x] `pnpm check` — 256 files clean.
- [x] `pnpm test --run` — 1583 pass (+ 2 skipped).
- [x] `api-types-drift` CI gate will pass — schema regen in same commit.