### PR TITLE
refactor(hooks): extract useJobIdParam for shared URL param flow (B-8)

### DIFF
--- a/frontend/src/hooks/useJobIdParam.test.ts
+++ b/frontend/src/hooks/useJobIdParam.test.ts
@@ -1,0 +1,104 @@
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { useJobIdParam } from "./useJobIdParam";
+
+function wrapperWith(initialUrl: string) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(MemoryRouter, { initialEntries: [initialUrl] }, children);
+}
+
+describe("useJobIdParam", () => {
+  it("hydrates jobId from ?job_id= on mount", () => {
+    const { result } = renderHook(() => useJobIdParam(), {
+      wrapper: wrapperWith("/?job_id=job_abc"),
+    });
+    expect(result.current.jobId).toBe("job_abc");
+  });
+
+  it("normalizes empty ?job_id= to null", () => {
+    const { result } = renderHook(() => useJobIdParam(), {
+      wrapper: wrapperWith("/?job_id="),
+    });
+    expect(result.current.jobId).toBeNull();
+  });
+
+  it("returns null when no ?job_id= param is present", () => {
+    const { result } = renderHook(() => useJobIdParam(), {
+      wrapper: wrapperWith("/"),
+    });
+    expect(result.current.jobId).toBeNull();
+  });
+
+  it("setJobId without writeUrl updates state only", () => {
+    const { result } = renderHook(() => useJobIdParam(), {
+      wrapper: wrapperWith("/"),
+    });
+    act(() => result.current.setJobId("job_new"));
+    expect(result.current.jobId).toBe("job_new");
+  });
+
+  it("setJobId with writeUrl=true updates state", () => {
+    // MemoryRouter does not expose `location.search` directly through
+    // renderHook; the integration effect (URL write triggers a re-read
+    // on the next mount) is covered by the pages that consume this
+    // hook. Here we verify the state side of the contract.
+    const { result } = renderHook(() => useJobIdParam(), {
+      wrapper: wrapperWith("/"),
+    });
+    act(() => result.current.setJobId("job_new", { writeUrl: true }));
+    expect(result.current.jobId).toBe("job_new");
+  });
+
+  it("setJobId(null, { writeUrl: true }) clears the state", () => {
+    const { result } = renderHook(() => useJobIdParam(), {
+      wrapper: wrapperWith("/?job_id=job_abc"),
+    });
+    expect(result.current.jobId).toBe("job_abc");
+    act(() => result.current.setJobId(null, { writeUrl: true }));
+    expect(result.current.jobId).toBeNull();
+  });
+
+  it("suppress=true blocks URL→state re-sync after local override", () => {
+    const { result, rerender } = renderHook(
+      ({ suppress }: { suppress: boolean }) => useJobIdParam({ suppress }),
+      {
+        wrapper: wrapperWith("/?job_id=job_abc"),
+        initialProps: { suppress: false },
+      },
+    );
+    expect(result.current.jobId).toBe("job_abc");
+    act(() => result.current.setJobId("job_local"));
+    expect(result.current.jobId).toBe("job_local");
+    // Re-running with suppress=true must not pull state back to the
+    // URL value when the effect re-fires.
+    rerender({ suppress: true });
+    expect(result.current.jobId).toBe("job_local");
+  });
+
+  it("filter change re-evaluates and promotes a previously-rejected id", () => {
+    // Simulates the InferencePage flow: the URL already carries a
+    // job_id on mount, but `completedJobs` is initially empty so the
+    // id cannot be validated. When `completedJobs` arrives (filter
+    // identity changes), the effect re-runs and promotes the id.
+    type FilterProps = { filter: (id: string) => boolean };
+    const { result, rerender } = renderHook(
+      ({ filter }: FilterProps) => useJobIdParam({ filter }),
+      {
+        wrapper: wrapperWith("/?job_id=job_abc"),
+        initialProps: { filter: (_id: string) => false } as FilterProps,
+      },
+    );
+    // Initial value comes from the URL before the first effect runs;
+    // the effect then sees `filter(...) === false` and leaves the
+    // state alone — which is still the initializer value. We clear
+    // local state via setJobId to prove subsequent URL→state sync
+    // honours the new filter.
+    act(() => result.current.setJobId(null));
+    expect(result.current.jobId).toBeNull();
+
+    rerender({ filter: (id: string) => id === "job_abc" });
+    expect(result.current.jobId).toBe("job_abc");
+  });
+});

--- a/frontend/src/hooks/useJobIdParam.ts
+++ b/frontend/src/hooks/useJobIdParam.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
+/**
+ * Hook for the shared `?job_id=<id>` URL-param workflow used by both
+ * WorkspacePage and InferencePage (docs/coupling-analysis.md B-8).
+ *
+ * Responsibilities:
+ * - Normalize `searchParams.get("job_id")` so an explicitly empty
+ *   `?job_id=` value reads back as `null` rather than `""`.
+ * - Hydrate an internal state slot from the URL on mount.
+ * - Re-sync state when the URL param changes after mount — important
+ *   because the initializer only fires once, and external links / Jobs
+ *   page navigation can push a new param without remounting the page.
+ * - Let callers `suppress` URL-driven updates while a page-local
+ *   operation is in flight (e.g. a freshly-started fit/tune job whose
+ *   URL hasn't been rewritten yet).
+ * - Let callers `filter` URL candidates (e.g. InferencePage only
+ *   accepts a job_id once the job appears in the completed list).
+ * - Expose `setJobId(next, { writeUrl })` so the caller can update
+ *   local state AND optionally push the new value back to
+ *   `setSearchParams` in one call.
+ */
+
+const PARAM_KEY = "job_id";
+
+export interface UseJobIdParamOptions {
+  /**
+   * When true, ignore URL→state sync. Workspace uses this during an
+   * active fit/tune so a lingering old URL param does not clobber the
+   * freshly-started job id owned by page state.
+   */
+  suppress?: boolean;
+  /**
+   * Optional validator. When provided, URL-sourced candidate ids are
+   * only copied into state when this returns true. Inference uses it
+   * to require that the id already appears in the completed-jobs list.
+   */
+  filter?: (jobId: string) => boolean;
+}
+
+export interface UseJobIdParamResult {
+  jobId: string | null;
+  /**
+   * Update the job id. Pass `{ writeUrl: true }` to also push the new
+   * value through `setSearchParams` (or clear the param if `next` is
+   * `null`); otherwise only the local state slot is touched, matching
+   * Workspace's "URL is read-only" convention.
+   */
+  setJobId: (next: string | null, opts?: { writeUrl?: boolean }) => void;
+}
+
+function readParam(params: URLSearchParams): string | null {
+  // `""` collapses to null so consumers never have to check both.
+  return params.get(PARAM_KEY) || null;
+}
+
+export function useJobIdParam(
+  options: UseJobIdParamOptions = {},
+): UseJobIdParamResult {
+  const { suppress = false, filter } = options;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [jobId, setJobIdState] = useState<string | null>(() =>
+    readParam(searchParams),
+  );
+
+  // Re-sync state when the URL param changes after mount (e.g. user
+  // clicks a "view in Workspace" link while already on the page).
+  // `filter` is read directly — storing it in a ref would complicate
+  // the API without benefit, and callers already memoize it via
+  // `useCallback` when needed.
+  useEffect(() => {
+    if (suppress) return;
+    const candidate = readParam(searchParams);
+    if (candidate === null) return;
+    if (filter && !filter(candidate)) return;
+    setJobIdState(candidate);
+  }, [searchParams, suppress, filter]);
+
+  const setJobId = useCallback(
+    (next: string | null, opts?: { writeUrl?: boolean }) => {
+      setJobIdState(next);
+      if (opts?.writeUrl) {
+        setSearchParams(
+          (prev) => {
+            const sp = new URLSearchParams(prev);
+            if (next === null) {
+              sp.delete(PARAM_KEY);
+            } else {
+              sp.set(PARAM_KEY, next);
+            }
+            return sp;
+          },
+          { replace: false },
+        );
+      }
+    },
+    [setSearchParams],
+  );
+
+  return { jobId, setJobId };
+}

--- a/frontend/src/pages/InferencePage.tsx
+++ b/frontend/src/pages/InferencePage.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import { getErrorMessage } from "@/api/errors";
 import {
@@ -12,13 +11,9 @@ import {
 import { ResultsPredOnly } from "@/components/inference/ResultsPredOnly";
 import { ResultsWithGT } from "@/components/inference/ResultsWithGT";
 import { SetupPanel } from "@/components/inference/SetupPanel";
+import { useJobIdParam } from "@/hooks/useJobIdParam";
 
 export function InferencePage() {
-  const [searchParams, setSearchParams] = useSearchParams();
-
-  const [selectedJobId, setSelectedJobId] = useState<string | null>(() =>
-    searchParams.get("job_id"),
-  );
   const [selectedInfId, setSelectedInfId] = useState<string | null>(null);
 
   // Fetch completed jobs
@@ -29,19 +24,18 @@ export function InferencePage() {
     [allJobs],
   );
 
-  // Auto-select job from URL param.
-  //
-  // HIGH-4: read the current value of the `job_id` query param on each
-  // run instead of closing over `initialJobId` from first render. That
-  // older pattern missed subsequent URL updates because the constant
-  // was never recomputed, so navigating to a different job via the URL
-  // bar silently kept the first-loaded selection.
-  useEffect(() => {
-    const jobIdParam = searchParams.get("job_id");
-    if (jobIdParam && completedJobs.some((j) => j.job_id === jobIdParam)) {
-      setSelectedJobId(jobIdParam);
-    }
-  }, [searchParams, completedJobs]);
+  // HIGH-4 (pre-B-8 context): URL→state sync must re-run when
+  // ``completedJobs`` changes so that a deep-link to ``?job_id=xyz``
+  // is honoured the moment ``xyz`` appears in the completed list.
+  // ``useJobIdParam`` re-evaluates the filter whenever its identity
+  // changes, so we memoize the filter against ``completedJobs``.
+  const filterByCompleted = useCallback(
+    (id: string) => completedJobs.some((j) => j.job_id === id),
+    [completedJobs],
+  );
+  const { jobId: selectedJobId, setJobId: setSelectedJobId } = useJobIdParam({
+    filter: filterByCompleted,
+  });
 
   // Fetch inference history for selected job.
   //
@@ -86,11 +80,10 @@ export function InferencePage() {
 
   const handleSelectJob = useCallback(
     (jobId: string) => {
-      setSelectedJobId(jobId);
+      setSelectedJobId(jobId, { writeUrl: true });
       setSelectedInfId(null);
-      setSearchParams({ job_id: jobId });
     },
-    [setSearchParams],
+    [setSelectedJobId],
   );
 
   const handleSelectInf = useCallback((infId: string) => {

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -1,7 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { BarChart3, Database, SlidersHorizontal } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { getErrorMessage } from "@/api/errors";
 import { useConfig, useUiSchema } from "@/api/queries";
@@ -18,6 +17,7 @@ import { ModelPanel } from "@/components/workspace/ModelPanel";
 import { ResultsPanel } from "@/components/workspace/ResultsPanel";
 import { useBackgroundNotification } from "@/hooks/useBackgroundNotification";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { useJobIdParam } from "@/hooks/useJobIdParam";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 
@@ -34,52 +34,29 @@ export function WorkspacePage() {
   const queryClient = useQueryClient();
   const [hasData, setHasData] = useState(false);
   const [task, setTask] = useState<string | null>(null);
-  // Issue #101: hydrate currentJobId from the `?job_id=<id>` query
-  // param so the Jobs page (or any external link) can navigate the
-  // user directly into the Workspace with a specific completed job
-  // selected. The query-param name matches the convention already
-  // established by InferencePage so links stay consistent across
-  // the two destinations.
-  const [searchParams] = useSearchParams();
-  // `searchParams.get("job_id")` returns `""` (not `null`) for an
-  // explicitly empty `?job_id=` value; normalize with `|| null` so the
-  // Results panel sees a clean null and does not try to render an
-  // empty-string job id.
-  const [currentJobId, setCurrentJobId] = useState<string | null>(
-    () => searchParams.get("job_id") || null,
-  );
   const [running, setRunning] = useState(false);
   const [modelTab, setModelTab] = useState<"fit" | "tune">("fit");
   const [mobileTab, setMobileTab] = useState<MobileTab>("data");
 
   const isMobile = useMediaQuery(MOBILE_QUERY);
 
-  // Re-hydrate when the URL param changes (e.g. the user clicks
-  // "Open in Workspace" on a SECOND job from the Jobs page, which
-  // only updates the search params without remounting this page).
-  // The `useState` initializer fires once on mount; without this
-  // effect the second navigation would silently keep the first job
-  // selected. Mirrors InferencePage's HIGH-4 fix. Suppressed while
-  // a fit / tune is actively running so a URL change does not clobber
-  // a freshly-started job id set from inside handleFit / handleTune.
+  // Issue #101: hydrate currentJobId from the `?job_id=<id>` query
+  // param so the Jobs page (or any external link) can navigate the
+  // user directly into the Workspace with a specific completed job
+  // selected. The query-param name matches the convention already
+  // established by InferencePage so links stay consistent across
+  // the two destinations. `useJobIdParam` (B-8) owns URL→state sync;
+  // we pass `suppress: running` so a URL change does not clobber a
+  // freshly-started job id set from handleFit / handleTune.
   //
   // Note on stale URL: after the user starts a fresh fit / tune via
   // the Workspace UI, we intentionally do NOT rewrite `?job_id=` in
   // the URL bar. If the user reloads the page in the middle of a new
-  // run, the URL still points at the previously-hydrated job and
-  // they will land back on that historical view. This matches the
-  // pre-Issue #101 behavior (reload = back to an empty Workspace)
-  // closely enough that we decided not to couple browser history to
-  // every in-run job_id change. A future improvement could call
-  // `setSearchParams({ job_id: newId })` inside handleFit / handleTune
-  // if user feedback asks for it.
-  useEffect(() => {
-    if (running) return;
-    const jobIdParam = searchParams.get("job_id");
-    if (jobIdParam) {
-      setCurrentJobId(jobIdParam);
-    }
-  }, [searchParams, running]);
+  // run, the URL still points at the previously-hydrated job — this
+  // matches the pre-Issue #101 behavior and we accept it consciously.
+  const { jobId: currentJobId, setJobId: setCurrentJobId } = useJobIdParam({
+    suppress: running,
+  });
 
   useDocumentTitle(running ? "Running..." : null);
   const notify = useBackgroundNotification();
@@ -105,7 +82,7 @@ export function WorkspacePage() {
       toast.error(`Fit failed: ${getErrorMessage(err)}`);
       setRunning(false);
     }
-  }, []);
+  }, [setCurrentJobId]);
 
   const handleTune = useCallback(async () => {
     setRunning(true);
@@ -116,7 +93,7 @@ export function WorkspacePage() {
       toast.error(`Tune failed: ${getErrorMessage(err)}`);
       setRunning(false);
     }
-  }, []);
+  }, [setCurrentJobId]);
 
   const handleApplyToFit = useCallback(
     async (fullConfig: Record<string, unknown>) => {
@@ -139,16 +116,19 @@ export function WorkspacePage() {
     notify("LizyStudio", "Job completed");
   }, [notify]);
 
-  const handleJobStarted = useCallback((childJobId: string) => {
-    // H-0062: Re-tune / Resume created a new child job — switch
-    // the workspace selection so the user sees its progress.
-    setCurrentJobId(childJobId);
-    setRunning(true);
-    // Issue #178: on mobile, the Results panel is on a separate tab —
-    // move focus to it when a child job starts so the user sees the
-    // progress view immediately instead of staying on Data/Model.
-    setMobileTab("results");
-  }, []);
+  const handleJobStarted = useCallback(
+    (childJobId: string) => {
+      // H-0062: Re-tune / Resume created a new child job — switch
+      // the workspace selection so the user sees its progress.
+      setCurrentJobId(childJobId);
+      setRunning(true);
+      // Issue #178: on mobile, the Results panel is on a separate tab —
+      // move focus to it when a child job starts so the user sees the
+      // progress view immediately instead of staying on Data/Model.
+      setMobileTab("results");
+    },
+    [setCurrentJobId],
+  );
 
   const shortcuts = useMemo(
     () => [


### PR DESCRIPTION
## Summary

Collapse the duplicated \`?job_id=<id>\` URL-param workflow shared by WorkspacePage and InferencePage into a single \`useJobIdParam\` hook. docs/coupling-analysis.md **B-8**.

Before this PR the two pages each carried their own copy of: hydrate local state from the URL on mount, re-sync via \`useEffect\` when the URL changed after mount, normalize the empty-\`?job_id=\` edge case, and guard against unwanted overwrites during an in-flight job. The implementations had already drifted — Workspace used a \`running\` suppress flag, Inference used a \`completedJobs.some(...)\` guard, and only Inference pushed back to the URL via \`setSearchParams\`.

## Changes

### \`frontend/src/hooks/useJobIdParam.ts\` (new)
- \`{ jobId, setJobId }\` return shape. \`setJobId(next, { writeUrl })\` optionally pushes to \`setSearchParams\` in the same call.
- \`suppress\` option for Workspace's "don't clobber a freshly-started fit/tune" case.
- \`filter\` option for Inference's "only accept ids that appear in the completed list" case. Re-evaluates when the filter's identity changes (e.g. \`completedJobs\` reload).
- Empty \`?job_id=\` normalizes to \`null\`.

### \`frontend/src/hooks/useJobIdParam.test.ts\` (new, 8 tests)
Covers: hydrate from URL, normalize empty param, null-when-missing, \`setJobId\` without/with \`writeUrl\`, clear param via \`setJobId(null, { writeUrl: true })\`, \`suppress\` blocks re-sync after local override, filter re-evaluation on identity change.

### \`WorkspacePage.tsx\`
- Drop \`useSearchParams\`, the \`useEffect\` URL→state sync, and the \`running\`-guarded re-hydration.
- \`const { jobId: currentJobId, setJobId: setCurrentJobId } = useJobIdParam({ suppress: running });\`
- Callback dependency arrays updated to include \`setCurrentJobId\` (which is now a \`useCallback\` identity from the hook, not a stable \`useState\` setter).

### \`InferencePage.tsx\`
- Drop \`useSearchParams\`, the manual \`useEffect\` guard, and the explicit \`setSearchParams({ job_id })\` call.
- \`const { jobId: selectedJobId, setJobId: setSelectedJobId } = useJobIdParam({ filter: filterByCompleted });\`
- \`handleSelectJob\` uses \`setSelectedJobId(id, { writeUrl: true })\`.

## Compatibility

- Behavior-preserving refactor. Workspace still suppresses URL→state sync during \`running\`; Inference still requires the id to appear in \`completedJobs\` before promoting it; only Inference writes back to the URL.
- No component-prop changes; downstream \`ResultsPanel\` / \`SetupPanel\` contracts untouched.

## Test plan

- [x] \`pnpm test --run\` — 1591 passed (2 skipped).
- [x] \`pnpm build\` — green (tsc -b + vite build).
- [x] \`pnpm check\` — biome clean, 258 files.