### PR TITLE
fix(services): InferenceStore resilience + _training_core abnormal-exit tests (#241/#240)

### DIFF
--- a/src/lizystudio/services/inference.py
+++ b/src/lizystudio/services/inference.py
@@ -31,6 +31,8 @@ from lizystudio.storage.versions import (
     write_versioned_json,
 )
 
+_logger = logging.getLogger(__name__)
+
 
 @dataclass
 class InferenceRecord:
@@ -99,20 +101,41 @@ class InferenceStore:
         return self._load_record(meta_path)
 
     def list(self, job_id: str) -> list[InferenceRecord]:
-        """List all inferences for a job, newest first."""
+        """List all inferences for a job, newest first.
+
+        Corrupt / in-flight records (e.g. an empty ``meta.json`` from a
+        crash mid-write, or a concurrent delete) are skipped with a
+        warning so one bad record does not take the whole endpoint to
+        500. Matches the ``JobStore.list`` resilience pattern (Issue
+        #241).
+        """
         inf_base = self.jobs_dir / job_id / "inferences"
         if not inf_base.exists():
             return []
         records: list[InferenceRecord] = []
         for d in inf_base.iterdir():
             mp = d / "meta.json"
-            if d.is_dir() and mp.exists():
+            if not (d.is_dir() and mp.exists()):
+                continue
+            try:
                 records.append(self._load_record(mp))
+            except (FileNotFoundError, OSError, json.JSONDecodeError, KeyError):
+                _logger.warning(
+                    "Skipping unreadable inference directory %s",
+                    d.name,
+                    exc_info=True,
+                )
+                continue
         records.sort(key=lambda r: r.created_at, reverse=True)
         return records
 
     def list_all(self) -> builtins.list[InferenceRecord]:
-        """List all inferences across all jobs, newest first (H-0010)."""
+        """List all inferences across all jobs, newest first (H-0010).
+
+        See :meth:`list` — corrupt records are skipped with a warning
+        rather than raising, to keep the history endpoint available
+        when one record is in flight.
+        """
         records: builtins.list[InferenceRecord] = []
         if not self.jobs_dir.exists():
             return records
@@ -124,8 +147,17 @@ class InferenceStore:
                 continue
             for d in inf_base.iterdir():
                 mp = d / "meta.json"
-                if d.is_dir() and mp.exists():
+                if not (d.is_dir() and mp.exists()):
+                    continue
+                try:
                     records.append(self._load_record(mp))
+                except (FileNotFoundError, OSError, json.JSONDecodeError, KeyError):
+                    _logger.warning(
+                        "Skipping unreadable inference directory %s",
+                        d.name,
+                        exc_info=True,
+                    )
+                    continue
         records.sort(key=lambda r: r.created_at, reverse=True)
         return records
 
@@ -284,7 +316,18 @@ def _compute_inference_metrics(
 def _compute_inf_metrics(
     pred_df: pd.DataFrame, model_info: dict[str, Any]
 ) -> dict[str, Any]:
-    """Compute basic inference metrics from predictions vs actuals."""
+    """Compute basic inference metrics from predictions vs actuals.
+
+    Raises a clear ``ValueError`` when the backend's prediction frame
+    lacks the expected ``pred`` column — otherwise the bare
+    ``pred_df["pred"]`` below would surface as a pandas ``KeyError``
+    leaked through the REST surface (Issue #241 M-3).
+    """
+    if "pred" not in pred_df.columns:
+        raise ValueError(
+            "prediction frame is missing the 'pred' column; "
+            f"got columns={list(pred_df.columns)}"
+        )
     actual = pred_df["actual"]
     pred = pred_df["pred"]
     task = model_info.get("task", "regression")

--- a/tests/test_inference_service.py
+++ b/tests/test_inference_service.py
@@ -725,3 +725,141 @@ def test_save_with_traversal_inf_id_raises(
     )
     with pytest.raises(ValueError, match="outside allowed root"):
         store.save(record, sample_predictions)
+
+
+# ---------------------------------------------------------------------------
+# Issue #241 — list / list_all tolerate a single corrupt meta.json
+# ---------------------------------------------------------------------------
+
+
+def _write_bad_meta(inf_dir: Path) -> None:
+    """Drop a bogus meta.json that will trip read_versioned_json."""
+    inf_dir.mkdir(parents=True, exist_ok=True)
+    (inf_dir / "meta.json").write_text("", encoding="utf-8")
+
+
+def test_list_skips_corrupt_meta_json(
+    inf_store: InferenceStore,
+    sample_predictions: pd.DataFrame,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """One corrupt record must not take the whole inference list down.
+
+    JobStore.list has skipped corrupt meta.json with a warning for a
+    long time; InferenceStore.list propagated the JSONDecodeError to
+    the REST handler → 500 on the history endpoint. This asserts the
+    two stores behave symmetrically (Issue #241).
+    """
+    healthy = InferenceRecord(
+        inf_id="inf_ok",
+        job_id="job_mixed",
+        data_ref=DataRef(
+            source_type="path",
+            path="/d.csv",
+            filename="d.csv",
+            fingerprint="fp",
+            shape=(5, 2),
+        ),
+        has_ground_truth=False,
+        created_at="2026-04-22T00:00:00Z",
+        row_count=5,
+        warnings=[],
+    )
+    inf_store.save(healthy, sample_predictions)
+
+    # Create a sibling directory with an empty meta.json (simulates a
+    # crash between truncate and write, or a concurrent delete).
+    bad_dir = inf_store.jobs_dir / "job_mixed" / "inferences" / "inf_bad"
+    _write_bad_meta(bad_dir)
+
+    with caplog.at_level("WARNING"):
+        records = inf_store.list("job_mixed")
+
+    assert [r.inf_id for r in records] == ["inf_ok"]
+    assert any("inf_bad" in rec.message for rec in caplog.records), (
+        "a warning must name the corrupt inference directory"
+    )
+
+
+def test_list_all_skips_corrupt_meta_json(
+    inf_store: InferenceStore,
+    sample_predictions: pd.DataFrame,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Cross-job variant of the above (list_all)."""
+    healthy = InferenceRecord(
+        inf_id="inf_ok",
+        job_id="job_a",
+        data_ref=DataRef(
+            source_type="path",
+            path="/d.csv",
+            filename="d.csv",
+            fingerprint="fp",
+            shape=(5, 2),
+        ),
+        has_ground_truth=False,
+        created_at="2026-04-22T00:00:00Z",
+        row_count=5,
+        warnings=[],
+    )
+    inf_store.save(healthy, sample_predictions)
+
+    bad_dir = inf_store.jobs_dir / "job_b" / "inferences" / "inf_bad"
+    _write_bad_meta(bad_dir)
+
+    with caplog.at_level("WARNING"):
+        records = inf_store.list_all()
+
+    assert [r.inf_id for r in records] == ["inf_ok"]
+    assert any("inf_bad" in rec.message for rec in caplog.records)
+
+
+def test_list_propagates_unexpected_errors(
+    inf_store: InferenceStore,
+    sample_predictions: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only expected I/O / JSON / key errors are swallowed; anything
+    else (e.g. programming errors in the record dataclass) must bubble
+    up so it can be debugged."""
+    healthy = InferenceRecord(
+        inf_id="inf_ok",
+        job_id="job_z",
+        data_ref=DataRef(
+            source_type="path",
+            path="/d.csv",
+            filename="d.csv",
+            fingerprint="fp",
+            shape=(5, 2),
+        ),
+        has_ground_truth=False,
+        created_at="2026-04-22T00:00:00Z",
+        row_count=5,
+        warnings=[],
+    )
+    inf_store.save(healthy, sample_predictions)
+
+    def _boom(_: Path) -> InferenceRecord:
+        raise RuntimeError("unexpected programming bug")
+
+    monkeypatch.setattr(inf_store, "_load_record", _boom)
+    with pytest.raises(RuntimeError, match="unexpected programming bug"):
+        inf_store.list("job_z")
+
+
+# ---------------------------------------------------------------------------
+# Issue #241 (M-3) — _compute_inf_metrics guards against missing 'pred' column
+# ---------------------------------------------------------------------------
+
+
+def test_compute_inf_metrics_raises_when_pred_column_missing() -> None:
+    """Backends that return a non-standard prediction column name must
+    surface a clear ValueError, not a late-bound KeyError that leaks
+    pandas internals through the REST surface."""
+    from lizystudio.services.inference import _compute_inf_metrics
+
+    pred_df = pd.DataFrame(
+        {"prediction": [0.1, 0.2], "actual": [0, 1]}  # 'pred' missing
+    )
+    with pytest.raises(ValueError, match="pred"):
+        _compute_inf_metrics(pred_df, {"task": "regression"})

--- a/tests/test_training_core_and_ws_encap.py
+++ b/tests/test_training_core_and_ws_encap.py
@@ -286,3 +286,299 @@ def test_register_and_previous_are_thread_safe() -> None:
     assert len(allowed) > 2, (
         f"test did not produce enough contention (allowed={len(allowed)})"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #240 — defensive branches in _training_core
+# ---------------------------------------------------------------------------
+
+
+class _StubJob:
+    """Minimal Job-shaped object for duration unit tests."""
+
+    def __init__(self, created_at: str | None, completed_at: str | None) -> None:
+        self.created_at = created_at
+        self.completed_at = completed_at
+
+
+def test_subprocess_duration_returns_zero_when_completed_at_missing() -> None:
+    """INV: duration helper never raises into the finally-block — return
+    0.0 when the subprocess child never stamped ``completed_at``."""
+    from lizystudio.services._training_core import _subprocess_duration_seconds
+
+    job = _StubJob(created_at="2026-04-22T00:00:00+00:00", completed_at=None)
+    assert _subprocess_duration_seconds(job) == 0.0
+
+
+def test_subprocess_duration_returns_zero_on_malformed_iso() -> None:
+    """INV: malformed timestamps must not raise — subprocess stamps can
+    be truncated by a crash mid-write."""
+    from lizystudio.services._training_core import _subprocess_duration_seconds
+
+    job = _StubJob(
+        created_at="2026-04-22T00:00:00+00:00", completed_at="not-an-iso-timestamp"
+    )
+    assert _subprocess_duration_seconds(job) == 0.0
+
+    job2 = _StubJob(created_at="garbage", completed_at="2026-04-22T00:01:00+00:00")
+    assert _subprocess_duration_seconds(job2) == 0.0
+
+
+def test_subprocess_duration_returns_elapsed_seconds() -> None:
+    """Sanity check — the happy path still works."""
+    from lizystudio.services._training_core import _subprocess_duration_seconds
+
+    job = _StubJob(
+        created_at="2026-04-22T00:00:00+00:00",
+        completed_at="2026-04-22T00:01:30+00:00",
+    )
+    assert _subprocess_duration_seconds(job) == 90.0
+
+
+def test_subprocess_duration_clamps_to_zero_on_reverse_order() -> None:
+    """Defensive: completed < created must not yield a negative value
+    (e.g. clock skew between fork and child process on Windows)."""
+    from lizystudio.services._training_core import _subprocess_duration_seconds
+
+    job = _StubJob(
+        created_at="2026-04-22T00:05:00+00:00",
+        completed_at="2026-04-22T00:00:00+00:00",
+    )
+    assert _subprocess_duration_seconds(job) == 0.0
+
+
+def test_run_pickle_preflight_translates_backend_exception() -> None:
+    """INV: CheckpointPreflightError is translated into
+    PicklePreflightFailedError so the service layer never leaks
+    backend-specific exception types through the HTTP boundary
+    (H-0068 contract)."""
+    from lizystudio.api.errors import PicklePreflightFailedError
+    from lizystudio.backends.exceptions import CheckpointPreflightError
+    from lizystudio.services._training_core import _run_pickle_preflight
+
+    class _StubBackend:
+        def preflight_checkpoint_dir(self, _job_dir: Path) -> None:
+            raise CheckpointPreflightError("schema mismatch")
+
+    with pytest.raises(PicklePreflightFailedError, match="schema mismatch"):
+        _run_pickle_preflight(_StubBackend(), Path("/tmp/unused"))
+
+
+def test_run_pickle_preflight_is_noop_when_backend_accepts() -> None:
+    """The happy path simply returns — no exception, no side effect."""
+    from lizystudio.services._training_core import _run_pickle_preflight
+
+    calls: list[Path] = []
+
+    class _StubBackend:
+        def preflight_checkpoint_dir(self, job_dir: Path) -> None:
+            calls.append(job_dir)
+
+    _run_pickle_preflight(_StubBackend(), Path("/tmp/jobdir"))
+    assert calls == [Path("/tmp/jobdir")]
+
+
+# --- Issue #240 — _run_subprocess_job optional-kwarg dispatch -------------
+
+
+class _StubBroadcaster:
+    """Minimal broadcaster for exercising _run_subprocess_job branches."""
+
+    def __init__(self) -> None:
+        self.errors: list[tuple[str, str, str | None]] = []
+
+    def send_error(self, job_id: str, message: str, code: str | None = None) -> None:
+        self.errors.append((job_id, message, code))
+
+    def send_progress(self, *_a: object, **_k: object) -> None:  # pragma: no cover
+        return None
+
+    def send_completed(self, *_a: object, **_k: object) -> None:  # pragma: no cover
+        return None
+
+
+class _StubJobStoreForSubprocess:
+    """JobStore stand-in exposing only what _run_subprocess_job touches."""
+
+    def __init__(self) -> None:
+        self.updates: list[object] = []
+        self.released: list[str] = []
+        self.terminals: list[tuple[str, str, float]] = []
+
+    def update(self, job: object) -> None:
+        self.updates.append(job)
+
+    def release_active(self, job_id: str) -> None:
+        self.released.append(job_id)
+
+    def record_job_terminal(
+        self, job_type: str, status: str, *, duration: float = 0.0
+    ) -> None:
+        self.terminals.append((job_type, status, duration))
+
+    def get(self, _job_id: str) -> object | None:
+        return None
+
+
+class _StubWsWithData:
+    """WorkspaceState stub with a loaded data_ref."""
+
+    class _DR:
+        path = "/tmp/data.csv"
+
+    def __init__(self) -> None:
+        self.data_ref = _StubWsWithData._DR()
+        self.noted: list[str] = []
+        self.completions: list[dict[str, object]] = []
+
+    def note_current_job(self, job_id: str) -> None:
+        self.noted.append(job_id)
+
+    def record_completion(self, **kwargs: object) -> None:
+        self.completions.append(kwargs)
+
+
+class _StubWsNoData:
+    """WorkspaceState stub without a loaded dataset."""
+
+    def __init__(self) -> None:
+        self.data_ref = None
+        self.noted: list[str] = []
+
+    def note_current_job(self, job_id: str) -> None:
+        self.noted.append(job_id)
+
+    def record_completion(self, **_: object) -> None:  # pragma: no cover
+        return None
+
+
+def _make_pending_tune_job() -> object:
+    """Construct a ``Job`` dataclass instance for these tests."""
+    from lizystudio.backends.types import DataRef
+    from lizystudio.services.jobs import Job
+
+    return Job(
+        job_id="j1",
+        status="pending",
+        backend_name="stub-backend",
+        config={},
+        data_ref=DataRef(
+            source_type="upload",
+            path="/tmp/data.csv",
+            filename="data.csv",
+            fingerprint="fp",
+            shape=(1, 1),
+        ),
+        job_type="tune",
+        created_at="2026-04-22T00:00:00+00:00",
+    )
+
+
+def test_run_subprocess_job_forwards_optional_kwargs_individually(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each optional retune/resume kwarg is forwarded to
+    ``run_job_in_subprocess`` only when set — covers the five branches
+    at lines 323 / 325 / 327 / 329 / 331 that previously had no test."""
+    import lizystudio.services.subprocess_runner as sr
+    import lizystudio.services.workspace as ws_mod
+    from lizystudio.services import _training_core
+
+    captured: dict[str, object] = {}
+
+    def _fake_run(**kwargs: object) -> object:
+        captured.update(kwargs)
+
+        class _Finished:
+            fit_result = None
+            tune_result = None
+            job_id = "j1"
+
+        return _Finished()
+
+    monkeypatch.setattr(sr, "run_job_in_subprocess", _fake_run)
+    monkeypatch.setattr(ws_mod, "get_backend_name", lambda _ws: "stub-backend")
+
+    job_store = _StubJobStoreForSubprocess()
+    _training_core._run_subprocess_job(
+        _StubWsWithData(),  # type: ignore[arg-type]
+        _make_pending_tune_job(),  # type: ignore[arg-type]
+        job_store,  # type: ignore[arg-type]
+        _StubBroadcaster(),  # type: ignore[arg-type]
+        mode="retune",
+        parent_job_id="parent-1",
+        retune_n_trials=20,
+        retune_expand_boundary=True,
+        retune_boundary_threshold=0.5,
+    )
+
+    assert captured["mode"] == "retune"
+    assert captured["parent_job_id"] == "parent-1"
+    assert captured["retune_n_trials"] == 20
+    assert captured["retune_expand_boundary"] is True
+    assert captured["retune_boundary_threshold"] == 0.5
+    assert job_store.released == ["j1"]
+
+
+def test_run_subprocess_job_omits_none_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Optional kwargs left at None are NOT forwarded — otherwise
+    ``run_job_in_subprocess`` would receive ``mode=None`` and collide
+    with its own defaults."""
+    import lizystudio.services.subprocess_runner as sr
+    import lizystudio.services.workspace as ws_mod
+    from lizystudio.services import _training_core
+
+    captured: dict[str, object] = {}
+
+    def _fake_run(**kwargs: object) -> object:
+        captured.update(kwargs)
+
+        class _Finished:
+            fit_result = None
+            tune_result = None
+            job_id = "j1"
+
+        return _Finished()
+
+    monkeypatch.setattr(sr, "run_job_in_subprocess", _fake_run)
+    monkeypatch.setattr(ws_mod, "get_backend_name", lambda _ws: "stub-backend")
+
+    _training_core._run_subprocess_job(
+        _StubWsWithData(),  # type: ignore[arg-type]
+        _make_pending_tune_job(),  # type: ignore[arg-type]
+        _StubJobStoreForSubprocess(),  # type: ignore[arg-type]
+        _StubBroadcaster(),  # type: ignore[arg-type]
+    )
+
+    assert "mode" not in captured
+    assert "parent_job_id" not in captured
+    assert "retune_n_trials" not in captured
+    assert "retune_expand_boundary" not in captured
+    assert "retune_boundary_threshold" not in captured
+
+
+def test_run_subprocess_job_fails_when_no_data_loaded() -> None:
+    """WS error path: without a loaded dataset the job transitions to
+    failed, the slot is released, a single terminal metric is recorded,
+    and the broadcaster observes a clear error message."""
+    from lizystudio.services import _training_core
+
+    job_store = _StubJobStoreForSubprocess()
+    broadcaster = _StubBroadcaster()
+
+    result = _training_core._run_subprocess_job(
+        _StubWsNoData(),  # type: ignore[arg-type]
+        _make_pending_tune_job(),  # type: ignore[arg-type]
+        job_store,  # type: ignore[arg-type]
+        broadcaster,  # type: ignore[arg-type]
+    )
+
+    assert result.status == "failed"  # type: ignore[attr-defined]
+    assert "No data loaded" in (result.error or "")  # type: ignore[attr-defined]
+    assert job_store.released == ["j1"]
+    assert any("No data loaded" in msg for _, msg, _ in broadcaster.errors)
+    # Exactly one terminal metric — finally-block must not double-count.
+    assert len(job_store.terminals) == 1
+    assert job_store.terminals[0][1] == "failed"


### PR DESCRIPTION
## Summary
- `InferenceStore.list` / `list_all` now skip corrupt / in-flight `meta.json` with a warning (matches `JobStore.list`'s long-standing resilience).
- `_compute_inf_metrics` raises a clear `ValueError` when the backend's prediction frame lacks the expected `pred` column, instead of leaking a bare pandas `KeyError` through the REST surface.
- Nine new `_training_core` unit tests cover the previously untested defensive branches: subprocess duration edge cases, pickle-preflight translation, the five optional retune/resume kwargs (forwarded when set, omitted when None), and the no-data WS error path.

## Invariants
- INV (#241): a single corrupt inference record must not take the history endpoint to 500; it is skipped with a warning naming the offending directory.
- INV (#241 M-3): a backend returning a non-standard prediction column surfaces as a clear `ValueError`, not a pandas `KeyError`.
- INV (#240): subprocess duration computation never raises from inside a `finally` block, and the no-data WS error path records exactly one terminal metric and releases the active slot.

## Failure Paths Covered
- [x] Empty `meta.json` in one inference record (simulates crash mid-write / concurrent delete) — `list` and `list_all`
- [x] Unexpected programming errors still bubble up (`_load_record` monkeypatched to `RuntimeError`)
- [x] Prediction frame without `pred` column
- [x] Subprocess duration: missing, malformed, happy, and reverse-ordered timestamps
- [x] Subprocess kwargs: each optional retune flag individually forwarded when set and omitted when None
- [x] WS no-data-loaded error path: slot released + single terminal metric + broadcaster message

## Reproduction
Before this PR (confirmed with a local PoC):
\`\`\`
InferenceStore.list raised JSONDecodeError: Expecting value: line 1 column 1
  → REST endpoint GET /api/inference/history returns 500
\`\`\`
After: `list` returns only the healthy record, a WARNING is written to the logger, the endpoint stays at 200.

## Verification
- Backend: **1177 pytest pass** (+13 from baseline 1164).
- `_training_core.py` coverage: **91% → 99%** (one remaining block at lines 200-201 for the log-persist `OSError` fallback — tracked as a follow-up since a cross-platform reproduction harness is needed).
- Overall backend coverage: **97% → 98%**.
- `uv run ruff check`, `ruff format --check`, `mypy src/lizystudio` — clean.
- Frontend: `pnpm build` + `pnpm check` clean (no frontend change).

## Test plan
- [x] `test_inference_service.py::test_list_skips_corrupt_meta_json`
- [x] `test_inference_service.py::test_list_all_skips_corrupt_meta_json`
- [x] `test_inference_service.py::test_list_propagates_unexpected_errors`
- [x] `test_inference_service.py::test_compute_inf_metrics_raises_when_pred_column_missing`
- [x] `test_training_core_and_ws_encap.py` — 4 duration tests + 2 preflight tests + 3 subprocess-dispatch tests
- [x] Existing 1164 tests remain green

Closes #240
Closes #241