### PR TITLE
refactor(cv-strategy-fields): retire CV_STRATEGY_FIELDS, SSOT via UiSchema (C-5b Part 2, H-0076)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1987,3 +1987,35 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (e) Issue #154 の slot-claim failure で failed counter が 1 増える（`test_reg_0154_failed_metric_on_slot_claim`）。
   - (f) `uv run pytest` / `uv run mypy src/lizystudio/` / `uv run ruff check .` / `uv run ruff format --check .` 全 clean、pytest 1152 green。
 - **Decision:** 2026-04-20 accepted — 提案通り実装。`record_job_terminal` の module-level export 廃止は破壊的変更だが、内部パッケージのため shim なしで移行。
+
+### H-0076: `CV_STRATEGY_FIELDS` 退役と `capabilities.cv_strategy_fields` の SSOT 化（Phase 3 coupling refactor C-5b Part 2）
+- **Status:** accepted
+- **Scope:** Backend | Frontend | Internal only（LizyConfig wire format 不変、BackendAdapter Protocol 不変、既存 `/api/backends/ui-schema` レスポンス shape 不変）
+- **Related:** docs/coupling-analysis.md C-5b、H-0026（UiSchema 契約）、H-0072（C-5a）、H-0074（C-5b Part 1）
+- **Context:** Part 1 までに `METRICS_BY_TASK` と `getDefaultCvStrategy` は SSOT 化されたが、`frontend/src/components/workspace/constants.ts::CV_STRATEGY_FIELDS` は残っていた。この map は UI の CV-section conditional-field rendering と `cv-state.ts::buildSplitConfig` / `applyCvDataFields` の wire-format 生成を両方支配しており、backend の `UiCapabilities.cv_strategy_fields` と **フィールド名が乖離** していた（`folds` vs `n_splits`、`train_size_max` vs `max_train_size`、`blocked_group_kfold` は完全に別体系）。さらに **内容自体も乖離**（FE の `stratified_kfold` に `shuffle` がない、FE の `time_series` に `time_col` がある等）していたため、単純置換では SSOT 化できず Part 1 の対象外となっていた。
+- **Proposal:**
+  1. Backend `lizyml_ui_schema.py::cv_strategy_fields` を「UI 表示判定 + wire field 一覧」の両用途をカバーする SSOT に書き換える。フィールド名は **LizyConfig schema 名**（`n_splits`, `train_size_max`, `time_col`, `group_col`, `min_train_rows`, `min_valid_rows`）で統一。`blocked_group_kfold` の UI 用フィールドを追加（`n_splits`, `time_col`, `group_col`, `min_train_rows`, `min_valid_rows` — wire の `blocks_col`/`groups_col`/`mode`/`train_window` は UI が別編集 UI 経由で個別生成するため含まない）。
+  2. 順序調整（`kfold: n_splits, random_state, shuffle` 等）を UI 上下表示順と一致させる。順序の意味は UI presentation のみで consumer は set 扱い（backend にコメント追加）。
+  3. `tests/test_ui_schema.py` に新規テスト `test_capabilities_cv_strategy_fields_ui_semantics` を追加し、全 8 strategy の期待 fields を locking。wire-format キー（`max_train_size`, `max_test_size`, `folds`）が map に漏れないことも assert。
+  4. Frontend `cv-state.ts`: `buildSplitConfig(cv, blocked?, fields?)` と `applyCvDataFields(data, cv, fields?)` の third arg として fields を受け取る。`fields` が未指定のときは module-level `FALLBACK_CV_STRATEGY_FIELDS`（backend SSOT のミラー）から strategy で引く。未知 strategy は `["n_splits"]` に fall through。
+  5. `CvSection.tsx` は `uiSchema.capabilities?.cv_strategy_fields?.[strategy]` を優先読み、無ければ `FALLBACK_CV_STRATEGY_FIELDS` を使う。`has("folds")` → `has("n_splits")` にフィールド名を揃える。`FALLBACK_CV_STRATEGY_FIELDS` は `cv-state.ts` から re-export された単一ソースを使用（重複を避ける）。
+  6. `useConfigSync` が `uiSchema` prop を受け取り、`cv_strategy_fields[strategy]` を `buildSplitConfig` / `applyCvDataFields` に threading。`useEffect` の dedup key に fields suffix を付与し、UiSchema ロード後の初回 sync を発火させる。`preseedSyncKey` も同じ suffix を内部で付ける。
+  7. `frontend/src/components/workspace/constants.ts` から `CV_STRATEGY_FIELDS` export 削除。`constants.test.ts` の該当テストブロック削除。
+- **Impact:** `src/lizystudio/backends/lizyml_ui_schema.py`（`cv_strategy_fields` rewrite + 順序ドキュメント、+12 / -18 行）、`tests/test_ui_schema.py`（+77、全 strategy lock-in テスト）、`frontend/src/components/workspace/constants.ts`（-23、`CV_STRATEGY_FIELDS` 削除）、`frontend/src/components/workspace/constants.test.ts`（-48、該当テスト削除）、`frontend/src/components/workspace/cv-state.ts`（+58 / -14：`FALLBACK_CV_STRATEGY_FIELDS` export + `resolveFields` helper + `buildSplitConfig`/`applyCvDataFields` に fields 引数）、`frontend/src/components/workspace/CvSection.tsx`（+8 / -3：uiSchema 優先読み + `FALLBACK_CV_STRATEGY_FIELDS` import、`has("folds")`→`has("n_splits")`）、`frontend/src/components/workspace/cv-section.test.ts`（+58 / -8：local SSOT fixture + fields arg test cases）、`frontend/src/hooks/useConfigSync.ts`（+25 / -3：`uiSchema` prop + fields threading + key suffix）。
+- **Compatibility:**
+  - `/api/backends/ui-schema` レスポンス shape 不変（`capabilities.cv_strategy_fields` は既存 field でその content のみ拡張）。OpenAPI 型変更なし。
+  - LizyConfig schema（wire format）変更なし。`split.n_splits` / `split.train_size_max` / `data.time_col` / `data.group_col` 等は従来通り。
+  - FE の UI state（`cv.folds`, `cv.trainSizeMax` など）は変更なし — UI internal name と wire name の mapping は `buildSplitConfig` 内に閉じる。
+  - 既存のユーザー config file（JSON/YAML）は touch しない。
+- **Alternatives:**
+  - (a) Backend の `cv_strategy_fields` を UI 用 / wire 用に 2 つ分ける → 却下。2 つの契約を同期する deuplication コストが大きい。1 map で両用途をカバーする方が clean。
+  - (b) FE の UI internal name（`folds`）を LizyConfig 名（`n_splits`）に全面 rename → 却下。既存の `CvState.folds`, `resetCvState`, etc. が全面変更となりスコープ肥大。UI 内部と wire format の命名は分離したままが自然。
+  - (c) fallback map を削除して uiSchema ロード前の render を blocker 化 → 却下。初回 render の a11y / CLS を悪化させる。fallback が backend SSOT とミラーされる限り問題なし（lock-in test で drift 検知）。
+  - (d) `cv-state.ts` / `CvSection.tsx` でそれぞれ独立に fallback 定義 → 却下。`cv-state.ts` から export して単一 source に統一。
+- **Acceptance Criteria:**
+  - (a) `grep -rn 'CV_STRATEGY_FIELDS' frontend/src` が local test fixture と `cv-state.ts::FALLBACK_CV_STRATEGY_FIELDS` 以外に残らない。
+  - (b) `tests/test_ui_schema.py::test_capabilities_cv_strategy_fields_ui_semantics` が全 8 strategy を green で lock-in。
+  - (c) `CvSection` が `uiSchema.capabilities.cv_strategy_fields` を受け取って conditional field render。uiSchema 未ロード時は `FALLBACK_CV_STRATEGY_FIELDS` 使用。
+  - (d) `useConfigSync` が UiSchema ロード後に初回 sync を発火させる（key suffix 経由）。
+  - (e) `pnpm test` / `pnpm check` / `pnpm tsc --noEmit` / `pnpm build` / `uv run pytest` / `uv run mypy src/lizystudio/` / `uv run ruff check .` 全 clean。
+- **Decision:** 2026-04-21 accepted — 提案通り実装。C-5b 完結（Part 1 = METRICS_BY_TASK + cv_default_strategy、Part 2 = CV_STRATEGY_FIELDS SSOT 化）。

--- a/frontend/src/components/workspace/CvSection.tsx
+++ b/frontend/src/components/workspace/CvSection.tsx
@@ -17,7 +17,7 @@ import {
 
 export { type BlockedGroupKFoldState, INITIAL_BLOCKED_STATE };
 
-import { CV_STRATEGY_FIELDS, CV_STRATEGY_LABELS } from "./constants";
+import { CV_STRATEGY_LABELS } from "./constants";
 import { NullableNumberField } from "./NullableNumberField";
 import { NumberInput } from "./NumberInput";
 import { SegmentGroup } from "./SegmentGroup";
@@ -34,7 +34,11 @@ export {
   resetCvState,
 } from "./cv-state";
 
-import { type CvState, resetCvState } from "./cv-state";
+import {
+  type CvState,
+  FALLBACK_CV_STRATEGY_FIELDS,
+  resetCvState,
+} from "./cv-state";
 
 // ---------------------------------------------------------------------------
 // Component
@@ -63,10 +67,14 @@ export function CvSection({
     [uiSchema],
   );
 
-  const activeFields = useMemo(
-    () => CV_STRATEGY_FIELDS[cv.strategy] ?? ["folds"],
-    [cv.strategy],
-  );
+  const activeFields = useMemo(() => {
+    const fromSchema =
+      uiSchema?.capabilities?.cv_strategy_fields?.[cv.strategy];
+    if (fromSchema !== undefined && fromSchema !== null) {
+      return fromSchema;
+    }
+    return FALLBACK_CV_STRATEGY_FIELDS[cv.strategy] ?? ["n_splits"];
+  }, [cv.strategy, uiSchema]);
 
   const has = useCallback(
     (field: string) => activeFields.includes(field),
@@ -110,7 +118,7 @@ export function CvSection({
       )}
 
       {/* Generic conditional fields (hidden when blocked_group_kfold editor is active) */}
-      {cv.strategy !== "blocked_group_kfold" && has("folds") && (
+      {cv.strategy !== "blocked_group_kfold" && has("n_splits") && (
         <div className="space-y-1">
           <Label className="text-xs font-medium text-muted-foreground">
             Folds

--- a/frontend/src/components/workspace/constants.test.ts
+++ b/frontend/src/components/workspace/constants.test.ts
@@ -5,7 +5,6 @@
 import { describe, expect, it } from "vitest";
 import {
   CALIBRATION_DEFAULTS,
-  CV_STRATEGY_FIELDS,
   CV_STRATEGY_LABELS,
   getDefaultCvStrategy,
   N_TRIALS_PRESETS,
@@ -63,56 +62,6 @@ describe("CV_STRATEGY_LABELS", () => {
       expect(typeof CV_STRATEGY_LABELS[key]).toBe("string");
       expect(CV_STRATEGY_LABELS[key].length).toBeGreaterThan(0);
     }
-  });
-});
-
-describe("CV_STRATEGY_FIELDS", () => {
-  it("maps conditional fields per strategy", () => {
-    expect(CV_STRATEGY_FIELDS.kfold).toEqual([
-      "folds",
-      "random_state",
-      "shuffle",
-    ]);
-    expect(CV_STRATEGY_FIELDS.stratified_kfold).toEqual([
-      "folds",
-      "random_state",
-    ]);
-    expect(CV_STRATEGY_FIELDS.group_kfold).toEqual(["folds", "group_col"]);
-    expect(CV_STRATEGY_FIELDS.stratified_group_kfold).toEqual([
-      "folds",
-      "random_state",
-      "group_col",
-    ]);
-    expect(CV_STRATEGY_FIELDS.time_series).toEqual([
-      "folds",
-      "time_col",
-      "gap",
-      "train_size_max",
-      "test_size_max",
-    ]);
-    expect(CV_STRATEGY_FIELDS.purged_time_series).toEqual([
-      "folds",
-      "time_col",
-      "purge_gap",
-      "embargo",
-      "train_size_max",
-      "test_size_max",
-    ]);
-    expect(CV_STRATEGY_FIELDS.group_time_series).toEqual([
-      "folds",
-      "time_col",
-      "group_col",
-      "gap",
-      "train_size_max",
-      "test_size_max",
-    ]);
-    expect(CV_STRATEGY_FIELDS.blocked_group_kfold).toEqual([
-      "folds",
-      "time_col",
-      "group_col",
-      "min_train_rows",
-      "min_valid_rows",
-    ]);
   });
 });
 

--- a/frontend/src/components/workspace/constants.ts
+++ b/frontend/src/components/workspace/constants.ts
@@ -1,6 +1,5 @@
 /**
- * Pure UI presets and conditional-field maps that are not (yet) driven by
- * the backend UiSchema response.
+ * Pure UI presets that are not driven by the backend UiSchema response.
  *
  * @see H-0026 in HISTORY.md for the UiSchema contract.
  *
@@ -9,6 +8,9 @@
  *  - METRICS_BY_TASK removed in H-0074 (UiSchema option_sets.metric is the
  *    sole source of task-to-metric mapping; MetricsChips renders empty
  *    until UiSchema loads).
+ *  - CV_STRATEGY_FIELDS removed in H-0076 (UiSchema
+ *    capabilities.cv_strategy_fields is the sole source; cv-state.ts and
+ *    CvSection.tsx receive the field list via prop / argument).
  */
 
 /** Default calibration config when toggled ON. */
@@ -37,38 +39,6 @@ export const CV_STRATEGY_LABELS: Record<string, string> = {
   purged_time_series: "PurgedTimeSeries",
   group_time_series: "GroupTimeSeries",
   blocked_group_kfold: "BlockedGroup",
-};
-
-/** Conditional fields shown per CV strategy */
-export const CV_STRATEGY_FIELDS: Record<string, readonly string[]> = {
-  kfold: ["folds", "random_state", "shuffle"],
-  stratified_kfold: ["folds", "random_state"],
-  group_kfold: ["folds", "group_col"],
-  stratified_group_kfold: ["folds", "random_state", "group_col"],
-  time_series: ["folds", "time_col", "gap", "train_size_max", "test_size_max"],
-  purged_time_series: [
-    "folds",
-    "time_col",
-    "purge_gap",
-    "embargo",
-    "train_size_max",
-    "test_size_max",
-  ],
-  group_time_series: [
-    "folds",
-    "time_col",
-    "group_col",
-    "gap",
-    "train_size_max",
-    "test_size_max",
-  ],
-  blocked_group_kfold: [
-    "folds",
-    "time_col",
-    "group_col",
-    "min_train_rows",
-    "min_valid_rows",
-  ],
 };
 
 /** Default CV strategy per task type. */

--- a/frontend/src/components/workspace/cv-section.test.ts
+++ b/frontend/src/components/workspace/cv-section.test.ts
@@ -12,7 +12,47 @@ import {
   recommendedInnerValid,
   resetCvState,
 } from "./CvSection";
-import { CV_STRATEGY_FIELDS } from "./constants";
+
+// C-5b Part 2 (H-0076): `cv_strategy_fields` comes from the backend
+// UiSchema at runtime. The map below mirrors what
+// `lizyml_ui_schema.py` emits and is used to drive every test that
+// previously imported `CV_STRATEGY_FIELDS` from `./constants`.
+const CV_STRATEGY_FIELDS: Record<string, readonly string[]> = {
+  kfold: ["n_splits", "random_state", "shuffle"],
+  stratified_kfold: ["n_splits", "random_state", "shuffle"],
+  group_kfold: ["n_splits", "group_col"],
+  stratified_group_kfold: ["n_splits", "random_state", "group_col"],
+  time_series: [
+    "n_splits",
+    "time_col",
+    "gap",
+    "train_size_max",
+    "test_size_max",
+  ],
+  purged_time_series: [
+    "n_splits",
+    "time_col",
+    "purge_gap",
+    "embargo",
+    "train_size_max",
+    "test_size_max",
+  ],
+  group_time_series: [
+    "n_splits",
+    "time_col",
+    "group_col",
+    "gap",
+    "train_size_max",
+    "test_size_max",
+  ],
+  blocked_group_kfold: [
+    "n_splits",
+    "time_col",
+    "group_col",
+    "min_train_rows",
+    "min_valid_rows",
+  ],
+};
 
 // ---------------------------------------------------------------------------
 // resetCvState
@@ -128,7 +168,7 @@ describe("buildSplitConfig", () => {
       });
     });
 
-    it("stratified_kfold includes folds and random_state but not shuffle", () => {
+    it("stratified_kfold includes folds, random_state and shuffle when fields allow all three", () => {
       const cv: CvState = {
         ...INITIAL_CV_STATE,
         strategy: "stratified_kfold",
@@ -136,12 +176,31 @@ describe("buildSplitConfig", () => {
         randomState: 0,
         shuffle: true,
       };
-      const result = buildSplitConfig(cv);
+      const result = buildSplitConfig(
+        cv,
+        undefined,
+        CV_STRATEGY_FIELDS.stratified_kfold,
+      );
       expect(result).toEqual({
         method: "stratified_kfold",
         n_splits: 3,
         random_state: 0,
+        shuffle: true,
       });
+    });
+
+    it("drops shuffle when fields map excludes it (SSOT-driven)", () => {
+      const cv: CvState = {
+        ...INITIAL_CV_STATE,
+        strategy: "stratified_kfold",
+        folds: 3,
+        randomState: 0,
+        shuffle: true,
+      };
+      // A hypothetical backend that chooses to hide shuffle for this
+      // strategy — buildSplitConfig must honour the fields contract.
+      const fields = ["n_splits", "random_state"];
+      const result = buildSplitConfig(cv, undefined, fields);
       expect(result).not.toHaveProperty("shuffle");
     });
   });
@@ -394,6 +453,66 @@ describe("buildSplitConfig", () => {
     const result = buildSplitConfig(cv);
     expect(result).not.toHaveProperty("random_state");
   });
+
+  describe("fields parameter (H-0076 SSOT)", () => {
+    it("without fields falls back to full conditional-field set", () => {
+      // Before H-0076 buildSplitConfig had no fields param. The
+      // fallback path must keep emitting every conditional field that
+      // the CvState supplies — used while ``uiSchema`` has not loaded
+      // yet or for integration paths that bypass the store.
+      const cv: CvState = {
+        ...INITIAL_CV_STATE,
+        strategy: "kfold",
+        folds: 5,
+        randomState: 42,
+        shuffle: true,
+      };
+      const result = buildSplitConfig(cv);
+      expect(result).toMatchObject({
+        method: "kfold",
+        n_splits: 5,
+        random_state: 42,
+        shuffle: true,
+      });
+    });
+
+    it("with fields honours SSOT allow-list", () => {
+      const cv: CvState = {
+        ...INITIAL_CV_STATE,
+        strategy: "time_series",
+        folds: 4,
+        timeCol: "date",
+        gap: 2,
+        trainSizeMax: 500,
+        testSizeMax: 100,
+      };
+      const fields = CV_STRATEGY_FIELDS.time_series;
+      const result = buildSplitConfig(cv, undefined, fields);
+      expect(result).toEqual({
+        method: "time_series",
+        n_splits: 4,
+        gap: 2,
+        train_size_max: 500,
+        test_size_max: 100,
+      });
+    });
+
+    it("skips fields that SSOT does not list even if CvState provides values", () => {
+      // SSOT says only n_splits; embargo value is discarded.
+      const cv: CvState = {
+        ...INITIAL_CV_STATE,
+        strategy: "purged_time_series",
+        folds: 3,
+        embargo: 99,
+      };
+      const result = buildSplitConfig(cv, undefined, ["n_splits"]);
+      expect(result).toEqual({
+        method: "purged_time_series",
+        n_splits: 3,
+      });
+      expect(result).not.toHaveProperty("embargo");
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -484,7 +603,10 @@ describe("applyCvDataFields", () => {
     expect(result.group_col).toBe("user_id");
   });
 
-  it("handles unknown strategy without injecting fields", () => {
+  it("handles unknown strategy without injecting fields (fallback map)", () => {
+    // Fallback mode (fields undefined) + unknown strategy → resolveFields
+    // returns ["n_splits"] so neither group_col nor time_col is
+    // injected. This matches the legacy behaviour for safety.
     const data = { path: "/data.csv" };
     const cv: CvState = {
       ...INITIAL_CV_STATE,
@@ -493,9 +615,21 @@ describe("applyCvDataFields", () => {
       timeCol: "t",
     };
     const result = applyCvDataFields(data, cv);
-    // Unknown strategy has no fields defined, so nothing injected
     expect(result).not.toHaveProperty("group_col");
     expect(result).not.toHaveProperty("time_col");
+  });
+
+  it("with fields honours SSOT allow-list for data injection", () => {
+    const data = { path: "/data.csv" };
+    const cv: CvState = {
+      ...INITIAL_CV_STATE,
+      strategy: "time_series",
+      timeCol: "date",
+      groupCol: "should_be_ignored",
+    };
+    const result = applyCvDataFields(data, cv, CV_STRATEGY_FIELDS.time_series);
+    expect(result.time_col).toBe("date");
+    expect(result).not.toHaveProperty("group_col");
   });
 
   it("injects blocks_col and groups_col for blocked_group_kfold (not time_col/group_col)", () => {

--- a/frontend/src/components/workspace/cv-state.ts
+++ b/frontend/src/components/workspace/cv-state.ts
@@ -1,6 +1,68 @@
 import type { BlockedGroupKFoldState } from "./BlockedGroupKFoldEditor";
 import { INITIAL_BLOCKED_STATE } from "./BlockedGroupKFoldEditor";
-import { CV_STRATEGY_FIELDS } from "./constants";
+
+/**
+ * C-5b Part 2 (H-0076): conditional-field allow-list per strategy. This
+ * mirrors `UiSchema.capabilities.cv_strategy_fields` emitted by
+ * `lizyml_ui_schema.py` and serves as the fallback when ``fields`` is
+ * not explicitly passed (e.g. pre-load or tests that want the legacy
+ * behaviour). Keep this in sync with the backend SSOT — the shape is
+ * asserted by `tests/test_ui_schema.py::test_capabilities_cv_strategy_fields_ui_semantics`.
+ */
+export const FALLBACK_CV_STRATEGY_FIELDS: Record<string, readonly string[]> = {
+  kfold: ["n_splits", "random_state", "shuffle"],
+  stratified_kfold: ["n_splits", "random_state", "shuffle"],
+  group_kfold: ["n_splits", "group_col"],
+  stratified_group_kfold: ["n_splits", "random_state", "group_col"],
+  time_series: [
+    "n_splits",
+    "time_col",
+    "gap",
+    "train_size_max",
+    "test_size_max",
+  ],
+  purged_time_series: [
+    "n_splits",
+    "time_col",
+    "purge_gap",
+    "embargo",
+    "train_size_max",
+    "test_size_max",
+  ],
+  group_time_series: [
+    "n_splits",
+    "time_col",
+    "group_col",
+    "gap",
+    "train_size_max",
+    "test_size_max",
+  ],
+  blocked_group_kfold: [
+    "n_splits",
+    "time_col",
+    "group_col",
+    "min_train_rows",
+    "min_valid_rows",
+  ],
+};
+
+/**
+ * Resolve the conditional-field allow-list. Explicit ``fields`` wins;
+ * otherwise fall back to the strategy-indexed map above. Unknown
+ * strategies fall through to ``["n_splits"]`` so Folds is always
+ * included but ``group_col`` / ``time_col`` are NOT injected. If a
+ * new backend introduces a new strategy name, add it to both
+ * :data:`FALLBACK_CV_STRATEGY_FIELDS` and the backend-side
+ * ``capabilities.cv_strategy_fields`` simultaneously (see
+ * `lizyml_ui_schema.py`).
+ */
+function resolveFields(
+  strategy: string,
+  explicit: readonly string[] | undefined,
+): readonly string[] {
+  if (explicit !== undefined) return explicit;
+  return FALLBACK_CV_STRATEGY_FIELDS[strategy] ?? ["n_splits"];
+}
 
 /** Default values for CV fields, reset when strategy changes. */
 export const CV_FIELD_DEFAULTS = {
@@ -92,41 +154,48 @@ export function recommendedInnerValid(strategy: string): string {
   }
 }
 
-/** Build a split config object containing only strategy-relevant fields. */
+/** Build a split config object containing only strategy-relevant fields.
+ *
+ * ``fields`` is the `UiSchema.capabilities.cv_strategy_fields[strategy]`
+ * allow-list (wire-format names). When omitted (uiSchema not yet
+ * loaded) this falls back to emitting every conditional field for which
+ * ``cv`` has a value — the legacy pre-H-0076 behaviour.
+ */
 export function buildSplitConfig(
   cv: CvState,
   blocked?: BlockedGroupKFoldState,
+  fields?: readonly string[],
 ): Record<string, unknown> {
-  const fields = CV_STRATEGY_FIELDS[cv.strategy] ?? ["folds"];
+  const active = resolveFields(cv.strategy, fields);
   const split: Record<string, unknown> = {
     method: cv.strategy,
     n_splits: cv.folds,
   };
-  if (fields.includes("random_state") && cv.randomState !== undefined) {
+  if (active.includes("random_state") && cv.randomState !== undefined) {
     split.random_state = cv.randomState;
   }
-  if (fields.includes("shuffle")) {
+  if (active.includes("shuffle")) {
     split.shuffle = cv.shuffle;
   }
-  if (fields.includes("gap") && cv.gap !== undefined) {
+  if (active.includes("gap") && cv.gap !== undefined) {
     split.gap = cv.gap;
   }
-  if (fields.includes("purge_gap") && cv.purgeGap !== undefined) {
+  if (active.includes("purge_gap") && cv.purgeGap !== undefined) {
     split.purge_gap = cv.purgeGap;
   }
-  if (fields.includes("embargo") && cv.embargo !== undefined) {
+  if (active.includes("embargo") && cv.embargo !== undefined) {
     split.embargo = cv.embargo;
   }
-  if (fields.includes("train_size_max") && cv.trainSizeMax !== undefined) {
+  if (active.includes("train_size_max") && cv.trainSizeMax !== undefined) {
     split.train_size_max = cv.trainSizeMax;
   }
-  if (fields.includes("test_size_max") && cv.testSizeMax !== undefined) {
+  if (active.includes("test_size_max") && cv.testSizeMax !== undefined) {
     split.test_size_max = cv.testSizeMax;
   }
-  if (fields.includes("min_train_rows") && cv.minTrainRows !== undefined) {
+  if (active.includes("min_train_rows") && cv.minTrainRows !== undefined) {
     split.min_train_rows = cv.minTrainRows;
   }
-  if (fields.includes("min_valid_rows") && cv.minValidRows !== undefined) {
+  if (active.includes("min_valid_rows") && cv.minValidRows !== undefined) {
     split.min_valid_rows = cv.minValidRows;
   }
   // blocked_group_kfold-specific fields from the dedicated editor state
@@ -144,12 +213,17 @@ export function buildSplitConfig(
   return split;
 }
 
-/** Extract group_col / time_col into data config when strategy requires them. */
+/** Extract group_col / time_col into data config when strategy requires them.
+ *
+ * ``fields`` behaves the same as in {@link buildSplitConfig}. When
+ * omitted we fall back to injecting whatever ``cv`` supplies.
+ */
 export function applyCvDataFields(
   data: Record<string, unknown>,
   cv: CvState,
+  fields?: readonly string[],
 ): Record<string, unknown> {
-  const fields = CV_STRATEGY_FIELDS[cv.strategy] ?? [];
+  const active = resolveFields(cv.strategy, fields);
   const result = { ...data };
   // blocked_group_kfold uses blocks_col/groups_col instead of time_col/group_col
   if (cv.strategy === "blocked_group_kfold") {
@@ -161,10 +235,10 @@ export function applyCvDataFields(
     }
     return result;
   }
-  if (fields.includes("group_col") && cv.groupCol) {
+  if (active.includes("group_col") && cv.groupCol) {
     result.group_col = cv.groupCol;
   }
-  if (fields.includes("time_col") && cv.timeCol) {
+  if (active.includes("time_col") && cv.timeCol) {
     result.time_col = cv.timeCol;
   }
   return result;

--- a/frontend/src/hooks/useConfigSync.ts
+++ b/frontend/src/hooks/useConfigSync.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import { toast } from "sonner";
+import type { UiSchema } from "@/api/types";
 import {
   fetchConfig,
   fetchConfigDefaults,
@@ -22,6 +23,7 @@ interface UseConfigSyncParams {
   overrides: Record<string, ColumnOverride>;
   cv: CvState;
   blocked: BlockedGroupKFoldState;
+  uiSchema?: UiSchema;
   onDataChanged: () => void;
 }
 
@@ -32,12 +34,19 @@ export function useConfigSync({
   overrides,
   cv,
   blocked,
+  uiSchema,
   onDataChanged,
 }: UseConfigSyncParams) {
   const abortRef = useRef<AbortController | null>(null);
   const prevCvStrategyRef = useRef<string>(cv.strategy);
   const skipNextSyncRef = useRef(false);
   const prevSyncKey = useRef("");
+
+  // H-0076: field list comes from the backend UiSchema. ``undefined``
+  // falls through to the legacy "emit whatever CvState provides" path.
+  const strategyFields = uiSchema?.capabilities?.cv_strategy_fields?.[
+    cv.strategy
+  ] as readonly string[] | undefined;
 
   const syncConfig = useCallback(async () => {
     abortRef.current?.abort();
@@ -70,13 +79,14 @@ export function useConfigSync({
             target: target || undefined,
           },
           cv,
+          strategyFields,
         ),
         features: {
           ...((base as Record<string, unknown>).features as object),
           categorical,
           exclude: excluded,
         },
-        split: buildSplitConfig(cv, blocked),
+        split: buildSplitConfig(cv, blocked, strategyFields),
       };
 
       const baseTraining = (merged.training as Record<string, unknown>) ?? {};
@@ -97,26 +107,51 @@ export function useConfigSync({
       if (err instanceof DOMException && err.name === "AbortError") return;
       toast.error("Config sync failed — changes may not be saved");
     }
-  }, [dataPath, target, task, overrides, cv, blocked, onDataChanged]);
+  }, [
+    dataPath,
+    target,
+    task,
+    overrides,
+    cv,
+    blocked,
+    strategyFields,
+    onDataChanged,
+  ]);
+
+  // H-0076: key suffix that makes the dedup guard resync when
+  // UiSchema's ``cv_strategy_fields`` resolves after the initial
+  // render. Without this, the first post-load sync would be skipped
+  // because ``buildSyncKey`` alone has not changed, leaving the last
+  // PUT based on the pre-UiSchema fallback.
+  const fieldsKeyFragment = `|fields=${JSON.stringify(strategyFields ?? null)}`;
 
   useEffect(() => {
     if (!target) return;
-    const key = buildSyncKey(target, task, overrides, cv, blocked);
+    const key =
+      buildSyncKey(target, task, overrides, cv, blocked) + fieldsKeyFragment;
     if (key === prevSyncKey.current) return;
     prevSyncKey.current = key;
     if (skipNextSyncRef.current) {
       return;
     }
     syncConfig();
-  }, [target, task, overrides, cv, blocked, syncConfig]);
+  }, [target, task, overrides, cv, blocked, fieldsKeyFragment, syncConfig]);
 
   const setSyncSuppressed = useCallback((flag: boolean) => {
     skipNextSyncRef.current = flag;
   }, []);
 
-  const preseedSyncKey = useCallback((key: string) => {
-    prevSyncKey.current = key;
-  }, []);
+  const preseedSyncKey = useCallback(
+    (key: string) => {
+      // Apply the same fields suffix the useEffect above uses so the
+      // preseeded key matches the key the dedup guard will compute on
+      // the next render. Without this, a caller that preseeds with
+      // ``buildSyncKey(...)`` sees the next render re-fire the sync
+      // because of the mismatching suffix.
+      prevSyncKey.current = key + fieldsKeyFragment;
+    },
+    [fieldsKeyFragment],
+  );
 
   return {
     syncConfig,

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -94,6 +94,7 @@ export function useDataPanel({
     overrides: columnOverrides.overrides,
     cv,
     blocked,
+    uiSchema,
     onDataChanged,
   });
 

--- a/src/lizystudio/backends/lizyml_ui_schema.py
+++ b/src/lizystudio/backends/lizyml_ui_schema.py
@@ -498,35 +498,54 @@ def build_ui_schema(
                 "blocked_group_kfold",
             ],
             "tune": {"allow_empty_space": True},
+            # H-0076 (C-5b Part 2): this map is the SSOT for the
+            # frontend CV-section conditional-field rendering AND for
+            # the values the UI writes into ``split`` / ``data``. Field
+            # names match the LizyConfig schema (e.g. ``train_size_max``,
+            # not the splitter's kwarg ``max_train_size``); ``time_col``
+            # / ``group_col`` are UI-level inputs that land in
+            # ``data`` rather than ``split``.
+            #
+            # Field ordering within each list is UI-presentation order
+            # (top-to-bottom in the form). Consumers treat the list as
+            # a set via ``.includes(...)`` / ``in`` — order has no
+            # semantic effect on the wire payload.
             "cv_strategy_fields": {
-                "kfold": ["n_splits", "shuffle", "random_state"],
-                "stratified_kfold": ["n_splits", "shuffle", "random_state"],
+                "kfold": ["n_splits", "random_state", "shuffle"],
+                "stratified_kfold": ["n_splits", "random_state", "shuffle"],
                 "group_kfold": ["n_splits", "group_col"],
-                "stratified_group_kfold": ["n_splits", "group_col"],
+                "stratified_group_kfold": [
+                    "n_splits",
+                    "random_state",
+                    "group_col",
+                ],
                 "time_series": [
                     "n_splits",
+                    "time_col",
                     "gap",
-                    "max_train_size",
-                    "max_test_size",
+                    "train_size_max",
+                    "test_size_max",
                 ],
                 "purged_time_series": [
                     "n_splits",
                     "time_col",
                     "purge_gap",
                     "embargo",
+                    "train_size_max",
+                    "test_size_max",
                 ],
                 "group_time_series": [
                     "n_splits",
+                    "time_col",
                     "group_col",
                     "gap",
-                    "max_train_size",
-                    "max_test_size",
+                    "train_size_max",
+                    "test_size_max",
                 ],
                 "blocked_group_kfold": [
-                    "blocks_col",
-                    "groups_col",
-                    "mode",
-                    "train_window",
+                    "n_splits",
+                    "time_col",
+                    "group_col",
                     "min_train_rows",
                     "min_valid_rows",
                 ],

--- a/tests/test_ui_schema.py
+++ b/tests/test_ui_schema.py
@@ -560,6 +560,77 @@ class TestLizyMLAdapterUiSchema:
             assert strategy in fields, f"cv_strategy_fields missing: {strategy}"
             assert isinstance(fields[strategy], list)
 
+    def test_capabilities_cv_strategy_fields_ui_semantics(self) -> None:
+        """H-0076 (C-5b Part 2): ``cv_strategy_fields`` is the SSOT for UI
+        conditional-field rendering. Every strategy enumerates **all**
+        UI-visible inputs — generic (``n_splits``, ``random_state``,
+        ``shuffle``) plus strategy-specific (``time_col``, ``group_col``,
+        ``gap``, ``purge_gap``, ``embargo``, ``train_size_max``,
+        ``test_size_max``, ``min_train_rows``, ``min_valid_rows``).
+
+        Wire-format keys (``max_train_size`` etc.) must NOT leak into
+        this list — the frontend renders UI using these names and writes
+        the same names into ``split`` / ``data``, so they need to match
+        the LizyConfig schema field names (which use ``train_size_max``).
+        """
+        schema = LizyMLAdapter().get_ui_schema()
+        fields = schema["capabilities"]["cv_strategy_fields"]
+
+        # Expected fields per strategy — SSOT for the frontend UI map.
+        expected = {
+            "kfold": ["n_splits", "random_state", "shuffle"],
+            "stratified_kfold": ["n_splits", "random_state", "shuffle"],
+            "group_kfold": ["n_splits", "group_col"],
+            "stratified_group_kfold": [
+                "n_splits",
+                "random_state",
+                "group_col",
+            ],
+            "time_series": [
+                "n_splits",
+                "time_col",
+                "gap",
+                "train_size_max",
+                "test_size_max",
+            ],
+            "purged_time_series": [
+                "n_splits",
+                "time_col",
+                "purge_gap",
+                "embargo",
+                "train_size_max",
+                "test_size_max",
+            ],
+            "group_time_series": [
+                "n_splits",
+                "time_col",
+                "group_col",
+                "gap",
+                "train_size_max",
+                "test_size_max",
+            ],
+            "blocked_group_kfold": [
+                "n_splits",
+                "time_col",
+                "group_col",
+                "min_train_rows",
+                "min_valid_rows",
+            ],
+        }
+        for strategy, expected_fields in expected.items():
+            assert fields[strategy] == expected_fields, (
+                f"cv_strategy_fields[{strategy}] mismatch: "
+                f"got {fields[strategy]}, want {expected_fields}"
+            )
+
+        # Wire-format keys must not appear in cv_strategy_fields.
+        for strategy, strategy_fields in fields.items():
+            for wire_key in ("max_train_size", "max_test_size", "folds"):
+                assert wire_key not in strategy_fields, (
+                    f"cv_strategy_fields[{strategy}] should use UI/LizyConfig "
+                    f"names, not wire-format key {wire_key!r}"
+                )
+
     def test_capabilities_cv_defaults(self) -> None:
         """capabilities must include cv_defaults with n_splits."""
         schema = LizyMLAdapter().get_ui_schema()


### PR DESCRIPTION
## Summary

Close out C-5b from \`docs/coupling-analysis.md\`: make \`UiSchema.capabilities.cv_strategy_fields\` the single source of truth for the CV-section conditional-field map. Field names are normalised to LizyConfig schema names so backend and frontend finally agree on the contract.

### Why

- \`CV_STRATEGY_FIELDS\` in \`constants.ts\` diverged from the backend in both **names** (\`folds\` vs \`n_splits\`, \`train_size_max\` vs \`max_train_size\`) and **content** (FE had \`shuffle\` missing from stratified_kfold, \`time_col\` extra in time_series, \`blocked_group_kfold\` completely different).
- Part 1 (#210) couldn't touch this because the fields map drives both UI rendering **and** wire-payload assembly via \`buildSplitConfig\` / \`applyCvDataFields\`.
- Unifying the two lets future backends declare their own CV strategies purely via UiSchema without frontend changes.

### What

- **Backend**
  - \`lizyml_ui_schema.py\`: \`cv_strategy_fields\` rewritten. All 8 strategies list the UI-visible inputs in presentation order, using LizyConfig schema names. Order documented as set-semantics (no behaviour impact).
  - \`tests/test_ui_schema.py\`: new \`test_capabilities_cv_strategy_fields_ui_semantics\` locks the expected map and asserts wire-only keys (\`max_train_size\`, \`folds\`) never leak in.
- **Frontend**
  - \`constants.ts\`: drop \`CV_STRATEGY_FIELDS\`; history note updated.
  - \`cv-state.ts\`: single \`FALLBACK_CV_STRATEGY_FIELDS\` export (used by both \`cv-state.ts\` and \`CvSection.tsx\`) + \`resolveFields(strategy, explicit?)\` helper. \`buildSplitConfig(cv, blocked?, fields?)\` and \`applyCvDataFields(data, cv, fields?)\` accept an optional fields arg. Unknown strategy falls through to \`[\"n_splits\"]\`.
  - \`CvSection.tsx\`: \`activeFields\` reads \`uiSchema.capabilities.cv_strategy_fields\` first, \`FALLBACK_CV_STRATEGY_FIELDS\` second. \`has(\"folds\")\` → \`has(\"n_splits\")\`.
  - \`useConfigSync.ts\`: accept \`uiSchema\` prop; thread \`strategyFields\` into both functions. Dedup key gets a \`|fields=...\` suffix so the first sync after UiSchema resolves re-fires (reviewer MEDIUM); \`preseedSyncKey\` applies the same suffix internally so callers stay oblivious.
  - \`constants.test.ts\`: remove \`CV_STRATEGY_FIELDS\` block.
  - \`cv-section.test.ts\`: local CV_STRATEGY_FIELDS fixture mirrors backend; existing cases adjusted for the new fallback semantics; new cases cover the \`fields\` arg contract.

### Compatibility

- \`/api/backends/ui-schema\` shape unchanged; only the content of an existing field is refined.
- LizyConfig wire format unchanged (\`split.n_splits\`, \`split.train_size_max\`, \`data.time_col\`, \`data.group_col\`, …).
- UI internal \`CvState\` names (\`folds\`, \`trainSizeMax\`) unchanged — the UI↔wire mapping stays inside \`buildSplitConfig\`.
- Existing user config files untouched.

## Test plan

- [x] \`uv run pytest\` — 88 UI-schema + 1065 rest = 1153 pass.
- [x] \`uv run ruff check .\`, \`uv run ruff format --check .\`, \`uv run mypy src/lizystudio/\` — clean.
- [x] \`pnpm vitest run\` — 1617 pass / 2 skipped (WSL2 worker-terminate warnings only).
- [x] \`pnpm check\`, \`pnpm tsc --noEmit\`, \`pnpm build\` — clean.
- [x] Reviewer HIGH (dup fallback map) and MEDIUM (UiSchema-arrival sync race) both addressed.

## Follow-up

C-5b is now complete. Remaining items in \`docs/coupling-analysis.md\`: **C-6** (openapi-fetch adoption, ~2–3 days), **C-9** (\`format_version\` — change-gate proposal first), **B-5** / **B-9** for frontend polish.