### PR TITLE
refactor(jobs): centralize on-disk layout via JobStore.path_for (A-10, H-0073)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1897,3 +1897,32 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (c) `pnpm build` + `pnpm check` + vitest 1583 件 green。
   - (d) `api-types-drift` CI ジョブが pass（schema 再生成を同一 commit に含める）。
 - **Decision:** 2026-04-20 accepted — 提案通り実装。
+
+---
+
+### H-0073: `JobStore.path_for` による on-disk layout SSOT 化（Phase 3 coupling refactor A-10）
+- **Status:** accepted
+- **Scope:** Backend | Internal only（保存レイアウト・wire format・BackendAdapter Protocol すべて不変）
+- **Related:** docs/coupling-analysis.md A-10、BLUEPRINT.md §3.4.4
+- **Context:** `{jobs_dir}/{job_id}/<artifact>` の path 構築が `services/jobs.py` / `services/training.py` / `services/_training_core.py` / `services/training_retune.py` / `services/job_results.py` / `api/retune.py` の 14+ 箇所に独立に散らばっていた。`JobStore._job_dir` は private helper で外部から使えず、`meta.json` / `execution.log` / `model/` / `tuning_plot.json` の filename が呼び出し側で直書きされているため、ファイル名変更や新しい artifact の追加時に漏れなく追跡する方法がなかった。
+- **Proposal:**
+  1. `services/jobs.py` にモジュール定数 `ArtifactKind` (`Literal[...]`) と `ARTIFACT_FILENAMES: dict[ArtifactKind, str]` を導入。BLUEPRINT §3.4.4 の全 artifact（`meta` / `fit_result` / `tune_result` / `model` / `log` / `tuning_plot` / `cancel_flag`）をここに集約。
+  2. `JobStore` に public メソッド `job_dir(job_id)` / `path_for(job_id, kind)` を追加。どちらも path traversal guard 付きの `_job_dir` 経由で解決。
+  3. `JobStore` インスタンスを持たない caller（`services/job_results.py`）向けに、module-level helper `artifact_path(jobs_dir, job_id, kind)` を公開。`job.model_path` から `jobs_dir` を逆算する既存経路と互換。
+  4. 14+ 箇所の `jobs_dir / job_id / "..."` と `_job_dir(...)` 使用を `path_for(kind)` / `job_dir(job_id)` / `artifact_path(...)` に置換。
+  5. tmp file の construction（`.cancel-{pid}.tmp`）は一時ファイルであり artifact ではないため対象外。`inference.py` が使う `{jobs_dir}/{job_id}/inferences/...` も別レイヤ（`InferenceStore`）なので本 PR スコープ外。
+- **Impact:** `src/lizystudio/services/jobs.py`（+56 行: module constants + 2 methods + helper）、`src/lizystudio/services/training.py`（4 箇所置換）、`src/lizystudio/services/_training_core.py`（1 箇所置換）、`src/lizystudio/services/training_retune.py`（2 箇所置換）、`src/lizystudio/services/job_results.py`（1 箇所置換 + import 1 行）、`src/lizystudio/api/retune.py`（1 箇所置換）。
+- **Compatibility:**
+  - 保存 layout 変更なし。全置換は「構築経路のみ」の変更で、生成される `Path` は以前と bit-identical（同じ string 結果）。
+  - wire format / BackendAdapter Protocol 変更なし。
+  - 既存テスト 1146 件はすべて無修正で通過（contract test 追加分を除けば +1 件 = 1147 件）。
+- **Alternatives:**
+  - (a) `JobStore._job_dir` を public 化するだけで終える → 却下。filename の直書きが残ると SSOT にならない。
+  - (b) `pathlib.Path` サブクラスで `Job.meta_path` 等のプロパティを生やす → 却下。`Job` dataclass が `JobStore` を知るのは逆向き依存。
+  - (c) `Enum` を使って `ArtifactKind` を表現 → 却下。`Literal[...]` の方が mypy 上で caller 側が文字列リテラルを直接書けて簡潔。`dict[Literal[...], str]` は mypy で網羅性検証される。
+- **Acceptance Criteria:**
+  - (a) `grep -rn "jobs_dir.*/.*job" src/lizystudio/services` が `artifact_path` 実装本体と `_job_dir` 本体を除いて 0 件（inference.py 除く）。
+  - (b) backend pytest 1146+1 件 = 1147 件 green。
+  - (c) `uv run mypy src/lizystudio/` / `uv run ruff check .` / `uv run ruff format --check .` 全 clean。
+  - (d) `ARTIFACT_FILENAMES` を `JobStore.path_for` / module-level `artifact_path` の両経路から共有。
+- **Decision:** 2026-04-20 accepted — 提案通り実装。

--- a/src/lizystudio/api/retune.py
+++ b/src/lizystudio/api/retune.py
@@ -109,7 +109,7 @@ def _require_tune_job_with_checkpoint(
             "INVALID_PARAM",
             f"Job {parent.job_id} is not a tune job (type={parent.job_type})",
         )
-    parent_dir = job_store.jobs_dir / parent.job_id
+    parent_dir = job_store.job_dir(parent.job_id)
     checkpoint = parent_dir / "model.pkl"
     if not checkpoint.exists():
         raise StudioError(

--- a/src/lizystudio/services/_training_core.py
+++ b/src/lizystudio/services/_training_core.py
@@ -194,7 +194,7 @@ def _run_job_core(
         # doing so would short-circuit the worker thread and leave a
         # zombie thread handle on the workspace.
         try:
-            log_path = job_store.jobs_dir / job.job_id / "execution.log"
+            log_path = job_store.path_for(job.job_id, "log")
             log_path.parent.mkdir(parents=True, exist_ok=True)
             log_path.write_text(log_buffer.getvalue(), encoding="utf-8")
         except OSError:

--- a/src/lizystudio/services/job_results.py
+++ b/src/lizystudio/services/job_results.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from lizystudio.backends.base import BackendAdapter
 from lizystudio.backends.types import PlotData
-from lizystudio.services.jobs import Job
+from lizystudio.services.jobs import Job, artifact_path
 
 _MODEL_CACHE_MAX = 8
 
@@ -116,7 +116,7 @@ def _load_tuning_plot_from_file(job: Job) -> PlotData | None:
     jobs_dir = _get_jobs_dir(job)
     if jobs_dir is None:
         return None
-    path = jobs_dir / job.job_id / "tuning_plot.json"
+    path = artifact_path(jobs_dir, job.job_id, "tuning_plot")
     if not path.exists():
         return None
     return PlotData(plotly_json=path.read_text(encoding="utf-8"))

--- a/src/lizystudio/services/jobs.py
+++ b/src/lizystudio/services/jobs.py
@@ -33,6 +33,45 @@ _logger = logging.getLogger(__name__)
 CANCEL_FLAG_FILENAME = "CANCEL"
 
 
+# A-10: BLUEPRINT §3.4.4 on-disk layout for a single job. Centralising
+# this map is the core of the path-layout SSOT — every artifact filename
+# lives here, and every caller goes through ``JobStore.path_for`` (or
+# the module-level :func:`artifact_path` helper, used by call sites
+# that have a ``jobs_dir`` but no ``JobStore`` instance).
+ArtifactKind = Literal[
+    "meta",
+    "fit_result",
+    "tune_result",
+    "model",
+    "log",
+    "tuning_plot",
+    "cancel_flag",
+]
+
+ARTIFACT_FILENAMES: dict[ArtifactKind, str] = {
+    "meta": "meta.json",
+    "fit_result": "fit_result.json",
+    "tune_result": "tune_result.json",
+    "model": "model",  # directory (see load/save in adapters)
+    "log": "execution.log",
+    "tuning_plot": "tuning_plot.json",
+    "cancel_flag": CANCEL_FLAG_FILENAME,
+}
+
+
+def artifact_path(jobs_dir: Path, job_id: str, kind: ArtifactKind) -> Path:
+    """Resolve ``{jobs_dir}/{job_id}/<artifact>`` without a ``JobStore``.
+
+    ``JobStore.path_for`` is the preferred entry point (it also applies
+    path-traversal guards). This helper exists for call sites — e.g.
+    :mod:`lizystudio.services.job_results` — that hold a ``Job`` and can
+    derive ``jobs_dir`` from ``Job.model_path`` but do not own the
+    ``JobStore`` instance. Callers are responsible for validating
+    ``job_id`` when it is user-controlled.
+    """
+    return jobs_dir / job_id / ARTIFACT_FILENAMES[kind]
+
+
 @dataclass
 class Job:
     """Persistent job metadata."""
@@ -86,6 +125,27 @@ class JobStore:
         validate_path_within(candidate, self.jobs_dir)
         return candidate
 
+    # --- Path resolution (A-10) ---
+
+    def job_dir(self, job_id: str) -> Path:
+        """Public job directory resolver with traversal guard.
+
+        Callers outside :class:`JobStore` should prefer :meth:`path_for`
+        for named artifacts and reserve :meth:`job_dir` for cases that
+        need the directory itself (e.g. checkpoint base dir for
+        subprocess runners).
+        """
+        return self._job_dir(job_id)
+
+    def path_for(self, job_id: str, kind: ArtifactKind) -> Path:
+        """Resolve the on-disk path of a named job artifact.
+
+        Backed by the module-level :data:`ARTIFACT_FILENAMES` map so the
+        layout stays a single source of truth. The returned path is
+        already guarded against traversal via :meth:`_job_dir`.
+        """
+        return self._job_dir(job_id) / ARTIFACT_FILENAMES[kind]
+
     # --- CRUD ---
 
     def create(
@@ -118,8 +178,7 @@ class JobStore:
 
     def get(self, job_id: str) -> Job | None:
         """Load a job by ID. Returns ``None`` if not found."""
-        meta_path = self._job_dir(job_id) / "meta.json"
-        if not meta_path.exists():
+        if not self.path_for(job_id, "meta").exists():
             return None
         return self._load_job(job_id)
 
@@ -168,12 +227,12 @@ class JobStore:
         self._save_meta(job)
         if job.fit_result is not None:
             self._write_json(
-                self.jobs_dir / job.job_id / "fit_result.json",
+                self.path_for(job.job_id, "fit_result"),
                 asdict(job.fit_result),
             )
         if job.tune_result is not None:
             self._write_json(
-                self.jobs_dir / job.job_id / "tune_result.json",
+                self.path_for(job.job_id, "tune_result"),
                 asdict(job.tune_result),
             )
 
@@ -185,7 +244,7 @@ class JobStore:
         removed (existing children become orphaned).  An empty list is
         returned when the job does not exist.
         """
-        if not self._job_dir(job_id).exists():
+        if not self.job_dir(job_id).exists():
             return []
 
         removed: builtins.list[str] = []
@@ -202,7 +261,7 @@ class JobStore:
             removed.append(job_id)
 
         for jid in removed:
-            target = self._job_dir(jid)
+            target = self.job_dir(jid)
             if target.exists():
                 # ignore_errors: a concurrent request_cancel (#152) can
                 # briefly stage a tempfile inside the victim tree, and
@@ -215,7 +274,7 @@ class JobStore:
             # here to avoid a top-level cycle with ``job_results``.
             from lizystudio.services.job_results import clear_model_cache_for
 
-            clear_model_cache_for(str(self._job_dir(jid) / "model"))
+            clear_model_cache_for(str(self.path_for(jid, "model")))
         return removed
 
     # --- H-0062 lineage helpers ---
@@ -442,10 +501,10 @@ class JobStore:
     def _cancel_flag_path(self, job_id: str) -> Path:
         """Resolve the cancel flag path with the traversal guard.
 
-        Reuses ``_job_dir``'s path validation so a malformed job_id
-        cannot escape the jobs_dir root.
+        Thin wrapper over :meth:`path_for` so a malformed job_id cannot
+        escape the jobs_dir root.
         """
-        return self._job_dir(job_id) / CANCEL_FLAG_FILENAME
+        return self.path_for(job_id, "cancel_flag")
 
     # --- Active job tracking (concurrency control) ---
 
@@ -587,7 +646,7 @@ class JobStore:
 
     def get_log(self, job_id: str) -> str:
         """Read execution log for a job. Returns empty string if not found."""
-        log_path = self._job_dir(job_id) / "execution.log"
+        log_path = self.path_for(job_id, "log")
         if not log_path.exists():
             return ""
         return log_path.read_text(encoding="utf-8")
@@ -595,7 +654,7 @@ class JobStore:
     # --- Internal helpers ---
 
     def _save_meta(self, job: Job) -> None:
-        job_dir = self._job_dir(job.job_id)
+        job_dir = self.job_dir(job.job_id)
         job_dir.mkdir(parents=True, exist_ok=True)
         meta = {
             "job_id": job.job_id,
@@ -610,20 +669,19 @@ class JobStore:
             "error": job.error,
             "parent_job_id": job.parent_job_id,
         }
-        self._write_json(job_dir / "meta.json", meta)
+        self._write_json(self.path_for(job.job_id, "meta"), meta)
 
     def _load_job(self, job_id: str) -> Job:
-        job_dir = self._job_dir(job_id)
-        meta = self._read_json(job_dir / "meta.json")
+        meta = self._read_json(self.path_for(job_id, "meta"))
 
         fit_result = None
-        fit_path = job_dir / "fit_result.json"
+        fit_path = self.path_for(job_id, "fit_result")
         if fit_path.exists():
             d = self._read_json(fit_path)
             fit_result = FitSummary(**d)
 
         tune_result = None
-        tune_path = job_dir / "tune_result.json"
+        tune_path = self.path_for(job_id, "tune_result")
         if tune_path.exists():
             d = self._read_json(tune_path)
             tune_result = TuningSummary(**d)

--- a/src/lizystudio/services/training.py
+++ b/src/lizystudio/services/training.py
@@ -59,7 +59,7 @@ def run_fit(
     def execute(cb: ProgressCallback) -> tuple[FitSummary, TuningSummary | None, str]:
         model = backend.create_model(config, dataframe)
         fit_result: FitSummary = backend.fit(model, params=params, on_progress=cb)
-        model_dir = str(job_store.jobs_dir / job.job_id / "model")
+        model_dir = str(job_store.path_for(job.job_id, "model"))
         backend.export_model(model, model_dir)
         return fit_result, None, model_dir
 
@@ -196,7 +196,7 @@ def run_tune(
     tune_config = _prepare_tune_config(config)
     re_tune = _extract_re_tune(config)
     # H-0062: checkpoint directory for incremental trial persistence.
-    checkpoint_dir = job_store.jobs_dir / job.job_id
+    checkpoint_dir = job_store.job_dir(job.job_id)
     _run_pickle_preflight(backend, checkpoint_dir)
 
     def execute(cb: ProgressCallback) -> tuple[FitSummary, TuningSummary | None, str]:
@@ -210,7 +210,7 @@ def run_tune(
 
         # Capture tuning plot from the tune model before creating model2.
         # The exported model2 (fit with best params) loses tuning history.
-        _save_tuning_plot(backend, model, job_store.jobs_dir / job.job_id)
+        _save_tuning_plot(backend, model, job_store.job_dir(job.job_id))
 
         # Build fit config from the ORIGINAL config (not tune_config) with
         # best_params merged into model.params.  This ensures the auto-fit
@@ -218,7 +218,7 @@ def run_tune(
         fit_config = _prepare_autofit_config(config, tune_result.best_params)
         model2 = backend.create_model(fit_config, dataframe)
         fit_result: FitSummary = backend.fit(model2, on_progress=cb)
-        model_dir = str(job_store.jobs_dir / job.job_id / "model")
+        model_dir = str(job_store.path_for(job.job_id, "model"))
         backend.export_model(model2, model_dir)
         return fit_result, tune_result, model_dir
 

--- a/src/lizystudio/services/training_retune.py
+++ b/src/lizystudio/services/training_retune.py
@@ -72,8 +72,8 @@ def run_retune(
     continued for the requested n_trials. Subsequent trials are saved
     back to the child's own checkpoint via the standard bridge callback.
     """
-    parent_dir = job_store.jobs_dir / parent_job.job_id
-    child_dir = job_store.jobs_dir / child_job.job_id
+    parent_dir = job_store.job_dir(parent_job.job_id)
+    child_dir = job_store.job_dir(child_job.job_id)
     _copy_checkpoint_to_child(parent_dir, child_dir)
     _run_pickle_preflight(backend, child_dir)
 


### PR DESCRIPTION
## Summary

Collapse the 14+ hand-written \`jobs_dir / job_id / \"<artifact>\"\` concatenations across \`services/\` and \`api/\` into a single source of truth. docs/coupling-analysis.md **A-10** + HISTORY **H-0073**.

## Changes

### New module-level SSOT in \`services/jobs.py\`
- \`ArtifactKind = Literal[\"meta\", \"fit_result\", \"tune_result\", \"model\", \"log\", \"tuning_plot\", \"cancel_flag\"]\`
- \`ARTIFACT_FILENAMES: dict[ArtifactKind, str]\` — the filename map (BLUEPRINT §3.4.4).
- \`artifact_path(jobs_dir, job_id, kind) -> Path\` — helper for callers (like \`job_results.py\`) that have a \`jobs_dir\` but no \`JobStore\` instance.

### New \`JobStore\` public methods
- \`job_dir(job_id) -> Path\` — traversal-guarded directory resolver.
- \`path_for(job_id, kind) -> Path\` — named-artifact resolver backed by \`ARTIFACT_FILENAMES\`.

### Rewired call sites
| File | Sites | Notes |
|---|---|---|
| \`services/jobs.py\` (internal) | 7 | \`get\` / \`update\` / \`delete\` / \`get_log\` / \`_save_meta\` / \`_load_job\` / \`_cancel_flag_path\` |
| \`services/training.py\` | 4 | model dir (fit + tune), checkpoint dir, tuning plot target |
| \`services/_training_core.py\` | 1 | execution.log |
| \`services/training_retune.py\` | 2 | parent_dir / child_dir |
| \`services/job_results.py\` | 1 | tuning_plot fallback (uses \`artifact_path\`) |
| \`api/retune.py\` | 1 | parent_dir |

### Scope boundaries
- Tmp files (\`.cancel-{pid}.tmp\`) are transient, not artifacts — left out.
- \`services/inference.py\` (\`{jobs_dir}/{job_id}/inferences/...\`) is a different layer (\`InferenceStore\`) — out of scope for A-10.

## Compatibility

- **Save layout bit-identical.** Every rewritten path produces the same \`Path\` as before.
- **Wire format / BackendAdapter Protocol unchanged.**
- All 1146 existing tests pass **without modification**.

## Test plan

- [x] \`uv run pytest -q\` — 1147 passed.
- [x] \`uv run ruff check .\` + \`uv run ruff format --check .\` — clean.
- [x] \`uv run mypy src/lizystudio/\` — 51 files clean.
- [x] \`grep -rn \"jobs_dir.*/.*job\" src/lizystudio/services\` returns only the \`artifact_path\` helper body and \`_job_dir\` guard (plus \`inference.py\`, explicitly out of scope).