### PR TITLE
refactor(frontend): retire METRICS_BY_TASK + SSOT cv_default_strategy (C-5b Part 1, H-0074)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1926,3 +1926,30 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (c) `uv run mypy src/lizystudio/` / `uv run ruff check .` / `uv run ruff format --check .` 全 clean。
   - (d) `ARTIFACT_FILENAMES` を `JobStore.path_for` / module-level `artifact_path` の両経路から共有。
 - **Decision:** 2026-04-20 accepted — 提案通り実装。
+
+### H-0074: `METRICS_BY_TASK` fallback 退役と `cv_default_strategy` の UiSchema 化（Phase 3 coupling refactor C-5b Part 1）
+- **Status:** accepted
+- **Scope:** Frontend | Internal only（wire format / BackendAdapter Protocol 不変、ユーザー体験は uiSchema ロード前の一瞬のみ変化）
+- **Related:** docs/coupling-analysis.md C-5b、H-0026（UiSchema 契約）、H-0072（C-5a）
+- **Context:** `frontend/src/components/workspace/constants.ts` に残る 3 種の "fallback" 定数（`METRICS_BY_TASK` / `CV_STRATEGY_FIELDS` / `getDefaultCvStrategy`）のうち、`METRICS_BY_TASK` は `MetricsChips` が `metricsByTask` prop（= `uiSchema.option_sets.metric`）を常に受け取る現状では uiSchema ロード前の一瞬しか使われておらず、また `getDefaultCvStrategy` は task → default CV strategy の map でバックエンド (`UiCapabilities.cv_default_strategy`) に SSOT が既に存在する。`CV_STRATEGY_FIELDS` は backend の `UiCapabilities.cv_strategy_fields` と**フィールド名が乖離**しており（UI internal name `folds`/`train_size_max` vs wire-format `n_splits`/`max_train_size`、`blocked_group_kfold` の fields は完全に別体系）、単純置換は破綻するため本 PR 対象外。
+- **Proposal:**
+  1. `MetricsChips.tsx` から `METRICS_BY_TASK` import と fallback ブロックを削除。`metricsByTask` が未指定の場合は `available=[]` になり、既存の早期 `return null` に到達する。
+  2. `constants.ts` から `METRICS_BY_TASK` エクスポートを削除。`constants.test.ts` から `METRICS_BY_TASK` テストブロックを削除。
+  3. `useDataPanel` に `uiSchema?: UiSchema` を受け取る既存 props を活性化し、`resolveDefaultCvStrategy(task)` helper で `uiSchema.capabilities?.cv_default_strategy?.[task] ?? getDefaultCvStrategy(task)` の順に引く。`handleTargetChange` / `handleTaskChange` 両方から使用。
+  4. `getDefaultCvStrategy` は**残置**。uiSchema がまだ来ていない最初の render で `INITIAL_CV_STATE` から task 変更を受けた際の fallback としてまだ必要。
+  5. `CV_STRATEGY_FIELDS` / `CV_STRATEGY_LABELS` は**残置**。前者は `cv-state.ts` の `buildSplitConfig` / `applyCvDataFields` が UI internal field name で依存しており、backend の `cv_strategy_fields` とフィールド名を揃える別 PR (C-5b Part 2) が必要。後者は表示名マップで backend に同等物が存在しない。
+- **Impact:** `frontend/src/components/workspace/MetricsChips.tsx`（import 1 行削除、`useMemo` 9 行 → 4 行に縮約）、`frontend/src/components/workspace/constants.ts`（header コメント更新 + `METRICS_BY_TASK` 削除、-23 行）、`frontend/src/components/workspace/constants.test.ts`（`METRICS_BY_TASK` test block 削除 -21 行）、`frontend/src/components/workspace/MetricsChips.test.tsx`（fallback 依存テスト 8 件に `metricsByTask` prop 明示、新規テスト 1 件追加）、`frontend/src/hooks/useDataPanel.ts`（`resolveDefaultCvStrategy` helper 導入 +7 行、既存 `_uiSchema` prop 活性化、2 箇所の `getDefaultCvStrategy` 呼び出しを置換）、`frontend/src/hooks/useDataPanel.test.ts`（新規テスト 3 件）。
+- **Compatibility:**
+  - Backend 側変更なし。`UiCapabilities.cv_default_strategy` は既に H-0026 時点で公開済みで schema 変更なし。
+  - `MetricsChips` が uiSchema ロード前に何も描画しない期間は従来 `METRICS_BY_TASK` fallback で 6 chip を見せていた一瞬が消える。実運用では `UiSchemaQuery` は `ConfigForm` mount と同時に走り、差は数 100ms 未満で視認困難。
+  - wire format / BackendAdapter Protocol / storage layout / ユーザー設定ファイル変更なし。
+- **Alternatives:**
+  - (a) Phase 3 の `CV_STRATEGY_FIELDS` 退役も同 PR で実施 → 却下。UI internal name `folds` と wire name `n_splits` を揃えるために `cv-state.ts` の全面改修と `UiCapabilities.cv_strategy_fields` のフィールド名再設計が必要。2-3 日規模で C-5b Part 2 として別 PR 化。
+  - (b) `METRICS_BY_TASK` を残して "loading 時の spinner 代わり" として維持 → 却下。実態として MetricsChips は初期状態で empty chips でも UX 問題がなく（Evaluation accordion が閉じている場合が多い）、SSOT 化の方が価値が高い。
+  - (c) `getDefaultCvStrategy` も削除し `INITIAL_CV_STATE.strategy` を UiSchema 後に同期 → 却下。`INITIAL_CV_STATE` は module-level const で uiSchema に依存できない。hook 側で fallback するのが最小変更。
+- **Acceptance Criteria:**
+  - (a) `grep -rn 'METRICS_BY_TASK' frontend/src` が 0 件。
+  - (b) `useDataPanel` が `uiSchema.capabilities.cv_default_strategy.{task}` を優先するテスト + 不在時は `stratified_kfold`/`kfold` に fallback するテストが両方 green。
+  - (c) `MetricsChips` が `metricsByTask` undefined で `null` を返すテスト green。
+  - (d) `pnpm test` / `pnpm check` / `pnpm tsc --noEmit` / `pnpm build` すべて clean、`uv run pytest` も変化なし。
+- **Decision:** 2026-04-20 accepted — 提案通り実装。C-5b Part 2（`CV_STRATEGY_FIELDS` retirement）は別 issue として起票予定。

--- a/frontend/src/components/workspace/MetricsChips.test.tsx
+++ b/frontend/src/components/workspace/MetricsChips.test.tsx
@@ -3,6 +3,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MetricEntry } from "@/api/types";
 import { MetricsChips } from "./MetricsChips";
 
+const BINARY_METRICS = {
+  binary: ["auc", "logloss", "accuracy", "f1", "precision", "recall"],
+};
+const REGRESSION_METRICS = {
+  regression: ["rmse", "mae", "r2", "mse"],
+};
+const ALL_METRICS = { ...BINARY_METRICS, ...REGRESSION_METRICS };
+
 describe("MetricsChips", () => {
   afterEach(() => {
     cleanup();
@@ -14,6 +22,7 @@ describe("MetricsChips", () => {
         task="binary"
         selectedMetrics={["auc"]}
         onChange={vi.fn()}
+        metricsByTask={BINARY_METRICS}
       />,
     );
     expect(screen.getByText("auc")).toBeInTheDocument();
@@ -30,6 +39,7 @@ describe("MetricsChips", () => {
         task="regression"
         selectedMetrics={["rmse"]}
         onChange={vi.fn()}
+        metricsByTask={REGRESSION_METRICS}
       />,
     );
     expect(screen.getByText("rmse")).toBeInTheDocument();
@@ -44,6 +54,7 @@ describe("MetricsChips", () => {
         task="binary"
         selectedMetrics={["auc"]}
         onChange={vi.fn()}
+        metricsByTask={BINARY_METRICS}
       />,
     );
     const aucBtn = screen.getByRole("button", { name: "auc" });
@@ -59,6 +70,7 @@ describe("MetricsChips", () => {
         task="binary"
         selectedMetrics={["auc"]}
         onChange={vi.fn()}
+        metricsByTask={BINARY_METRICS}
       />,
     );
     expect(screen.getByRole("button", { name: "auc" })).toHaveAttribute(
@@ -78,6 +90,7 @@ describe("MetricsChips", () => {
         task="binary"
         selectedMetrics={["auc", "logloss"]}
         onChange={onChange}
+        metricsByTask={BINARY_METRICS}
       />,
     );
     fireEvent.click(screen.getByText("auc").closest("button") as Element);
@@ -91,6 +104,7 @@ describe("MetricsChips", () => {
         task="binary"
         selectedMetrics={["auc"]}
         onChange={onChange}
+        metricsByTask={BINARY_METRICS}
       />,
     );
     fireEvent.click(screen.getByText("auc").closest("button") as Element);
@@ -104,6 +118,7 @@ describe("MetricsChips", () => {
         task="binary"
         selectedMetrics={["auc"]}
         onChange={onChange}
+        metricsByTask={BINARY_METRICS}
       />,
     );
     fireEvent.click(screen.getByText("logloss").closest("button") as Element);
@@ -117,6 +132,7 @@ describe("MetricsChips", () => {
         task="binary"
         selectedMetrics={["auc"]}
         onChange={onChange}
+        metricsByTask={ALL_METRICS}
       />,
     );
     rerender(
@@ -124,6 +140,7 @@ describe("MetricsChips", () => {
         task="regression"
         selectedMetrics={["auc"]}
         onChange={onChange}
+        metricsByTask={ALL_METRICS}
       />,
     );
     // Should be called with all regression defaults
@@ -136,7 +153,15 @@ describe("MetricsChips", () => {
         task="unknown_task"
         selectedMetrics={[]}
         onChange={vi.fn()}
+        metricsByTask={BINARY_METRICS}
       />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when metricsByTask is undefined (uiSchema not yet loaded)", () => {
+    const { container } = render(
+      <MetricsChips task="binary" selectedMetrics={[]} onChange={vi.fn()} />,
     );
     expect(container.firstChild).toBeNull();
   });

--- a/frontend/src/components/workspace/MetricsChips.tsx
+++ b/frontend/src/components/workspace/MetricsChips.tsx
@@ -3,7 +3,6 @@ import type { MetricEntry } from "@/api/types";
 import { metricEntryName } from "@/api/types";
 import { ChipGroup } from "./ChipGroup";
 import { CompactStepper } from "./CompactStepper";
-import { METRICS_BY_TASK } from "./constants";
 
 interface ConditionalParamDef {
   label: string;
@@ -54,22 +53,12 @@ export function MetricsChips({
   metricsByTask,
   conditionalParams,
 }: MetricsChipsProps) {
-  // Merge backend option_sets with fallback constants
-  // Default: ALL metrics enabled for the task
-  const effectiveMetrics = useMemo(() => {
-    if (metricsByTask?.[task]) {
-      const available = metricsByTask[task];
-      return { available, defaults: [...available] };
-    }
-    const fallback = METRICS_BY_TASK[task];
-    if (fallback) {
-      return {
-        available: fallback.available,
-        defaults: [...fallback.available],
-      };
-    }
-    return { available: [], defaults: [] };
-  }, [task, metricsByTask]);
+  // Metric catalog is backend-driven via UiSchema option_sets.metric.
+  // Default on task change: ALL metrics enabled for the task.
+  const available = useMemo(
+    () => metricsByTask?.[task] ?? [],
+    [task, metricsByTask],
+  );
 
   const prevTask = useRef(task);
 
@@ -77,15 +66,12 @@ export function MetricsChips({
   useEffect(() => {
     const taskChanged = task !== prevTask.current;
     prevTask.current = task;
-    if (
-      (taskChanged || selectedMetrics.length === 0) &&
-      effectiveMetrics.defaults.length > 0
-    ) {
-      onChange([...effectiveMetrics.defaults]);
+    if ((taskChanged || selectedMetrics.length === 0) && available.length > 0) {
+      onChange([...available]);
     }
-  }, [task, onChange, effectiveMetrics, selectedMetrics.length]);
+  }, [task, onChange, available, selectedMetrics.length]);
 
-  if (effectiveMetrics.available.length === 0) return null;
+  if (available.length === 0) return null;
 
   const names = selectedNames(selectedMetrics);
 
@@ -130,7 +116,7 @@ export function MetricsChips({
   return (
     <div className="flex flex-col gap-2">
       <ChipGroup
-        options={effectiveMetrics.available}
+        options={available}
         selected={names}
         onChange={handleChipChange}
         minSelected={1}

--- a/frontend/src/components/workspace/constants.test.ts
+++ b/frontend/src/components/workspace/constants.test.ts
@@ -8,7 +8,6 @@ import {
   CV_STRATEGY_FIELDS,
   CV_STRATEGY_LABELS,
   getDefaultCvStrategy,
-  METRICS_BY_TASK,
   N_TRIALS_PRESETS,
   TIMEOUT_PRESETS,
 } from "./constants";
@@ -35,28 +34,6 @@ describe("TIMEOUT_PRESETS", () => {
     for (const p of TIMEOUT_PRESETS.slice(1)) {
       expect(typeof p.value).toBe("number");
       expect(p.value).toBeGreaterThan(0);
-    }
-  });
-});
-
-describe("METRICS_BY_TASK", () => {
-  it("has entries for binary, multiclass, regression", () => {
-    expect(METRICS_BY_TASK).toHaveProperty("binary");
-    expect(METRICS_BY_TASK).toHaveProperty("multiclass");
-    expect(METRICS_BY_TASK).toHaveProperty("regression");
-  });
-
-  it("each task has available array with at least one metric", () => {
-    for (const [, info] of Object.entries(METRICS_BY_TASK)) {
-      expect(info.available.length).toBeGreaterThan(0);
-    }
-  });
-
-  it("uses lowercase metric names", () => {
-    for (const [, info] of Object.entries(METRICS_BY_TASK)) {
-      for (const m of info.available) {
-        expect(m).toBe(m.toLowerCase());
-      }
     }
   });
 });

--- a/frontend/src/components/workspace/constants.ts
+++ b/frontend/src/components/workspace/constants.ts
@@ -1,31 +1,15 @@
 /**
- * Fallback constants for when GET /api/backends/ui-schema is not yet loaded.
- * Prefer values from the UiSchema API response.
- * @see H-0026 in HISTORY.md
+ * Pure UI presets and conditional-field maps that are not (yet) driven by
+ * the backend UiSchema response.
  *
- * NOTE: KNOWN_PARAMS and RANGE_DEFAULTS were removed in H-0053.
- * Search space defaults are now provided by the Adapter contract
- * via `default_mode` and `default_range` fields on each catalog entry.
+ * @see H-0026 in HISTORY.md for the UiSchema contract.
+ *
+ * Historical notes:
+ *  - KNOWN_PARAMS / RANGE_DEFAULTS removed in H-0053 (adapter-driven now).
+ *  - METRICS_BY_TASK removed in H-0074 (UiSchema option_sets.metric is the
+ *    sole source of task-to-metric mapping; MetricsChips renders empty
+ *    until UiSchema loads).
  */
-
-/** Task-specific evaluation metrics. */
-export const METRICS_BY_TASK: Record<
-  string,
-  { available: string[]; defaults: string[] }
-> = {
-  binary: {
-    available: ["auc", "logloss", "accuracy", "f1", "precision", "recall"],
-    defaults: ["auc", "logloss"],
-  },
-  multiclass: {
-    available: ["accuracy", "f1_macro", "multi_logloss"],
-    defaults: ["accuracy", "multi_logloss"],
-  },
-  regression: {
-    available: ["rmse", "mae", "r2", "mse"],
-    defaults: ["rmse", "mae"],
-  },
-};
 
 /** Default calibration config when toggled ON. */
 export const CALIBRATION_DEFAULTS = {

--- a/frontend/src/hooks/useDataPanel.test.ts
+++ b/frontend/src/hooks/useDataPanel.test.ts
@@ -3,7 +3,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { queryKeys } from "@/api/queryKeys";
-import type { ColumnInfo, ColumnsResponse } from "@/api/types";
+import type { ColumnInfo, ColumnsResponse, UiSchema } from "@/api/types";
 
 const mocks = vi.hoisted(() => ({
   loadDataFromPath: vi.fn(),
@@ -287,6 +287,87 @@ describe("useDataPanel", () => {
     // waiting for a refetch.
     const cached = queryClient.getQueryData(queryKeys.config());
     expect(cached).toEqual(merged);
+  });
+
+  // --- C-5b: uiSchema.capabilities.cv_default_strategy overrides hard-coded fallback ---
+
+  it("handleTargetChange uses uiSchema.capabilities.cv_default_strategy when provided", async () => {
+    mocks.fetchColumns.mockResolvedValue(COLS_OK);
+    mocks.fetchConfigDefaults.mockResolvedValue({
+      config_version: 1,
+      task: "binary",
+      data: { path: null, target: null },
+      features: { categorical: [], exclude: [] },
+      split: { method: "kfold", n_splits: 5 },
+      model: { name: "lgbm", params: {} },
+    });
+
+    const uiSchema = {
+      capabilities: {
+        cv_default_strategy: { binary: "group_kfold" },
+        cv_strategies: ["kfold", "stratified_kfold", "group_kfold"],
+        tune: { allow_empty_space: true },
+      },
+    } as unknown as UiSchema;
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useDataPanel({ onDataChanged: vi.fn(), uiSchema }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.handleTargetChange("a");
+    });
+
+    expect(result.current.cv.strategy).toBe("group_kfold");
+  });
+
+  it("handleTargetChange falls back to hard-coded default when uiSchema is absent", async () => {
+    mocks.fetchColumns.mockResolvedValue(COLS_OK);
+    mocks.fetchConfigDefaults.mockResolvedValue({
+      config_version: 1,
+      task: "binary",
+      data: { path: null, target: null },
+      features: { categorical: [], exclude: [] },
+      split: { method: "kfold", n_splits: 5 },
+      model: { name: "lgbm", params: {} },
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useDataPanel({ onDataChanged: vi.fn() }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.handleTargetChange("a");
+    });
+
+    // Binary task → stratified_kfold (hard-coded fallback).
+    expect(result.current.cv.strategy).toBe("stratified_kfold");
+  });
+
+  it("handleTaskChange uses uiSchema.capabilities.cv_default_strategy when provided", () => {
+    const uiSchema = {
+      capabilities: {
+        cv_default_strategy: { regression: "time_series" },
+        cv_strategies: ["kfold", "time_series"],
+        tune: { allow_empty_space: true },
+      },
+    } as unknown as UiSchema;
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useDataPanel({ onDataChanged: vi.fn(), uiSchema }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.handleTaskChange("regression");
+    });
+
+    expect(result.current.cv.strategy).toBe("time_series");
   });
 });
 

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -44,9 +44,16 @@ interface UseDataPanelParams {
 export function useDataPanel({
   onDataChanged,
   onTaskChanged,
-  uiSchema: _uiSchema,
+  uiSchema,
 }: UseDataPanelParams) {
   const queryClient = useQueryClient();
+
+  const resolveDefaultCvStrategy = useCallback(
+    (taskName: string): string =>
+      uiSchema?.capabilities?.cv_default_strategy?.[taskName] ??
+      getDefaultCvStrategy(taskName),
+    [uiSchema],
+  );
 
   const [target, setTarget] = useState<string | null>(null);
   const [task, setTask] = useState<TaskType | null>(null);
@@ -106,7 +113,7 @@ export function useDataPanel({
           detectedTask = t;
           setTask(t);
           onTaskChanged?.(t);
-          detectedStrategy = getDefaultCvStrategy(t);
+          detectedStrategy = resolveDefaultCvStrategy(t);
           nextCv = resetCvState(detectedStrategy);
           setCv(nextCv);
         }
@@ -159,17 +166,21 @@ export function useDataPanel({
       onDataChanged,
       onTaskChanged,
       queryClient,
+      resolveDefaultCvStrategy,
       columnOverrides.setOverrides,
       configSync.setSyncSuppressed,
       configSync.preseedSyncKey,
     ],
   );
 
-  const handleTaskChange = (newTask: TaskType) => {
-    setTask(newTask);
-    onTaskChanged?.(newTask);
-    setCv(resetCvState(getDefaultCvStrategy(newTask)));
-  };
+  const handleTaskChange = useCallback(
+    (newTask: TaskType) => {
+      setTask(newTask);
+      onTaskChanged?.(newTask);
+      setCv(resetCvState(resolveDefaultCvStrategy(newTask)));
+    },
+    [onTaskChanged, resolveDefaultCvStrategy],
+  );
 
   return {
     sourceType: dataLoad.sourceType,


### PR DESCRIPTION
## Summary

Part 1 of the C-5b constants retirement from `docs/coupling-analysis.md`.

- Retire `METRICS_BY_TASK` in `frontend/src/components/workspace/constants.ts`. `UiSchema.option_sets.metric` has been the real source of truth since H-0026; the fallback only ever showed for a sub-second window before `UiSchemaQuery` resolved.
- Activate the long-unused `uiSchema` prop on `useDataPanel` via a new `resolveDefaultCvStrategy(task)` helper that reads `uiSchema.capabilities.cv_default_strategy.{task}` and falls back to `getDefaultCvStrategy(task)` when the schema has not loaded yet.
- Wrap `handleTaskChange` in `useCallback` for referential stability (reviewer MEDIUM).

Intentionally **kept**: `CV_STRATEGY_FIELDS` / `CV_STRATEGY_LABELS` / `getDefaultCvStrategy`. The former two require normalising UI internal field names against backend wire-format (`folds` vs `n_splits`, `train_size_max` vs `max_train_size`, and the separate `blocked_group_kfold` field set) which is being scoped as C-5b Part 2 in a follow-up issue. The latter remains as a module-level fallback for the pre-load window.

## Changes

- `frontend/src/components/workspace/MetricsChips.tsx` (-12 net): drop fallback branch, tighten `useMemo`.
- `frontend/src/components/workspace/constants.ts` (-23 net): remove `METRICS_BY_TASK`, header comment updated to H-0074.
- `frontend/src/components/workspace/constants.test.ts` (-23): remove `METRICS_BY_TASK` tests.
- `frontend/src/components/workspace/MetricsChips.test.tsx` (+25): add `metricsByTask` to 8 pre-existing cases + new null-render case for pre-load.
- `frontend/src/hooks/useDataPanel.ts` (+25 -7): `resolveDefaultCvStrategy` helper, wrap `handleTaskChange` in `useCallback`.
- `frontend/src/hooks/useDataPanel.test.ts` (+82): 3 new tests for uiSchema precedence / fallback / handleTaskChange.
- `HISTORY.md`: H-0074 decision record.

## Compatibility

- Wire format / BackendAdapter / storage layout / user-facing config files unchanged.
- Backend untouched; the `UiCapabilities.cv_default_strategy` field has been in the response since H-0026.
- Sole user-observable change: the 6 binary-task metric chips no longer flash for ~100ms before `UiSchemaQuery` resolves.

## Test plan

- [x] `pnpm vitest run src/components/workspace/MetricsChips.test.tsx src/hooks/useDataPanel.test.ts src/components/workspace/constants.test.ts` — 39/39 pass
- [x] `pnpm vitest run` full suite — 1613 pass / 2 skipped (WSL2 V8 worker-terminate warnings only)
- [x] `pnpm check` — clean
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm build` — clean
- [x] `uv run pytest tests/test_ui_schema.py` — 87 pass (backend untouched, sanity only)
- [x] `grep -rn 'METRICS_BY_TASK' frontend/src` returns only the H-0074 historical note in `constants.ts`

## Follow-up

File a separate issue tracking C-5b Part 2 (`CV_STRATEGY_FIELDS` retirement with UI↔wire-format name normalisation).