### PR TITLE
fix(server,ws): CORS env + WS origin cache (H-0083, #233/#234)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2192,4 +2192,45 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - 2026-04-22 **Proposed** — Proposal のみ PR #229 で merge、実装は後続 PR。着手前に reviewer 合意を得るためのゲート entry。
   - 2026-04-22 **Implemented** — `src/lizystudio/storage/` パッケージを新規作成（`__init__.py` / `versions.py` / `migrations.py`）、`STUDIO_FORMAT_VERSION = 1` + `write_versioned_json` / `read_versioned_json` helper + `MIGRATIONS` chain + `migrate_to_current`。`backends/exceptions.py` に `IncompatibleFormatVersionError` 追加。`services/jobs.py` の `_write_json` / `_read_json` helper を versioned I/O に委譲（`_save_meta` と `update(fit_result / tune_result)` が全て自動で version 埋込）。`services/inference.py` の `save` (meta.json 書込) と `_load_record` (meta.json 読込) を versioned helper に置換。`format_version` は JSON の**先頭 key** として埋込（grep / head 友好的）。**Scope 調整** (Proposal §5 からの乖離): `inferences/{inf_id}/metrics.json` のみ **versioned 化から除外**。理由は backend-dependent な flat `{mae: 0.3, rmse: 0.5, ...}` 構造で、先頭 key 埋込は将来 `format_version` という metric と衝突、envelope 化は frontend の `fetchInferenceMetrics: Promise<Record<string, unknown>>` 契約を破壊するため。代わりに writer 箇所に NOTE コメントで revisit 条件（metrics.json が backend で Pydantic `response_model` を持った時）を明記。これにより対象は 4 種類に縮減 (meta.json / fit_result.json / tune_result.json / inference/meta.json)。Acceptance Criteria 達成状況: (a) 4 種類の writer 全てで `format_version: 1` 埋込 ✅（metrics.json は scope 外として明示）、(b) `tests/regression/test_reg_0081_v0_workspace_backward_compat.py` で pre-C-9 workspace が `JobStore.get` / `InferenceStore.get` から load できることを確認 ✅、(c) `format_version: 99` 等 unknown を読ませると `IncompatibleFormatVersionError` が raise される (`tests/test_storage_versions.py::test_unknown_version_raises_incompatible_error`) ✅、(d) `_migrate_v0_to_v1` は pure function で direct 呼び出し test 済 ✅、(e) 1164 pytest pass / ruff / ruff format / mypy / biome / tsc / pnpm build / raw-color-guard / no-apifetch-guard 全 clean ✅、(f) `model_meta.json` の `pickle_schema` は触らず H-0068 checkpoint 検証ロジック回帰なし ✅。
 
-
+### H-0083: CORS / WS origin の env driven 化と WS allowlist 単発評価（Issue #233 / #234）
+- **Status:** proposed
+- **Scope:** Backend / Ops | **change-gate 対象** (新規 env 契約 `LIZYSTUDIO_CORS_ALLOWED_ORIGINS` 追加、deployment 前提が変わる)
+- **Related:** H-0069（WS discriminated union）、C-10（PR #199 — `LIZYSTUDIO_WS_ALLOWED_ORIGINS` 導入）、Issue #233（HTTP CORS がハードコード）、Issue #234（WS origin allowlist が handshake 毎に env を再パース）
+- **Context:** C-10 で WS origin allowlist は `LIZYSTUDIO_WS_ALLOWED_ORIGINS` env で上書き可能になったが、HTTP CORS 側は `server.py:182` で `allow_origins=["http://localhost:5173"]` のハードコード、`allow_methods=["*"]` / `allow_headers=["*"]` のワイルドカードのまま。デプロイターゲット（reverse proxy 配下、別 origin）では **source 編集なしに動かない**。PoC (`FastAPI TestClient` で `https://app.example.com` origin を送る) で `Access-Control-Allow-Origin` が付かないことを確認済み。
+  - 併せて Issue #234: `ws/progress.py:249` の `get_allowed_ws_origins()` が WS ハンドシェイク毎に `os.environ.get` + `split` + 空文字フィルタを再実行している。TOCTOU（起動後の環境変数変更が後続 handshake に反映される非契約挙動）と微小な perf オーバーヘッドを避けるため、プロセス起動時の 1 度評価に固定する。テスト時は `cache_clear()` で再評価可能にする。
+- **Invariants:**
+  - INV-1: `LIZYSTUDIO_CORS_ALLOWED_ORIGINS` に列挙された origin からの CORS preflight は `Access-Control-Allow-Origin` を返し、列挙されていない origin からのそれには付けない。
+  - INV-2: `LIZYSTUDIO_CORS_ALLOWED_ORIGINS` が未設定 / 空のとき、開発用 fallback `http://localhost:5173` のみを許可する（挙動後方互換）。
+  - INV-3: `get_allowed_ws_origins()` はプロセス起動後に `os.environ` を再評価しない（明示的 `cache_clear()` 以外では）。
+- **Proposal:**
+  1. **CORS env 追加**: `LIZYSTUDIO_CORS_ALLOWED_ORIGINS` をカンマ区切りで受ける。空白 trim、空エントリは filter out。未設定・空なら fallback に `["http://localhost:5173"]`。
+  2. **methods / headers 明示化**: `allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]`、`allow_headers=["Content-Type", "Authorization"]`。`allow_credentials=True` は保持。
+  3. **WS origin cache**: `get_allowed_ws_origins()` を `@functools.lru_cache(maxsize=None)` でラップ。関数内 `import os` は module top-level に移動して LOW-2 も解消。テスト用の fixture で `get_allowed_ws_origins.cache_clear()` を呼んで再評価可能にする（既存 WS handshake テストが env 切替を期待しているならその数箇所）。
+  4. **docs/deployment note**: README に 1 行追記（"Set LIZYSTUDIO_CORS_ALLOWED_ORIGINS when deploying behind a non-localhost origin"）。README の既存構造に最小追記。
+- **Impact:**
+  - 修正: `src/lizystudio/server.py` の CORS block（~8 行）、`src/lizystudio/ws/progress.py` の関数 2〜3 行 + import 整理。
+  - 追加テスト:
+    - `tests/test_server_cors.py`（新規 or 既存 server テストへ追記）— env 設定で preflight が通る / 未設定で fallback / 未登録 origin で `Access-Control-Allow-Origin` が付かない、3 case。
+    - `tests/test_ws_origin_allowlist.py`（新規 or 既存 WS テストへ追記）— `cache_clear` なしでは env 変更が反映されない / `cache_clear` 後は反映される、2 case。
+  - wire format / API 契約: 不変。
+  - 既存 1164+3 tests への影響: なし（他の挙動は保持）。
+- **Compatibility:**
+  - 未設定時 fallback が `["http://localhost:5173"]` で従来と同一 → 既存 dev workflow に影響なし。
+  - `allow_methods` / `allow_headers` の明示化は production で未使用のメソッド・ヘッダを拒否する方向の変更。現状 LizyStudio が使うメソッドは全て含めているので既存 caller には影響ゼロ。将来エンドポイント追加時に OPTIONS preflight で reject される場合は list を更新する契約。
+  - WS cache: 起動後の env 変更が反映されなくなる = 既に C-10 の契約通り "起動時設定" 扱いに格上げ。テストが env 変更に依存していた場合は `cache_clear()` で明示的に更新する。
+- **Alternatives considered:**
+  - (a) **`LIZYSTUDIO_CORS_ALLOWED_ORIGINS` を採用** (採用): WS の env 名と対称、1 つの env で設定が揃う。
+  - (b) **WS と CORS を同じ env で共有**: 却下。WS の origin と HTTP CORS の origin は同じとは限らない（WS subprotocol 上で別 port を使うケース等）。個別 env で独立制御できた方が運用柔軟。
+  - (c) **設定ファイル (`config.toml`) 経由**: 却下。LizyStudio は現状 env only で全てを制御している、新規ファイル増やす価値が小。
+  - (d) **wildcard 対応 (例: `https://*.example.com`)**: 将来課題。現時点は厳密一致で十分、必要になった時点で別 Proposal。
+  - (e) **WS cache を `cache_clear()` なしで不変にする**: 却下。テスト で env 切り替えができないと WS origin 挙動を自動検証できない。
+- **Acceptance Criteria:**
+  - (a) `LIZYSTUDIO_CORS_ALLOWED_ORIGINS=https://app.example.com` で preflight 応答に `Access-Control-Allow-Origin: https://app.example.com` が付く（新テスト）。
+  - (b) 未設定時は `http://localhost:5173` のみ allow（新テスト）。
+  - (c) 登録外 origin では `Access-Control-Allow-Origin` が付かない（新テスト）。
+  - (d) `get_allowed_ws_origins()` は 2 回呼ばれても `os.environ` アクセスは 1 度のみ（`monkeypatch.setattr(os, "environ", ...)` + call-count spy、新テスト）。
+  - (e) `cache_clear()` 後に env 変更が反映される（新テスト）。
+  - (f) README に env 名 1 行追記。
+  - (g) 既存 pytest + static gates + CI guards 全 green。
+- **Decision:**
+  - 2026-04-22 **Proposed & Implemented** — 本 PR で Proposal + 実装 + テストを同時 merge。change-gate 最小構成。

--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ lizystudio --port 9000  # custom port
 
 Open your browser and navigate to the URL shown in the terminal.
 
+### Deploying behind a non-localhost origin
+
+Set the comma-separated allowlist env vars so the server accepts your
+production URLs:
+
+```bash
+export LIZYSTUDIO_CORS_ALLOWED_ORIGINS="https://studio.example.com"
+export LIZYSTUDIO_WS_ALLOWED_ORIGINS="https://studio.example.com"
+```
+
+Both default to `http://localhost:5173` / the dev localhost set when the
+variables are unset.
+
 ### Typical workflow
 
 1. **Load data** — upload a CSV/Parquet or select a local file

--- a/src/lizystudio/server.py
+++ b/src/lizystudio/server.py
@@ -63,6 +63,24 @@ _CSP_DEV = (
 )
 
 
+_DEFAULT_CORS_ORIGINS = ("http://localhost:5173",)
+"""Development fallback when LIZYSTUDIO_CORS_ALLOWED_ORIGINS is unset."""
+
+
+def _parse_cors_allowed_origins(raw: str | None) -> list[str]:
+    """Parse the comma-separated env var for CORS allowlist (H-0083).
+
+    Returns the dev fallback when the variable is unset or empty. Blank
+    entries are filtered out: a stray empty string in ``allow_origins``
+    would accept unauthenticated cross-origin requests (mirrors the
+    C-10 WS origin guard).
+    """
+    if not raw:
+        return list(_DEFAULT_CORS_ORIGINS)
+    parsed = [entry.strip() for entry in raw.split(",") if entry.strip()]
+    return parsed or list(_DEFAULT_CORS_ORIGINS)
+
+
 def _warmup_adapter(adapter: object) -> None:
     """Pre-import ML backend modules to avoid import-lock deadlocks.
 
@@ -176,13 +194,20 @@ def create_app() -> FastAPI:
         ).observe(elapsed)
         return response
 
-    # CORS — allow frontend dev server during development
+    # CORS — allow the Vite dev server during development, or whatever
+    # origins the deployment specifies via LIZYSTUDIO_CORS_ALLOWED_ORIGINS
+    # (comma-separated). H-0083 mirrors the WS LIZYSTUDIO_WS_ALLOWED_ORIGINS
+    # pattern so production deployments behind a reverse proxy do not
+    # require a source edit.
+    cors_origins = _parse_cors_allowed_origins(
+        os.environ.get("LIZYSTUDIO_CORS_ALLOWED_ORIGINS")
+    )
     application.add_middleware(
         CORSMiddleware,
-        allow_origins=["http://localhost:5173"],
+        allow_origins=cors_origins,
         allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
+        allow_headers=["Content-Type", "Authorization"],
     )
 
     # Exception handlers

--- a/src/lizystudio/ws/progress.py
+++ b/src/lizystudio/ws/progress.py
@@ -16,14 +16,18 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import json
 import logging
+import os
 import threading
 from typing import TYPE_CHECKING, Any
 
 from fastapi import WebSocket, WebSocketDisconnect
 
 from lizystudio.ws.messages import WsCompleted, WsError, WsPing, WsProgress
+
+# ``functools.lru_cache`` wraps ``get_allowed_ws_origins`` below (H-0083).
 
 if TYPE_CHECKING:
     from lizystudio.metrics import MetricsRegistry
@@ -246,21 +250,24 @@ _DEFAULT_WS_ORIGINS: frozenset[str] = frozenset(
 )
 
 
-def get_allowed_ws_origins() -> set[str]:
+@functools.cache
+def get_allowed_ws_origins() -> frozenset[str]:
     """Return the allowlist of origins accepted on the progress WebSocket.
 
-    Reads ``LIZYSTUDIO_WS_ALLOWED_ORIGINS`` (comma-separated) at call
-    time so remote deployments don't need to patch the source. Blank
+    H-0083: evaluated **once** per process (cached) so WS handshakes do
+    not re-parse ``os.environ`` on every connection. Call
+    :meth:`get_allowed_ws_origins.cache_clear` in tests that need to
+    observe an updated ``LIZYSTUDIO_WS_ALLOWED_ORIGINS`` value.
+
+    Reads ``LIZYSTUDIO_WS_ALLOWED_ORIGINS`` (comma-separated). Blank
     entries are filtered — the Origin check treats an empty string as
     "no Origin header", so a stray "" in the allowlist would accept
     unauthenticated cross-origin WebSockets (C-10 fix).
     """
-    import os
-
     raw = os.environ.get("LIZYSTUDIO_WS_ALLOWED_ORIGINS")
     if not raw:
-        return set(_DEFAULT_WS_ORIGINS)
-    return {entry.strip() for entry in raw.split(",") if entry.strip()}
+        return _DEFAULT_WS_ORIGINS
+    return frozenset(entry.strip() for entry in raw.split(",") if entry.strip())
 
 
 async def websocket_progress(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,21 @@ def _disable_subprocess_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def _reset_ws_origin_cache() -> Iterator[None]:
+    """Clear the WS origin allowlist cache before and after each test
+    (H-0083). ``get_allowed_ws_origins`` is ``lru_cache``'d to avoid
+    re-parsing ``os.environ`` on every WS handshake in production, but
+    that process-wide memoisation otherwise leaks state between tests
+    that monkeypatch ``LIZYSTUDIO_WS_ALLOWED_ORIGINS``.
+    """
+    from lizystudio.ws.progress import get_allowed_ws_origins
+
+    get_allowed_ws_origins.cache_clear()
+    yield
+    get_allowed_ws_origins.cache_clear()
+
+
 @pytest.fixture()
 def tmp_jobs_dir(tmp_path: Path) -> Path:
     """Return a temporary directory for job storage."""

--- a/tests/test_c_mopup.py
+++ b/tests/test_c_mopup.py
@@ -83,10 +83,11 @@ def test_c10_ws_allowed_origins_env_var_overrides_defaults(
         "LIZYSTUDIO_WS_ALLOWED_ORIGINS",
         "https://studio.example.com,https://staging.example.com",
     )
-    # Force a fresh read — the helper accepts an env lookup at call time
-    # so we don't depend on import order.
+    # H-0083: get_allowed_ws_origins() is lru_cache'd per process, so
+    # tests that change the env must reset the cache before the call.
     from lizystudio.ws.progress import get_allowed_ws_origins
 
+    get_allowed_ws_origins.cache_clear()
     origins = get_allowed_ws_origins()
     assert "https://studio.example.com" in origins
     assert "https://staging.example.com" in origins
@@ -101,6 +102,7 @@ def test_c10_ws_allowed_origins_default_when_env_unset(
     monkeypatch.delenv("LIZYSTUDIO_WS_ALLOWED_ORIGINS", raising=False)
     from lizystudio.ws.progress import get_allowed_ws_origins
 
+    get_allowed_ws_origins.cache_clear()
     origins = get_allowed_ws_origins()
     assert "http://localhost:5173" in origins
     assert "http://127.0.0.1:5173" in origins
@@ -119,10 +121,53 @@ def test_c10_ws_allowed_origins_ignores_blank_entries(
     )
     from lizystudio.ws.progress import get_allowed_ws_origins
 
+    get_allowed_ws_origins.cache_clear()
     origins = get_allowed_ws_origins()
     assert "" not in origins
     assert "https://a.example.com" in origins
     assert "https://b.example.com" in origins
+
+
+# ---------------------------------------------------------------------------
+# H-0083 — WS origin allowlist cache behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_h0083_ws_allowed_origins_is_cached_across_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Second call returns the value captured at the first call even if
+    the env var was changed afterwards (Issue #234)."""
+    from lizystudio.ws.progress import get_allowed_ws_origins
+
+    monkeypatch.setenv("LIZYSTUDIO_WS_ALLOWED_ORIGINS", "https://first.example.com")
+    get_allowed_ws_origins.cache_clear()
+    first = get_allowed_ws_origins()
+    assert "https://first.example.com" in first
+
+    # Env change without cache_clear is NOT observed.
+    monkeypatch.setenv("LIZYSTUDIO_WS_ALLOWED_ORIGINS", "https://second.example.com")
+    cached = get_allowed_ws_origins()
+    assert cached is first
+    assert "https://second.example.com" not in cached
+
+
+def test_h0083_ws_allowed_origins_cache_clear_reevaluates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After ``cache_clear`` the helper reads the env again (Issue #234)."""
+    from lizystudio.ws.progress import get_allowed_ws_origins
+
+    monkeypatch.setenv("LIZYSTUDIO_WS_ALLOWED_ORIGINS", "https://first.example.com")
+    get_allowed_ws_origins.cache_clear()
+    first = get_allowed_ws_origins()
+    assert "https://first.example.com" in first
+
+    monkeypatch.setenv("LIZYSTUDIO_WS_ALLOWED_ORIGINS", "https://second.example.com")
+    get_allowed_ws_origins.cache_clear()
+    refreshed = get_allowed_ws_origins()
+    assert "https://second.example.com" in refreshed
+    assert "https://first.example.com" not in refreshed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -188,3 +188,90 @@ def test_create_app_custom_jobs_dir_env(
     with TestClient(app) as tc:
         res = tc.get("/api/jobs/")
         assert res.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# H-0083 — CORS allow_origins is driven by LIZYSTUDIO_CORS_ALLOWED_ORIGINS
+# ---------------------------------------------------------------------------
+
+
+def _cors_preflight(tc: TestClient, origin: str) -> str | None:
+    """Run a CORS preflight and return the allow-origin response header."""
+    res = tc.options(
+        "/api/backends",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "content-type",
+        },
+    )
+    return res.headers.get("access-control-allow-origin")
+
+
+def test_h0083_cors_env_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A production-like origin is honoured when listed in the env var."""
+    monkeypatch.setenv("LIZYSTUDIO_JOBS_DIR", str(tmp_path / "jobs"))
+    monkeypatch.setenv(
+        "LIZYSTUDIO_CORS_ALLOWED_ORIGINS",
+        "https://app.example.com,https://staging.example.com",
+    )
+    from lizystudio.server import create_app
+
+    app = create_app()
+    with TestClient(app) as tc:
+        allowed = _cors_preflight(tc, "https://app.example.com")
+        assert allowed == "https://app.example.com"
+        # An unlisted origin must not receive an allow-origin header.
+        assert _cors_preflight(tc, "https://evil.example.com") is None
+
+
+def test_h0083_cors_fallback_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Without the env var only localhost:5173 is allowed."""
+    monkeypatch.setenv("LIZYSTUDIO_JOBS_DIR", str(tmp_path / "jobs"))
+    monkeypatch.delenv("LIZYSTUDIO_CORS_ALLOWED_ORIGINS", raising=False)
+    from lizystudio.server import create_app
+
+    app = create_app()
+    with TestClient(app) as tc:
+        assert _cors_preflight(tc, "http://localhost:5173") == "http://localhost:5173"
+        assert _cors_preflight(tc, "https://app.example.com") is None
+
+
+def test_h0083_cors_blank_entries_are_filtered(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Blank / whitespace entries in the env list must be dropped so a
+    stray '' never widens the allowlist to every origin.
+    """
+    monkeypatch.setenv("LIZYSTUDIO_JOBS_DIR", str(tmp_path / "jobs"))
+    monkeypatch.setenv(
+        "LIZYSTUDIO_CORS_ALLOWED_ORIGINS",
+        "https://a.example.com, ,https://b.example.com",
+    )
+    from lizystudio.server import create_app
+
+    app = create_app()
+    with TestClient(app) as tc:
+        assert _cors_preflight(tc, "https://a.example.com") == "https://a.example.com"
+        assert _cors_preflight(tc, "https://b.example.com") == "https://b.example.com"
+        # An empty origin string must not match.
+        assert _cors_preflight(tc, "") is None
+
+
+def test_h0083_cors_parse_allowed_origins_helper() -> None:
+    """Parser unit test — isolates the env-splitting logic from FastAPI."""
+    from lizystudio.server import _parse_cors_allowed_origins
+
+    assert _parse_cors_allowed_origins(None) == ["http://localhost:5173"]
+    assert _parse_cors_allowed_origins("") == ["http://localhost:5173"]
+    assert _parse_cors_allowed_origins("   ") == ["http://localhost:5173"]
+    assert _parse_cors_allowed_origins("a,b") == ["a", "b"]
+    assert _parse_cors_allowed_origins("a, ,b") == ["a", "b"]
+    assert _parse_cors_allowed_origins(" https://x.example , https://y.example ") == [
+        "https://x.example",
+        "https://y.example",
+    ]


### PR DESCRIPTION
## Summary
- HISTORY H-0083 Proposal documenting the new `LIZYSTUDIO_CORS_ALLOWED_ORIGINS` env contract and the WS-cache invariant.
- `server.py` reads CORS allowlist from env (comma-separated), falls back to `http://localhost:5173`. `allow_methods` / `allow_headers` tightened from `["*"]` to the actual verbs + headers we use.
- `ws/progress.py::get_allowed_ws_origins` is now wrapped with `functools.lru_cache(maxsize=None)`; top-level `import os`.
- `conftest.py` autouse fixture resets the WS cache around every test.
- README gets a two-env section under Quick start.

## Invariants
- INV-1 (CORS): origins listed in `LIZYSTUDIO_CORS_ALLOWED_ORIGINS` are allowed; others do not receive an `Access-Control-Allow-Origin` header.
- INV-2 (CORS fallback): when the env is unset/blank, only the dev localhost origin is allowed (backwards-compatible).
- INV-3 (WS cache): `get_allowed_ws_origins` reads `os.environ` at most once per process lifetime (until `cache_clear()`).

## Failure Paths Covered
- [x] Normal completion (preflight from allowed origin → echoed)
- [x] Unlisted origin (no `Access-Control-Allow-Origin` header)
- [x] Blank/whitespace entries in env (filtered out — no silent wildcard)
- [x] Empty string (`""`) origin rejected
- [x] Env change without cache_clear → old value (documented behaviour)
- [x] Env change with cache_clear → new value

## Reproduction
Before the fix:
\`\`\`
LIZYSTUDIO_CORS_ALLOWED_ORIGINS=https://app.example.com (set)
Prod-like origin https://app.example.com → allow-origin: None   ← broken
Dev origin       http://localhost:5173    → allow-origin: http://localhost:5173
\`\`\`
After: the production origin is echoed and unlisted origins stay blocked.

## Verification
- Backend: **1170 pytest pass** (+6 new); pre-existing unrelated `subprocess_runner` runtime warning only.
- `uv run ruff check`, `ruff format --check`, `mypy src/lizystudio` — all clean.
- Frontend: `pnpm build` + `pnpm check` clean (no frontend code change in this PR).

## Test plan
- [x] `test_server.py::test_h0083_cors_env_override`
- [x] `test_server.py::test_h0083_cors_fallback_when_env_unset`
- [x] `test_server.py::test_h0083_cors_blank_entries_are_filtered`
- [x] `test_server.py::test_h0083_cors_parse_allowed_origins_helper`
- [x] `test_c_mopup.py::test_h0083_ws_allowed_origins_is_cached_across_calls`
- [x] `test_c_mopup.py::test_h0083_ws_allowed_origins_cache_clear_reevaluates`
- [x] Existing C-10 WS origin tests still green (updated with `cache_clear`)
- [x] `tests/test_ws_messages.py::test_websocket_handler_accepts_connection` still green (conftest autouse fixture keeps cache fresh)

## Acceptance Criteria (H-0083)
- [x] (a) Listed origin → `Access-Control-Allow-Origin` echoed
- [x] (b) Env unset → localhost:5173 only
- [x] (c) Unlisted origin → no header
- [x] (d) WS cache: `os.environ` accessed once per process
- [x] (e) `cache_clear()` re-evaluates env
- [x] (f) README updated
- [x] (g) Full backend suite + static gates + CI guards green

Closes #233
Closes #234