### PR TITLE
fix(a11y): add aria-label to FeatureWeightsEditor Switch

### DIFF
--- a/frontend/src/components/workspace/FeatureWeightsEditor.test.tsx
+++ b/frontend/src/components/workspace/FeatureWeightsEditor.test.tsx
@@ -18,6 +18,23 @@ describe("FeatureWeightsEditor", () => {
     cleanup();
   });
 
+  describe("accessibility", () => {
+    // Radix <Switch> renders as a <button role="switch">. Axe's
+    // ``button-name`` rule computes the accessible name via WAI-ARIA
+    // spec and rejects FormField's <Label htmlFor> association for
+    // button-typed labelable elements in practice (Nightly #188 /
+    // PR #220 artefact). An explicit ``aria-label`` is the only
+    // reliable remediation, so we assert it directly rather than
+    // relying on testing-library's get-by-role name lookup (which
+    // over-estimates the accessible name relative to axe).
+    it("Switch has an explicit aria-label attribute", () => {
+      renderEditor({ weights: null, columns: COLUMNS, onChange: vi.fn() });
+      const switchEl = screen.getByRole("switch");
+      expect(switchEl).toHaveAttribute("aria-label");
+      expect(switchEl.getAttribute("aria-label")).toMatch(/feature weights/i);
+    });
+  });
+
   describe("OFF state (weights is null)", () => {
     it("renders Feature Weights label", () => {
       renderEditor({ weights: null, columns: COLUMNS, onChange: vi.fn() });

--- a/frontend/src/components/workspace/FeatureWeightsEditor.tsx
+++ b/frontend/src/components/workspace/FeatureWeightsEditor.tsx
@@ -64,7 +64,11 @@ export function FeatureWeightsEditor({
         label="Feature Weights"
         description="Assign custom weights to features for training"
       >
-        <Switch checked={enabled} onCheckedChange={handleToggle} />
+        <Switch
+          checked={enabled}
+          onCheckedChange={handleToggle}
+          aria-label="Enable feature weights"
+        />
       </FormField>
 
       {enabled && (


### PR DESCRIPTION
## Summary

Resolves the one critical ``button-name`` axe violation reported by the **Nightly #188** a11y job on the Workspace page (artefact: `a11y-accessibility-Accessi-fdcf5-no-critical-a11y-violations-chromium/error-context.md`).

Radix ``<Switch>`` renders as ``<button role="switch">``. FormField wires ``<Label htmlFor={id}>`` to the child, which is enough for testing-library's ``getByRole(name: ...)`` but **not** enough for axe's WAI-ARIA-spec accessible-name computation — axe reports ``explicit-label: Element does not have an explicit <label>``. An explicit ``aria-label`` is the only reliable fix.

## Why the regression test checks the attribute directly

Added test asserts ``aria-label`` is present and matches ``/feature weights/i`` — rather than ``getByRole("switch", { name: ... })`` — because the latter returned GREEN even before the fix due to testing-library's looser accessible-name calculation, which doesn't reflect axe's reality. The Nightly a11y job is the source of truth.

## Test plan

- [x] ``pnpm vitest run src/components/workspace/FeatureWeightsEditor.test.tsx`` — 18 pass (17 existing + 1 new a11y test)
- [x] ``pnpm check`` (biome) — clean
- [x] ``pnpm exec tsc --noEmit`` — clean
- [x] ``pnpm build`` — clean (22.38s)
- [x] ``bash scripts/check-raw-colors.sh`` — OK (no raw colors introduced)
- [x] CI: all PR-blocking jobs green
- [ ] Nightly (post-merge): ``E2E visual + a11y`` job no longer reports the ``button-name`` violation on Workspace

## Scope / change-gate

Single-component a11y attribute fix. No public API, Protocol, storage, or dependency changes. Not a change-gate candidate.

## Refs

- Nightly #188 (run 24703973482) failed job 72252999560
- Memory: ``project_coupling_refactor_progress.md`` — listed as the a11y follow-up surfaced by PR #220