### PR TITLE
docs(c6): openapi-fetch adoption plan (Phase 0, H-0080 Proposal)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2104,3 +2104,33 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (c) `raw-color-guard` job が `.github/workflows/ci.yml` の PR blocking ジョブに組み込まれ、develop/main 向け PR で自動実行される。
   - (d) vitest 1620 pass / biome / tsc / pnpm build 全 clean（ResultsPanel 変更の regression 確認）。
 - **Decision:** 2026-04-21 accepted — H-0078 の self-defending guard として実装。allowlist に JobList/JobDetail を追加した差分は Part 1 の scope-out 漏れとして扱い、新規の色使用ポリシー変更ではない。
+
+### H-0080: openapi-fetch 導入で frontend の URL パス手書きを廃止する計画（Phase 3 coupling refactor C-6）
+- **Status:** proposed (plan doc only — no code change in this PR)
+- **Scope:** Frontend | Internal only（wire format / BackendAdapter Protocol / storage layout 不変、公開 API 契約不変）
+- **Related:** docs/coupling-analysis.md C-6、docs/c6-openapi-fetch-plan.md（本 PR で新規作成）、H-0068（C-1 `response_model` 完全化）、H-0071（C-4 SSOT JobSummary/JobDetail）、H-0072（C-5a SSOT UiSchema）
+- **Context:** C-6 は 2026-04-17 の coupling-analysis 時点で未着手として残っていた最大項目。現状 `frontend/src/api/{jobs,inference,workspace,files}.ts` の 46 call site が URL を文字列結合 + `apiFetch<T>(url)` の型パラメータを手書きで指定しており、`server.py:184-200` の prefix 変更や Pydantic `response_model` の変更が TS で検出されない。既に `openapi-typescript@^7.13.0` で `generated/schema.d.ts` を出力しており、`paths` / `operations` / `components` は完備しているので、`openapi-fetch`（同一作者・+4.7 KB gzipped）を採用すれば URL + request + response を 1 箇所の型から推論できる。46 call site と 51 consumer import に一括で手を入れると diff が肥大化するため Phase 分割する。
+- **Proposal:**
+  1. `docs/c6-openapi-fetch-plan.md` を作成し、採用技術比較（openapi-fetch / openapi-typescript-fetch / Zodios / ky / 手書き builder）、Phase 分割（0–5 の 6 PR）、ApiError middleware 方針、MSW handler typing、破綻リスクと緩和策、全 Phase 完了時 acceptance を集約。
+  2. `docs/coupling-analysis.md` の C-6 entry に plan doc へのリンクと H-0080 参照を追記。
+  3. 本 Proposal を HISTORY.md に記録し、Phase 1 以降の実装 PR で各 Phase 完了時に本 entry の **Decision** を更新していく。
+  4. Phase 1 は `pnpm add openapi-fetch` + `apiClient` 併設 + `files.ts` (2 call site) のみ、最小スコープで migration pattern を確立。
+- **Impact:** `docs/c6-openapi-fetch-plan.md`（+172 行の新規）、`docs/coupling-analysis.md` C-6 entry（+1 行）、本 HISTORY.md entry。コード変更・依存追加・wire format 変更は一切なし。
+- **Compatibility:** ゼロ差分（docs のみ）。後続 Phase 1-5 の実装 PR は individual に review & rollback 可能、途中 state でも既存 `apiFetch` と新 `apiClient` が並行稼働するため機能停止なし。
+- **Alternatives:**
+  - (a) 1 PR で全 46 call site 一括置換 → 却下。diff ~1500+ 行で review 負担が大きく、問題発生時の bisect が困難。
+  - (b) openapi-typescript-fetch（openapi-fetch の前身）→ 却下、メンテ停止。
+  - (c) Zodios / oRPC / tRPC → 却下、FastAPI 生成 OpenAPI 経由では middleware が必要で依存増大、現 stack (React Query + openapi-typescript) との整合コストが型推論の利益を上回る。
+  - (d) ky / axios ラッパー → 却下、path 型推論がないため URL 手書きは残る。C-6 の本質に効かない。
+  - (e) 手書き URL builder 関数で型を付ける → 却下、`paths` interface と重複実装になり、generated 型の二重定義問題が発生。
+  - (f) 実装を proposal 省略で直接開始 → 却下、bundle size / error middleware パターン / MSW typing / Phase 境界を事前合意しないと Phase 間で方針漂流しやすい。
+- **Acceptance Criteria:**（本 Proposal PR）
+  - (a) `docs/c6-openapi-fetch-plan.md` が reviewer から approach / Phase 分割 / risk 緩和について合意を得る。
+  - (b) `docs/coupling-analysis.md` C-6 entry に plan doc link が入り、将来の調査者が H-0080 にたどり着ける。
+  - (c) この PR はコード変更・依存追加・wire format 変更を含まず、CI は既存通り green。
+- **Acceptance Criteria:**（全 Phase 完了時）
+  - (a) `grep -rn 'apiFetch(' frontend/src/` が 0 件。
+  - (b) `grep -rn "\`/[a-z]" frontend/src/api/*.ts` がゼロ（URL 直書き消滅）。
+  - (c) Bundle size 増加 +5 KB 以内（gzip）。
+  - (d) 既存 CI gate（`api-types-drift`, `raw-color-guard`, `e2e-chromium`, `frontend`, `backend`）全 green を維持。
+- **Decision:** 2026-04-21 proposed — Phase 0 plan doc のみ本 PR で merge、Phase 1 以降は順次別 PR で実装予定。各 Phase 完了時に本 entry の Decision line を update する。

--- a/docs/c6-openapi-fetch-plan.md
+++ b/docs/c6-openapi-fetch-plan.md
@@ -1,0 +1,188 @@
+# C-6: openapi-fetch 導入計画
+
+**作成日**: 2026-04-21
+**Related**: [docs/coupling-analysis.md §C-6](./coupling-analysis.md#c-6-url-パスが完全手書きprefix-変更追跡なし) / HISTORY.md H-0080
+**Status**: proposal (this PR) — implementation PRs will follow
+**Change-gate**: 不要（FE 内部 refactor、wire format / BackendAdapter / storage 不変）
+
+---
+
+## 1. 背景
+
+`frontend/src/api/{jobs,inference,workspace,files}.ts` の 46 箇所の fetch 呼び出しは、URL パス・クエリ文字列・リクエスト body 構築を手書きで行っている。
+
+```ts
+// 現状: jobs.ts
+export function fetchJobImportance(jobId: string, kind = "default"): Promise<ImportanceResponse> {
+  return apiFetch(
+    `/jobs/${encodeURIComponent(jobId)}/importance?kind=${encodeURIComponent(kind)}`,
+  );
+}
+```
+
+問題点:
+
+1. **URL パス drift が型で検出されない**。`server.py` の prefix (`/api/jobs`) を変えても TS は silent、ランタイム 404 で初めて気づく。
+2. **response 型が手書き契約**。C-1/C-2/C-3/C-4/C-5 で Pydantic `response_model` と generated `schema.d.ts` は整備済みだが、**consumer 側は `apiFetch<T>(url)` の型パラメータ `T` を手で指定**しており、generated 型と consumer 側 `Promise<T>` が乖離しても検出されない。
+3. **クエリ文字列の組み立てが ad-hoc**。`jobs.ts:fetchJobPlot` は `URLSearchParams`、`inference.ts:fetchInferencePlot` は `${encodeURIComponent(...)}` を手書き、`files.ts:fetchDirectory` は `?path=${encodeURIComponent(path)}` と3通り混在。
+4. **backend が増えた時の追跡コストが高い**。path 命名規則の統一や deprecation を type 駆動で強制できない。
+
+## 2. 採用する技術
+
+### `openapi-fetch` (Drew Powers / openapi-ts)
+
+既に採用済みの `openapi-typescript@^7.13.0` と同じエコシステム。`schema.d.ts` の `export interface paths` を型パラメータに渡すだけでフェッチ関数が得られる。
+
+```ts
+// After: jobs.ts
+import createClient from "openapi-fetch";
+import type { paths } from "./generated/schema";
+
+const client = createClient<paths>({ baseUrl: "/api" });
+
+export async function fetchJobImportance(jobId: string, kind = "default") {
+  const { data, error } = await client.GET("/jobs/{job_id}/importance", {
+    params: { path: { job_id: jobId }, query: { kind } },
+  });
+  if (error) throw new ApiError(500, error);
+  return data;  // type inferred as components["schemas"]["ImportanceResponse"]
+}
+```
+
+### なぜ `openapi-fetch` か
+
+| 候補 | 判定 | 理由 |
+|---|---|---|
+| **openapi-fetch** | ✅ 採用 | `openapi-typescript` と同一作者、path/params/response を同じ `schema.d.ts` から推論。4.7 KB (min+gzip)。`fetch` ベースなので MSW とシームレス |
+| openapi-typescript-fetch | ❌ | メンテ停止、`openapi-fetch` の前身 |
+| Zodios / oRPC / tRPC | ❌ | FastAPI 生成 OpenAPI と連携するには middleware 必要、依存増大 |
+| 手書きの builder 関数 | ❌ | C-6 の前提そのもの、型推論の恩恵が限定的 |
+| ky / axios | ❌ | path 型推論なし、URL 結合は手書きのまま |
+
+### Runtime cost
+
+- Bundle size: +4.7 KB gzipped (既存 `apiFetch` 40行を置換、差し引き +3 KB 程度)
+- Runtime: 薄い wrapper、既存 `apiFetch` と同等
+- SSR / worker: fetch API 互換のみ要求、現行 Vite + Vitest + MSW 環境と問題なし
+
+## 3. スコープと分割
+
+全 46 call site を 1 PR で置換すると diff が大きすぎるため、**5 段階** に分割する。
+
+### Phase 0 (this PR): plan doc のみ
+- `docs/c6-openapi-fetch-plan.md` (本文書)
+- HISTORY.md H-0080 entry (proposal スタイル)
+- 着手合意を取る
+
+### Phase 1: deps 追加 + client 併設 + files.ts 移行
+- `pnpm add openapi-fetch` (+4.7 KB)
+- `src/api/client.ts` に `apiClient` を**追加** (既存 `apiFetch` は残す)
+- `files.ts` の 2 call site を `apiClient` に切り替え
+- `apiClient` のユニットテスト、MSW handler の型が `paths` ベースで通ることを確認
+- **理由**: 最小スコープで migration pattern を確立、rollback 可能
+
+### Phase 2: inference.ts (10 call sites)
+- 全 10 関数を `apiClient` に移行
+- `fetchInferencePlot` / `fetchInferenceShapPlot` の plot_type path param の型推論を検証
+- `getInferenceDownloadUrl` は URL を返す純関数なので `apiClient` 不使用 (generated `paths` の型で URL 構築に限定する helper に切り替え)
+
+### Phase 3: workspace.ts (17 call sites)
+- FormData アップロード 3 箇所 (`uploadData` / `uploadConfig` / `uploadInferenceData`) が特殊、`bodySerializer` override で対応
+- `fetchConfig` / `updateConfig` の `AbortSignal` 伝播を維持
+
+### Phase 4: jobs.ts (16 call sites)
+- `fetchJobPlot` の可変クエリ (`metrics` / `kind`) が `query` パラメータに綺麗にマップされることを確認
+- 最大の call site 数、同時に consumer (`src/hooks/use*.ts`) へのインパクトを測る
+
+### Phase 5: cleanup
+- `apiFetch` / `ApiError` を `apiClient` ベースで再定義し、旧 `apiFetch` を削除
+- `client.ts` を 40行 → 80行程度にリライト (新 error handling + typed client 提供)
+- CHANGELOG / BLUEPRINT に generated-types-first policy を明記
+
+合計 **6 PR**（Phase 0 含む）。各 PR 独立にマージ可能、途中で中断しても既存コードは動作する。
+
+## 4. 契約とエラー処理の方針
+
+### 既存 ApiError の保持
+
+```ts
+// client.ts (Phase 1 併設)
+import createClient, { type Middleware } from "openapi-fetch";
+import type { paths } from "./generated/schema";
+
+const rawClient = createClient<paths>({ baseUrl: "/api" });
+
+const errorMiddleware: Middleware = {
+  async onResponse({ response }) {
+    if (!response.ok) {
+      const body = await response.clone().json().catch(() => null);
+      throw new ApiError(response.status, body);
+    }
+    return response;
+  },
+};
+
+rawClient.use(errorMiddleware);
+
+export const apiClient = rawClient;
+```
+
+`ApiError` は既存 51 箇所の consumer が catch しているので**互換保持**。`openapi-fetch` のデフォルト `{ data, error }` パターンは使わず、middleware で `throw` に寄せる。consumer 側は `await apiClient.GET(...)` の `data` が non-null になる (Promise reject path のみを使う)。
+
+### Response 型の推論
+
+```ts
+const { data } = await apiClient.GET("/jobs/{job_id}", {
+  params: { path: { job_id: jobId } },
+});
+// data: components["schemas"]["JobDetail"] | undefined
+// non-null assertion is safe after error middleware throws on !ok.
+```
+
+### Union 型のリクエスト (e.g. path variant)
+
+`openapi-fetch` は `operationId` 単位で overload するので、consumer 側で `// @ts-expect-error` は原則不要。1 つの endpoint が union response を返す場合 (e.g. `/inference/{inf_id}/plot/{plot_type}`) は backend 側で `response_model` を union にする必要あり (C-2 で整備済み)。
+
+## 5. テスト戦略
+
+### 既存テスト (3064 行) の保持
+
+- `api-contract.test.ts` (478行): 既存は `apiFetch` の契約テスト。Phase 5 で `apiClient` 版に書き換える。途中の Phase では **両方の client が同じ MSW handler に対して動く**ことで contract parity を担保。
+- `jobs.test.ts` / `inference.test.ts` / `workspace.test.ts` / `files.test.ts`: Phase ごとに assertion を更新、`expect(fetchJobs()).resolves.toEqual(...)` の shape は不変。
+
+### 新規追加
+
+- Phase 1 で `client.test.ts` に `apiClient` 専用テストを追加
+  - `ApiError` が status/body 正しく throw される
+  - `signal: AbortSignal` 伝播
+  - 成功パスで `data` が schema 型どおり
+
+### MSW handler の typing
+
+`handlers.ts` は現状 39 行と小さい。**既存 handler は `http.get("/api/...")` で OK**（MSW は path を string で受けるため）。ただし response shape の型付けを `components["schemas"]["JobDetail"]` に揃えると drift を防げる。これは Phase 5 の cleanup で一括対応。
+
+## 6. 破綻リスクと緩和
+
+| リスク | 緩和策 |
+|---|---|
+| generated `schema.d.ts` が out-of-date だと全 Phase でビルド失敗 | 既存 `api-types-drift` CI job (C-1) が PR ブロックするため、迷惑がかかる前に検出 |
+| middleware throw のパターンが openapi-fetch 内部実装と相性悪い | Phase 1 で unit test で担保、問題あれば `{ data, error }` の on-site 分岐に revert (差分小) |
+| File upload が特殊 (multipart) | `bodySerializer` override で `FormData` を pass-through、Phase 3 で検証 |
+| 既存 `apiFetch` 51 consumer を 6 PR で移行中に mixed state | 各 Phase で `apiFetch` も `apiClient` も並行して稼働、どちらも同じ `ApiError` を throw |
+| Phase 5 で削除する `apiFetch` に残り consumer が見つかる | `grep -rn 'apiFetch' src/` を CI の最終 gate に加える (Phase 5 PR で script 追加) |
+
+## 7. Acceptance criteria (全 Phase 完了時)
+
+- (a) `grep -rn 'apiFetch(' frontend/src/` が 0 件、`client.ts` にも `apiFetch` export が残っていない。
+- (b) `grep -rn '\`/[a-z]' frontend/src/api/*.ts` がゼロ (URL の直書きが消えた)。
+- (c) `generated/schema.d.ts` の `paths` interface キーと実際の fetch 呼び出し endpoint が 1:1 対応。
+- (d) `pnpm check` / `tsc --noEmit` / `pnpm build` / `pnpm vitest run` / `pnpm test:e2e` 全 clean。
+- (e) Bundle size の増加が gzip で +5 KB 以内。
+- (f) CI 既存 gate (`api-types-drift`, `raw-color-guard`, `e2e-chromium`) すべて green。
+
+## 8. 非目標 (Out of scope)
+
+- **WebSocket client の置換**: `src/api/websocket.ts` (101行) は OpenAPI には乗らないので openapi-fetch スコープ外。C-3 で Pydantic discriminated union 化済み。
+- **React Query との統合層の書き換え**: `src/api/queries/*.ts` と `src/hooks/*.ts` の fetcher を call する部分は同じ signature を維持。query hooks は変更不要。
+- **Backend OpenAPI の書き換え**: `response_model` は C-2 で整備済み、本計画では現状スキーマを消費するだけ。
+- **非 API fetch (static assets, websocket)**: 対象外。

--- a/docs/coupling-analysis.md
+++ b/docs/coupling-analysis.md
@@ -165,6 +165,7 @@
 ### 🟠 C-6. URL パスが完全手書き、prefix 変更追跡なし
 - **場所**: `frontend/src/api/{jobs,inference,workspace,files}.ts` 全てで `/jobs/${id}/...` を文字列結合。`server.py:184-200` の prefix を変えても TS は無検出。
 - **対策**: `openapi-fetch` など `paths` 型に基づく URL ビルダーを採用（response 型も自動同期）。
+- **計画**: [docs/c6-openapi-fetch-plan.md](./c6-openapi-fetch-plan.md) に Phase 分割 (6 PR)・採用技術比較・リスク緩和策を記載（H-0080, 2026-04-21 proposal）。
 
 ### 🟠 C-7. Job status 表記ゆれ `canceled` vs `cancelled`
 - **場所**: backend 7 ファイル、frontend 8 ファイルに散在。`metrics.py` は `canceled`、他は `cancelled`。


### PR DESCRIPTION
## Summary

Phase 0 of the **C-6** coupling refactor (URL paths are hand-written in `frontend/src/api/*.ts`). This PR is **docs-only** — it establishes approach agreement before code changes land.

- New `docs/c6-openapi-fetch-plan.md` documenting the 6-PR phased migration to `openapi-fetch` (same author as our existing `openapi-typescript@^7.13.0`).
- Cross-links `docs/coupling-analysis.md` C-6 entry to the plan doc.
- Records H-0080 in `HISTORY.md` as a Proposal (change-gate not required — no wire format / Protocol / storage changes).

## Why this is a Phase 0 / docs-only PR

C-6 touches **46 `apiFetch` call sites across 4 modules** with **51 downstream consumer imports**. A single-PR migration would produce a 1500+ line diff that is hard to bisect if something regresses. The plan splits the work into 6 independently-mergeable PRs with explicit Phase boundaries:

| Phase | Scope |
|---|---|
| **0 (this PR)** | Plan doc + H-0080 — no code |
| 1 | `pnpm add openapi-fetch` + `apiClient` co-existing with `apiFetch` + `files.ts` (2 call sites) as the proof-of-concept |
| 2 | `inference.ts` (10 call sites, plot path params) |
| 3 | `workspace.ts` (17 call sites, 3 FormData uploads, AbortSignal) |
| 4 | `jobs.ts` (16 call sites, `fetchJobPlot` multi-query) |
| 5 | Retire `apiFetch`, tighten MSW handler types, grep-based guard script |

During Phase 1-4 both clients coexist and throw the **same `ApiError`** so consumers don't need to change.

## Decisions recorded for review

- **openapi-fetch over alternatives** — justified against openapi-typescript-fetch (deprecated), Zodios/oRPC/tRPC (heavier integration cost), ky/axios (no path inference), hand-rolled builders (duplicates generated types). See plan §2.
- **Error-throwing middleware** — keeps the 51 existing `catch (e: ApiError)` consumers working. See plan §4.
- **MSW handler typing deferred to Phase 5** — existing 39-line handlers.ts already works, retyping in the middle of the migration would cause churn. See plan §5.
- **WebSocket client and React Query hooks are out of scope** — WS isn't in OpenAPI; hooks only see the fetcher's return Promise shape which stays identical.

## Test plan

- [x] No code changes → all existing CI jobs (`backend`, `frontend`, `e2e-chromium`, `raw-color-guard`, `api-types-drift`) pass unchanged.
- [ ] Reviewer confirms the 6-PR phase boundaries make sense for their review bandwidth.
- [ ] Reviewer confirms the error-throwing middleware pattern over openapi-fetch's default `{ data, error }` return.
- [ ] Reviewer approves deferring MSW handler typing to Phase 5.
- [ ] After merge: open Phase 1 PR (\`feat/c6-phase1-files-openapi-fetch\`).

## Change-gate

Not required. This PR changes only docs; the full C-6 rollout is an internal FE refactor with no `BackendAdapter` / wire format / storage / public-API impact. H-0080 acceptance (plan-level) is captured in HISTORY.md for traceability, per the project's Proposal-style convention (cf. H-0077 / H-0078 / H-0079).

## Related

- [docs/coupling-analysis.md §C-6](./docs/coupling-analysis.md)
- Previous C-series landings: H-0068 (C-1/C-2), H-0069 (C-3), H-0071 (C-4), H-0072 (C-5a), H-0074 / H-0076 (C-5b), H-0079 (B-9 Part 2 CI guard)