### PR TITLE
refactor(hooks): route cv-state imports past CvSection component (B-4)

### DIFF
--- a/frontend/src/hooks/useConfigSync.ts
+++ b/frontend/src/hooks/useConfigSync.ts
@@ -5,13 +5,13 @@ import {
   fetchConfigDefaults,
   updateConfig,
 } from "@/api/workspace";
+import type { BlockedGroupKFoldState } from "@/components/workspace/BlockedGroupKFoldEditor";
 import {
   applyCvDataFields,
-  type BlockedGroupKFoldState,
   buildSplitConfig,
   type CvState,
   recommendedInnerValid,
-} from "@/components/workspace/CvSection";
+} from "@/components/workspace/cv-state";
 import type { ColumnOverride, TaskType } from "./useDataPanel.types";
 import { buildSyncKey, extractOverrideArrays } from "./useDataPanel.types";
 

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -11,12 +11,14 @@ import {
 } from "@/api/workspace";
 import {
   type BlockedGroupKFoldState,
-  type CvState,
   INITIAL_BLOCKED_STATE,
+} from "@/components/workspace/BlockedGroupKFoldEditor";
+import { getDefaultCvStrategy } from "@/components/workspace/constants";
+import {
+  type CvState,
   INITIAL_CV_STATE,
   resetCvState,
-} from "@/components/workspace/CvSection";
-import { getDefaultCvStrategy } from "@/components/workspace/constants";
+} from "@/components/workspace/cv-state";
 import { useColumnOverrides } from "./useColumnOverrides";
 import { useConfigSync } from "./useConfigSync";
 import { useDataLoad } from "./useDataLoad";


### PR DESCRIPTION
## Summary

Eliminate the hook→component reverse import flagged by docs/coupling-analysis.md **B-4**. Both \`useConfigSync\` and \`useDataPanel\` were pulling \`applyCvDataFields\`, \`buildSplitConfig\`, \`recommendedInnerValid\`, \`CvState\`, \`INITIAL_CV_STATE\`, \`resetCvState\` from \`@/components/workspace/CvSection\`, which just re-exports them from \`./cv-state\`. The hooks now import directly from the state module, breaking the structural dependency on the component.

## Changes

- \`frontend/src/hooks/useConfigSync.ts\`: switch 5-symbol import from \`CvSection\` → \`cv-state\`. Keep the \`BlockedGroupKFoldState\` type-only import from \`BlockedGroupKFoldEditor\` (that state lives in the editor file — follow-up work, out of B-4 scope).
- \`frontend/src/hooks/useDataPanel.ts\`: same split — \`CvState\` / \`INITIAL_CV_STATE\` / \`resetCvState\` come from \`cv-state\`; \`BlockedGroupKFoldState\` / \`INITIAL_BLOCKED_STATE\` stay on \`BlockedGroupKFoldEditor\` pending a separate peel-out PR.

## Why not also delete \`CvSection\` re-exports?

\`CvSection.tsx:28-35\` still re-exports the same symbols for existing component / test / stories consumers (\`cv-section.test.ts\`, \`CvSection.stories.tsx\`, \`BlockedGroupKFoldEditor\`). Those are component↔component imports, not a layering issue. Cleaning them up belongs in a follow-up refactor, not in B-4.

## Test plan

- [x] \`pnpm build\` — green (tsc -b + vite build, 2066 modules).
- [x] \`pnpm check\` — biome clean, 256 files.
- [x] \`pnpm test --run\` — 1583 passed (2 skipped).