### PR TITLE
refactor(hooks): extract useTargetSelection from useDataPanel (B-5, H-0077)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2019,3 +2019,32 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (d) `useConfigSync` が UiSchema ロード後に初回 sync を発火させる（key suffix 経由）。
   - (e) `pnpm test` / `pnpm check` / `pnpm tsc --noEmit` / `pnpm build` / `uv run pytest` / `uv run mypy src/lizystudio/` / `uv run ruff check .` 全 clean。
 - **Decision:** 2026-04-21 accepted — 提案通り実装。C-5b 完結（Part 1 = METRICS_BY_TASK + cv_default_strategy、Part 2 = CV_STRATEGY_FIELDS SSOT 化）。
+
+### H-0077: `useDataPanel` のオーケストレーション化と `useTargetSelection` 抽出（Phase 3 coupling refactor B-5）
+- **Status:** accepted
+- **Scope:** Frontend | Internal only（外部 API `useDataPanel({...})` の戻り値 shape 不変、wire format / BackendAdapter Protocol 不変）
+- **Related:** docs/coupling-analysis.md B-5、H-0074（Part 1 で `resolveDefaultCvStrategy` 初導入）、H-0076（Part 2 で `buildSplitConfig` の fields SSOT 化）
+- **Context:** `useDataPanel.ts` が 217 行・26 戻り値のハブ hook として肥大化し、`handleTargetChange` 単独で 60 行超（fetch columns + task 検出 + merged config 生成 + updateConfig PUT + queryClient cache seed + preseedSyncKey + Radix focus ワークアラウンド rAF blur まで全部）。B-5 の方針は「orchestration のみに削り、target 変更時ロジックは `useTargetSelection` mutation hook に分離」。
+- **Proposal:**
+  1. `frontend/src/hooks/useTargetSelection.ts` を新規作成し、`handleTargetChange` の実装をそのまま移植。依存は全て props 経由で受け取る（`task`, `cv`, `blocked`, `dataPath`, `uiSchema`, 5 setters, 2 configSync callbacks, `onDataChanged`, `onTaskChanged`）。
+  2. `useDataPanel.ts` は state cells の宣言 + 兄弟 hooks の wiring + 軽量な `handleTaskChange` のみに残す。`useTargetSelection` を呼んで `{ handleTargetChange }` を受け取り、戻り値 map に含める（shape 完全互換）。
+  3. `resolveDefaultCvStrategy` の duplication（`useTargetSelection` と `useDataPanel::handleTaskChange` で同一 3 行）を `cv-state.ts::getEffectiveCvStrategy(task, uiSchema)` として抽出・export、両 hook から import。
+  4. 新規 `useTargetSelection.test.ts` を追加（3 test: suppress-flag bookends / error path toast / uiSchema precedence）。既存 `useDataPanel.test.ts` は touch なしで 14 test 継続 pass → 戻り値 shape 保全の回帰ガード。
+  5. `requestAnimationFrame` による blur が test harness に leak しないよう `beforeEach` で `vi.stubGlobal("requestAnimationFrame", ...)` + `afterEach` で `vi.unstubAllGlobals()`。
+  6. Vitest `vi.fn()` の generic type が TS 5.x build で narrow signature と不整合を起こすため、test-local な `Fn<[Args]>` helper を定義してビルド互換性を確保。
+- **Impact:** `frontend/src/hooks/useDataPanel.ts`（217→143 行、-74）、`frontend/src/hooks/useTargetSelection.ts`（+156 行、新規）、`frontend/src/hooks/useTargetSelection.test.ts`（+189 行、新規）、`frontend/src/components/workspace/cv-state.ts`（`getEffectiveCvStrategy` export +15 行）。
+- **Compatibility:**
+  - `useDataPanel` 戻り値 shape bit-identical。consumer（`DataPanel.tsx`）無変更。
+  - `handleTargetChange` の挙動・エラーパス・state mutation 順序は同一。既存 `useDataPanel.test.ts` 14 件 touch なしで pass。
+  - wire format / BackendAdapter Protocol / storage layout / ユーザー設定ファイル無変更。
+- **Alternatives:**
+  - (a) `setState` + `callbacks` の facade サブオブジェクト化 → 却下。14 params の explicit list は DI として自己文書的で、facade 化は over-engineering。
+  - (b) `handleTargetChange` を `useMutation` に置き換える → 却下。state-sync 順序（setSyncSuppressed(true) → setTarget → fetch → setColumns → ...）を TanStack Query の mutation lifecycle に落とし込むと読みづらくなる。useCallback のままで十分。
+  - (c) `resolveDefaultCvStrategy` を各 hook に残す duplication 許容 → 却下。3 行 × 2 箇所は抽出する価値ありと reviewer 指摘で確認。
+- **Acceptance Criteria:**
+  - (a) `useDataPanel.ts` が 150 行未満（143 行達成）。
+  - (b) `useDataPanel.test.ts` 14 件 touch なしで継続 green（external contract 保全）。
+  - (c) `useTargetSelection.test.ts` 3 件 green、`suppress bookends` / `error toast` / `uiSchema precedence` を individual に検証可能に。
+  - (d) `getEffectiveCvStrategy` が `cv-state.ts` に export され両 hook から共有。
+  - (e) `pnpm test` / `pnpm check` / `pnpm tsc --noEmit` / `pnpm build` 全 clean、1620 vitest pass。
+- **Decision:** 2026-04-21 accepted — 提案通り実装。reviewer MEDIUM（duplication 抽出、rAF leak 対策）修正済み。

--- a/frontend/src/components/workspace/cv-state.ts
+++ b/frontend/src/components/workspace/cv-state.ts
@@ -1,5 +1,24 @@
+import type { UiSchema } from "@/api/types";
 import type { BlockedGroupKFoldState } from "./BlockedGroupKFoldEditor";
 import { INITIAL_BLOCKED_STATE } from "./BlockedGroupKFoldEditor";
+import { getDefaultCvStrategy } from "./constants";
+
+/**
+ * B-5 / H-0077: resolve the default CV strategy for a task, preferring
+ * the backend's `UiSchema.capabilities.cv_default_strategy` before
+ * falling back to the UI-local `getDefaultCvStrategy` (H-0074 map).
+ * Extracted so `useDataPanel` and `useTargetSelection` share one
+ * resolution path instead of each reimplementing the nullish chain.
+ */
+export function getEffectiveCvStrategy(
+  task: string,
+  uiSchema: UiSchema | undefined,
+): string {
+  return (
+    uiSchema?.capabilities?.cv_default_strategy?.[task] ??
+    getDefaultCvStrategy(task)
+  );
+}
 
 /**
  * C-5b Part 2 (H-0076): conditional-field allow-list per strategy. This

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -1,21 +1,12 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
-import { toast } from "sonner";
-import { getErrorMessage } from "@/api/errors";
-import { queryKeys } from "@/api/queryKeys";
 import type { ColumnInfo, UiSchema } from "@/api/types";
-import {
-  fetchColumns,
-  fetchConfigDefaults,
-  updateConfig,
-} from "@/api/workspace";
 import {
   type BlockedGroupKFoldState,
   INITIAL_BLOCKED_STATE,
 } from "@/components/workspace/BlockedGroupKFoldEditor";
-import { getDefaultCvStrategy } from "@/components/workspace/constants";
 import {
   type CvState,
+  getEffectiveCvStrategy,
   INITIAL_CV_STATE,
   resetCvState,
 } from "@/components/workspace/cv-state";
@@ -25,12 +16,12 @@ import { useDataLoad } from "./useDataLoad";
 import {
   buildMergedConfig,
   buildOverridesFromColumns,
-  buildSyncKey,
   type ColumnOverride,
   type SourceType,
   TASK_OPTIONS,
   type TaskType,
 } from "./useDataPanel.types";
+import { useTargetSelection } from "./useTargetSelection";
 
 export type { ColumnOverride, SourceType, TaskType };
 export { buildMergedConfig, buildOverridesFromColumns, TASK_OPTIONS };
@@ -46,15 +37,6 @@ export function useDataPanel({
   onTaskChanged,
   uiSchema,
 }: UseDataPanelParams) {
-  const queryClient = useQueryClient();
-
-  const resolveDefaultCvStrategy = useCallback(
-    (taskName: string): string =>
-      uiSchema?.capabilities?.cv_default_strategy?.[taskName] ??
-      getDefaultCvStrategy(taskName),
-    [uiSchema],
-  );
-
   const [target, setTarget] = useState<string | null>(null);
   const [task, setTask] = useState<TaskType | null>(null);
   const [allColumnNames, setAllColumnNames] = useState<string[]>([]);
@@ -98,89 +80,30 @@ export function useDataPanel({
     onDataChanged,
   });
 
-  const handleTargetChange = useCallback(
-    async (value: string) => {
-      configSync.setSyncSuppressed(true);
-      setTarget(value);
-      try {
-        const cols = await fetchColumns(value);
-        setColumns(cols.columns);
-
-        let detectedTask: TaskType | null = task;
-        let detectedStrategy = cv.strategy;
-        let nextCv = cv;
-        if (cols.suggested_task) {
-          const t = cols.suggested_task as TaskType;
-          detectedTask = t;
-          setTask(t);
-          onTaskChanged?.(t);
-          detectedStrategy = resolveDefaultCvStrategy(t);
-          nextCv = resetCvState(detectedStrategy);
-          setCv(nextCv);
-        }
-
-        const newOverrides = buildOverridesFromColumns(cols.columns);
-        columnOverrides.setOverrides(newOverrides);
-
-        if (detectedTask) {
-          const defaults = await fetchConfigDefaults(detectedTask, value);
-          const merged = buildMergedConfig({
-            defaults,
-            task: detectedTask,
-            strategy: detectedStrategy,
-            // Use nextCv.folds (post-reset) so the merged split config
-            // matches the cv state the sync effect will observe next;
-            // otherwise the pre-reset cv.folds could leak into the PUT
-            // while preseedSyncKey uses nextCv.
-            folds: nextCv.folds,
-            dataPath: dataLoad.dataPath,
-            target: value,
-            overrides: newOverrides,
-          });
-          await updateConfig(merged);
-          queryClient.setQueryData(queryKeys.config(), merged);
-          configSync.preseedSyncKey(
-            buildSyncKey(value, detectedTask, newOverrides, nextCv, blocked),
-          );
-          onDataChanged();
-        }
-      } catch (err) {
-        toast.error(`Column detection failed: ${getErrorMessage(err)}`);
-      } finally {
-        configSync.setSyncSuppressed(false);
-        // Radix Select returns focus to the trigger on close via
-        // `onCloseAutoFocus`, which runs AFTER our finally block. Defer
-        // the blur to the next animation frame so it fires after Radix
-        // has restored focus, otherwise `:focus-visible` matches and the
-        // 3px focus ring combined with the 1px border reads as a doubled
-        // outline. Keyboard users regain the ring on subsequent Tab.
-        requestAnimationFrame(() => {
-          (document.activeElement as HTMLElement | null)?.blur();
-        });
-      }
-    },
-    [
-      task,
-      cv,
-      dataLoad.dataPath,
-      blocked,
-      onDataChanged,
-      onTaskChanged,
-      queryClient,
-      resolveDefaultCvStrategy,
-      columnOverrides.setOverrides,
-      configSync.setSyncSuppressed,
-      configSync.preseedSyncKey,
-    ],
-  );
+  const { handleTargetChange } = useTargetSelection({
+    task,
+    cv,
+    blocked,
+    dataPath: dataLoad.dataPath,
+    uiSchema,
+    setTarget,
+    setTask,
+    setCv,
+    setColumns,
+    setOverrides: columnOverrides.setOverrides,
+    setSyncSuppressed: configSync.setSyncSuppressed,
+    preseedSyncKey: configSync.preseedSyncKey,
+    onDataChanged,
+    onTaskChanged,
+  });
 
   const handleTaskChange = useCallback(
     (newTask: TaskType) => {
       setTask(newTask);
       onTaskChanged?.(newTask);
-      setCv(resetCvState(resolveDefaultCvStrategy(newTask)));
+      setCv(resetCvState(getEffectiveCvStrategy(newTask, uiSchema)));
     },
-    [onTaskChanged, resolveDefaultCvStrategy],
+    [onTaskChanged, uiSchema],
   );
 
   return {

--- a/frontend/src/hooks/useTargetSelection.test.ts
+++ b/frontend/src/hooks/useTargetSelection.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for useTargetSelection — the target-column mutation hook
+ * extracted from useDataPanel in B-5 (H-0077). Most end-to-end paths
+ * are covered by useDataPanel.test.ts; this file pins down the
+ * contract of the isolated hook (params wiring + state mutation order)
+ * so the extraction stays reversible.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ColumnInfo, ColumnsResponse, UiSchema } from "@/api/types";
+import { INITIAL_BLOCKED_STATE } from "@/components/workspace/BlockedGroupKFoldEditor";
+import {
+  type CvState,
+  INITIAL_CV_STATE,
+} from "@/components/workspace/cv-state";
+
+const mocks = vi.hoisted(() => ({
+  fetchColumns: vi.fn(),
+  fetchConfigDefaults: vi.fn(),
+  updateConfig: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("@/api/workspace", () => ({
+  fetchColumns: mocks.fetchColumns,
+  fetchConfigDefaults: mocks.fetchConfigDefaults,
+  updateConfig: mocks.updateConfig,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: mocks.toastError,
+    success: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+import { useTargetSelection } from "./useTargetSelection";
+
+const COLS_OK: ColumnsResponse = {
+  target: null,
+  suggested_task: "binary",
+  columns: [
+    {
+      name: "a",
+      dtype: "float64",
+      unique_count: 10,
+      suggested_type: "numeric",
+      suggested_excluded: false,
+      exclude_reason: null,
+    } as ColumnInfo,
+  ],
+};
+
+function createWrapper(): ({ children }: { children: ReactNode }) => ReactNode {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+// ``vi.fn()`` returns a widely-typed ``Mock<Procedure | Constructable>``
+// that TS 5.x refuses to narrow to specific signatures like
+// ``(flag: boolean) => void``. We pre-cast each mock so the renderHook
+// call site accepts them without casting per-field.
+type Fn<A extends unknown[] = never[]> = ((...args: A) => void) & {
+  mock: { calls: A[] };
+};
+
+function fn<A extends unknown[] = never[]>(): Fn<A> {
+  return vi.fn() as unknown as Fn<A>;
+}
+
+interface HookDeps {
+  uiSchema?: UiSchema;
+  setTarget: Fn<[string]>;
+  setTask: Fn<[string]>;
+  setCv: Fn<[CvState]>;
+  setColumns: Fn<[ColumnInfo[]]>;
+  setOverrides: Fn<[Record<string, unknown>]>;
+  setSyncSuppressed: Fn<[boolean]>;
+  preseedSyncKey: Fn<[string]>;
+  onDataChanged: Fn<[]>;
+  onTaskChanged: Fn<[string | null]>;
+}
+
+function setupHook(overrides: Partial<HookDeps> = {}) {
+  const deps: HookDeps = {
+    setTarget: fn(),
+    setTask: fn(),
+    setCv: fn(),
+    setColumns: fn(),
+    setOverrides: fn(),
+    setSyncSuppressed: fn(),
+    preseedSyncKey: fn(),
+    onDataChanged: fn(),
+    onTaskChanged: fn(),
+    ...overrides,
+  };
+  const { result } = renderHook(
+    () =>
+      useTargetSelection({
+        task: null,
+        cv: INITIAL_CV_STATE,
+        blocked: INITIAL_BLOCKED_STATE,
+        dataPath: "/data/x.csv",
+        uiSchema: deps.uiSchema,
+        setTarget: deps.setTarget,
+        setTask: deps.setTask,
+        setCv: deps.setCv,
+        setColumns: deps.setColumns,
+        setOverrides: deps.setOverrides,
+        setSyncSuppressed: deps.setSyncSuppressed,
+        preseedSyncKey: deps.preseedSyncKey,
+        onDataChanged: deps.onDataChanged,
+        onTaskChanged: deps.onTaskChanged,
+      }),
+    { wrapper: createWrapper() },
+  );
+  return { result, deps };
+}
+
+describe("useTargetSelection", () => {
+  beforeEach(() => {
+    for (const m of Object.values(mocks)) m.mockReset?.();
+    // The hook schedules a rAF-based blur inside the finally block
+    // (Radix focus workaround). Stubbing the callback to a no-op keeps
+    // pending frames from leaking into the next test without having
+    // to flush fake timers.
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      (_cb: FrameRequestCallback) => 0 as unknown as number,
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("wraps the mutation in setSyncSuppressed(true)/false bookends", async () => {
+    mocks.fetchColumns.mockResolvedValue(COLS_OK);
+    mocks.fetchConfigDefaults.mockResolvedValue({
+      config_version: 1,
+      task: "binary",
+      data: {},
+      features: {},
+      split: { method: "kfold", n_splits: 5 },
+      model: { name: "lgbm", params: {} },
+    });
+    mocks.updateConfig.mockResolvedValue(undefined);
+
+    const { result, deps } = setupHook();
+
+    await act(async () => {
+      await result.current.handleTargetChange("a");
+    });
+
+    expect(deps.setSyncSuppressed).toHaveBeenNthCalledWith(1, true);
+    expect(deps.setSyncSuppressed).toHaveBeenLastCalledWith(false);
+  });
+
+  it("propagates fetchColumns errors through a toast and still releases the suppress flag", async () => {
+    mocks.fetchColumns.mockRejectedValue(new Error("column load failed"));
+
+    const { result, deps } = setupHook();
+
+    await act(async () => {
+      await result.current.handleTargetChange("a");
+    });
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      expect.stringContaining("Column detection failed"),
+    );
+    // Suppress flag must still be released even on error — otherwise
+    // the next legitimate edit skips its sync silently.
+    expect(deps.setSyncSuppressed).toHaveBeenLastCalledWith(false);
+  });
+
+  it("prefers uiSchema.capabilities.cv_default_strategy over the hard-coded fallback", async () => {
+    mocks.fetchColumns.mockResolvedValue(COLS_OK);
+    mocks.fetchConfigDefaults.mockResolvedValue({
+      config_version: 1,
+      task: "binary",
+      data: {},
+      features: {},
+      split: { method: "kfold", n_splits: 5 },
+      model: { name: "lgbm", params: {} },
+    });
+    mocks.updateConfig.mockResolvedValue(undefined);
+
+    const uiSchema = {
+      capabilities: {
+        cv_default_strategy: { binary: "group_kfold" },
+        cv_strategies: ["kfold", "group_kfold"],
+        tune: { allow_empty_space: true },
+      },
+    } as unknown as UiSchema;
+
+    const { result, deps } = setupHook({ uiSchema });
+
+    await act(async () => {
+      await result.current.handleTargetChange("a");
+    });
+
+    const setCvCall = deps.setCv.mock.calls.at(-1)?.[0];
+    expect(setCvCall?.strategy).toBe("group_kfold");
+  });
+});

--- a/frontend/src/hooks/useTargetSelection.ts
+++ b/frontend/src/hooks/useTargetSelection.ts
@@ -1,0 +1,152 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { getErrorMessage } from "@/api/errors";
+import { queryKeys } from "@/api/queryKeys";
+import type { ColumnInfo, UiSchema } from "@/api/types";
+import {
+  fetchColumns,
+  fetchConfigDefaults,
+  updateConfig,
+} from "@/api/workspace";
+import type { BlockedGroupKFoldState } from "@/components/workspace/BlockedGroupKFoldEditor";
+import {
+  type CvState,
+  getEffectiveCvStrategy,
+  resetCvState,
+} from "@/components/workspace/cv-state";
+import {
+  buildMergedConfig,
+  buildOverridesFromColumns,
+  buildSyncKey,
+  type ColumnOverride,
+  type TaskType,
+} from "./useDataPanel.types";
+
+/**
+ * B-5 (H-0077): the target-selection mutation extracted from
+ * {@link useDataPanel} so the top-level orchestration hook stays lean.
+ *
+ * The function mutates four React state cells (target, task, columns,
+ * cv) plus two sibling-hook registries (column overrides, config sync).
+ * All of those are threaded in as params so this hook holds no state of
+ * its own — it is just the combined side-effect chain of "user picked a
+ * new target column".
+ */
+interface UseTargetSelectionParams {
+  task: TaskType | null;
+  cv: CvState;
+  blocked: BlockedGroupKFoldState;
+  dataPath: string;
+  uiSchema?: UiSchema;
+  setTarget: (value: string) => void;
+  setTask: (task: TaskType) => void;
+  setCv: (cv: CvState) => void;
+  setColumns: (columns: ColumnInfo[]) => void;
+  setOverrides: (overrides: Record<string, ColumnOverride>) => void;
+  setSyncSuppressed: (flag: boolean) => void;
+  preseedSyncKey: (key: string) => void;
+  onDataChanged: () => void;
+  onTaskChanged?: (task: string | null) => void;
+}
+
+export function useTargetSelection({
+  task,
+  cv,
+  blocked,
+  dataPath,
+  uiSchema,
+  setTarget,
+  setTask,
+  setCv,
+  setColumns,
+  setOverrides,
+  setSyncSuppressed,
+  preseedSyncKey,
+  onDataChanged,
+  onTaskChanged,
+}: UseTargetSelectionParams) {
+  const queryClient = useQueryClient();
+
+  const handleTargetChange = useCallback(
+    async (value: string) => {
+      setSyncSuppressed(true);
+      setTarget(value);
+      try {
+        const cols = await fetchColumns(value);
+        setColumns(cols.columns);
+
+        let detectedTask: TaskType | null = task;
+        let detectedStrategy = cv.strategy;
+        let nextCv = cv;
+        if (cols.suggested_task) {
+          const t = cols.suggested_task as TaskType;
+          detectedTask = t;
+          setTask(t);
+          onTaskChanged?.(t);
+          detectedStrategy = getEffectiveCvStrategy(t, uiSchema);
+          nextCv = resetCvState(detectedStrategy);
+          setCv(nextCv);
+        }
+
+        const newOverrides = buildOverridesFromColumns(cols.columns);
+        setOverrides(newOverrides);
+
+        if (detectedTask) {
+          const defaults = await fetchConfigDefaults(detectedTask, value);
+          const merged = buildMergedConfig({
+            defaults,
+            task: detectedTask,
+            strategy: detectedStrategy,
+            // Use nextCv.folds (post-reset) so the merged split config
+            // matches the cv state the sync effect will observe next;
+            // otherwise the pre-reset cv.folds could leak into the PUT
+            // while preseedSyncKey uses nextCv.
+            folds: nextCv.folds,
+            dataPath,
+            target: value,
+            overrides: newOverrides,
+          });
+          await updateConfig(merged);
+          queryClient.setQueryData(queryKeys.config(), merged);
+          preseedSyncKey(
+            buildSyncKey(value, detectedTask, newOverrides, nextCv, blocked),
+          );
+          onDataChanged();
+        }
+      } catch (err) {
+        toast.error(`Column detection failed: ${getErrorMessage(err)}`);
+      } finally {
+        setSyncSuppressed(false);
+        // Radix Select returns focus to the trigger on close via
+        // `onCloseAutoFocus`, which runs AFTER our finally block. Defer
+        // the blur to the next animation frame so it fires after Radix
+        // has restored focus, otherwise `:focus-visible` matches and the
+        // 3px focus ring combined with the 1px border reads as a doubled
+        // outline. Keyboard users regain the ring on subsequent Tab.
+        requestAnimationFrame(() => {
+          (document.activeElement as HTMLElement | null)?.blur();
+        });
+      }
+    },
+    [
+      task,
+      cv,
+      blocked,
+      dataPath,
+      uiSchema,
+      onDataChanged,
+      onTaskChanged,
+      queryClient,
+      setTarget,
+      setTask,
+      setCv,
+      setColumns,
+      setOverrides,
+      setSyncSuppressed,
+      preseedSyncKey,
+    ],
+  );
+
+  return { handleTargetChange };
+}


### PR DESCRIPTION
## Summary

Close the B-5 item from \`docs/coupling-analysis.md\`: trim \`useDataPanel\` into an orchestration-only hub and move the 60-line \`handleTargetChange\` mutation into a dedicated \`useTargetSelection\` hook. External API unchanged.

### Why

- \`useDataPanel\` was 217 lines and returned 26 fields. \`handleTargetChange\` alone combined: \`fetchColumns\`, task detection, \`buildMergedConfig\`, \`updateConfig\`, React Query cache seeding, \`preseedSyncKey\`, and a \`requestAnimationFrame\` blur workaround. None of that was unit-testable without exercising the whole hub.
- Splitting the mutation into its own hook makes the side-effect chain DI-ed (all dependencies are explicit params), testable in isolation, and easier to reason about.

### What

- **\`frontend/src/hooks/useTargetSelection.ts\`** (new, 156 LOC): takes \`task\`, \`cv\`, \`blocked\`, \`dataPath\`, \`uiSchema\`, five state setters, two \`configSync\` callbacks, \`onDataChanged\`, \`onTaskChanged\`. Returns only \`{ handleTargetChange }\`.
- **\`frontend/src/hooks/useDataPanel.ts\`** (217 → 143 LOC): state declarations + composition of \`useDataLoad\` / \`useColumnOverrides\` / \`useConfigSync\` / \`useTargetSelection\` + a trimmed \`handleTaskChange\`. The return map is byte-identical so the existing 14-test \`useDataPanel.test.ts\` stays untouched.
- **\`frontend/src/components/workspace/cv-state.ts\`**: new pure helper \`getEffectiveCvStrategy(task, uiSchema)\` — eliminates the \`resolveDefaultCvStrategy\` nullish-chain duplication that the reviewer flagged.
- **\`frontend/src/hooks/useTargetSelection.test.ts\`** (new, 3 tests):
  - \`setSyncSuppressed(true)/false\` bookends are respected.
  - \`fetchColumns\` rejection → toast + suppress flag still released.
  - \`uiSchema.capabilities.cv_default_strategy\` wins over the hard-coded fallback.
  - \`vi.stubGlobal(\"requestAnimationFrame\", …)\` keeps the Radix blur rAF from leaking into subsequent tests.
- **\`HISTORY.md\`**: H-0077 decision record.

### Compatibility

- \`useDataPanel({...})\` return shape bit-identical — the sole consumer (\`DataPanel.tsx\`) is untouched.
- \`handleTargetChange\` state-mutation order, error paths, and side effects are 1:1 preserved (guarded by the untouched \`useDataPanel.test.ts\`).
- Wire format / BackendAdapter Protocol / storage layout / user config files unchanged.

## Test plan

- [x] \`pnpm vitest run\` — **1620 pass / 2 skipped** (+3 new useTargetSelection tests, no regressions).
- [x] \`pnpm check\`, \`pnpm tsc --noEmit\`, \`pnpm build\` — clean.
- [x] \`useDataPanel.test.ts\` (14 tests) touched in no way and stays green — external contract preserved.
- [x] Reviewer MEDIUM (duplication extraction, rAF leak) both addressed.

## Follow-up

B-5 done. Remaining in \`docs/coupling-analysis.md\`: **C-6** (openapi-fetch, session-exclusive), **C-9** (\`format_version\`, Change Gate Proposal required), **B-9** (design-tokens activation).