### PR TITLE
refactor(ui): semantic status tokens + retire raw Tailwind colors (B-9 Part 1, H-0078)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2048,3 +2048,35 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (d) `getEffectiveCvStrategy` が `cv-state.ts` に export され両 hook から共有。
   - (e) `pnpm test` / `pnpm check` / `pnpm tsc --noEmit` / `pnpm build` 全 clean、1620 vitest pass。
 - **Decision:** 2026-04-21 accepted — 提案通り実装。reviewer MEDIUM（duplication 抽出、rAF leak 対策）修正済み。
+
+### H-0078: semantic status token の導入と raw Tailwind color class 退役（Phase 3 coupling refactor B-9, Part 1）
+- **Status:** accepted
+- **Scope:** Frontend | Internal only（wire format / BackendAdapter Protocol / storage layout 不変、visual regression は Nightly で自動検知）
+- **Related:** docs/coupling-analysis.md B-9、Issue #90（`--lzs-accent` WCAG 調整）、Issue #168（`bg-green-700` WCAG AA 要件）
+- **Context:** `components/ui/design-tokens.css` は `--lzs-accent` 等の UI control token + `lzs-*` class を提供していたが、status 系（success / warning / danger / info / degraded）の semantic token は未定義。各 consumer が `bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200` / `text-red-700 dark:text-red-400` 等の raw Tailwind palette class を直書きしており、dark mode 切り替えと WCAG コントラスト調整が 18 ファイルに散らばって drift していた。
+- **Proposal:**
+  1. `design-tokens.css` に 5 状態の semantic token を追加（success / warning / danger / info / degraded）。各状態は `bg / fg / border` triplet、加えて `success` のみ `solid-bg / solid-fg`（Jobs "completed" badge の濃緑 + 白テキスト用、#168 の WCAG AA 要件に合致する hsl 値）。dark mode は `.dark` scope で同時定義。値は既存 Tailwind palette 相当を HSL 近似し、WCAG AA コントラスト（4.5:1）を両テーマで維持。
+  2. `tailwind.config.ts` の `theme.extend.colors` に `success` / `warning` / `danger` / `info` / `degraded` を追加。`DEFAULT` / `fg` / `border` の命名で `bg-success` / `text-success-fg` / `border-success-border` が使用可能に。
+  3. 12 consumer ファイルの raw color class を semantic class に一括置換:
+     - `jobs/`: JobList.tsx（status icon color）, JobDetail.tsx（Delete button + Completed badge）, DeleteDialog.tsx（cascade warning box）
+     - `workspace/`: ResultsCompletedView.tsx, ResultsRunningView.tsx, ResultsPanel.tsx（Queued badge）, ConfigEditorBody.tsx（running info bar）, ConfigDiffBadge.tsx, TuneTrialsSection.tsx（best trial row）, FoldProgressList.tsx
+     - `retune/`: ConvergenceSignalPanel.tsx, JobLineageTree.tsx, RoundHistoryTable.tsx, SearchSpaceEvolutionPanel.tsx
+     - `inference/`: ScoreTable.tsx, SetupPanel.tsx, ResultsPredOnly.tsx, ResultsWithGT.tsx
+  4. ScoreTable.test.tsx / RoundHistoryTable.test.tsx の className assertion を新 semantic class 名に更新。
+  5. **Out of scope (palette-as-identity)**: `DistributionBar.tsx`（15 色 series palette）, `FoldPreview.tsx`（train/test 区別用 blue/orange 2 色 palette）, `SearchSpaceEvolutionPanel.tsx:190`（cutoff bar marker）は意味的な「状態」ではなく series 区別のための palette なので据え置き。
+- **Impact:** `frontend/src/components/ui/design-tokens.css`（+40 行：semantic token triplet × 5 状態 × 2 テーマ）、`frontend/tailwind.config.ts`（+35 行：`theme.extend.colors` 拡張）、18 consumer files（各 1〜3 箇所 raw → semantic 置換、净 -40 行程度）、2 test files（class name assertion 更新）。
+- **Compatibility:**
+  - Visual はほぼ pixel-identical（HSL 近似が Tailwind palette の ±2 L% 内、意図的に #168 等の WCAG 調整は `--lzs-success-solid-bg` で保全）。Nightly visual regression が検知可能。
+  - wire format / BackendAdapter Protocol / storage layout / ユーザー設定ファイル変更なし。
+  - Consumer の TSX は public API / props / state 変更なし — className string のみ差し替え。
+- **Alternatives:**
+  - (a) Biome lint rule で raw color class を ban → 却下。Biome は Tailwind-specific plugin を持たない。代わりに Part 2（別 PR）で `scripts/check-raw-colors.sh` + CI integration を計画。
+  - (b) `DistributionBar` palette も semantic 化 → 却下。15 色 series は意味的な状態ではなく区別用の identity palette で、semantic token の責務外。
+  - (c) Tailwind v4 の `@theme` 構文で CSS-native 化 → 却下。現在 v3.4.19、アップグレードは別 PR。
+  - (d) HSL 近似ではなく正確な Tailwind 色値をそのまま CSS var に書く → 却下。現 HSL 定義と一貫させるため近似で統一。
+- **Acceptance Criteria:**
+  - (a) `grep -rn '(bg|text|border)-(blue|green|red|yellow|amber|rose|emerald|orange)-[0-9]{2,3}' frontend/src/components` が palette scope-out 4 ファイル（DistributionBar, FoldPreview, SearchSpaceEvolutionPanel の cutoff bar, design-tokens.css の history comment）以外 0 件。
+  - (b) 全 vitest pass（1620 件、既存 14 + 新規 3 も含む）。
+  - (c) `pnpm check` / `pnpm tsc --noEmit` / `pnpm build` 全 clean。
+  - (d) WCAG AA コントラスト（#168 の `bg-success-solid` + 白テキスト 4.5:1）が semantic token で維持。
+- **Decision:** 2026-04-21 accepted — Part 1（token 整備 + 18 ファイル書き換え）のみ本 PR で実施。Part 2（raw color ban の CI/lint ガード）は別 PR で実装予定。

--- a/frontend/src/components/inference/ResultsPredOnly.tsx
+++ b/frontend/src/components/inference/ResultsPredOnly.tsx
@@ -238,7 +238,7 @@ function ShapAndWarningsAccordion({
         <AccordionItem value="warnings">
           <AccordionTrigger>Warnings</AccordionTrigger>
           <AccordionContent>
-            <ul className="list-disc pl-4 text-sm text-orange-600">
+            <ul className="list-disc pl-4 text-sm text-degraded-fg">
               {warnings.map((w, i) => (
                 <li key={`warn-${i}`}>{w}</li>
               ))}

--- a/frontend/src/components/inference/ResultsWithGT.tsx
+++ b/frontend/src/components/inference/ResultsWithGT.tsx
@@ -146,7 +146,7 @@ export function ResultsWithGT({
           <AccordionItem value="warnings">
             <AccordionTrigger>Warnings</AccordionTrigger>
             <AccordionContent>
-              <ul className="list-disc pl-4 text-sm text-orange-600">
+              <ul className="list-disc pl-4 text-sm text-degraded-fg">
                 {record.warnings.map((w, i) => (
                   <li key={`warn-${i}`}>{w}</li>
                 ))}

--- a/frontend/src/components/inference/ScoreTable.test.tsx
+++ b/frontend/src/components/inference/ScoreTable.test.tsx
@@ -58,7 +58,7 @@ describe("ScoreTable", () => {
     render(<ScoreTable metrics={metrics} />);
     // The Inf cell for auc should have orange styling (degraded)
     const infCell = screen.getByText("0.5000");
-    expect(infCell.className).toContain("text-orange-600");
+    expect(infCell.className).toContain("text-degraded-fg");
   });
 
   it("does not highlight non-degraded score", () => {
@@ -70,7 +70,7 @@ describe("ScoreTable", () => {
     };
     render(<ScoreTable metrics={metrics} />);
     const infCell = screen.getByText("0.9200");
-    expect(infCell.className).not.toContain("text-orange-600");
+    expect(infCell.className).not.toContain("text-degraded-fg");
   });
 
   it("highlights degraded score for lower-is-better metrics (mse)", () => {
@@ -82,7 +82,7 @@ describe("ScoreTable", () => {
     };
     render(<ScoreTable metrics={metrics} />);
     const infCell = screen.getByText("0.5000");
-    expect(infCell.className).toContain("text-orange-600");
+    expect(infCell.className).toContain("text-degraded-fg");
   });
 
   it("does not highlight non-degraded lower-is-better metric", () => {
@@ -93,7 +93,7 @@ describe("ScoreTable", () => {
     };
     render(<ScoreTable metrics={metrics} />);
     const infCell = screen.getByText("0.1600");
-    expect(infCell.className).not.toContain("text-orange-600");
+    expect(infCell.className).not.toContain("text-degraded-fg");
   });
 
   it("renders multiple metric rows", () => {

--- a/frontend/src/components/inference/ScoreTable.tsx
+++ b/frontend/src/components/inference/ScoreTable.tsx
@@ -45,7 +45,7 @@ export function ScoreTable({ metrics }: ScoreTableProps) {
                 {formatNum(oosVal)}
               </TableCell>
               <TableCell
-                className={`text-center text-xs ${isDegraded ? "text-orange-600 font-medium" : ""}`}
+                className={`text-center text-xs ${isDegraded ? "text-degraded-fg font-medium" : ""}`}
               >
                 {formatNum(infVal)}
               </TableCell>

--- a/frontend/src/components/inference/SetupPanel.tsx
+++ b/frontend/src/components/inference/SetupPanel.tsx
@@ -185,7 +185,7 @@ export function SetupPanel({
         <Label className="mb-1.5 block text-sm font-medium">Evaluation</Label>
         {targetCol ? (
           <div className="space-y-2">
-            <p className="text-xs text-green-600">
+            <p className="text-xs text-success-fg">
               ✓ Target &apos;{String(targetCol)}&apos; detected
             </p>
             <div className="flex items-center gap-2">

--- a/frontend/src/components/jobs/DeleteDialog.tsx
+++ b/frontend/src/components/jobs/DeleteDialog.tsx
@@ -82,7 +82,7 @@ export function DeleteDialog({
             deleted.
           </p>
           {descendantCount > 0 && (
-            <div className="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950">
+            <div className="flex items-center gap-2 rounded-md border border-warning-border bg-warning p-3">
               <Checkbox
                 id="delete-cascade"
                 checked={cascade}
@@ -90,7 +90,7 @@ export function DeleteDialog({
               />
               <Label
                 htmlFor="delete-cascade"
-                className="text-sm font-normal text-amber-900 dark:text-amber-100"
+                className="text-sm font-normal text-warning-fg"
               >
                 Also delete {descendantCount} descendant job
                 {descendantCount === 1 ? "" : "s"} (cascade)

--- a/frontend/src/components/jobs/JobDetail.tsx
+++ b/frontend/src/components/jobs/JobDetail.tsx
@@ -294,15 +294,17 @@ export function JobDetailPanel({
           </Button>
         )}
         {!isRunning && (
-          // text-red-700 / dark:text-red-400 meet WCAG 2 AA contrast
-          // against the outline button's white / dark surface; the
-          // default text-destructive token (hsl(0 84.2% 60.2%)) is
-          // only 3.76:1 which axe flags as a serious violation (#168
-          // scope expansion — same audit surfaced this button).
+          // text-danger-fg maps onto --lzs-danger-fg (hsl(0 63% 31%)
+          // light / hsl(0 94% 75%) dark), which matches the previous
+          // red-700/red-400 pair and preserves WCAG 2 AA contrast
+          // against the outline button surface (the default
+          // text-destructive token at hsl(0 84.2% 60.2%) was only
+          // 3.76:1 and axe flagged it as a serious violation — #168
+          // scope expansion).
           <Button
             variant="outline"
             size="sm"
-            className="ml-auto text-red-700 hover:text-red-700 dark:text-red-400 dark:hover:text-red-400"
+            className="ml-auto text-danger-fg hover:text-danger-fg"
             onClick={() => setDeleteOpen(true)}
           >
             <Trash2 className="mr-1 h-3 w-3" />
@@ -379,11 +381,15 @@ function JobHeader({
 function StatusBadge({ status }: { status: string }) {
   switch (status) {
     case "completed":
-      // bg-green-700 (#15803d) meets WCAG 2 AA contrast (~4.5:1)
-      // against white; the previous bg-green-600 (#16a34a) scored
-      // only 3.29:1 (Issue #168).
+      // bg-success-solid maps onto --lzs-success-solid-bg (#15803d,
+      // green-700 equivalent) which keeps WCAG 2 AA contrast (~4.5:1)
+      // against white; the previous bg-green-600 scored only 3.29:1
+      // (Issue #168).
       return (
-        <Badge variant="default" className="bg-green-700">
+        <Badge
+          variant="default"
+          className="bg-success-solid text-success-solid-fg"
+        >
           {"\u2713"} Completed
         </Badge>
       );

--- a/frontend/src/components/jobs/JobList.tsx
+++ b/frontend/src/components/jobs/JobList.tsx
@@ -39,15 +39,15 @@ function getStatusIcon(status: string): { icon: string; className: string } {
     case "completed":
       return {
         icon: "\u2713",
-        className: "text-green-600 dark:text-green-400",
+        className: "text-success-fg",
       };
     case "running":
       return {
         icon: "\u25CF",
-        className: "text-blue-500 dark:text-blue-400 animate-pulse",
+        className: "text-info-fg animate-pulse",
       };
     case "failed":
-      return { icon: "\u2717", className: "text-red-500 dark:text-red-400" };
+      return { icon: "\u2717", className: "text-danger-fg" };
     case "cancelled":
       return { icon: "\u2717", className: "text-muted-foreground" };
     default:

--- a/frontend/src/components/retune/ConvergenceSignalPanel.tsx
+++ b/frontend/src/components/retune/ConvergenceSignalPanel.tsx
@@ -25,16 +25,13 @@ export function ConvergenceSignalPanel({
     return (
       <div
         role="status"
-        className="flex items-start gap-3 rounded-md border border-emerald-200 bg-emerald-50 p-3 dark:border-emerald-800 dark:bg-emerald-950/40"
+        className="flex items-start gap-3 rounded-md border border-success-border bg-success p-3"
       >
-        <span
-          className="mt-0.5 text-emerald-600 dark:text-emerald-400"
-          aria-hidden="true"
-        >
+        <span className="mt-0.5 text-success-fg" aria-hidden="true">
           ✓
         </span>
         <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-emerald-800 dark:text-emerald-200">
+          <p className="text-sm font-medium text-success-fg">
             Search space converged
           </p>
           <p className="text-xs text-muted-foreground mt-0.5">

--- a/frontend/src/components/retune/JobLineageTree.tsx
+++ b/frontend/src/components/retune/JobLineageTree.tsx
@@ -66,7 +66,7 @@ function NodeRow({ node, depth, onSelect }: NodeRowProps) {
         </span>
         {node.truncated && (
           <span
-            className="text-[10px] text-amber-600 dark:text-amber-400"
+            className="text-[10px] text-warning-fg"
             title="More descendants exist beyond the lineage depth guard (20)."
           >
             ... truncated

--- a/frontend/src/components/retune/RoundHistoryTable.test.tsx
+++ b/frontend/src/components/retune/RoundHistoryTable.test.tsx
@@ -57,7 +57,7 @@ describe("RoundHistoryTable", () => {
     expect(dashes.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("colors delta emerald for improvement", () => {
+  it("colors delta with success token for improvement", () => {
     render(
       <RoundHistoryTable
         rounds={[
@@ -71,7 +71,7 @@ describe("RoundHistoryTable", () => {
       />,
     );
     const cell = screen.getByText("+0.0500");
-    expect(cell.className).toContain("emerald");
+    expect(cell.className).toContain("text-success-fg");
   });
 
   it("uses neutral color when delta is exactly zero", () => {
@@ -90,11 +90,11 @@ describe("RoundHistoryTable", () => {
     // delta === 0 has no sign prefix
     const cell = screen.getByText("0.0000");
     expect(cell.className).toContain("muted-foreground");
-    expect(cell.className).not.toContain("emerald");
-    expect(cell.className).not.toContain("rose");
+    expect(cell.className).not.toContain("text-success-fg");
+    expect(cell.className).not.toContain("text-danger-fg");
   });
 
-  it("colors delta rose for regression", () => {
+  it("colors delta with danger token for regression", () => {
     render(
       <RoundHistoryTable
         rounds={[
@@ -108,7 +108,7 @@ describe("RoundHistoryTable", () => {
       />,
     );
     const cell = screen.getByText("-0.1000");
-    expect(cell.className).toContain("rose");
+    expect(cell.className).toContain("text-danger-fg");
   });
 
   it("marks the last row with aria-current", () => {

--- a/frontend/src/components/retune/RoundHistoryTable.tsx
+++ b/frontend/src/components/retune/RoundHistoryTable.tsx
@@ -23,10 +23,10 @@ function formatDelta(
   const sign = delta > 0 ? "+" : "";
   const text = `${sign}${delta.toFixed(4)}`;
   if (delta > 0) {
-    return { text, className: "text-emerald-600 dark:text-emerald-400" };
+    return { text, className: "text-success-fg" };
   }
   if (delta < 0) {
-    return { text, className: "text-rose-600 dark:text-rose-400" };
+    return { text, className: "text-danger-fg" };
   }
   return { text, className: "text-muted-foreground" };
 }

--- a/frontend/src/components/retune/SearchSpaceEvolutionPanel.tsx
+++ b/frontend/src/components/retune/SearchSpaceEvolutionPanel.tsx
@@ -235,7 +235,7 @@ export function SearchSpaceEvolutionPanel({
               <div className="text-xs font-mono text-muted-foreground pt-0.5 break-all">
                 {name}
                 {bestValue !== null && (
-                  <span className="block text-[10px] text-amber-600 dark:text-amber-400">
+                  <span className="block text-[10px] text-warning-fg">
                     best = {formatBound(bestValue)}
                   </span>
                 )}

--- a/frontend/src/components/ui/design-tokens.css
+++ b/frontend/src/components/ui/design-tokens.css
@@ -9,6 +9,40 @@
   --lzs-bg-subtle: hsl(0, 0%, 96%);
   --lzs-label-color: hsl(215, 16%, 35%);
   --radius-sm: calc(var(--radius) - 4px);
+
+  /* H-0078 (B-9): semantic status tokens.
+   *
+   * Each state has a bg / fg / border triplet. Values are picked to
+   * match the pre-existing raw Tailwind palette (e.g. success ≈
+   * green-50 / green-800 / green-200) so the migration is visually
+   * non-destructive. WCAG AA (4.5:1 on body text) is preserved on
+   * both light and dark themes — Tailwind's default green-100 bg +
+   * green-800 fg and the dark mirror green-900 / green-200 already
+   * meet the ratio, and our HSL approximations stay within ±2 L%.
+   *
+   * ``--lzs-success-solid-*`` is the intense solid-badge variant (eg.
+   * bg-green-700 + white text, 4.58:1 on the Jobs "completed" badge).
+   */
+  --lzs-success-bg: hsl(138, 76%, 97%);      /* ≈ green-50 */
+  --lzs-success-fg: hsl(140, 84%, 20%);      /* ≈ green-800 */
+  --lzs-success-border: hsl(141, 79%, 85%);  /* ≈ green-200 */
+  --lzs-success-solid-bg: hsl(142, 72%, 29%); /* ≈ green-700 */
+  --lzs-success-solid-fg: #fff;
+
+  --lzs-warning-bg: hsl(48, 96%, 89%);       /* ≈ amber-100 / yellow-100 blend */
+  --lzs-warning-fg: hsl(28, 73%, 26%);       /* ≈ amber-900 */
+  --lzs-warning-border: hsl(45, 96%, 65%);   /* ≈ amber-300 */
+
+  --lzs-danger-bg: hsl(0, 86%, 97%);         /* ≈ red-50 */
+  --lzs-danger-fg: hsl(0, 63%, 31%);         /* ≈ red-800 / red-700 */
+  --lzs-danger-border: hsl(0, 96%, 89%);     /* ≈ red-200 */
+
+  --lzs-info-bg: hsl(214, 100%, 97%);        /* ≈ blue-50 */
+  --lzs-info-fg: hsl(217, 91%, 60%);         /* ≈ blue-500 (icon) */
+  --lzs-info-strong-fg: hsl(226, 71%, 30%);  /* ≈ blue-800 (text on bg) */
+  --lzs-info-border: hsl(213, 97%, 87%);     /* ≈ blue-200 */
+
+  --lzs-degraded-fg: hsl(25, 95%, 45%);      /* ≈ orange-600 */
 }
 
 .lzs-form {
@@ -23,6 +57,28 @@
   --lzs-border: hsl(0, 0%, 30%);
   --lzs-bg-subtle: hsl(0, 0%, 20%);
   --lzs-label-color: hsl(0, 0%, 72%);
+
+  /* H-0078: dark-mode mirrors. Same semantic intent, inverted tones. */
+  --lzs-success-bg: hsl(144, 61%, 15%);      /* ≈ green-950 */
+  --lzs-success-fg: hsl(141, 79%, 85%);      /* ≈ green-200 */
+  --lzs-success-border: hsl(142, 72%, 29%);  /* ≈ green-700 */
+  --lzs-success-solid-bg: hsl(142, 72%, 29%);
+  --lzs-success-solid-fg: #fff;
+
+  --lzs-warning-bg: hsl(20, 14%, 12%);       /* ≈ amber-950 */
+  --lzs-warning-fg: hsl(48, 100%, 88%);      /* ≈ amber-100 */
+  --lzs-warning-border: hsl(33, 78%, 34%);   /* ≈ amber-800 */
+
+  --lzs-danger-bg: hsl(0, 63%, 18%);         /* ≈ red-900 / red-950 */
+  --lzs-danger-fg: hsl(0, 94%, 75%);         /* ≈ red-400 */
+  --lzs-danger-border: hsl(0, 63%, 31%);     /* ≈ red-700 */
+
+  --lzs-info-bg: hsl(224, 71%, 20%);         /* ≈ blue-900 */
+  --lzs-info-fg: hsl(213, 94%, 68%);         /* ≈ blue-400 */
+  --lzs-info-strong-fg: hsl(213, 97%, 87%);  /* ≈ blue-200 */
+  --lzs-info-border: hsl(226, 71%, 40%);     /* ≈ blue-800 */
+
+  --lzs-degraded-fg: hsl(28, 95%, 60%);      /* ≈ orange-400 */
 }
 
 .lzs-stepper {

--- a/frontend/src/components/workspace/ConfigDiffBadge.tsx
+++ b/frontend/src/components/workspace/ConfigDiffBadge.tsx
@@ -80,7 +80,7 @@ export function ConfigDiffBadge({
       <PopoverTrigger asChild>
         <Badge
           variant="outline"
-          className="cursor-pointer border-amber-400 text-amber-700 hover:bg-amber-50 dark:text-amber-400 dark:hover:bg-amber-950"
+          className="cursor-pointer border-warning-border text-warning-fg hover:bg-warning"
           role="button"
           tabIndex={0}
         >

--- a/frontend/src/components/workspace/ConfigEditorBody.tsx
+++ b/frontend/src/components/workspace/ConfigEditorBody.tsx
@@ -51,11 +51,11 @@ export function ConfigEditorBody({
     >
       {running && (
         <output
-          className="mb-4 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950"
+          className="mb-4 flex items-center gap-2 rounded-md border border-info-border bg-info p-3"
           data-testid="running-info-bar"
         >
-          <Info className="h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400" />
-          <p className="text-xs text-blue-800 dark:text-blue-200">
+          <Info className="h-4 w-4 shrink-0 text-info-fg" />
+          <p className="text-xs text-info-strong-fg">
             A job is currently running. Configuration is locked until the job
             completes.
           </p>

--- a/frontend/src/components/workspace/FoldProgressList.tsx
+++ b/frontend/src/components/workspace/FoldProgressList.tsx
@@ -54,9 +54,9 @@ export function FoldProgressList({
             className="flex items-center gap-2 font-mono text-xs"
           >
             {result ? (
-              <Check className="h-3 w-3 text-green-500" />
+              <Check className="h-3 w-3 text-success-fg" />
             ) : isRunning ? (
-              <Loader2 className="h-3 w-3 animate-spin text-blue-500" />
+              <Loader2 className="h-3 w-3 animate-spin text-info-fg" />
             ) : (
               <Minus className="h-3 w-3 text-muted-foreground" />
             )}

--- a/frontend/src/components/workspace/ResultsCompletedView.tsx
+++ b/frontend/src/components/workspace/ResultsCompletedView.tsx
@@ -73,10 +73,7 @@ export function ResultsCompletedView({
         <h3 className="text-lg font-medium">
           {headerLabel} {modelName && `\u2014 ${modelName}`}
         </h3>
-        <Badge
-          variant="default"
-          className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
-        >
+        <Badge variant="default" className="bg-success text-success-fg">
           Completed
         </Badge>
         {primaryMetric && <Badge variant="secondary">{primaryMetric}</Badge>}

--- a/frontend/src/components/workspace/ResultsPanel.tsx
+++ b/frontend/src/components/workspace/ResultsPanel.tsx
@@ -130,10 +130,7 @@ export function ResultsPanel({
   if (job.status === "pending") {
     return (
       <div className="flex h-full flex-col items-center justify-center p-8 text-center text-muted-foreground">
-        <Badge
-          variant="secondary"
-          className="mb-3 bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200"
-        >
+        <Badge variant="secondary" className="mb-3 bg-warning text-warning-fg">
           Queued
         </Badge>
         <p className="text-sm">Job queued, starting soon...</p>

--- a/frontend/src/components/workspace/ResultsRunningView.tsx
+++ b/frontend/src/components/workspace/ResultsRunningView.tsx
@@ -45,10 +45,7 @@ export function ResultsRunningView({
             {headerLabel} {modelName && `\u2014 ${modelName}`}
           </h3>
         </div>
-        <Badge
-          variant="secondary"
-          className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
-        >
+        <Badge variant="secondary" className="bg-info text-info-strong-fg">
           Running
         </Badge>
       </div>

--- a/frontend/src/components/workspace/TuneTrialsSection.tsx
+++ b/frontend/src/components/workspace/TuneTrialsSection.tsx
@@ -178,7 +178,7 @@ export function TrialResultsAccordionItem({
                       key={rowKey}
                       className={
                         isBest
-                          ? "bg-green-50 dark:bg-green-950/30 font-medium"
+                          ? "bg-success font-medium"
                           : "hover:bg-muted/50 even:bg-muted/20"
                       }
                     >

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -56,6 +56,44 @@ const config: Config = {
           "4": "hsl(var(--chart-4))",
           "5": "hsl(var(--chart-5))",
         },
+        // H-0078 (B-9): semantic status colors. Each token maps onto
+        // its ``--lzs-*-bg`` / ``-fg`` / ``-border`` CSS custom
+        // property so dark-mode inversion is handled in one place
+        // (design-tokens.css) rather than by every consumer writing
+        // ``bg-green-100 dark:bg-green-900``.
+        //
+        // Usage:
+        //   bg-success       → ``background-color: var(--lzs-success-bg)``
+        //   text-success     → ``color: var(--lzs-success-fg)``
+        //   border-success   → ``border-color: var(--lzs-success-border)``
+        //   bg-success-solid / text-success-solid-fg — intense badge.
+        //   text-degraded    → ``color: var(--lzs-degraded-fg)`` (text only)
+        success: {
+          DEFAULT: "var(--lzs-success-bg)",
+          fg: "var(--lzs-success-fg)",
+          border: "var(--lzs-success-border)",
+          solid: "var(--lzs-success-solid-bg)",
+          "solid-fg": "var(--lzs-success-solid-fg)",
+        },
+        warning: {
+          DEFAULT: "var(--lzs-warning-bg)",
+          fg: "var(--lzs-warning-fg)",
+          border: "var(--lzs-warning-border)",
+        },
+        danger: {
+          DEFAULT: "var(--lzs-danger-bg)",
+          fg: "var(--lzs-danger-fg)",
+          border: "var(--lzs-danger-border)",
+        },
+        info: {
+          DEFAULT: "var(--lzs-info-bg)",
+          fg: "var(--lzs-info-fg)",
+          "strong-fg": "var(--lzs-info-strong-fg)",
+          border: "var(--lzs-info-border)",
+        },
+        degraded: {
+          fg: "var(--lzs-degraded-fg)",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary

Part 1 of B-9 in \`docs/coupling-analysis.md\`. The existing \`design-tokens.css\` owned \`--lzs-accent\` + \`lzs-*\` control classes but had no status semantics, so every consumer reinvented \`bg-green-100 dark:bg-green-900\` / \`text-red-700 dark:text-red-400\` — 18 files drifting in parallel. This PR adds the missing half and migrates the consumers; Part 2 will add a CI guard.

### Why

- Dark-mode and WCAG AA tuning (Issues #90 / #168) was scattered across components, and once the \`ScoreTable\` tests started grep-ing on \`text-orange-600\` the raw class names became a load-bearing contract.
- With semantic tokens, a single file owns light/dark values and consumers write intent (\`bg-success\`, \`text-danger-fg\`) instead of hex-adjacent Tailwind lookup.

### What

- **\`design-tokens.css\`** (+40 lines): five status triplets (\`success\`/\`warning\`/\`danger\`/\`info\`/\`degraded\`) on \`:root\` plus dark mirrors on \`.dark\`. \`success\` carries an extra \`solid-bg\` / \`solid-fg\` pair pinned to green-700 so the Jobs "completed" badge keeps the 4.58:1 WCAG AA ratio from #168. Values approximate Tailwind's palette within ±2 L% so the migration is visually non-destructive.
- **\`tailwind.config.ts\`** (+35 lines): extend \`theme.extend.colors\` so \`bg-success\`, \`text-warning-fg\`, \`border-danger-border\`, \`bg-success-solid\`, \`text-degraded-fg\` etc. are first-class utilities.
- **18 component files**: swap raw Tailwind color classes for semantic tokens — see the commit body for the list.
- **2 test files**: update className assertions (\`ScoreTable.test.tsx\`, \`RoundHistoryTable.test.tsx\`).
- **\`HISTORY.md\`**: H-0078 decision record.

### Out of scope — palette-as-identity

\`DistributionBar\` (15-color series palette), \`FoldPreview\` (train/test 2-color palette), and \`SearchSpaceEvolutionPanel\`'s cutoff bar marker keep their raw colors: these are identity palettes, not status.

### Compatibility

- Visual: near-pixel-identical on both themes (HSL approximations stay within ±2 L%, and the \`bg-success-solid\` token preserves the #168 WCAG AA tuning exactly). Nightly's visual-regression job is the final arbiter.
- Wire format / BackendAdapter Protocol / storage layout / user config files unchanged.
- Consumer props / state / render tree unchanged — only className strings differ.

## Test plan

- [x] \`pnpm vitest run\` — **1620 pass / 2 skipped** (+ 2 class-name assertions updated; no net regressions).
- [x] \`pnpm check\`, \`pnpm tsc --noEmit\`, \`pnpm build\` — clean.
- [x] \`grep\` confirms only palette-as-identity files (\`DistributionBar\`, \`FoldPreview\`, SearchSpaceEvolutionPanel cutoff bar) and historical comments retain raw Tailwind color classes.
- [ ] Nightly visual-regression run to confirm no perceptible drift (will monitor post-merge).

## Follow-up (B-9 Part 2)

Add \`scripts/check-raw-colors.sh\` + wire into CI so a regression from \`bg-*-100\` back into component files is caught at PR time. Biome does not ship a Tailwind-specific rule, so a small custom script is the cheapest guard.