### PR TITLE
ci(frontend): raw Tailwind color CI guard (B-9 Part 2, H-0079)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,20 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  # B-9 Part 2 (H-0078 follow-up): guard against raw Tailwind color
+  # utilities in frontend source. After the semantic-token migration
+  # (design-tokens.css + tailwind.config.ts), classes like ``bg-green-100``
+  # / ``text-red-600`` bypass dark-mode inversion and the WCAG-audited
+  # palette. Biome has no Tailwind plugin, so a grep-based check is the
+  # cheapest guard. Allowlist lives inside the script.
+  raw-color-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Scan frontend/src for raw Tailwind color classes
+        working-directory: frontend
+        run: bash scripts/check-raw-colors.sh
+
   # C-1 / INV-CI-1: committed schema.d.ts must match freshly-generated
   # output. Prevents drift between backend response_model declarations
   # and the TypeScript types that the frontend compiles against.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2080,3 +2080,27 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (c) `pnpm check` / `pnpm tsc --noEmit` / `pnpm build` 全 clean。
   - (d) WCAG AA コントラスト（#168 の `bg-success-solid` + 白テキスト 4.5:1）が semantic token で維持。
 - **Decision:** 2026-04-21 accepted — Part 1（token 整備 + 18 ファイル書き換え）のみ本 PR で実施。Part 2（raw color ban の CI/lint ガード）は別 PR で実装予定。
+
+### H-0079: raw Tailwind color class の CI guard（B-9 Part 2）
+- **Status:** accepted
+- **Scope:** CI / Tooling | Internal only（src 変更は ResultsPanel の 1 箇所 cleanup のみ、wire format / Protocol / storage 不変）
+- **Related:** H-0078 Part 1（semantic token 導入）、docs/coupling-analysis.md B-9 Part 2
+- **Context:** H-0078 で `frontend/src/components/**` の raw Tailwind color class（`bg-green-100`, `text-red-600` 等）を semantic token に移行したが、Biome には Tailwind-aware な lint rule がなく、PR 中に再び raw class が入り込んでも自動検知できない。Part 1 の scope-out は `DistributionBar` / `FoldPreview` / `SearchSpaceEvolutionPanel` の 3 ファイル（palette-as-identity）だけが対象だったが、その後の調査で `JobList.tsx:194` の fit/tune badge（job-type identifier）と `JobDetail.tsx:386` の historical WCAG comment、`design-tokens.css` の token-to-Tailwind mapping comment も同様に identity/documentation 目的で残存していることが判明。`ResultsPanel.tsx:203` の `bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200` は shadcn `Badge variant="secondary"` のデフォルトと完全に重複していたため、Part 1 時点で漏れた取りこぼし。
+- **Proposal:**
+  1. `frontend/scripts/check-raw-colors.sh` を追加。`grep -rEHn` で `src/**` を走査し、`(bg|text|border|ring|fill|stroke|from|to|via)-(blue|green|red|...|stone)-[0-9]{2,3}` パターンを検出。allowlist 外で 1 件でも hit したら exit 1。
+  2. allowlist は shell variable `ALLOWLIST_REGEX` に集約（`DistributionBar.tsx` / `FoldPreview.tsx` / `SearchSpaceEvolutionPanel.tsx` / `JobList.tsx` / `JobDetail.tsx` / `design-tokens.css` の 6 ファイル）。追加する際はスクリプト冒頭のコメントブロックで justification を明記するルールを導入。
+  3. `.github/workflows/ci.yml` に `raw-color-guard` job を追加。checkout のみで pnpm/node セットアップは不要（純 bash + grep）。
+  4. Part 1 の取りこぼし `ResultsPanel.tsx:203` を `<Badge variant="secondary">Cancelled</Badge>` に簡素化（`bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200` が secondary variant のデフォルト `bg-secondary text-secondary-foreground` と機能的に等価）。
+- **Impact:** `frontend/scripts/check-raw-colors.sh`（新規 80 行）、`.github/workflows/ci.yml`（+14 行で 1 job 追加）、`frontend/src/components/workspace/ResultsPanel.tsx`（-6 行、visual は unchanged）。
+- **Compatibility:** wire format / Protocol / storage 不変、ResultsPanel の cancelled badge は shadcn default と同じレンダリング結果になるため visual regression なし（既存の Nightly ゴールデンが検知可能）。
+- **Alternatives:**
+  - (a) `ripgrep` を使う → 却下。Ubuntu CI runner には標準で入っていないため `rg: command not found` が silent success になるリスクがあり（初回実装で実際に遭遇）、`grep -rE` に切り替え。
+  - (b) Biome custom rule で実装 → 却下。Biome v2 は external custom rule を未サポート、Tailwind plugin も未提供。
+  - (c) stylelint + `declaration-property-value-disallowed-list` → 却下。Biome に統一する方針（CLAUDE.md §3「ESLint / Prettier は使用禁止」）と矛盾し、依存を 1 つ増やすコストに見合わない。
+  - (d) Part 1 で Acceptance Criterion に含めた grep 判定を CI jobs に埋め込む → 却下。shell script として切り出す方が allowlist 管理が読みやすく、ローカル `bash scripts/check-raw-colors.sh` で再現可能。
+- **Acceptance Criteria:**
+  - (a) clean tree で `bash scripts/check-raw-colors.sh` が exit 0 + `OK: no raw ...` を出力。
+  - (b) 故意に `bg-blue-500` を任意ファイルに入れると exit 1 で違反行を表示（ローカルで確認済み）。
+  - (c) `raw-color-guard` job が `.github/workflows/ci.yml` の PR blocking ジョブに組み込まれ、develop/main 向け PR で自動実行される。
+  - (d) vitest 1620 pass / biome / tsc / pnpm build 全 clean（ResultsPanel 変更の regression 確認）。
+- **Decision:** 2026-04-21 accepted — H-0078 の self-defending guard として実装。allowlist に JobList/JobDetail を追加した差分は Part 1 の scope-out 漏れとして扱い、新規の色使用ポリシー変更ではない。

--- a/frontend/scripts/check-raw-colors.sh
+++ b/frontend/scripts/check-raw-colors.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# CI guard: forbid raw Tailwind color utilities in application source.
+#
+# After B-9 Part 1 (H-0078) migrated all status/chrome coloring to semantic
+# tokens defined in design-tokens.css + tailwind.config.ts, regressions like
+# ``bg-green-100`` / ``text-red-600`` are considered bugs: they bypass the
+# dark-mode inversion layer and the WCAG-audited contrast palette.
+#
+# Exit 1 if any forbidden class is found outside the allowlist below.
+# Usage: bash scripts/check-raw-colors.sh
+#
+# Allowlist (palette-as-identity, not status colors):
+#   - DistributionBar.tsx                — categorical palette for feature slices
+#   - FoldPreview.tsx                    — train/valid fold highlight colors
+#   - SearchSpaceEvolutionPanel.tsx      — cutoff bar identity color
+#   - JobList.tsx                        — fit/tune job-type identifier
+#   - design-tokens.css                  — comments mapping tokens back to Tailwind shades
+#   - JobDetail.tsx                      — comment explaining a historical contrast fix
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FRONTEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$FRONTEND_DIR"
+
+# Color utilities that must NOT appear in src/** outside the allowlist.
+# Matches e.g. bg-blue-500, text-red-600, border-yellow-300, ring-emerald-400,
+# from-slate-900, to-gray-100, via-pink-200, fill-amber-500, stroke-rose-400.
+PATTERN='(bg|text|border|ring|fill|stroke|from|to|via)-(blue|green|red|yellow|amber|rose|emerald|orange|slate|gray|zinc|sky|indigo|violet|purple|pink|fuchsia|cyan|teal|lime|neutral|stone)-[0-9]{2,3}'
+
+# Files exempted from the check. Keep this list short; every addition is
+# technical debt until justified as palette-as-identity.
+ALLOWLIST_REGEX='^src/(components/workspace/DistributionBar\.tsx|components/workspace/FoldPreview\.tsx|components/retune/SearchSpaceEvolutionPanel\.tsx|components/jobs/JobList\.tsx|components/jobs/JobDetail\.tsx|components/ui/design-tokens\.css)$'
+
+echo "Scanning src/ for raw Tailwind color utilities (B-9 Part 2 guard)..."
+
+# Use grep -r which is ubiquitous. -E enables extended regex; -H prints the
+# filename; -n prints the line number. ``|| true`` swallows the ``no match''
+# exit code (1) but would also hide a command-not-found error (127) — the
+# leading ``command -v grep`` check prevents that.
+if ! command -v grep >/dev/null 2>&1; then
+  echo "ERROR: grep is required but not found in PATH." >&2
+  exit 2
+fi
+
+MATCHES="$(grep -rEHn \
+  --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx' --include='*.css' \
+  "$PATTERN" src/ || true)"
+
+# Filter out allowlisted files. The ``src/foo/bar.tsx:NN:line`` output format
+# from grep lets us split on the first colon to isolate the path.
+VIOLATIONS=""
+if [[ -n "$MATCHES" ]]; then
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    path="${line%%:*}"
+    if [[ ! "$path" =~ $ALLOWLIST_REGEX ]]; then
+      VIOLATIONS+="${line}"$'\n'
+    fi
+  done <<< "$MATCHES"
+fi
+
+if [[ -n "$VIOLATIONS" ]]; then
+  echo ""
+  echo "ERROR: raw Tailwind color classes found outside the allowlist:"
+  echo ""
+  printf '%s' "$VIOLATIONS"
+  echo ""
+  echo "Fix: replace with a semantic token from design-tokens.css"
+  echo "  (bg-success / text-warning-fg / border-danger / bg-info etc.)"
+  echo "  or, if this is truly a palette-as-identity usage, add the file to"
+  echo "  the ALLOWLIST_REGEX in frontend/scripts/check-raw-colors.sh and"
+  echo "  explain why in the comment block at the top."
+  exit 1
+fi
+
+echo "OK: no raw Tailwind color classes outside the allowlist."

--- a/frontend/src/components/workspace/ResultsPanel.tsx
+++ b/frontend/src/components/workspace/ResultsPanel.tsx
@@ -198,12 +198,7 @@ export function ResultsPanel({
           <h3 className="text-lg font-medium">
             {headerLabel} {modelName && `\u2014 ${modelName}`}
           </h3>
-          <Badge
-            variant="secondary"
-            className="bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-          >
-            Cancelled
-          </Badge>
+          <Badge variant="secondary">Cancelled</Badge>
         </div>
         <p className="text-sm text-muted-foreground">
           This job was cancelled before completion.


### PR DESCRIPTION
## Summary

- Adds `frontend/scripts/check-raw-colors.sh` + `raw-color-guard` CI job to prevent future regressions of the H-0078 semantic-token migration (raw Tailwind color classes silently bypass dark-mode inversion and the WCAG-audited palette).
- Fold-back for one H-0078 Part 1 oversight: collapses the cancelled-job badge in `ResultsPanel.tsx` to shadcn `Badge variant="secondary"` (semantically equivalent, same rendered output).
- Adds `HISTORY.md` H-0079 entry covering the allowlist rationale, `rg` → `grep` pivot, and Biome custom-rule rejection.

## Why `grep` instead of `ripgrep`

First iteration used `rg`, which surfaced a `rg: command not found` silent-success bug (the `|| true` mask for "no match" also swallows exit 127). Ubuntu CI runners do not ship `rg` by default; `grep -rEHn` is POSIX, ubiquitous, and the regex is small enough that the perf gap is irrelevant. Captured in H-0079 **Alternatives (a)**.

## Allowlist (6 files)

| File | Why |
|---|---|
| `workspace/DistributionBar.tsx` | 15-color categorical palette for feature slices |
| `workspace/FoldPreview.tsx` | train/valid fold identity colors |
| `retune/SearchSpaceEvolutionPanel.tsx` | cutoff bar identity marker |
| `jobs/JobList.tsx` | fit/tune job-type identifier badge |
| `jobs/JobDetail.tsx` | comment referencing historical `bg-green-600` contrast fix |
| `ui/design-tokens.css` | token-to-Tailwind shade mapping comments |

Every entry is documented at the top of `check-raw-colors.sh`.

## Test plan

- [x] `cd frontend && bash scripts/check-raw-colors.sh` → exit 0 on clean tree
- [x] Injected `bg-blue-500 text-red-600` into a probe file → exit 1, violation shown, probe deleted
- [x] `pnpm vitest run --no-coverage` → 1620 pass / 2 skipped
- [x] `pnpm check` (biome) → clean
- [x] `pnpm exec tsc --noEmit` → clean
- [x] `pnpm build` → clean (5.6 MB JS, 21.69s)
- [x] `uv run ruff check .` / `ruff format --check .` → clean (no backend change, sanity)
- [ ] CI: new `raw-color-guard` job reports green on this PR
- [ ] CI: all existing gates (`frontend`, `e2e-chromium`, `api-types-drift`, `backend`) stay green

## Scope / change-gate

CI/tooling + one src cleanup line-for-line equivalent to the shadcn default. Not a change-gate candidate (no public API / Protocol / storage / dependency surface changes).

## Closes / refs

- Completes `docs/coupling-analysis.md` **B-9 Part 2** follow-up to H-0078.
- Memory: `project_coupling_refactor_progress.md` lists this as the trivial closer before C-6 / C-9.