### PR TITLE
fix(hooks): release Job UI on cancel failure + stabilise cancel ref (#237/#238)

### DIFF
--- a/frontend/src/hooks/useJobLifecycle.test.ts
+++ b/frontend/src/hooks/useJobLifecycle.test.ts
@@ -68,4 +68,68 @@ describe("useJobLifecycle", () => {
     await new Promise((r) => setTimeout(r, 30));
     expect(fetchJob).not.toHaveBeenCalled();
   });
+
+  // --------------------------------------------------------------------
+  // Issue #237 — cancel failure must still release the UI
+  // --------------------------------------------------------------------
+  it("cancel rejection still clears progress + fires onTerminal (Issue #237)", async () => {
+    const onTerminal = vi.fn();
+    (cancelJob as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("500 Internal Server Error"),
+    );
+
+    const { result } = renderHook(
+      () => useJobLifecycle({ jobId: "j1", onTerminal }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.job?.status).toBe("running"));
+
+    await act(async () => {
+      await result.current.cancel();
+    });
+
+    // API was attempted.
+    expect(cancelJob).toHaveBeenCalledWith("j1");
+    // Even though the server errored, the UI must NOT stay in
+    // "Cancelling..." — the parent's running flag is released via
+    // onTerminal and the transient progress is cleared.
+    expect(onTerminal).toHaveBeenCalled();
+    expect(result.current.progress).toBeNull();
+  });
+
+  // --------------------------------------------------------------------
+  // Issue #238 — callback stability across renders
+  // --------------------------------------------------------------------
+  it("cancel reference stays stable across pure re-renders (Issue #238)", async () => {
+    const { result, rerender } = renderHook(
+      () => useJobLifecycle({ jobId: "j1" }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.job?.status).toBe("running"));
+
+    const cancelA = result.current.cancel;
+    rerender();
+    const cancelB = result.current.cancel;
+    rerender();
+    const cancelC = result.current.cancel;
+
+    // React.memo on downstream Button components relies on reference
+    // equality. A fresh ``cancel`` each render defeats memoisation.
+    expect(cancelA).toBe(cancelB);
+    expect(cancelB).toBe(cancelC);
+  });
+
+  it("clearProgress reference stays stable across pure re-renders", async () => {
+    const { result, rerender } = renderHook(
+      () => useJobLifecycle({ jobId: "j1" }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.job?.status).toBe("running"));
+
+    const clearA = result.current.clearProgress;
+    rerender();
+    const clearB = result.current.clearProgress;
+
+    expect(clearA).toBe(clearB);
+  });
 });

--- a/frontend/src/hooks/useJobLifecycle.ts
+++ b/frontend/src/hooks/useJobLifecycle.ts
@@ -11,7 +11,7 @@
  */
 
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { toast } from "sonner";
 import { cancelJob } from "@/api/jobs";
 import { queryKeys } from "@/api/queryKeys";
@@ -33,7 +33,7 @@ export function useJobLifecycle({
 }: UseJobLifecycleParams) {
   const queryClient = useQueryClient();
   const { data: job, refetch: refetchJob } = useJob(jobId);
-  const progress = useJobProgress({
+  const { progress, foldLog, clearProgress } = useJobProgress({
     jobId,
     job,
     onTerminal,
@@ -41,26 +41,45 @@ export function useJobLifecycle({
     onWsError,
   });
 
+  // Issue #238: ``useQueryClient`` returns the same underlying client
+  // across renders but the hook's return value itself is not reference-
+  // stable in every React Query version. Pin it behind a ref so the
+  // cancel callback's deps are all stable.
+  const queryClientRef = useRef(queryClient);
+  queryClientRef.current = queryClient;
+
+  // Issue #237: even when cancelJob rejects (5xx, network error), the
+  // UI must not stay in "Cancelling..." forever. Run the release path
+  // in finally so the parent's running flag flips and the transient
+  // progress state is cleared regardless of the outcome.
+  //
+  // Issue #238: deps list only stable references. ``queryClientRef``
+  // is a ref (stable by definition); ``clearProgress`` is memoised in
+  // useJobProgress; ``refetchJob`` is stable via useQuery.
   const cancel = useCallback(async () => {
     if (!jobId) return;
     try {
       await cancelJob(jobId);
       toast.info("Job cancelled");
-      progress.clearProgress();
-      refetchJob();
-      queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
-      onTerminal?.();
     } catch {
       toast.error("Failed to cancel job");
+    } finally {
+      clearProgress();
+      await refetchJob();
+      queryClientRef.current.invalidateQueries({
+        queryKey: queryKeys.job(jobId),
+      });
+      queryClientRef.current.invalidateQueries({ queryKey: queryKeys.jobs() });
+      onTerminal?.();
     }
-  }, [jobId, refetchJob, queryClient, onTerminal, progress]);
+  }, [jobId, refetchJob, onTerminal, clearProgress]);
 
   return {
     job,
     refetchJob,
-    progress: progress.progress,
-    foldLog: progress.foldLog,
-    clearProgress: progress.clearProgress,
+    progress,
+    foldLog,
+    clearProgress,
     cancel,
   };
 }

--- a/frontend/src/hooks/useJobProgress.ts
+++ b/frontend/src/hooks/useJobProgress.ts
@@ -146,12 +146,16 @@ export function useJobProgress({
     }
   }, [jobId, job?.status, fireTerminal, trackFoldLog]);
 
+  // Memoised so useJobLifecycle's cancel callback keeps a stable
+  // reference across renders — see Issue #238.
+  const clearProgress = useCallback(() => {
+    setProgress(null);
+    if (trackFoldLog) setFoldLog([]);
+  }, [trackFoldLog]);
+
   return {
     progress,
     foldLog,
-    clearProgress: () => {
-      setProgress(null);
-      if (trackFoldLog) setFoldLog([]);
-    },
+    clearProgress,
   };
 }


### PR DESCRIPTION
## Summary
- `cancel` catch no longer leaves the UI stuck: `clearProgress` + cache invalidation + `onTerminal` run in a `finally` block so the release path fires even when `cancelJob` rejects.
- `clearProgress` memoised with `useCallback` in `useJobProgress`.
- `useQueryClient` pinned behind a ref so `cancel`'s deps are stable and React.memo on downstream buttons stays effective.
- `queryKeys.job(jobId)` now invalidated alongside `queryKeys.jobs()` to avoid the brief stale-detail flash.

## Invariants
- INV (Issue #237): once the user triggers `cancel`, the parent's `running` flag is released within the same call, regardless of the API outcome.
- INV (Issue #238): `cancel` and `clearProgress` keep the same reference across re-renders when inputs are unchanged.

## Failure Paths Covered
- [x] Normal completion (existing test: cancel → onTerminal fired)
- [x] Cancel rejection (new test: cancel throws → UI still releases)
- [x] `jobId=null` (existing test: cancel is no-op)
- [x] Pure re-render stability (new tests: cancel ref + clearProgress ref)

## Reproduction
Before the fix — PoC using RTL (same pattern as the new test):
\`\`\`
cancelJob rejects → onTerminal not called (PASS on buggy code)
                    clearProgress not called
                    progress stays at last running snapshot
\`\`\`
After: `onTerminal` called, `progress === null`, both references stable across `rerender()`.

## Verification
- `pnpm vitest run src/hooks/useJobLifecycle.test.ts src/hooks/useJobProgress.test.ts` — **22/22 pass** (+3 new)
- Full frontend suite: **1627 pass + 2 skipped** (baseline 1624 + 3 new tests, no regressions)
- `pnpm check` (Biome), `pnpm build` — clean
- No backend changes

## Test plan
- [x] New: `cancel rejection still clears progress + fires onTerminal (Issue #237)`
- [x] New: `cancel reference stays stable across pure re-renders (Issue #238)`
- [x] New: `clearProgress reference stays stable across pure re-renders`
- [x] Existing 4 `useJobLifecycle` tests
- [x] Existing 15 `useJobProgress` tests (terminalFiredRef guard etc.)
- [x] ResultsPanel / JobDetail integration suites (still green in full run)

Closes #237
Closes #238