### PR TITLE
refactor(metrics): per-app MetricsRegistry on app.state (A-9, H-0075)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1953,3 +1953,37 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (c) `MetricsChips` が `metricsByTask` undefined で `null` を返すテスト green。
   - (d) `pnpm test` / `pnpm check` / `pnpm tsc --noEmit` / `pnpm build` すべて clean、`uv run pytest` も変化なし。
 - **Decision:** 2026-04-20 accepted — 提案通り実装。C-5b Part 2（`CV_STRATEGY_FIELDS` retirement）は別 issue として起票予定。
+
+### H-0075: Prometheus メトリクスの per-app `MetricsRegistry` 化（Phase 3 coupling refactor A-9）
+- **Status:** accepted
+- **Scope:** Backend | Internal only（wire format / scrape 出力 / BackendAdapter Protocol すべて不変）
+- **Related:** docs/coupling-analysis.md A-9、H-0065（メトリクス初版）、H-0066（jobs_duration histogram）
+- **Context:** `src/lizystudio/metrics.py` の `Counter` / `Histogram` / `Gauge` は prometheus_client の default `REGISTRY` に module-level で登録されていた。このため pytest で 2 つの `FastAPI` app を同プロセスで作ると 2 度目の `create_app()` が `Duplicated timeseries in CollectorRegistry` で失敗する。また `ACTIVE_JOBS.set(0)` が process-wide state であり、テスト間で active-job gauge が leak していた。multi-backend ML 対応を見据えて、app ごとに独立したメトリクスバンドルを持ちたい。
+- **Proposal:**
+  1. `metrics.py` を書き換え、`MetricsRegistry` dataclass に全 6 instrument（`requests_total` / `request_duration` / `jobs_total` / `active_jobs` / `jobs_duration` / `progress_dropped_total`）をインスタンスフィールドとして束ねる。各 instrument は自前の `CollectorRegistry` に登録される。`record_job_terminal(job_type, status, duration)` はメソッド化。
+  2. `server.py` (`create_app`) で `metrics = MetricsRegistry()` を 1 度だけ構築し、`app.state.metrics` に bind。`JobStore(jobs_dir, metrics=metrics)` と `ProgressBroadcaster(metrics=metrics)` にも注入。middleware は closure 経由で同じ `metrics` を参照。
+  3. `api/deps.py` に `get_metrics(connection: HTTPConnection) -> MetricsRegistry` factory を追加。
+  4. `api/metrics_api.py` は `Depends(get_metrics)` で受け取り `generate_latest(registry.registry)` を返す。
+  5. `JobStore.record_job_terminal(job_type, status, duration)` は bound registry へのデリゲーション。`metrics=None` (subprocess child 経路) の場合は no-op。gauge 更新も `_set_active_gauge(value)` helper 経由。
+  6. `_training_core.py` / `training_retune.py` / `api/workspace.py` の 8+ 箇所の `record_job_terminal(...)` 呼び出しを `job_store.record_job_terminal(...)` に置換。
+  7. `ws/progress.py`: `ProgressBroadcaster(metrics=None)` + `self._record_drop()` メソッド化、`_enqueue` は `self` を使うため `@staticmethod` を外す。module-level lazy `_record_drop` helper 削除。
+  8. `tests/test_metrics_registry.py` を新規追加。A-9 の acceptance core（2 app が同プロセスで共存、それぞれ独立した registry を持つ）を 5 test で validate。
+  9. 既存テスト（`tests/test_metrics_api.py`、`tests/regression/test_reg_0151_*`、`tests/regression/test_reg_0154_*`）を `client.app.state.metrics` 経由に書き換え。
+- **Impact:** `src/lizystudio/metrics.py`（module-level globals → dataclass、-30 / +90 行）、`src/lizystudio/server.py`（+6）、`src/lizystudio/api/deps.py`（+15）、`src/lizystudio/api/metrics_api.py`（Depends 化 +7）、`src/lizystudio/services/jobs.py`（+40: `metrics` 引数・`_set_active_gauge` helper・`record_job_terminal` delegation）、`src/lizystudio/services/_training_core.py`（+5 置換）、`src/lizystudio/services/training_retune.py`（+2 置換）、`src/lizystudio/api/workspace.py`（import 削除・4 箇所置換）、`src/lizystudio/ws/progress.py`（`metrics` 引数・`_record_drop` メソッド化・`@staticmethod` 削除）、テスト 4 ファイル更新 + 1 新規。
+- **Compatibility:**
+  - Prometheus scrape 出力（メトリクス名・labels・buckets）は bit-identical。
+  - wire format / BackendAdapter Protocol / storage layout 変更なし。
+  - **破壊的変更**: `from lizystudio.metrics import record_job_terminal` / `JOBS_TOTAL` / `ACTIVE_JOBS` / `PROGRESS_DROPPED_TOTAL` の module-level export は削除。これらを直接 import する外部統合（監視プラグイン等）は破綻するが、LizyStudio は内部パッケージで外部公開していないため shim は提供しない。
+  - Subprocess child (`subprocess_runner.py` の `JobStore(jobs_dir)`) は `metrics=None` を受け取り、`record_job_terminal` / `_set_active_gauge` が no-op になる。子プロセスの Prometheus 出力は親がスクレイプしないため機能的に同等。親プロセスは subprocess 終了後に `_emit_terminal_metric(job_store, job, duration)` で正しい registry に counter を bump する。
+- **Alternatives:**
+  - (a) Module-level globals を維持し conftest で `REGISTRY._names_to_collectors.clear()` する → 却下。prometheus_client の private attribute に依存する fragile な approach で、library の minor version 変更で壊れる。
+  - (b) `record_job_terminal(metrics, ...)` を caller から全関数に引数で threading する → 却下。`JobStore` に delegation させる方が caller 改修量が少なく、既存の DI (`Depends(get_job_store)`) と揃う。
+  - (c) Deprecation shim (`metrics.__getattr__` で module-level 名を現 app の state から引く) を残す → 却下。global singleton を暗黙的に復活させ A-9 の目的を半減させる。
+- **Acceptance Criteria:**
+  - (a) `tests/test_metrics_registry.py::test_two_apps_can_coexist_in_the_same_process` が green（2 app 同時起動で counter 独立）。
+  - (b) Prometheus scrape 出力に 6 instrument すべての `# TYPE` / `# HELP` ヘッダが含まれる（`test_metrics_api.py::test_metrics_contains_all_declared_series`）。
+  - (c) `active_jobs` が fresh app で 0 を返す（`test_active_jobs_gauge_starts_at_zero`）。
+  - (d) Issue #151 の overflow drop counter が自前 `MetricsRegistry` で increment する（`test_reg_0151_progress_queue_bounded`）。
+  - (e) Issue #154 の slot-claim failure で failed counter が 1 増える（`test_reg_0154_failed_metric_on_slot_claim`）。
+  - (f) `uv run pytest` / `uv run mypy src/lizystudio/` / `uv run ruff check .` / `uv run ruff format --check .` 全 clean、pytest 1152 green。
+- **Decision:** 2026-04-20 accepted — 提案通り実装。`record_job_terminal` の module-level export 廃止は破壊的変更だが、内部パッケージのため shim なしで移行。

--- a/src/lizystudio/api/deps.py
+++ b/src/lizystudio/api/deps.py
@@ -23,6 +23,7 @@ from lizystudio.services.workspace import get_workspace
 
 if TYPE_CHECKING:
     from lizystudio.backends.base import BackendAdapter
+    from lizystudio.metrics import MetricsRegistry
     from lizystudio.ws.progress import ProgressBroadcaster
 
 
@@ -30,6 +31,7 @@ __all__ = [
     "get_backend",
     "get_broadcaster",
     "get_job_store",
+    "get_metrics",
     "get_workspace",
 ]
 
@@ -58,3 +60,14 @@ def get_backend(connection: HTTPConnection) -> BackendAdapter:
     have to depend on the whole :class:`WorkspaceState`.
     """
     return connection.app.state.workspace.backend  # type: ignore[no-any-return]
+
+
+def get_metrics(connection: HTTPConnection) -> MetricsRegistry:
+    """Return the per-app :class:`MetricsRegistry` (A-9).
+
+    Populated by :func:`lizystudio.server.create_app` before the
+    application starts serving requests. Routers that need to observe
+    or bump a metric should ``Depends(get_metrics)`` rather than
+    importing module-level globals.
+    """
+    return connection.app.state.metrics  # type: ignore[no-any-return]

--- a/src/lizystudio/api/metrics_api.py
+++ b/src/lizystudio/api/metrics_api.py
@@ -1,22 +1,30 @@
-"""Prometheus metrics endpoint (BLUEPRINT §5.9, H-0065).
+"""Prometheus metrics endpoint (BLUEPRINT §5.9, H-0065, H-0075).
 
-Issue #30 Phase 2. Returns the default prometheus_client registry as
-text format. Counter / Histogram / Gauge definitions live in
-`lizystudio.metrics`.
+Issue #30 Phase 2. Renders the per-app :class:`MetricsRegistry`
+(A-9) as Prometheus text format. Counter / Histogram / Gauge
+definitions live on :class:`lizystudio.metrics.MetricsRegistry`.
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Response
+from fastapi import APIRouter, Depends, Response
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+from lizystudio.api.deps import get_metrics
+from lizystudio.metrics import MetricsRegistry
 
 router = APIRouter()
 
 
 @router.get("")
-def metrics() -> Response:
+def metrics(
+    registry: MetricsRegistry = Depends(get_metrics),
+) -> Response:
     """Return all registered Prometheus metrics in text format.
 
     Authentication-free, mirroring the probe philosophy of `/api/health`.
     """
-    return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
+    return Response(
+        content=generate_latest(registry.registry),
+        media_type=CONTENT_TYPE_LATEST,
+    )

--- a/src/lizystudio/api/workspace.py
+++ b/src/lizystudio/api/workspace.py
@@ -41,7 +41,6 @@ from lizystudio.api.models import (
     ValidationResponse,
     WorkspaceStatusResponse,
 )
-from lizystudio.metrics import record_job_terminal
 from lizystudio.security import (
     check_dataframe_memory,
     read_upload_checked,
@@ -549,7 +548,7 @@ def workspace_fit(
         # Issue #154: record the terminal status so the
         # lizystudio_jobs_total{status="failed"} counter is not under-
         # counted on slot-claim-after-claim failures.
-        record_job_terminal(job.job_type, "failed")
+        job_store.record_job_terminal(job.job_type, "failed")
         raise JobConflictError(job.job_id) from None
     except Exception:
         # Any other failure after we claimed the slot must release it,
@@ -557,7 +556,7 @@ def workspace_fit(
         # failed metric (#154) before re-raising so the counter
         # reflects the true failure count.
         job_store.release_active(job.job_id)
-        record_job_terminal(job.job_type, "failed")
+        job_store.record_job_terminal(job.job_type, "failed")
         raise
     return {"job_id": job_id}
 
@@ -620,10 +619,10 @@ def workspace_tune(
         job_store.update(job)
         job_store.release_active(job.job_id)
         # Issue #154: record the terminal status (same fix as /fit).
-        record_job_terminal(job.job_type, "failed")
+        job_store.record_job_terminal(job.job_type, "failed")
         raise JobConflictError(job.job_id) from None
     except Exception:
         job_store.release_active(job.job_id)
-        record_job_terminal(job.job_type, "failed")
+        job_store.record_job_terminal(job.job_type, "failed")
         raise
     return {"job_id": job_id}

--- a/src/lizystudio/metrics.py
+++ b/src/lizystudio/metrics.py
@@ -1,61 +1,28 @@
-"""Prometheus metrics (BLUEPRINT §5.9, H-0065).
+"""Prometheus metrics (BLUEPRINT §5.9, H-0065, H-0075).
 
-Issue #30 Phase 2. Centralizes metric definitions so both the ASGI
-middleware (`server.py`) and the service-layer hooks (`services/jobs.py`,
-`services/training.py`) can bump counters without each site having to
-know prometheus_client internals.
+A-9: metrics are owned by a per-app :class:`MetricsRegistry` living on
+``FastAPI.state.metrics``. Each app instantiates its own
+``prometheus_client.CollectorRegistry`` so the test suite can build
+two apps in the same process without the second one tripping
+``Duplicated timeseries in CollectorRegistry``. The registry also
+bundles ``record_job_terminal`` as a method so call sites in
+``services/*`` and ``api/workspace.py`` reach the right registry via
+DI (``Depends(get_metrics)``) rather than a module-level global.
 
-Using the default CollectorRegistry is intentional — it keeps
-`generate_latest()` in `api/metrics_api.py` one line and avoids the
-need to thread a registry through app.state.
+The constants in ``JOBS_DURATION_BUCKETS`` are module-level because
+they are static configuration, not per-instance state.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Literal
 
-from prometheus_client import Counter, Gauge, Histogram
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
 
-# HTTP request counter. Labels:
-#   method  — HTTP verb
-#   path    — FastAPI route template (e.g. "/api/jobs/{job_id}"), or
-#             "unmatched" for 4xx paths that did not hit any router
-#   status  — numeric HTTP status code as a string
-REQUESTS_TOTAL = Counter(
-    "lizystudio_requests_total",
-    "HTTP requests handled by LizyStudio",
-    labelnames=("method", "path", "status"),
-)
-
-# HTTP request duration histogram. Labels kept lean (no status) so
-# latency analysis does not require summing across status buckets.
-REQUEST_DURATION = Histogram(
-    "lizystudio_request_duration_seconds",
-    "HTTP request latency",
-    labelnames=("method", "path"),
-)
-
-# Terminal-state ML job counter. Bumped from the training service layer
-# once a subprocess / thread reports its final status.
-JOBS_TOTAL = Counter(
-    "lizystudio_jobs_total",
-    "ML jobs by terminal status",
-    labelnames=("job_type", "status"),
-)
-
-# Current active-job gauge. JobStore holds at most one active slot per
-# process, so this is effectively a 0-or-1 signal. Exposed as a gauge
-# (not a counter) so external alerting can trigger on "stuck for >N
-# minutes" by combining it with request_duration.
-ACTIVE_JOBS = Gauge(
-    "lizystudio_active_jobs",
-    "Currently running ML jobs (0 or 1)",
-)
-
-# H-0066: ML job wall-clock duration. Buckets target real fit / tune
+# H-0066: ML job wall-clock duration buckets. Targets real fit / tune
 # workloads (seconds to one hour). prometheus_client's default 5ms–10s
-# ladder would collapse everything into the +Inf bucket for this
-# domain.
+# ladder would collapse everything into the +Inf bucket.
 JOBS_DURATION_BUCKETS: tuple[float, ...] = (
     1.0,
     5.0,
@@ -69,42 +36,113 @@ JOBS_DURATION_BUCKETS: tuple[float, ...] = (
     3600.0,
 )
 
-JOBS_DURATION = Histogram(
-    "lizystudio_jobs_duration_seconds",
-    "ML job wall-clock duration from claim_active to terminal state",
-    labelnames=("job_type", "status"),
-    buckets=JOBS_DURATION_BUCKETS,
-)
-
-# Issue #151: counts progress messages that the WebSocket broadcaster
-# dropped because a subscriber queue was full. Non-terminal messages
-# are droppable; terminal (completed/error) messages are not and will
-# evict an older non-terminal rather than being dropped themselves.
-PROGRESS_DROPPED_TOTAL = Counter(
-    "lizystudio_progress_dropped_total",
-    "Progress messages dropped due to a full subscriber queue",
-)
-
 
 JobType = Literal["fit", "tune"]
 TerminalStatus = Literal["completed", "failed", "cancelled"]
 
 
-def record_job_terminal(
-    job_type: JobType,
-    status: TerminalStatus,
-    duration: float = 0.0,
-) -> None:
-    """Record one terminal transition for a ML job.
+@dataclass
+class MetricsRegistry:
+    """Per-app Prometheus instrument bundle (A-9).
 
-    Increments `lizystudio_jobs_total{job_type, status}` by 1 and, when
-    *duration* is known, observes the elapsed seconds in
-    `lizystudio_jobs_duration_seconds{job_type, status}`.
+    Owns a fresh :class:`CollectorRegistry` and every Counter /
+    Histogram / Gauge the service layer bumps. Construct exactly once
+    per :class:`FastAPI` app in :func:`lizystudio.server.create_app` and
+    inject through ``Depends(lizystudio.api.deps.get_metrics)``.
 
-    *duration* defaults to 0.0 for early-fail paths (e.g. retune data
-    missing) where the wall-clock is effectively zero because the job
-    never reached the training phase. Counter emission stays correct
-    even for those paths.
+    All instruments are mirrors of the pre-A-9 module-level globals;
+    names and labels are unchanged so the scrape output is bit-compatible.
     """
-    JOBS_TOTAL.labels(job_type=job_type, status=status).inc()
-    JOBS_DURATION.labels(job_type=job_type, status=status).observe(duration)
+
+    registry: CollectorRegistry = field(default_factory=CollectorRegistry)
+
+    requests_total: Counter = field(init=False)
+    request_duration: Histogram = field(init=False)
+    jobs_total: Counter = field(init=False)
+    active_jobs: Gauge = field(init=False)
+    jobs_duration: Histogram = field(init=False)
+    progress_dropped_total: Counter = field(init=False)
+
+    def __post_init__(self) -> None:
+        # HTTP request counter. Labels:
+        #   method  — HTTP verb
+        #   path    — FastAPI route template (e.g. "/api/jobs/{job_id}"),
+        #             or "unmatched" for 4xx paths that did not hit any router
+        #   status  — numeric HTTP status code as a string
+        self.requests_total = Counter(
+            "lizystudio_requests_total",
+            "HTTP requests handled by LizyStudio",
+            labelnames=("method", "path", "status"),
+            registry=self.registry,
+        )
+
+        # HTTP request duration histogram. Labels kept lean (no status) so
+        # latency analysis does not require summing across status buckets.
+        self.request_duration = Histogram(
+            "lizystudio_request_duration_seconds",
+            "HTTP request latency",
+            labelnames=("method", "path"),
+            registry=self.registry,
+        )
+
+        # Terminal-state ML job counter. Bumped from the training service
+        # layer once a subprocess / thread reports its final status.
+        self.jobs_total = Counter(
+            "lizystudio_jobs_total",
+            "ML jobs by terminal status",
+            labelnames=("job_type", "status"),
+            registry=self.registry,
+        )
+
+        # Current active-job gauge. JobStore holds at most one active
+        # slot per process, so this is effectively a 0-or-1 signal.
+        self.active_jobs = Gauge(
+            "lizystudio_active_jobs",
+            "Currently running ML jobs (0 or 1)",
+            registry=self.registry,
+        )
+
+        # H-0066: ML job wall-clock duration histogram.
+        self.jobs_duration = Histogram(
+            "lizystudio_jobs_duration_seconds",
+            "ML job wall-clock duration from claim_active to terminal state",
+            labelnames=("job_type", "status"),
+            buckets=JOBS_DURATION_BUCKETS,
+            registry=self.registry,
+        )
+
+        # Issue #151: counts progress messages that the WebSocket
+        # broadcaster dropped because a subscriber queue was full.
+        self.progress_dropped_total = Counter(
+            "lizystudio_progress_dropped_total",
+            "Progress messages dropped due to a full subscriber queue",
+            registry=self.registry,
+        )
+
+    def record_job_terminal(
+        self,
+        job_type: JobType,
+        status: TerminalStatus,
+        duration: float = 0.0,
+    ) -> None:
+        """Record one terminal transition for a ML job.
+
+        Increments ``lizystudio_jobs_total{job_type, status}`` by 1 and,
+        when *duration* is known, observes the elapsed seconds in
+        ``lizystudio_jobs_duration_seconds{job_type, status}``.
+
+        *duration* defaults to 0.0 for early-fail paths (e.g. retune
+        data missing) where the wall-clock is effectively zero because
+        the job never reached the training phase. Counter emission
+        stays correct even for those paths.
+        """
+        self.jobs_total.labels(job_type=job_type, status=status).inc()
+        self.jobs_duration.labels(job_type=job_type, status=status).observe(duration)
+
+
+__all__ = [
+    "JOBS_DURATION_BUCKETS",
+    "JobType",
+    "MetricsRegistry",
+    "TerminalStatus",
+]

--- a/src/lizystudio/server.py
+++ b/src/lizystudio/server.py
@@ -33,7 +33,7 @@ from lizystudio.api.errors import (
     validation_error_handler,
 )
 from lizystudio.backends.registry import get_adapter
-from lizystudio.metrics import REQUEST_DURATION, REQUESTS_TOTAL
+from lizystudio.metrics import MetricsRegistry
 from lizystudio.services.jobs import JobStore
 from lizystudio.services.workspace import WorkspaceState
 from lizystudio.ws.progress import ProgressBroadcaster, websocket_progress
@@ -92,15 +92,23 @@ def create_app() -> FastAPI:
     backend_name = os.environ.get("LIZYSTUDIO_BACKEND", "lizyml")
     jobs_dir = Path(os.environ.get("LIZYSTUDIO_JOBS_DIR", ".lizystudio/jobs"))
 
+    # A-9: per-app Prometheus registry. Instantiated before ``lifespan``
+    # so both the metrics_middleware closure below and the JobStore can
+    # bind to the same registry. Each ``create_app()`` invocation builds
+    # a fresh :class:`CollectorRegistry`, so two apps can coexist in
+    # the same process (e.g. pytest).
+    metrics = MetricsRegistry()
+
     @asynccontextmanager
     async def lifespan(application: FastAPI) -> AsyncIterator[None]:
         adapter = get_adapter(backend_name)
         # Eagerly import the ML backend to avoid import-lock deadlocks
         # when concurrent API requests trigger lazy imports in threads.
         _warmup_adapter(adapter)
+        application.state.metrics = metrics
         application.state.workspace = WorkspaceState(backend=adapter)
-        application.state.job_store = JobStore(jobs_dir)
-        broadcaster = ProgressBroadcaster()
+        application.state.job_store = JobStore(jobs_dir, metrics=metrics)
+        broadcaster = ProgressBroadcaster(metrics=metrics)
         broadcaster.set_loop(asyncio.get_running_loop())
         application.state.broadcaster = broadcaster
         yield
@@ -157,12 +165,12 @@ def create_app() -> FastAPI:
         route = request.scope.get("route")
         label_path = getattr(route, "path", None) or "unmatched"
 
-        REQUESTS_TOTAL.labels(
+        metrics.requests_total.labels(
             method=request.method,
             path=label_path,
             status=str(response.status_code),
         ).inc()
-        REQUEST_DURATION.labels(
+        metrics.request_duration.labels(
             method=request.method,
             path=label_path,
         ).observe(elapsed)

--- a/src/lizystudio/services/_training_core.py
+++ b/src/lizystudio/services/_training_core.py
@@ -30,7 +30,6 @@ from typing import TYPE_CHECKING, Any
 
 from lizystudio.backends.base import BackendAdapter, ProgressCallback
 from lizystudio.backends.types import FitSummary, TuningSummary
-from lizystudio.metrics import record_job_terminal
 from lizystudio.services.jobs import Job, JobStore
 
 if TYPE_CHECKING:
@@ -103,18 +102,19 @@ def _subprocess_duration_seconds(job: Job) -> float:
     return max(0.0, (completed - created).total_seconds())
 
 
-def _emit_terminal_metric(job: Job, duration: float = 0.0) -> None:
+def _emit_terminal_metric(job_store: JobStore, job: Job, duration: float = 0.0) -> None:
     """Bump ``lizystudio_jobs_total`` and observe duration (H-0065, H-0066).
 
-    Centralises the per-literal dispatch that mypy requires for Literal
-    narrowing.
+    A-9: delegates to the bound :class:`~lizystudio.metrics.MetricsRegistry`
+    via ``job_store.record_job_terminal``. Centralises the per-literal
+    dispatch that mypy requires for Literal narrowing.
     """
     if job.status == "completed":
-        record_job_terminal(job.job_type, "completed", duration=duration)
+        job_store.record_job_terminal(job.job_type, "completed", duration=duration)
     elif job.status == "failed":
-        record_job_terminal(job.job_type, "failed", duration=duration)
+        job_store.record_job_terminal(job.job_type, "failed", duration=duration)
     elif job.status == "cancelled":
-        record_job_terminal(job.job_type, "cancelled", duration=duration)
+        job_store.record_job_terminal(job.job_type, "cancelled", duration=duration)
 
 
 def _run_job_core(
@@ -141,7 +141,7 @@ def _run_job_core(
             broadcaster.send_error(
                 job.job_id, "Another job is already running", code="JOB_CONFLICT"
             )
-        record_job_terminal(job.job_type, "failed")
+        job_store.record_job_terminal(job.job_type, "failed")
         return job
 
     job.status = "running"
@@ -187,7 +187,7 @@ def _run_job_core(
         job_store.release_active(job.job_id)
         job_store.clear_cancel(job.job_id)
         elapsed = time.monotonic() - start_time
-        _emit_terminal_metric(job, duration=elapsed)  # H-0065 / H-0066
+        _emit_terminal_metric(job_store, job, duration=elapsed)  # H-0065 / H-0066
         job_logger.removeHandler(handler)
         handler.close()
         # Persist captured logs. OSError here must not propagate —
@@ -314,7 +314,7 @@ def _run_subprocess_job(
                 if broadcaster is not None:
                     broadcaster.send_error(job.job_id, job.error)
                 ws.note_current_job(job.job_id)
-                record_job_terminal(job.job_type, "failed")
+                job_store.record_job_terminal(job.job_type, "failed")
                 terminal_already_recorded = True
             return job
         data_path = ws.data_ref.path
@@ -352,7 +352,7 @@ def _run_subprocess_job(
             latest = job_store.get(job.job_id)
             if latest is not None:
                 duration = _subprocess_duration_seconds(latest)
-                _emit_terminal_metric(latest, duration=duration)
+                _emit_terminal_metric(job_store, latest, duration=duration)
 
 
 __all__ = [

--- a/src/lizystudio/services/jobs.py
+++ b/src/lizystudio/services/jobs.py
@@ -12,14 +12,16 @@ import threading
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
 from fastapi import Request
 
 from lizystudio.backends.types import DataRef, FitSummary, TuningSummary
-from lizystudio.metrics import ACTIVE_JOBS
 from lizystudio.security import validate_path_within  # noqa: E402
+
+if TYPE_CHECKING:
+    from lizystudio.metrics import JobType, MetricsRegistry, TerminalStatus
 
 _logger = logging.getLogger(__name__)
 
@@ -104,13 +106,25 @@ class JobStore:
         {jobs_dir}/{job_id}/model/
     """
 
-    def __init__(self, jobs_dir: Path) -> None:
+    def __init__(
+        self,
+        jobs_dir: Path,
+        metrics: MetricsRegistry | None = None,
+    ) -> None:
         self.jobs_dir = jobs_dir
         self.jobs_dir.mkdir(parents=True, exist_ok=True)
         self._cancel_requested: set[str] = set()
         self._cancel_lock = threading.Lock()
         self._active_job_id: str | None = None
         self._active_lock = threading.Lock()
+        # A-9: the active-slot gauge lives on the per-app MetricsRegistry.
+        # ``metrics`` is None in the subprocess child path
+        # (:func:`subprocess_runner._run_job_in_subprocess`) where the
+        # child's Prometheus state is isolated from the parent and
+        # scrape output comes from the parent's registry only — bumping
+        # a disconnected gauge inside the child would be a no-op, so we
+        # simply skip it.
+        self._metrics = metrics
         # H-0062: per-parent exclusive lock for Re-tune / Resume children.
         # Maps parent_job_id -> child_job_id currently holding the slot.
         # In-memory only; cleared naturally on process restart because
@@ -118,6 +132,29 @@ class JobStore:
         # already marked failed at restart time.
         self._parent_locks: dict[str, str] = {}
         self._parent_lock_mutex = threading.Lock()
+
+    def _set_active_gauge(self, value: float) -> None:
+        """Update the active-jobs gauge on the bound MetricsRegistry."""
+        if self._metrics is not None:
+            self._metrics.active_jobs.set(value)
+
+    def record_job_terminal(
+        self,
+        job_type: JobType,
+        status: TerminalStatus,
+        duration: float = 0.0,
+    ) -> None:
+        """Forward a terminal transition to the bound :class:`MetricsRegistry`.
+
+        A-9: the training service layer already threads a ``JobStore``
+        through every call path, so re-using it as the metrics entry
+        point avoids duplicating the plumbing. A ``None`` registry is
+        a no-op (used by the subprocess child where Prometheus output
+        is never scraped).
+        """
+        if self._metrics is None:
+            return
+        self._metrics.record_job_terminal(job_type, status, duration=duration)
 
     def _job_dir(self, job_id: str) -> Path:
         """Resolve job directory with traversal guard."""
@@ -564,7 +601,7 @@ class JobStore:
                 parent_job_id=parent_job_id,
             )
             self._active_job_id = job.job_id
-            ACTIVE_JOBS.set(1)
+            self._set_active_gauge(1)
             return job
 
     def _is_slot_holder_stale_locked(self) -> bool:
@@ -594,10 +631,10 @@ class JobStore:
         with self._active_lock:
             if self._active_job_id is None:
                 self._active_job_id = job_id
-                ACTIVE_JOBS.set(1)
+                self._set_active_gauge(1)
                 return True
             # H-0065: the `self._active_job_id == job_id` re-claim
-            # branch intentionally skips `ACTIVE_JOBS.set(1)` — the
+            # branch intentionally skips the gauge update — the
             # gauge was already set to 1 by the original
             # `create_and_claim_active` or `claim_active` call that
             # acquired the slot, and bumping it again would be a
@@ -609,7 +646,7 @@ class JobStore:
         with self._active_lock:
             if self._active_job_id == job_id:
                 self._active_job_id = None
-                ACTIVE_JOBS.set(0)
+                self._set_active_gauge(0)
 
     def force_release_active_if(self, expected_job_id: str) -> bool:
         """Atomically release the slot iff it is still held by *expected_job_id*.
@@ -629,7 +666,7 @@ class JobStore:
         with self._active_lock:
             if self._active_job_id == expected_job_id:
                 self._active_job_id = None
-                ACTIVE_JOBS.set(0)
+                self._set_active_gauge(0)
                 return True
             return False
 

--- a/src/lizystudio/services/training_retune.py
+++ b/src/lizystudio/services/training_retune.py
@@ -23,7 +23,6 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from lizystudio.backends.base import BackendAdapter, ProgressCallback
 from lizystudio.backends.types import FitSummary, TuningSummary
-from lizystudio.metrics import record_job_terminal
 from lizystudio.services._training_core import (
     _join_previous_thread,
     _prepare_autofit_config,
@@ -147,7 +146,7 @@ def _mark_retune_child_failed(
     ws.note_current_job(child_job.job_id)
     if broadcaster is not None:
         broadcaster.send_error(child_job.job_id, message)
-    record_job_terminal(child_job.job_type, "failed")
+    job_store.record_job_terminal(child_job.job_type, "failed")
 
 
 def _run_retune_subprocess(

--- a/src/lizystudio/ws/progress.py
+++ b/src/lizystudio/ws/progress.py
@@ -19,11 +19,14 @@ import contextlib
 import json
 import logging
 import threading
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fastapi import WebSocket, WebSocketDisconnect
 
 from lizystudio.ws.messages import WsCompleted, WsError, WsPing, WsProgress
+
+if TYPE_CHECKING:
+    from lizystudio.metrics import MetricsRegistry
 
 _logger = logging.getLogger(__name__)
 
@@ -58,10 +61,16 @@ class ProgressBroadcaster:
       full queue the oldest non-terminal item is evicted to make room.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, metrics: MetricsRegistry | None = None) -> None:
         self._queues: dict[str, list[asyncio.Queue[dict[str, Any]]]] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
         self._lock = threading.Lock()
+        # A-9: the progress-dropped counter lives on the per-app
+        # :class:`MetricsRegistry`. ``metrics`` is ``None`` when the
+        # broadcaster is stood up outside the normal app lifespan (e.g.
+        # legacy tests) — the drop accounting silently no-ops in that
+        # case instead of bumping a disconnected global.
+        self._metrics = metrics
 
     def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
         """Store the event loop reference for thread-safe enqueuing."""
@@ -98,8 +107,8 @@ class ProgressBroadcaster:
         for q in qs:
             self._loop.call_soon_threadsafe(self._enqueue, q, message, is_terminal)
 
-    @staticmethod
     def _enqueue(
+        self,
         q: asyncio.Queue[dict[str, Any]],
         message: dict[str, Any],
         is_terminal: bool,
@@ -107,9 +116,9 @@ class ProgressBroadcaster:
         """Best-effort enqueue with the Issue #151 overflow policy.
 
         Runs on the event loop thread via ``call_soon_threadsafe`` so
-        ``asyncio.Queue`` operations are safe. Importing the metrics
-        counter lazily keeps the import graph free of a cycle between
-        ``ws.progress`` and ``metrics`` (metrics is a leaf module).
+        ``asyncio.Queue`` operations are safe. Needs ``self`` so it can
+        reach the per-app ``MetricsRegistry`` (A-9) when the drop
+        policy has to bump ``progress_dropped_total``.
         """
         try:
             q.put_nowait(message)
@@ -132,7 +141,7 @@ class ProgressBroadcaster:
                     preserved_terminals.append(head)
                     continue
                 # Found a non-terminal to evict.
-                _record_drop()
+                self._record_drop()
                 evicted_nonterminal = True
                 break
             # Put the preserved terminals back first (FIFO order
@@ -168,7 +177,12 @@ class ProgressBroadcaster:
                     )
             return
         # Non-terminal on a full queue: drop silently, record metric.
-        _record_drop()
+        self._record_drop()
+
+    def _record_drop(self) -> None:
+        """Increment ``progress_dropped_total`` on the bound registry."""
+        if self._metrics is not None:
+            self._metrics.progress_dropped_total.inc()
 
     def send_progress(
         self,
@@ -220,19 +234,6 @@ class ProgressBroadcaster:
             self.send_progress(job_id, current=current, total=total, message=message)
 
         return callback
-
-
-def _record_drop() -> None:
-    """Increment the progress-dropped counter without a hard import.
-
-    Kept module-private and lazy so importing ``ws.progress`` does not
-    force metrics into the import graph during test collection.
-    """
-    try:
-        from lizystudio.metrics import PROGRESS_DROPPED_TOTAL
-    except ImportError:  # pragma: no cover — metrics is optional
-        return
-    PROGRESS_DROPPED_TOTAL.inc()
 
 
 _DEFAULT_WS_ORIGINS: frozenset[str] = frozenset(

--- a/tests/regression/test_reg_0151_progress_queue_bounded.py
+++ b/tests/regression/test_reg_0151_progress_queue_bounded.py
@@ -213,16 +213,24 @@ def test_two_terminals_on_full_queue_both_survive_or_first_wins() -> None:
 
 
 def test_dropped_counter_increments_on_overflow() -> None:
-    """Observability: PROGRESS_DROPPED_TOTAL increments on overflow."""
-    from lizystudio.metrics import PROGRESS_DROPPED_TOTAL
+    """Observability: ``progress_dropped_total`` increments on overflow.
 
-    broadcaster = ProgressBroadcaster()
+    A-9: the counter lives on a per-app :class:`MetricsRegistry`
+    injected into the broadcaster at construction time. Using a fresh
+    registry here isolates the drop accounting from whatever
+    counts the main ``client`` fixture's app may also be emitting in
+    the same pytest session.
+    """
+    from lizystudio.metrics import MetricsRegistry
+
+    metrics = MetricsRegistry()
+    broadcaster = ProgressBroadcaster(metrics=metrics)
 
     async def scenario() -> None:
         broadcaster.set_loop(asyncio.get_event_loop())
         q = broadcaster.subscribe("job_counter")
         try:
-            before = PROGRESS_DROPPED_TOTAL._value.get()  # type: ignore[attr-defined]
+            before = metrics.progress_dropped_total._value.get()  # type: ignore[attr-defined]
 
             overflow = MAX_QUEUE_SIZE
             total = MAX_QUEUE_SIZE + overflow
@@ -232,7 +240,7 @@ def test_dropped_counter_increments_on_overflow() -> None:
                 )
                 await asyncio.sleep(0)
 
-            after = PROGRESS_DROPPED_TOTAL._value.get()  # type: ignore[attr-defined]
+            after = metrics.progress_dropped_total._value.get()  # type: ignore[attr-defined]
             assert after - before >= overflow, (
                 f"expected at least {overflow} drops, got delta={after - before}"
             )

--- a/tests/regression/test_reg_0154_failed_metric_on_slot_claim.py
+++ b/tests/regression/test_reg_0154_failed_metric_on_slot_claim.py
@@ -20,11 +20,14 @@ from fastapi.testclient import TestClient
 pytestmark = pytest.mark.integration
 
 
-def _jobs_total(labels: dict[str, str]) -> float:
-    """Read the current value of JOBS_TOTAL for the given label set."""
-    from lizystudio.metrics import JOBS_TOTAL
+def _jobs_total(client: TestClient, labels: dict[str, str]) -> float:
+    """Read the current ``jobs_total`` value for the given label set.
 
-    return JOBS_TOTAL.labels(**labels)._value.get()  # type: ignore[attr-defined]
+    A-9: the counter now lives on the per-app :class:`MetricsRegistry`
+    bound to ``app.state.metrics``.
+    """
+    metrics = client.app.state.metrics  # type: ignore[attr-defined]
+    return metrics.jobs_total.labels(**labels)._value.get()  # type: ignore[attr-defined]
 
 
 def _seed_workspace(client: TestClient, tmp_path: Path) -> None:
@@ -64,10 +67,10 @@ def test_fit_previous_job_running_emits_failed_metric(
 
     monkeypatch.setattr(ws_mod, "start_fit_async", _raise_previous)
 
-    before = _jobs_total({"job_type": "fit", "status": "failed"})
+    before = _jobs_total(client, {"job_type": "fit", "status": "failed"})
     response = client.post("/api/workspace/fit")
     assert response.status_code == 409, response.text
-    after = _jobs_total({"job_type": "fit", "status": "failed"})
+    after = _jobs_total(client, {"job_type": "fit", "status": "failed"})
     assert after - before == 1, (
         f"expected 1 failed-metric emission, got delta={after - before}"
     )
@@ -87,10 +90,10 @@ def test_tune_previous_job_running_emits_failed_metric(
 
     monkeypatch.setattr(ws_mod, "start_tune_async", _raise_previous)
 
-    before = _jobs_total({"job_type": "tune", "status": "failed"})
+    before = _jobs_total(client, {"job_type": "tune", "status": "failed"})
     response = client.post("/api/workspace/tune")
     assert response.status_code == 409, response.text
-    after = _jobs_total({"job_type": "tune", "status": "failed"})
+    after = _jobs_total(client, {"job_type": "tune", "status": "failed"})
     assert after - before == 1
 
 
@@ -114,10 +117,10 @@ def test_fit_generic_thread_start_failure_emits_failed_metric(
 
     monkeypatch.setattr(ws_mod, "start_fit_async", _raise_runtime)
 
-    before = _jobs_total({"job_type": "fit", "status": "failed"})
+    before = _jobs_total(client, {"job_type": "fit", "status": "failed"})
     with pytest.raises(RuntimeError, match="thread start failed"):
         client.post("/api/workspace/fit")
-    after = _jobs_total({"job_type": "fit", "status": "failed"})
+    after = _jobs_total(client, {"job_type": "fit", "status": "failed"})
     assert after - before == 1
 
 
@@ -134,8 +137,8 @@ def test_tune_generic_thread_start_failure_emits_failed_metric(
 
     monkeypatch.setattr(ws_mod, "start_tune_async", _raise_runtime)
 
-    before = _jobs_total({"job_type": "tune", "status": "failed"})
+    before = _jobs_total(client, {"job_type": "tune", "status": "failed"})
     with pytest.raises(RuntimeError, match="thread start failed"):
         client.post("/api/workspace/tune")
-    after = _jobs_total({"job_type": "tune", "status": "failed"})
+    after = _jobs_total(client, {"job_type": "tune", "status": "failed"})
     assert after - before == 1

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -155,9 +155,8 @@ def test_jobs_duration_uses_ml_workload_buckets(client: TestClient) -> None:
     Note: prometheus_client only emits `_bucket` lines after the first
     observation — prime the histogram with one sample before reading.
     """
-    from lizystudio.metrics import record_job_terminal
-
-    record_job_terminal("fit", "completed", duration=0.5)
+    metrics = client.app.state.metrics  # type: ignore[attr-defined]
+    metrics.record_job_terminal("fit", "completed", duration=0.5)
 
     body = client.get("/api/metrics").text
     # A handful of bucket edges we promised in BLUEPRINT §5.9.
@@ -173,11 +172,11 @@ def test_record_job_terminal_accepts_duration(client: TestClient) -> None:
     The helper is the single entry point used across the training
     service; adding a duration arg keeps the call sites uniform.
     """
-    from lizystudio.metrics import record_job_terminal
+    metrics = client.app.state.metrics  # type: ignore[attr-defined]
 
     # Should not raise; duration is optional.
-    record_job_terminal("fit", "completed", duration=1.23)
-    record_job_terminal("tune", "failed")  # backward-compat: no duration
+    metrics.record_job_terminal("fit", "completed", duration=1.23)
+    metrics.record_job_terminal("tune", "failed")  # backward-compat: no duration
 
 
 def test_active_jobs_gauge_starts_at_zero(client: TestClient) -> None:

--- a/tests/test_metrics_registry.py
+++ b/tests/test_metrics_registry.py
@@ -1,0 +1,138 @@
+"""Tests for the per-app MetricsRegistry (A-9).
+
+The registry replaces the module-level Counter / Histogram / Gauge
+globals so that pytest can build two FastAPI apps in the same process
+without `prometheus_client.core.Collector._metrics` raising
+``Duplicated timeseries`` on the second app's import.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from prometheus_client import Counter, Gauge, Histogram
+
+from lizystudio.metrics import MetricsRegistry
+from lizystudio.server import create_app
+
+pytestmark = pytest.mark.integration
+
+
+def test_metrics_registry_has_all_declared_instruments() -> None:
+    """Every metric name referenced by the codebase must exist on the registry."""
+    registry = MetricsRegistry()
+
+    # Counters
+    assert isinstance(registry.requests_total, Counter)
+    assert isinstance(registry.jobs_total, Counter)
+    assert isinstance(registry.progress_dropped_total, Counter)
+
+    # Histograms
+    assert isinstance(registry.request_duration, Histogram)
+    assert isinstance(registry.jobs_duration, Histogram)
+
+    # Gauges
+    assert isinstance(registry.active_jobs, Gauge)
+
+
+def test_metrics_registry_instances_are_independent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two registry instances must not collide on the prometheus global.
+
+    Before A-9, re-importing the module would raise ``ValueError:
+    Duplicated timeseries in CollectorRegistry`` because Counter /
+    Histogram / Gauge construction registers on the default global
+    ``REGISTRY``. After A-9 each registry owns its own
+    ``CollectorRegistry``.
+    """
+    monkeypatch.setenv("LIZYSTUDIO_JOBS_DIR", str(tmp_path / "jobs"))
+
+    first = MetricsRegistry()
+    second = MetricsRegistry()
+
+    # Each must be a distinct Python object with its own registry.
+    assert first is not second
+    assert first.registry is not second.registry
+    # Counter instances differ too.
+    assert first.jobs_total is not second.jobs_total
+
+
+def test_two_apps_can_coexist_in_the_same_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two FastAPI apps must be instantiable in the same pytest process.
+
+    This is the core A-9 acceptance: module-level globals used to make
+    the second ``create_app()`` raise when prometheus re-registered
+    ``lizystudio_requests_total`` etc. After A-9 each app has its own
+    ``app.state.metrics`` and survives side-by-side instantiation.
+    """
+    jobs_a = tmp_path / "jobs_a"
+    jobs_b = tmp_path / "jobs_b"
+    monkeypatch.setenv("LIZYSTUDIO_JOBS_DIR", str(jobs_a))
+
+    app_a = create_app()
+    # Swap env so the second app does not share job storage (otherwise
+    # it would use the same JobStore dir, which is orthogonal to the
+    # metrics isolation question but keeps the fixture realistic).
+    monkeypatch.setenv("LIZYSTUDIO_JOBS_DIR", str(jobs_b))
+    app_b = create_app()
+
+    with TestClient(app_a) as client_a, TestClient(app_b) as client_b:
+        body_a = client_a.get("/api/metrics").text
+        body_b = client_b.get("/api/metrics").text
+
+        # Both apps must expose the declared series names.
+        assert "lizystudio_requests_total" in body_a
+        assert "lizystudio_requests_total" in body_b
+
+        # Each app's registry is independent: traffic against app_a
+        # must not bump app_b's counter.
+        client_a.get("/api/workspace/status")
+        client_a.get("/api/workspace/status")
+        client_a.get("/api/workspace/status")
+
+        def _status_count(body: str) -> float:
+            for line in body.splitlines():
+                if (
+                    line.startswith("lizystudio_requests_total{")
+                    and "/api/workspace/status" in line
+                    and not line.startswith("#")
+                ):
+                    return float(line.rsplit(" ", 1)[1])
+            return 0.0
+
+        body_a_after = client_a.get("/api/metrics").text
+        body_b_after = client_b.get("/api/metrics").text
+
+        # app_a saw three hits; app_b saw zero. Registry isolation
+        # means the second app's status counter is still at or below 0.
+        assert _status_count(body_a_after) >= 3.0
+        assert _status_count(body_b_after) == 0.0
+
+
+def test_app_state_metrics_is_wired(
+    client: TestClient,
+) -> None:
+    """``app.state.metrics`` must expose the active :class:`MetricsRegistry`."""
+    metrics = client.app.state.metrics  # type: ignore[attr-defined]
+    assert isinstance(metrics, MetricsRegistry)
+
+
+def test_record_job_terminal_is_a_method(
+    client: TestClient,
+) -> None:
+    """``record_job_terminal`` moved from module-level to an instance method.
+
+    Callers now reach it via ``app.state.metrics.record_job_terminal(...)``
+    (or through ``Depends(get_metrics)`` in routers).
+    """
+    metrics = client.app.state.metrics  # type: ignore[attr-defined]
+    assert callable(getattr(metrics, "record_job_terminal", None))
+
+    # Smoke: must not raise; backward-compatible signature.
+    metrics.record_job_terminal("fit", "completed", duration=0.25)
+    metrics.record_job_terminal("tune", "failed")


### PR DESCRIPTION
## Summary

Close the A-9 item in \`docs/coupling-analysis.md\`: replace module-level \`prometheus_client\` globals with a per-app \`MetricsRegistry\` dataclass bound to \`FastAPI.state.metrics\`.

### Why

- pytest could only build one \`FastAPI\` app per process — the second \`create_app()\` tripped \`Duplicated timeseries in CollectorRegistry\` because module-level \`Counter\` / \`Histogram\` / \`Gauge\` registered on the default \`REGISTRY\`.
- \`ACTIVE_JOBS.set(0)\` was process-wide, so tests that exercised the slot machinery leaked gauge state.
- multi-backend support (future work) wants one registry per backend session.

### What

- \`metrics.py\`: \`MetricsRegistry\` dataclass owns its own \`CollectorRegistry\` and all 6 instruments. \`record_job_terminal(job_type, status, duration)\` is now a method on the registry.
- \`server.py\`: \`metrics = MetricsRegistry()\` instantiated once per \`create_app()\`, threaded into \`JobStore(metrics=...)\`, \`ProgressBroadcaster(metrics=...)\`, and the middleware closure. Stored on \`app.state.metrics\` for router DI.
- \`api/deps.py\`: new \`get_metrics(connection)\` dependency factory.
- \`api/metrics_api.py\`: \`Depends(get_metrics)\` → \`generate_latest(registry.registry)\`.
- \`services/jobs.py\`: \`JobStore(jobs_dir, metrics=None)\` optional; \`_set_active_gauge\` helper + \`record_job_terminal\` delegation using the \`JobType\` / \`TerminalStatus\` literals. Subprocess children pass \`metrics=None\` and cleanly no-op.
- \`services/_training_core.py\` / \`training_retune.py\` / \`api/workspace.py\`: 8+ \`record_job_terminal(...)\` call sites rewritten to \`job_store.record_job_terminal(...)\`.
- \`ws/progress.py\`: \`ProgressBroadcaster(metrics=None)\`, \`self._record_drop()\` method, \`_enqueue\` de-staticmethoded to access \`self._metrics\`; module-level lazy \`_record_drop\` helper removed.
- Tests: new \`tests/test_metrics_registry.py\` with 5 cases (core A-9 acceptance — two apps with independent counters in the same process); \`test_metrics_api\` + two regression files updated to read from \`client.app.state.metrics\`.

### Compatibility

- Prometheus scrape output (names, labels, bucket boundaries) is **bit-identical** to pre-A-9.
- Wire format / BackendAdapter / storage layout / UI schemas unchanged.
- **Breaking (internal only)**: \`from lizystudio.metrics import record_job_terminal / JOBS_TOTAL / ACTIVE_JOBS / PROGRESS_DROPPED_TOTAL\` is gone. LizyStudio is an internal package, so no deprecation shim is provided — see H-0075 \"Alternatives\" for the rationale.

## Test plan

- [x] \`uv run pytest\` — **1152 pass** (was 1147, +5 new tests in \`test_metrics_registry.py\`).
- [x] \`uv run mypy src/lizystudio/\` — clean.
- [x] \`uv run ruff check .\` — clean.
- [x] \`uv run ruff format --check .\` — clean.
- [x] Core A-9 acceptance: \`test_two_apps_can_coexist_in_the_same_process\` — two \`create_app()\` calls in the same pytest process, each with an independent counter, traffic against app A does not bump app B's counter.
- [x] Subprocess path still works: \`JobStore(jobs_dir)\` in \`subprocess_runner.py:583\` receives \`metrics=None\`, counter bumps inside the child are no-ops, parent ingests terminal state via \`_emit_terminal_metric(job_store, job, duration)\` after joining.
- [x] Code review: HIGH (\`JobStore.record_job_terminal\` literal type mismatch) fixed, MEDIUM test-strength improvement applied (\`isinstance\` assertions).

## Follow-up

None required for this PR. The A-9 acceptance criterion (two apps in one process) is now green and unblocks any future multi-backend / multi-session testing.