### PR TITLE
refactor(frontend): typed accessors for JobDetail.config (B-10)

### DIFF
--- a/frontend/src/components/jobs/JobDetail.tsx
+++ b/frontend/src/components/jobs/JobDetail.tsx
@@ -31,7 +31,11 @@ import {
 } from "@/components/ui/dialog";
 import { Progress } from "@/components/ui/progress";
 import { useJobLifecycle } from "@/hooks/useJobLifecycle";
-import { defaultRetuneTrials, remainingRetuneTrials } from "@/lib/job-config";
+import {
+  defaultRetuneTrials,
+  getModelName,
+  remainingRetuneTrials,
+} from "@/lib/job-config";
 import { CompletedContent } from "./CompletedContent";
 import { ConfigTreeView } from "./ConfigTreeView";
 import { DeleteDialog } from "./DeleteDialog";
@@ -107,9 +111,7 @@ export function JobDetailPanel({
     [invalidateJobs, onJobSelect],
   );
 
-  const modelName = (job?.config?.model as Record<string, unknown>)?.name as
-    | string
-    | undefined;
+  const modelName = getModelName(job) || undefined;
 
   const handleCancel = useCallback(async () => {
     await cancel();

--- a/frontend/src/components/workspace/ResultsPanel.tsx
+++ b/frontend/src/components/workspace/ResultsPanel.tsx
@@ -12,7 +12,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useJobLifecycle } from "@/hooks/useJobLifecycle";
-import { remainingRetuneTrials } from "@/lib/job-config";
+import { getModelName, remainingRetuneTrials } from "@/lib/job-config";
 import { ResultsCompletedView } from "./ResultsCompletedView";
 import { ResultsRunningView } from "./ResultsRunningView";
 
@@ -67,9 +67,7 @@ export function ResultsPanel({
       ? allJobs.length - allJobs.findIndex((j) => j.job_id === job.job_id)
       : null;
 
-  const modelName = (job?.config?.model as Record<string, unknown>)?.name as
-    | string
-    | undefined;
+  const modelName = getModelName(job) || undefined;
 
   const handleCancel = useCallback(async () => {
     await cancel();

--- a/frontend/src/components/workspace/TuneTrialsSection.tsx
+++ b/frontend/src/components/workspace/TuneTrialsSection.tsx
@@ -16,6 +16,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { getModelParams, getModelSection } from "@/lib/job-config";
 import { formatNum } from "@/lib/utils";
 import { PlotlyChart } from "./PlotlyChart";
 
@@ -32,15 +33,19 @@ function buildFitConfig(
   job: JobDetail,
   bestParams: Record<string, unknown>,
 ): Record<string, unknown> {
-  const { tuning: _stripped, ...baseWithoutTuning } =
-    (job.config as Record<string, unknown>) ?? {};
-  const baseModel = (baseWithoutTuning.model as Record<string, unknown>) ?? {};
+  // ``job.config`` is typed as ``Record<string, unknown> | null | undefined``
+  // on the OpenAPI schema. Spreading it (with an empty-object fallback)
+  // keeps the outer shape intact while we pull the model subsection
+  // through the typed accessors.
+  const { tuning: _stripped, ...baseWithoutTuning } = job.config ?? {};
+  const baseModel = getModelSection(job);
+  const baseParams = getModelParams(job);
   return {
     ...baseWithoutTuning,
     model: {
       ...baseModel,
       params: {
-        ...((baseModel.params as Record<string, unknown>) ?? {}),
+        ...baseParams,
         ...bestParams,
       },
     },

--- a/frontend/src/hooks/useJobResultData.ts
+++ b/frontend/src/hooks/useJobResultData.ts
@@ -32,6 +32,7 @@ import type {
   PlotResponse,
   SplitSummaryRow,
 } from "@/api/types";
+import { getEvaluationSection } from "@/lib/job-config";
 import { pivotMetrics } from "@/lib/metrics";
 
 export interface UseJobResultDataParams {
@@ -220,7 +221,7 @@ export function useJobResultData({
     : undefined;
   const hasFolds = fitResult != null && fitResult.fold_count > 1;
 
-  const evalConfig = (job.config?.evaluation as Record<string, unknown>) ?? {};
+  const evalConfig = getEvaluationSection(job);
   const annotateMetric = (name: string): string => {
     if (name === "precision_at_k") {
       const entries = Array.isArray(evalConfig.metrics)

--- a/frontend/src/lib/job-config.test.ts
+++ b/frontend/src/lib/job-config.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import type { JobDetail } from "@/api/types";
+import {
+  defaultRetuneTrials,
+  getConfigSection,
+  getDataSection,
+  getEvaluationSection,
+  getModelName,
+  getModelParams,
+  getModelSection,
+  getTargetColumn,
+  remainingRetuneTrials,
+} from "./job-config";
+
+function jobWith(
+  config: Record<string, unknown> | null | undefined,
+): JobDetail {
+  return {
+    job_id: "test-job",
+    job_type: "fit",
+    status: "completed",
+    backend_name: "lizyml",
+    model_name: "lgbm",
+    created_at: "2026-01-01T00:00:00Z",
+    completed_at: "2026-01-01T00:01:00Z",
+    error: null,
+    primary_score: 0.9,
+    parent_job_id: null,
+    fit_result: null,
+    tune_result: null,
+    config,
+  } as JobDetail;
+}
+
+describe("getConfigSection", () => {
+  it("returns the section when it is an object", () => {
+    const job = jobWith({ model: { name: "lgbm" } });
+    expect(getConfigSection(job, "model")).toEqual({ name: "lgbm" });
+  });
+
+  it("returns undefined when the job is nullish", () => {
+    expect(getConfigSection(null, "model")).toBeUndefined();
+    expect(getConfigSection(undefined, "model")).toBeUndefined();
+  });
+
+  it("returns undefined when the section is missing", () => {
+    const job = jobWith({});
+    expect(getConfigSection(job, "model")).toBeUndefined();
+  });
+
+  it("returns undefined when the section is not an object", () => {
+    const job = jobWith({ model: "lgbm" });
+    expect(getConfigSection(job, "model")).toBeUndefined();
+  });
+
+  it("returns undefined when the section is an array", () => {
+    const job = jobWith({ model: ["lgbm"] });
+    expect(getConfigSection(job, "model")).toBeUndefined();
+  });
+
+  it("returns undefined when the config itself is null", () => {
+    const job = jobWith(null);
+    expect(getConfigSection(job, "model")).toBeUndefined();
+  });
+});
+
+describe("getModelSection / getModelParams", () => {
+  it("returns the model object", () => {
+    const job = jobWith({ model: { name: "lgbm", params: { lr: 0.1 } } });
+    expect(getModelSection(job)).toEqual({ name: "lgbm", params: { lr: 0.1 } });
+  });
+
+  it("returns empty object when model is absent", () => {
+    expect(getModelSection(jobWith({}))).toEqual({});
+    expect(getModelSection(null)).toEqual({});
+  });
+
+  it("returns nested params when present", () => {
+    const job = jobWith({ model: { params: { lr: 0.1, num_leaves: 31 } } });
+    expect(getModelParams(job)).toEqual({ lr: 0.1, num_leaves: 31 });
+  });
+
+  it("returns empty object when params are absent or malformed", () => {
+    expect(getModelParams(jobWith({ model: {} }))).toEqual({});
+    expect(getModelParams(jobWith({ model: { params: "oops" } }))).toEqual({});
+    expect(getModelParams(null)).toEqual({});
+  });
+});
+
+describe("getEvaluationSection / getDataSection", () => {
+  it("returns the evaluation object", () => {
+    const job = jobWith({ evaluation: { metrics: ["auc"] } });
+    expect(getEvaluationSection(job)).toEqual({ metrics: ["auc"] });
+  });
+
+  it("returns the data object", () => {
+    const job = jobWith({ data: { target: "y" } });
+    expect(getDataSection(job)).toEqual({ target: "y" });
+  });
+
+  it("returns empty objects when sections are absent", () => {
+    expect(getEvaluationSection(null)).toEqual({});
+    expect(getDataSection(null)).toEqual({});
+  });
+});
+
+describe("getModelName", () => {
+  it("returns model.name", () => {
+    expect(getModelName(jobWith({ model: { name: "lgbm" } }))).toBe("lgbm");
+  });
+
+  it("returns empty string when missing or non-string", () => {
+    expect(getModelName(jobWith({}))).toBe("");
+    expect(getModelName(jobWith({ model: { name: 42 } }))).toBe("");
+    expect(getModelName(null)).toBe("");
+  });
+});
+
+describe("getTargetColumn", () => {
+  it("returns data.target", () => {
+    expect(getTargetColumn(jobWith({ data: { target: "y" } }))).toBe("y");
+  });
+
+  it("returns empty string when missing or non-string", () => {
+    expect(getTargetColumn(jobWith({}))).toBe("");
+    expect(getTargetColumn(jobWith({ data: { target: null } }))).toBe("");
+    expect(getTargetColumn(null)).toBe("");
+  });
+});
+
+describe("defaultRetuneTrials / remainingRetuneTrials", () => {
+  it("reads n_trials from config.tuning.optuna.params", () => {
+    const job = jobWith({
+      tuning: { optuna: { params: { n_trials: 123 } } },
+    });
+    expect(defaultRetuneTrials(job)).toBe(123);
+  });
+
+  it("falls back to 50 when the config is malformed", () => {
+    expect(defaultRetuneTrials(jobWith({}))).toBe(50);
+    expect(defaultRetuneTrials(jobWith({ tuning: "nope" }))).toBe(50);
+    expect(defaultRetuneTrials(jobWith({ tuning: { optuna: "nope" } }))).toBe(
+      50,
+    );
+  });
+
+  it("remaining subtracts completed trial count with a floor of 1", () => {
+    const job = {
+      ...jobWith({ tuning: { optuna: { params: { n_trials: 10 } } } }),
+      tune_result: { trials: [{}, {}, {}] } as unknown,
+    } as JobDetail;
+    expect(remainingRetuneTrials(job)).toBe(7);
+  });
+
+  it("remaining stays at 1 even when all trials finished", () => {
+    const job = {
+      ...jobWith({ tuning: { optuna: { params: { n_trials: 3 } } } }),
+      tune_result: { trials: [{}, {}, {}, {}, {}] } as unknown,
+    } as JobDetail;
+    expect(remainingRetuneTrials(job)).toBe(1);
+  });
+});

--- a/frontend/src/lib/job-config.ts
+++ b/frontend/src/lib/job-config.ts
@@ -1,12 +1,105 @@
 /**
- * Helpers for poking at the deeply-nested ``tuning.optuna.params``
- * section of a job config. Previously each Re-tune UI site duplicated
- * the same 5-level optional-chain (``config?.tuning?.optuna?.params?.
- * n_trials``), which B-2 in docs/coupling-analysis.md flagged as a
- * twin-helper drift hazard.
+ * Typed accessors for the job config (docs/coupling-analysis.md B-10).
+ *
+ * The backend stores ``Job.config`` as a free-form ``dict[str, Any]``
+ * because the shape is backend-specific (LizyML's Pydantic schema is
+ * the source of truth, but LizyStudio only sees the serialised dict).
+ * Without accessors every consumer reached into the dict with its own
+ * ``(config.xxx as Record<string, unknown>)`` cast chain, which drifts
+ * and hides typos.
+ *
+ * Every helper here:
+ * - accepts a ``JobDetail`` (or ``undefined``/``null`` where noted),
+ * - returns ``undefined`` / empty when the section is absent, and
+ * - keeps the raw ``Record<string, unknown>`` shape so callers can
+ *   still index into it for fields we do not model individually.
  */
 
 import type { JobDetail } from "@/api/types";
+
+// ---------------------------------------------------------------------------
+// Section accessors
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a top-level section from ``job.config`` narrowed to a
+ * ``Record<string, unknown>``.  Returns ``undefined`` when the job is
+ * missing, the config is missing, or the section is not an object.
+ */
+export function getConfigSection(
+  job: JobDetail | null | undefined,
+  key: string,
+): Record<string, unknown> | undefined {
+  const config = job?.config;
+  if (!config) return undefined;
+  const value = config[key];
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+/** ``config.model`` section, empty object when absent. */
+export function getModelSection(
+  job: JobDetail | null | undefined,
+): Record<string, unknown> {
+  return getConfigSection(job, "model") ?? {};
+}
+
+/** ``config.model.params``, empty object when absent. */
+export function getModelParams(
+  job: JobDetail | null | undefined,
+): Record<string, unknown> {
+  const model = getModelSection(job);
+  const params = model.params;
+  if (params && typeof params === "object" && !Array.isArray(params)) {
+    return params as Record<string, unknown>;
+  }
+  return {};
+}
+
+/** ``config.evaluation`` section, empty object when absent. */
+export function getEvaluationSection(
+  job: JobDetail | null | undefined,
+): Record<string, unknown> {
+  return getConfigSection(job, "evaluation") ?? {};
+}
+
+/** ``config.data`` section, empty object when absent. */
+export function getDataSection(
+  job: JobDetail | null | undefined,
+): Record<string, unknown> {
+  return getConfigSection(job, "data") ?? {};
+}
+
+// ---------------------------------------------------------------------------
+// Scalar accessors
+// ---------------------------------------------------------------------------
+
+/**
+ * ``config.model.name`` as a string; empty string when absent or not a
+ * string. Chosen as empty-string rather than ``undefined`` to match
+ * what the backend ``_job_summary`` helper emits for ``model_name``
+ * (H-0071), so call sites can treat both fields interchangeably.
+ */
+export function getModelName(job: JobDetail | null | undefined): string {
+  const name = getModelSection(job).name;
+  return typeof name === "string" ? name : "";
+}
+
+/**
+ * ``config.data.target`` as a string; empty string when absent or not
+ * a string. Used by the Inference flow to detect whether ground truth
+ * is available in the uploaded dataset.
+ */
+export function getTargetColumn(job: JobDetail | null | undefined): string {
+  const target = getDataSection(job).target;
+  return typeof target === "string" ? target : "";
+}
+
+// ---------------------------------------------------------------------------
+// Re-tune helpers (pre-B-10)
+// ---------------------------------------------------------------------------
 
 /** Default n_trials value shown in the Re-tune dialog. */
 const DEFAULT_N_TRIALS = 50;
@@ -22,11 +115,16 @@ export function defaultRetuneTrials(job: JobDetail): number {
 }
 
 function _pokeOptunaParam(job: JobDetail, key: string): unknown {
-  const config = job.config as Record<string, unknown> | undefined;
-  const tuning = config?.tuning as Record<string, unknown> | undefined;
-  const optuna = tuning?.optuna as Record<string, unknown> | undefined;
-  const params = optuna?.params as Record<string, unknown> | undefined;
-  return params?.[key];
+  const tuning = getConfigSection(job, "tuning");
+  const optuna = tuning?.optuna;
+  if (!optuna || typeof optuna !== "object" || Array.isArray(optuna)) {
+    return undefined;
+  }
+  const params = (optuna as Record<string, unknown>).params;
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return undefined;
+  }
+  return (params as Record<string, unknown>)[key];
 }
 
 /**

--- a/frontend/src/pages/InferencePage.tsx
+++ b/frontend/src/pages/InferencePage.tsx
@@ -12,6 +12,7 @@ import { ResultsPredOnly } from "@/components/inference/ResultsPredOnly";
 import { ResultsWithGT } from "@/components/inference/ResultsWithGT";
 import { SetupPanel } from "@/components/inference/SetupPanel";
 import { useJobIdParam } from "@/hooks/useJobIdParam";
+import { getTargetColumn } from "@/lib/job-config";
 
 export function InferencePage() {
   const [selectedInfId, setSelectedInfId] = useState<string | null>(null);
@@ -115,11 +116,7 @@ export function InferencePage() {
   // Fetch job detail to get config.data.target for ground-truth detection
   const { data: jobDetail } = useJob(selectedJobId);
 
-  const targetCol = useMemo(() => {
-    if (!jobDetail?.config) return "";
-    const data = jobDetail.config.data as Record<string, unknown> | undefined;
-    return String(data?.target ?? "");
-  }, [jobDetail]);
+  const targetCol = useMemo(() => getTargetColumn(jobDetail), [jobDetail]);
 
   return (
     <div className="flex h-full">


### PR DESCRIPTION
## Summary

Collapse the repeated deep-cast ladder for \`JobDetail.config\` into typed accessors. docs/coupling-analysis.md **B-10** (scoped to the frontend accessor layer; the companion backend-side Pydantic \`JobConfigResponse\` work is deferred).

Before this PR, six call sites each pried open the free-form config dict with their own cast chain:

\`\`\`ts
const modelName = (job?.config?.model as Record<string, unknown>)?.name as string | undefined;
const evalConfig = (job.config?.evaluation as Record<string, unknown>) ?? {};
const baseModel = (baseWithoutTuning.model as Record<string, unknown>) ?? {};
const data = jobDetail.config.data as Record<string, unknown> | undefined;
// ...
\`\`\`

## Changes

### \`lib/job-config.ts\` — new accessors (+ 21 tests)
- \`getConfigSection(job, key)\` — generic; returns the section only when it is a plain object (rejects arrays and scalars).
- \`getModelSection\` / \`getModelParams\` / \`getEvaluationSection\` / \`getDataSection\` — thin wrappers that bottom out at \`{}\` so spread sites (e.g. \`buildFitConfig\`) need no extra guard.
- \`getModelName\` — empty-string fallback matches the backend \`_job_summary\` emission shape (H-0071).
- \`getTargetColumn\` — used by \`InferencePage\` to detect ground-truth availability.
- Existing \`_pokeOptunaParam\` (Re-tune helper) routes through \`getConfigSection\` so the cast ladder lives in one module.

### Consumer cleanup (6 files)
| File | Before | After |
|---|---|---|
| \`ResultsPanel.tsx\` | \`(job?.config?.model as Record...)?.name as string\` | \`getModelName(job)\` |
| \`JobDetail.tsx\` | same | \`getModelName(job)\` |
| \`InferencePage.tsx\` | \`(jobDetail.config.data as Record...)?.target\` in \`useMemo\` | \`getTargetColumn(jobDetail)\` |
| \`TuneTrialsSection.tsx\` | three chained casts in \`buildFitConfig\` | \`getModelSection\` + \`getModelParams\` |
| \`useJobResultData.ts\` | \`(job.config?.evaluation as Record...)\` | \`getEvaluationSection(job)\` |
| \`ResultsCompletedView.tsx\` | — (kept, generic prop passthrough) | — |

After this PR, \`job.config ... as Record<string, unknown>\` only appears at the generic-prop passthrough in \`ResultsCompletedView.tsx:84\` and inside \`lib/job-config.ts\` itself.

## Compatibility

- No backend change. Wire format unchanged.
- Pure frontend refactor — component props and rendering behaviour untouched.
- \`modelName\` semantics preserved via \`|| undefined\` on \`getModelName\`'s empty-string fallback so \`modelName && ...\` conditional rendering keeps working.

## Test plan

- [x] \`pnpm test --run\` — 1612 passed (2 skipped). 21 new lib/job-config tests cover nullish inputs, malformed sections, and all accessor paths.
- [x] \`pnpm build\` — green.
- [x] \`pnpm check\` — biome clean, 259 files.