### PR TITLE
refactor(services): per-app ModelCache on JobStore (H-0084, #235)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2192,4 +2192,45 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - 2026-04-22 **Proposed** — Proposal のみ PR #229 で merge、実装は後続 PR。着手前に reviewer 合意を得るためのゲート entry。
   - 2026-04-22 **Implemented** — `src/lizystudio/storage/` パッケージを新規作成（`__init__.py` / `versions.py` / `migrations.py`）、`STUDIO_FORMAT_VERSION = 1` + `write_versioned_json` / `read_versioned_json` helper + `MIGRATIONS` chain + `migrate_to_current`。`backends/exceptions.py` に `IncompatibleFormatVersionError` 追加。`services/jobs.py` の `_write_json` / `_read_json` helper を versioned I/O に委譲（`_save_meta` と `update(fit_result / tune_result)` が全て自動で version 埋込）。`services/inference.py` の `save` (meta.json 書込) と `_load_record` (meta.json 読込) を versioned helper に置換。`format_version` は JSON の**先頭 key** として埋込（grep / head 友好的）。**Scope 調整** (Proposal §5 からの乖離): `inferences/{inf_id}/metrics.json` のみ **versioned 化から除外**。理由は backend-dependent な flat `{mae: 0.3, rmse: 0.5, ...}` 構造で、先頭 key 埋込は将来 `format_version` という metric と衝突、envelope 化は frontend の `fetchInferenceMetrics: Promise<Record<string, unknown>>` 契約を破壊するため。代わりに writer 箇所に NOTE コメントで revisit 条件（metrics.json が backend で Pydantic `response_model` を持った時）を明記。これにより対象は 4 種類に縮減 (meta.json / fit_result.json / tune_result.json / inference/meta.json)。Acceptance Criteria 達成状況: (a) 4 種類の writer 全てで `format_version: 1` 埋込 ✅（metrics.json は scope 外として明示）、(b) `tests/regression/test_reg_0081_v0_workspace_backward_compat.py` で pre-C-9 workspace が `JobStore.get` / `InferenceStore.get` から load できることを確認 ✅、(c) `format_version: 99` 等 unknown を読ませると `IncompatibleFormatVersionError` が raise される (`tests/test_storage_versions.py::test_unknown_version_raises_incompatible_error`) ✅、(d) `_migrate_v0_to_v1` は pure function で direct 呼び出し test 済 ✅、(e) 1164 pytest pass / ruff / ruff format / mypy / biome / tsc / pnpm build / raw-color-guard / no-apifetch-guard 全 clean ✅、(f) `model_meta.json` の `pickle_schema` は触らず H-0068 checkpoint 検証ロジック回帰なし ✅。
 
-
+### H-0084: ModelCache の per-app 化（Phase 3 coupling refactor A-7 follow-up、Issue #235）
+- **Status:** proposed
+- **Scope:** Backend / Services | **change-gate 対象** (内部 API 変更：`services/jobs.py` の back-compat re-export からいくつかの名前を除去、`JobStore` に `load_model` / `clear_model_cache_for` メソッド追加)
+- **Related:** A-7（PR #194, H-0070 — `services/jobs.py` の God Module 分割）、A-9（PR #211, H-0075 — per-app `MetricsRegistry`）、Issue #235
+- **Context:** A-7 で `services/jobs.py` から分離した `services/job_results.py` はモジュール level の global `_model_cache` / `_model_cache_lock` を持ち、`load_job_model` / `clear_model_cache` / `clear_model_cache_for` が関数としてそれを参照する。このパターンは A-9 で per-app 化した `MetricsRegistry` の方向性と逆行しており、2 つの app instance を同一プロセスで走らせると cache 内容が混線する。テストが `clear_model_cache()` を fixture で明示的に呼ぶ necessity も、global state が原因である。
+- **Invariants:**
+  - INV-1: 2 つの `JobStore` インスタンスは互いに model cache を共有しない。片方で load / cache したモデルは他方からは観測されない。
+  - INV-2: `JobStore.delete(job_id)` は、削除対象の `model_path` に対応する cache エントリを削除する（A-7 時代の動作を保持）。
+  - INV-3: 公開 API （`JobStore.load_model`, `JobStore.clear_model_cache`, `JobStore.clear_model_cache_for`）は caller から安全に呼べる（内部 lock で synchronized）。
+- **Proposal:**
+  1. **`ModelCache` クラス新設**: `services/job_results.py` に `class ModelCache` を定義（LRU OrderedDict + `threading.Lock` を保持）。`load`/`clear`/`clear_for` メソッド。モジュール level の global state（`_model_cache`, `_model_cache_lock`）は削除。
+  2. **`JobStore` に ModelCache を所有**: `JobStore.__init__` で `self.model_cache = ModelCache(max_size=_MODEL_CACHE_MAX)`。`JobStore.load_model(job, backend)` / `JobStore.clear_model_cache()` / `JobStore.clear_model_cache_for(model_path)` メソッドを追加。
+  3. **dispatch helpers (`get_metrics_table`, `get_importance` 等) は `cache: ModelCache` 引数を受け取る**: 既存の `(job, backend)` シグネチャを `(job, backend, cache)` に変更（breaking change、全 caller は `api/jobs.py` の 6 箇所）。caller は `ws.job_store.model_cache` を渡す形になる。
+  4. **モジュール level global 関数 `load_job_model` / `clear_model_cache` / `clear_model_cache_for` を削除**: `services/jobs.py` の back-compat re-export block からも除去。`__all__` からも除去。
+  5. **テスト更新**: `test_job_results.py` の 10 箇所と `test_jobs.py` の 1 箇所を ModelCache インスタンスベースに書き換え。`_reset_model_cache` autouse fixture は不要化（ModelCache インスタンスが test ごとに切れる）。
+  6. **新規テスト**: `test_model_cache_is_per_app` — 2 つの `JobStore` インスタンスが同じプロセス内で cache を分離することを assert（INV-1）。
+- **Impact:**
+  - 修正: `src/lizystudio/services/job_results.py`（LRU global → ModelCache クラス、helper 関数 6 個に `cache` 引数追加、合計 ~80 行の書き換え）。
+  - 修正: `src/lizystudio/services/jobs.py`（`JobStore` に 3 メソッド追加、`delete` 内の import を self.clear_model_cache_for に置換、back-compat re-export block から 3 名削除）。
+  - 修正: `src/lizystudio/api/jobs.py`（dispatch helper の 6 call site に `ws.job_store.model_cache` を追加）。
+  - 修正: `tests/test_job_results.py`（10 箇所を ModelCache 経由に変更）、`tests/test_jobs.py`（1 箇所を `JobStore.load_model` 経由に変更）。
+  - 追加: `tests/test_job_results.py` に `test_model_cache_is_per_app` 1 件。
+  - wire format / API 契約: 不変。
+  - 既存 1170+ tests の挙動変化: 関数シグネチャ変更に追従するが、assert は同じ。
+- **Compatibility:**
+  - **破壊的変更（repo 内部のみ）**: `load_job_model`, `clear_model_cache`, `clear_model_cache_for` のモジュールレベル関数、および `services/jobs.py` の同名 re-export が削除される。全 caller は repo 内部のため影響範囲は明確（PyPI export には含まれない）。
+  - `services/jobs.py` の back-compat re-export から `_get_jobs_dir` / `_load_tuning_plot_from_file` / 残 `get_*` helpers は保持（H-3 の指摘は別 Issue／別 PR で対応）。
+  - `ModelCache` クラス API は新規導入のため、既存依存なし。
+- **Alternatives considered:**
+  - (a) **shim を残す**: モジュール level の global を `_default_cache = ModelCache()` として残し、`load_job_model` / `clear_model_cache*` は deprecation warning で shim に委譲。**却下**：Issue #235 の目的（2 app 分離）を達成しない、deprecated が沈殿する。A-9 は shim なしで global→per-app を一気に倒した、PR-3 だけ shim 残すと方針不整合。
+  - (b) **helper を `JobStore` メソッドに統合**: `get_metrics_table` 等を全部 `JobStore.get_metrics_table(job, backend)` のメソッドにする。**採用しない**：dispatch helpers は "model" + "backend" 両方を横断する純粋関数なので、JobStore の責務（disk CRUD）と直交している。cache 引数化の方が責務分離が明確。
+  - (c) **`dataclass` ベースの ModelCache**: 内部 OrderedDict を dataclass field で持つ。**却下**：class だけで十分、dataclass にする利点なし。
+  - (d) **`weakref.WeakValueDictionary` で GC 任せ**: モデルオブジェクトへの weak reference で自動解放。**却下**：`maxsize=8` の LRU 契約を weak ref で保てない（GC タイミング非決定）、明示的な LRU の方が挙動が読める。
+- **Acceptance Criteria:**
+  - (a) `ModelCache` クラスが `services/job_results.py` に存在し、モジュール level global は削除。
+  - (b) `JobStore.__init__` で `ModelCache` インスタンスを所有、`JobStore.load_model` / `clear_model_cache` / `clear_model_cache_for` メソッドが動作。
+  - (c) `test_model_cache_is_per_app`: 2 つの `JobStore` が互いの cache を観測できない（INV-1）。
+  - (d) `JobStore.delete` が依然として対応 `model_path` の cache を invalidate（INV-2、既存 `test_job_store_delete_invalidates_model_cache` の書き換え版で）。
+  - (e) 既存 1170 pytest + 追加 1 件 = 1171 全 pass、ruff / ruff format / mypy / biome / tsc / pnpm build 全 clean。
+  - (f) `services/jobs.py` の `__all__` から `clear_model_cache`, `clear_model_cache_for`, `load_job_model` が除去される。
+- **Decision:**
+  - 2026-04-22 **Proposed & Implemented** — 本 PR で Proposal + 実装 + テスト書き換えを同時 merge。change-gate 最小構成。

--- a/src/lizystudio/api/jobs.py
+++ b/src/lizystudio/api/jobs.py
@@ -236,7 +236,7 @@ def get_job_metrics_endpoint(
     job = _get_job_or_404(job_id, job_store)
     _require_completed(job)
     try:
-        return get_metrics_table(job, ws.backend)
+        return get_metrics_table(job, ws.backend, job_store.model_cache)
     except Exception as exc:
         raise BackendError(exc) from exc
 
@@ -251,7 +251,7 @@ def get_job_split_summary_endpoint(
     job = _get_job_or_404(job_id, job_store)
     _require_completed(job)
     try:
-        return get_split_summary(job, ws.backend)
+        return get_split_summary(job, ws.backend, job_store.model_cache)
     except Exception as exc:
         raise BackendError(exc) from exc
 
@@ -267,7 +267,7 @@ def get_job_importance_endpoint(
     job = _get_job_or_404(job_id, job_store)
     _require_completed(job)
     try:
-        return get_importance(job, ws.backend, kind=kind)
+        return get_importance(job, ws.backend, job_store.model_cache, kind=kind)
     except Exception as exc:
         raise BackendError(exc) from exc
 
@@ -282,7 +282,7 @@ def get_job_importance_kinds_endpoint(
     job = _get_job_or_404(job_id, job_store)
     _require_completed(job)
     try:
-        return get_importance_kinds(job, ws.backend)
+        return get_importance_kinds(job, ws.backend, job_store.model_cache)
     except Exception as exc:
         raise BackendError(exc) from exc
 
@@ -302,7 +302,7 @@ def get_job_learning_curve_metrics_endpoint(
     job = _get_job_or_404(job_id, job_store)
     _require_completed(job)
     try:
-        return get_learning_curve_metrics(job, ws.backend)
+        return get_learning_curve_metrics(job, ws.backend, job_store.model_cache)
     except Exception as exc:
         raise BackendError(exc) from exc
 
@@ -345,7 +345,9 @@ def get_job_plot_endpoint(
             raise StudioError("INVALID_PARAM", f"Invalid kind: {kind!r}", 400)
         kwargs["kind"] = kind
     try:
-        plot_data = get_job_plot(job, ws.backend, plot_type, **kwargs)
+        plot_data = get_job_plot(
+            job, ws.backend, job_store.model_cache, plot_type, **kwargs
+        )
         return {"plotly_json": plot_data.plotly_json}
     except Exception as exc:
         raise BackendError(exc) from exc
@@ -361,7 +363,7 @@ def get_job_available_plots_endpoint(
     job = _get_job_or_404(job_id, job_store)
     _require_completed(job)
     try:
-        return get_available_plots(job, ws.backend)
+        return get_available_plots(job, ws.backend, job_store.model_cache)
     except Exception as exc:
         raise BackendError(exc) from exc
 

--- a/src/lizystudio/services/job_results.py
+++ b/src/lizystudio/services/job_results.py
@@ -9,8 +9,13 @@ The cache is keyed by ``(backend_name, model_path)`` rather than by job
 identity because different jobs can legitimately share a model path
 (e.g. Re-tune children that export under a parent directory) and because
 the same path deserializes identically regardless of which Job instance
-asked for it. Invalidate via :func:`clear_model_cache` when a path is
+asked for it. Invalidate via :meth:`ModelCache.clear_for` when a path is
 overwritten.
+
+H-0084 (Issue #235): the cache lives on a :class:`ModelCache` instance
+owned by ``JobStore`` rather than at module scope, so two apps sharing
+a process do not cross-contaminate each other. See the History entry
+H-0084 for the invariants and the migration trade-off.
 """
 
 from __future__ import annotations
@@ -24,83 +29,103 @@ from lizystudio.backends.base import BackendAdapter
 from lizystudio.backends.types import PlotData
 from lizystudio.services.jobs import Job, artifact_path
 
-_MODEL_CACHE_MAX = 8
-
-_model_cache: OrderedDict[tuple[str, str], Any] = OrderedDict()
-_model_cache_lock = threading.Lock()
+MODEL_CACHE_MAX = 8
+"""Default maximum number of deserialised models kept per app."""
 
 
-def clear_model_cache() -> None:
-    """Drop all memoized models. Call after a path is overwritten."""
-    with _model_cache_lock:
-        _model_cache.clear()
+class ModelCache:
+    """LRU cache of deserialised backend models, scoped per ``JobStore``.
 
-
-def clear_model_cache_for(model_path: str) -> None:
-    """Drop cached entries for a specific model path across all backends."""
-    with _model_cache_lock:
-        stale = [k for k in _model_cache if k[1] == model_path]
-        for key in stale:
-            del _model_cache[key]
-
-
-def load_job_model(job: Job, backend: BackendAdapter) -> Any:
-    """Load a trained model from a completed job, memoized in an LRU cache.
-
-    The cache critical section wraps the adapter ``load_model`` call so a
-    concurrent :func:`clear_model_cache_for` invalidation cannot interleave
-    between "cache miss" and "write result" and resurrect a path that was
-    meant to be dropped. The per-process cache is small (``maxsize=8``) and
-    model deserialization is fast enough that a single lock is simpler than
-    a per-key Event barrier.
+    The critical section wraps the adapter ``load_model`` call so a
+    concurrent :meth:`clear_for` invalidation cannot interleave between
+    "cache miss" and "write result" and resurrect a path that was meant
+    to be dropped. The per-app cache is small (``max_size=8`` by default)
+    and model deserialisation is fast enough that a single lock is
+    simpler than a per-key Event barrier.
     """
-    if job.model_path is None:
-        msg = f"Job {job.job_id} has no saved model"
-        raise ValueError(msg)
 
-    key = (job.backend_name, job.model_path)
-    with _model_cache_lock:
-        if key in _model_cache:
-            _model_cache.move_to_end(key)
-            return _model_cache[key]
+    def __init__(self, max_size: int = MODEL_CACHE_MAX) -> None:
+        self._entries: OrderedDict[tuple[str, str], Any] = OrderedDict()
+        self._lock = threading.Lock()
+        self._max_size = max_size
 
-        model = backend.load_model(job.model_path)
-        _model_cache[key] = model
-        _model_cache.move_to_end(key)
-        while len(_model_cache) > _MODEL_CACHE_MAX:
-            _model_cache.popitem(last=False)
-        return model
+    def load(self, job: Job, backend: BackendAdapter) -> Any:
+        """Load a trained model, memoising the result."""
+        if job.model_path is None:
+            msg = f"Job {job.job_id} has no saved model"
+            raise ValueError(msg)
+
+        key = (job.backend_name, job.model_path)
+        with self._lock:
+            if key in self._entries:
+                self._entries.move_to_end(key)
+                return self._entries[key]
+
+            model = backend.load_model(job.model_path)
+            self._entries[key] = model
+            self._entries.move_to_end(key)
+            while len(self._entries) > self._max_size:
+                self._entries.popitem(last=False)
+            return model
+
+    def clear(self) -> None:
+        """Drop all memoised models (e.g. after an app-wide rollover)."""
+        with self._lock:
+            self._entries.clear()
+
+    def clear_for(self, model_path: str) -> None:
+        """Drop cached entries for a specific ``model_path`` across all backends."""
+        with self._lock:
+            stale = [k for k in self._entries if k[1] == model_path]
+            for key in stale:
+                del self._entries[key]
+
+    def __contains__(self, key: tuple[str, str]) -> bool:
+        """Test helper — expose membership checks without the internal dict."""
+        with self._lock:
+            return key in self._entries
 
 
-def get_metrics_table(job: Job, backend: BackendAdapter) -> list[dict[str, Any]]:
+def get_metrics_table(
+    job: Job, backend: BackendAdapter, cache: ModelCache
+) -> list[dict[str, Any]]:
     """Get the metrics evaluation table for a completed job."""
-    model = load_job_model(job, backend)
+    model = cache.load(job, backend)
     return backend.evaluate_table(model)
 
 
-def get_split_summary(job: Job, backend: BackendAdapter) -> list[dict[str, Any]]:
+def get_split_summary(
+    job: Job, backend: BackendAdapter, cache: ModelCache
+) -> list[dict[str, Any]]:
     """Get fold/split summary for a completed job."""
-    model = load_job_model(job, backend)
+    model = cache.load(job, backend)
     return backend.split_summary(model)
 
 
 def get_importance(
-    job: Job, backend: BackendAdapter, kind: str = "split"
+    job: Job,
+    backend: BackendAdapter,
+    cache: ModelCache,
+    kind: str = "split",
 ) -> dict[str, float]:
     """Get feature importance for a completed job."""
-    model = load_job_model(job, backend)
+    model = cache.load(job, backend)
     return backend.importance(model, kind=kind)
 
 
-def get_importance_kinds(job: Job, backend: BackendAdapter) -> list[str]:
+def get_importance_kinds(
+    job: Job, backend: BackendAdapter, cache: ModelCache
+) -> list[str]:
     """Get the list of valid importance kind identifiers for a completed job."""
-    model = load_job_model(job, backend)
+    model = cache.load(job, backend)
     return backend.importance_kinds(model)
 
 
-def get_learning_curve_metrics(job: Job, backend: BackendAdapter) -> list[str]:
+def get_learning_curve_metrics(
+    job: Job, backend: BackendAdapter, cache: ModelCache
+) -> list[str]:
     """Get the list of metric names available in the learning curve history."""
-    model = load_job_model(job, backend)
+    model = cache.load(job, backend)
     return backend.learning_curve_metrics(model)
 
 
@@ -123,10 +148,14 @@ def _load_tuning_plot_from_file(job: Job) -> PlotData | None:
 
 
 def get_job_plot(
-    job: Job, backend: BackendAdapter, plot_type: str, **kwargs: Any
+    job: Job,
+    backend: BackendAdapter,
+    cache: ModelCache,
+    plot_type: str,
+    **kwargs: Any,
 ) -> Any:
     """Get a plot for a completed job. Returns PlotData."""
-    model = load_job_model(job, backend)
+    model = cache.load(job, backend)
     if plot_type == "tuning":
         try:
             return backend.plot(model, plot_type, **kwargs)
@@ -138,9 +167,11 @@ def get_job_plot(
     return backend.plot(model, plot_type, **kwargs)
 
 
-def get_available_plots(job: Job, backend: BackendAdapter) -> list[str]:
+def get_available_plots(
+    job: Job, backend: BackendAdapter, cache: ModelCache
+) -> list[str]:
     """Get list of available plot types for a completed job."""
-    model = load_job_model(job, backend)
+    model = cache.load(job, backend)
     plots = list(backend.available_plots(model))
     if "tuning" not in plots and job.job_type == "tune":
         saved = _load_tuning_plot_from_file(job)

--- a/src/lizystudio/services/jobs.py
+++ b/src/lizystudio/services/jobs.py
@@ -25,6 +25,7 @@ from lizystudio.storage.versions import (  # noqa: E402
 )
 
 if TYPE_CHECKING:
+    from lizystudio.backends.base import BackendAdapter
     from lizystudio.metrics import JobType, MetricsRegistry, TerminalStatus
 
 _logger = logging.getLogger(__name__)
@@ -136,6 +137,25 @@ class JobStore:
         # already marked failed at restart time.
         self._parent_locks: dict[str, str] = {}
         self._parent_lock_mutex = threading.Lock()
+        # H-0084 (Issue #235): model cache lives on the JobStore so two
+        # app instances sharing a process keep their caches isolated.
+        # Imported lazily to avoid a top-level cycle with job_results.
+        from lizystudio.services.job_results import ModelCache
+
+        self.model_cache: ModelCache = ModelCache()
+
+    def load_model(self, job: Job, backend: BackendAdapter) -> Any:
+        """Load a trained model, memoised via the owned ``ModelCache``
+        (H-0084)."""
+        return self.model_cache.load(job, backend)
+
+    def clear_model_cache(self) -> None:
+        """Drop all memoised models (H-0084)."""
+        self.model_cache.clear()
+
+    def clear_model_cache_for(self, model_path: str) -> None:
+        """Drop memoised entries for a specific model path (H-0084)."""
+        self.model_cache.clear_for(model_path)
 
     def _set_active_gauge(self, value: float) -> None:
         """Update the active-jobs gauge on the bound MetricsRegistry."""
@@ -311,11 +331,9 @@ class JobStore:
                 # deleted anyway; swallow the transient error instead
                 # of propagating it out of delete().
                 shutil.rmtree(target, ignore_errors=True)
-            # Drop any cached deserialized model for this job. Imported
-            # here to avoid a top-level cycle with ``job_results``.
-            from lizystudio.services.job_results import clear_model_cache_for
-
-            clear_model_cache_for(str(self.path_for(jid, "model")))
+            # Drop any cached deserialised model for this job via the
+            # JobStore-owned cache (H-0084).
+            self.clear_model_cache_for(str(self.path_for(jid, "model")))
         return removed
 
     # --- H-0062 lineage helpers ---
@@ -777,12 +795,14 @@ def get_job_store(request: Request) -> JobStore:
 
 # --- Back-compat re-exports (A-7: dispatch helpers moved to job_results) ---
 # External callers historically import these from services.jobs. The logic
-# now lives in services/job_results.py alongside the model LRU cache.
+# now lives in services/job_results.py. H-0084: the cache-management
+# helpers (clear_model_cache / clear_model_cache_for / load_job_model)
+# have been retired in favour of the JobStore-owned ModelCache; use
+# ``JobStore.load_model`` / ``JobStore.clear_model_cache`` / the helpers
+# below that accept a ``cache`` argument instead.
 from lizystudio.services.job_results import (  # noqa: E402
     _get_jobs_dir,
     _load_tuning_plot_from_file,
-    clear_model_cache,
-    clear_model_cache_for,
     get_available_plots,
     get_importance,
     get_importance_kinds,
@@ -790,7 +810,6 @@ from lizystudio.services.job_results import (  # noqa: E402
     get_learning_curve_metrics,
     get_metrics_table,
     get_split_summary,
-    load_job_model,
 )
 
 __all__ = [
@@ -799,8 +818,6 @@ __all__ = [
     "JobStore",
     "_get_jobs_dir",
     "_load_tuning_plot_from_file",
-    "clear_model_cache",
-    "clear_model_cache_for",
     "get_available_plots",
     "get_importance",
     "get_importance_kinds",
@@ -809,5 +826,4 @@ __all__ = [
     "get_learning_curve_metrics",
     "get_metrics_table",
     "get_split_summary",
-    "load_job_model",
 ]

--- a/tests/test_job_results.py
+++ b/tests/test_job_results.py
@@ -1,8 +1,9 @@
-"""Tests for services.job_results — dispatch helpers + model LRU cache.
+"""Tests for services.job_results — ModelCache + dispatch helpers.
 
-Covers A-7 split: dispatch-layer helpers that transform a ``Job`` +
-``BackendAdapter`` into result data. Persistence-layer tests live in
-``test_jobs.py``.
+Covers the A-7 split (dispatch helpers that transform a ``Job`` +
+``BackendAdapter`` into result data) and the H-0084 refactor
+(per-app :class:`ModelCache` owned by :class:`JobStore`). Persistence
+tests live in ``test_jobs.py``.
 """
 
 from __future__ import annotations
@@ -15,7 +16,7 @@ import pytest
 
 from lizystudio.backends.types import DataRef, PlotData
 from lizystudio.services.job_results import (
-    clear_model_cache,
+    ModelCache,
     get_available_plots,
     get_importance,
     get_importance_kinds,
@@ -23,7 +24,6 @@ from lizystudio.services.job_results import (
     get_learning_curve_metrics,
     get_metrics_table,
     get_split_summary,
-    load_job_model,
 )
 from lizystudio.services.jobs import JobStore
 
@@ -46,12 +46,6 @@ def sample_data_ref() -> DataRef:
     )
 
 
-@pytest.fixture(autouse=True)
-def _reset_model_cache() -> None:
-    """Ensure each test starts with a clean cache — avoids cross-test leakage."""
-    clear_model_cache()
-
-
 def _make_completed_job(
     job_store: JobStore, data_ref: DataRef, job_type: str = "fit"
 ) -> Any:
@@ -68,14 +62,14 @@ def _make_completed_job(
 
 
 # ---------------------------------------------------------------------------
-# load_job_model — error path + LRU cache
+# ModelCache — error path + LRU semantics (H-0084)
 # ---------------------------------------------------------------------------
 
 
-def test_load_job_model_raises_when_no_model_path(
+def test_model_cache_load_raises_when_no_model_path(
     job_store: JobStore, sample_data_ref: DataRef
 ) -> None:
-    """load_job_model must raise ValueError when model_path is None."""
+    """load must raise ValueError when job.model_path is None."""
     job = job_store.create(
         backend_name="lizyml",
         config={},
@@ -86,23 +80,23 @@ def test_load_job_model_raises_when_no_model_path(
     backend = MagicMock()
 
     with pytest.raises(ValueError, match="no saved model"):
-        load_job_model(job, backend)
+        job_store.model_cache.load(job, backend)
 
 
-def test_load_job_model_returns_loaded_model(
+def test_model_cache_load_returns_loaded_model(
     job_store: JobStore, sample_data_ref: DataRef
 ) -> None:
     job = _make_completed_job(job_store, sample_data_ref)
     backend = MagicMock()
     backend.load_model.return_value = "MODEL_OBJ"
 
-    model = load_job_model(job, backend)
+    model = job_store.model_cache.load(job, backend)
 
     assert model == "MODEL_OBJ"
     backend.load_model.assert_called_once_with(job.model_path)
 
 
-def test_load_job_model_caches_by_path_and_backend(
+def test_model_cache_caches_by_path_and_backend(
     job_store: JobStore, sample_data_ref: DataRef
 ) -> None:
     """Second call with same (model_path, backend_name) must hit cache."""
@@ -110,14 +104,14 @@ def test_load_job_model_caches_by_path_and_backend(
     backend = MagicMock()
     backend.load_model.return_value = "MODEL_OBJ"
 
-    first = load_job_model(job, backend)
-    second = load_job_model(job, backend)
+    first = job_store.model_cache.load(job, backend)
+    second = job_store.model_cache.load(job, backend)
 
     assert first is second
     assert backend.load_model.call_count == 1
 
 
-def test_load_job_model_different_backends_do_not_share_cache(
+def test_model_cache_different_backends_do_not_share(
     job_store: JobStore, sample_data_ref: DataRef
 ) -> None:
     """Cache key includes backend_name, so two backends load independently."""
@@ -130,28 +124,26 @@ def test_load_job_model_different_backends_do_not_share_cache(
     backend_b = MagicMock()
     backend_b.load_model.return_value = "B"
 
-    # Prime both
-    assert load_job_model(job_a, backend_a) == "A"
-    assert load_job_model(job_b, backend_b) == "B"
+    assert job_store.model_cache.load(job_a, backend_a) == "A"
+    assert job_store.model_cache.load(job_b, backend_b) == "B"
 
-    # Repeat — both should be cached
-    load_job_model(job_a, backend_a)
-    load_job_model(job_b, backend_b)
+    job_store.model_cache.load(job_a, backend_a)
+    job_store.model_cache.load(job_b, backend_b)
 
     assert backend_a.load_model.call_count == 1
     assert backend_b.load_model.call_count == 1
 
 
-def test_clear_model_cache_forces_reload(
+def test_model_cache_clear_forces_reload(
     job_store: JobStore, sample_data_ref: DataRef
 ) -> None:
     job = _make_completed_job(job_store, sample_data_ref)
     backend = MagicMock()
     backend.load_model.return_value = "M"
 
-    load_job_model(job, backend)
-    clear_model_cache()
-    load_job_model(job, backend)
+    job_store.model_cache.load(job, backend)
+    job_store.clear_model_cache()
+    job_store.model_cache.load(job, backend)
 
     assert backend.load_model.call_count == 2
 
@@ -160,24 +152,51 @@ def test_job_store_delete_invalidates_model_cache(
     job_store: JobStore, sample_data_ref: DataRef
 ) -> None:
     """Deleting a job drops its cached model so a reused path never returns
-    a stale, pre-delete deserialized object.
+    a stale, pre-delete deserialised object (INV-2).
     """
-    from lizystudio.services.job_results import _model_cache
-
     job = _make_completed_job(job_store, sample_data_ref)
     backend = MagicMock()
     backend.load_model.return_value = "M"
 
-    load_job_model(job, backend)
+    job_store.model_cache.load(job, backend)
     key = (job.backend_name, job.model_path)
-    assert key in _model_cache
+    assert key in job_store.model_cache
 
     job_store.delete(job.job_id)
 
-    assert key not in _model_cache
+    assert key not in job_store.model_cache
 
 
-def test_load_job_model_cache_write_is_atomic_under_concurrent_reads(
+def test_model_cache_is_per_app(tmp_path: Path, sample_data_ref: DataRef) -> None:
+    """H-0084 INV-1: two JobStore instances do not share model cache."""
+    store_a = JobStore(tmp_path / "a" / "jobs")
+    store_b = JobStore(tmp_path / "b" / "jobs")
+    assert store_a.model_cache is not store_b.model_cache
+
+    job_a = _make_completed_job(store_a, sample_data_ref)
+    job_b = _make_completed_job(store_b, sample_data_ref)
+
+    backend_a = MagicMock()
+    backend_a.load_model.return_value = "A-model"
+    backend_b = MagicMock()
+    backend_b.load_model.return_value = "B-model"
+
+    store_a.model_cache.load(job_a, backend_a)
+    store_b.model_cache.load(job_b, backend_b)
+
+    # Cache entry visible only in the owning store.
+    assert (job_a.backend_name, job_a.model_path) in store_a.model_cache
+    assert (job_a.backend_name, job_a.model_path) not in store_b.model_cache
+    assert (job_b.backend_name, job_b.model_path) in store_b.model_cache
+    assert (job_b.backend_name, job_b.model_path) not in store_a.model_cache
+
+    # Clearing one store must not affect the other.
+    store_a.clear_model_cache()
+    assert (job_a.backend_name, job_a.model_path) not in store_a.model_cache
+    assert (job_b.backend_name, job_b.model_path) in store_b.model_cache
+
+
+def test_model_cache_load_is_atomic_under_concurrent_reads(
     job_store: JobStore, sample_data_ref: DataRef
 ) -> None:
     """Concurrent callers on the same (backend, path) trigger at most one
@@ -202,7 +221,7 @@ def test_load_job_model_cache_write_is_atomic_under_concurrent_reads(
     results: list[Any] = []
 
     def call() -> None:
-        results.append(load_job_model(job, backend))
+        results.append(job_store.model_cache.load(job, backend))
 
     t1 = _threading.Thread(target=call)
     t2 = _threading.Thread(target=call)
@@ -217,8 +236,31 @@ def test_load_job_model_cache_write_is_atomic_under_concurrent_reads(
     assert backend.load_model.call_count == 1
 
 
+def test_model_cache_respects_max_size() -> None:
+    """LRU eviction drops the oldest entry past max_size."""
+    cache = ModelCache(max_size=2)
+
+    class _FakeJob:
+        def __init__(self, path: str, backend: str = "b") -> None:
+            self.model_path = path
+            self.backend_name = backend
+            self.job_id = path
+
+    backend = MagicMock()
+    backend.load_model.side_effect = lambda p: f"model-{p}"
+
+    cache.load(_FakeJob("p1"), backend)  # type: ignore[arg-type]
+    cache.load(_FakeJob("p2"), backend)  # type: ignore[arg-type]
+    cache.load(_FakeJob("p3"), backend)  # type: ignore[arg-type]
+
+    # p1 evicted, p2 + p3 retained.
+    assert ("b", "p1") not in cache
+    assert ("b", "p2") in cache
+    assert ("b", "p3") in cache
+
+
 # ---------------------------------------------------------------------------
-# Dispatch helpers
+# Dispatch helpers — now take an explicit ``cache`` argument
 # ---------------------------------------------------------------------------
 
 
@@ -230,7 +272,7 @@ def test_get_metrics_table_delegates_to_backend(
     backend.load_model.return_value = "MODEL"
     backend.evaluate_table.return_value = [{"metric": "rmse", "value": 0.1}]
 
-    result = get_metrics_table(job, backend)
+    result = get_metrics_table(job, backend, job_store.model_cache)
 
     assert result == [{"metric": "rmse", "value": 0.1}]
     backend.evaluate_table.assert_called_once_with("MODEL")
@@ -244,7 +286,9 @@ def test_get_split_summary_delegates(
     backend.load_model.return_value = "M"
     backend.split_summary.return_value = [{"fold": 0, "score": 0.9}]
 
-    assert get_split_summary(job, backend) == [{"fold": 0, "score": 0.9}]
+    assert get_split_summary(job, backend, job_store.model_cache) == [
+        {"fold": 0, "score": 0.9}
+    ]
 
 
 def test_get_importance_passes_kind(
@@ -255,7 +299,7 @@ def test_get_importance_passes_kind(
     backend.load_model.return_value = "M"
     backend.importance.return_value = {"f1": 0.5}
 
-    result = get_importance(job, backend, kind="gain")
+    result = get_importance(job, backend, job_store.model_cache, kind="gain")
 
     backend.importance.assert_called_once_with("M", kind="gain")
     assert result == {"f1": 0.5}
@@ -269,7 +313,10 @@ def test_get_importance_kinds_delegates(
     backend.load_model.return_value = "M"
     backend.importance_kinds.return_value = ["split", "gain"]
 
-    assert get_importance_kinds(job, backend) == ["split", "gain"]
+    assert get_importance_kinds(job, backend, job_store.model_cache) == [
+        "split",
+        "gain",
+    ]
 
 
 def test_get_learning_curve_metrics_delegates(
@@ -280,7 +327,10 @@ def test_get_learning_curve_metrics_delegates(
     backend.load_model.return_value = "M"
     backend.learning_curve_metrics.return_value = ["rmse", "mae"]
 
-    assert get_learning_curve_metrics(job, backend) == ["rmse", "mae"]
+    assert get_learning_curve_metrics(job, backend, job_store.model_cache) == [
+        "rmse",
+        "mae",
+    ]
 
 
 def test_get_job_plot_delegates(job_store: JobStore, sample_data_ref: DataRef) -> None:
@@ -290,7 +340,9 @@ def test_get_job_plot_delegates(job_store: JobStore, sample_data_ref: DataRef) -
     expected = PlotData(plotly_json='{"data": []}')
     backend.plot.return_value = expected
 
-    assert get_job_plot(job, backend, "learning_curve") is expected
+    assert (
+        get_job_plot(job, backend, job_store.model_cache, "learning_curve") is expected
+    )
     backend.plot.assert_called_once_with("M", "learning_curve")
 
 
@@ -306,7 +358,7 @@ def test_get_job_plot_tuning_falls_back_to_file(
     backend.load_model.return_value = "M"
     backend.plot.side_effect = RuntimeError("study missing")
 
-    result = get_job_plot(job, backend, "tuning")
+    result = get_job_plot(job, backend, job_store.model_cache, "tuning")
 
     assert isinstance(result, PlotData)
     assert result.plotly_json == '{"stored": true}'
@@ -321,7 +373,7 @@ def test_get_job_plot_tuning_raises_when_no_fallback(
     backend.plot.side_effect = RuntimeError("study missing")
 
     with pytest.raises(RuntimeError, match="study missing"):
-        get_job_plot(job, backend, "tuning")
+        get_job_plot(job, backend, job_store.model_cache, "tuning")
 
 
 def test_get_available_plots_appends_tuning_when_fallback_exists(
@@ -335,7 +387,7 @@ def test_get_available_plots_appends_tuning_when_fallback_exists(
     backend.load_model.return_value = "M"
     backend.available_plots.return_value = ["learning_curve"]
 
-    plots = get_available_plots(job, backend)
+    plots = get_available_plots(job, backend, job_store.model_cache)
 
     assert "tuning" in plots
     assert "learning_curve" in plots
@@ -349,7 +401,7 @@ def test_get_available_plots_does_not_duplicate_tuning(
     backend.load_model.return_value = "M"
     backend.available_plots.return_value = ["tuning", "learning_curve"]
 
-    plots = get_available_plots(job, backend)
+    plots = get_available_plots(job, backend, job_store.model_cache)
 
     assert plots.count("tuning") == 1
 
@@ -365,22 +417,24 @@ def test_get_available_plots_fit_job_does_not_add_tuning(
     backend.load_model.return_value = "M"
     backend.available_plots.return_value = ["learning_curve"]
 
-    plots = get_available_plots(job, backend)
+    plots = get_available_plots(job, backend, job_store.model_cache)
 
     assert "tuning" not in plots
 
 
 # ---------------------------------------------------------------------------
-# Re-export back-compat — jobs.py must still expose the symbols
+# Re-export back-compat — jobs.py keeps the dispatch helpers (cache-taking
+# variants); the global load_job_model / clear_model_cache* names were
+# retired in H-0084.
 # ---------------------------------------------------------------------------
 
 
 def test_jobs_module_reexports_dispatch_helpers() -> None:
-    """External imports from services.jobs must continue to work."""
+    """External imports from services.jobs must continue to work for the
+    ``cache``-taking dispatch helpers."""
     from lizystudio.services import jobs as jobs_mod
 
     for name in (
-        "load_job_model",
         "get_metrics_table",
         "get_split_summary",
         "get_importance",
@@ -390,3 +444,20 @@ def test_jobs_module_reexports_dispatch_helpers() -> None:
         "get_available_plots",
     ):
         assert hasattr(jobs_mod, name), f"jobs module missing re-export: {name}"
+
+
+def test_retired_globals_are_gone() -> None:
+    """H-0084: global cache helpers are removed in favour of JobStore
+    methods and the ModelCache class."""
+    from lizystudio.services import job_results as jr
+    from lizystudio.services import jobs as jobs_mod
+
+    assert not hasattr(jr, "load_job_model")
+    assert not hasattr(jr, "clear_model_cache")
+    assert not hasattr(jr, "clear_model_cache_for")
+    assert not hasattr(jr, "_model_cache")
+
+    # services/jobs __all__ must not re-advertise the removed names.
+    assert "load_job_model" not in jobs_mod.__all__
+    assert "clear_model_cache" not in jobs_mod.__all__
+    assert "clear_model_cache_for" not in jobs_mod.__all__

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -146,17 +146,15 @@ def test_list_returns_empty_when_jobs_dir_missing(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# load_job_model — no model_path raises ValueError
+# JobStore.load_model — no model_path raises ValueError (H-0084)
 # ---------------------------------------------------------------------------
 
 
-def test_load_job_model_raises_when_no_model_path(
+def test_job_store_load_model_raises_when_no_model_path(
     job_store: JobStore, sample_data_ref: DataRef
 ) -> None:
-    """load_job_model must raise ValueError when model_path is None."""
+    """JobStore.load_model must raise ValueError when model_path is None."""
     from unittest.mock import MagicMock
-
-    from lizystudio.services.jobs import load_job_model
 
     job = job_store.create(
         backend_name="lizyml",
@@ -168,7 +166,7 @@ def test_load_job_model_raises_when_no_model_path(
     backend = MagicMock()
 
     with pytest.raises(ValueError, match="no saved model"):
-        load_job_model(job, backend)
+        job_store.load_model(job, backend)
 
 
 # ---------------------------------------------------------------------------
@@ -311,7 +309,7 @@ def test_get_job_plot_tuning_falls_back_to_file(
     # Backend raises when trying to get tuning plot from exported model
     backend.plot.side_effect = RuntimeError("No Optuna study data")
 
-    result = get_job_plot(job, backend, "tuning")
+    result = get_job_plot(job, backend, job_store.model_cache, "tuning")
     assert isinstance(result, PlotData)
     assert result.plotly_json == plot_json
 
@@ -337,7 +335,7 @@ def test_get_job_plot_tuning_reraises_when_no_file(
     backend.plot.side_effect = RuntimeError("No Optuna study data")
 
     with pytest.raises(RuntimeError, match="No Optuna study data"):
-        get_job_plot(job, backend, "tuning")
+        get_job_plot(job, backend, job_store.model_cache, "tuning")
 
 
 def test_get_job_plot_non_tuning_delegates_to_backend(
@@ -362,7 +360,7 @@ def test_get_job_plot_non_tuning_delegates_to_backend(
     backend.load_model.return_value = MagicMock()
     backend.plot.return_value = expected
 
-    result = get_job_plot(job, backend, "learning-curve")
+    result = get_job_plot(job, backend, job_store.model_cache, "learning-curve")
     assert result is expected
 
 
@@ -396,7 +394,7 @@ def test_get_available_plots_adds_tuning_from_file(
     backend.load_model.return_value = MagicMock()
     backend.available_plots.return_value = ["learning-curve", "importance"]
 
-    result = get_available_plots(job, backend)
+    result = get_available_plots(job, backend, job_store.model_cache)
     assert "tuning" in result
 
 
@@ -420,7 +418,7 @@ def test_get_available_plots_no_tuning_when_file_absent(
     backend.load_model.return_value = MagicMock()
     backend.available_plots.return_value = ["learning-curve"]
 
-    result = get_available_plots(job, backend)
+    result = get_available_plots(job, backend, job_store.model_cache)
     assert "tuning" not in result
 
 


### PR DESCRIPTION
## Summary
- HISTORY H-0084 Proposal records the change-gate entry (internal API variation: ModelCache class, JobStore methods, retired globals).
- `ModelCache` class in `services/job_results.py` replaces the module-level `_model_cache` / `_model_cache_lock` globals. Exposes `load` / `clear` / `clear_for` + a `__contains__` helper for tests.
- `JobStore` owns one `ModelCache` (self.model_cache) and offers `load_model` / `clear_model_cache` / `clear_model_cache_for` convenience methods.
- Dispatch helpers (`get_metrics_table`, `get_split_summary`, `get_importance`, `get_importance_kinds`, `get_learning_curve_metrics`, `get_job_plot`, `get_available_plots`) now accept `cache: ModelCache` — all seven call sites in `api/jobs.py` pass `job_store.model_cache`.
- `JobStore.delete` uses self.clear_model_cache_for (INV-2 preserved).
- Retired globals (`load_job_model`, `clear_model_cache`, `clear_model_cache_for`) and their re-exports in `services/jobs.py::__all__`. Any in-repo caller must migrate (they all are).

## Invariants
- INV-1: two `JobStore` instances do not share a model cache; new test `test_model_cache_is_per_app` observes that caching in one instance does not surface in the other and vice versa.
- INV-2: `JobStore.delete` drops the cache entry for the deleted job's `model_path`.
- INV-3: `ModelCache.load` / `clear` / `clear_for` are thread-safe — the existing concurrent-readers test keeps passing.

## Failure Paths Covered
- [x] No model_path → clear `ValueError`
- [x] LRU eviction past `max_size` (new `test_model_cache_respects_max_size`)
- [x] Concurrent readers — `backend.load_model` called at most once
- [x] Two-app isolation — new per-app test
- [x] Retired globals don't accidentally return — new `test_retired_globals_are_gone`

## Verification
- Backend: **1167 pytest pass** (same total as before the PR: old test count included a dedicated `_reset_model_cache` autouse fixture and a `clear_model_cache_forces_reload` test; the new layout adds `test_model_cache_is_per_app`, `test_model_cache_respects_max_size`, and `test_retired_globals_are_gone` while dropping the now-redundant helpers).
- `uv run ruff check`, `ruff format --check`, `mypy src/lizystudio` — all clean.
- Frontend: `pnpm build` + `pnpm check` clean (no frontend change).

## Test plan
- [x] `test_job_results.py::test_model_cache_is_per_app` — INV-1
- [x] `test_job_results.py::test_job_store_delete_invalidates_model_cache` — INV-2 (updated to the new API)
- [x] `test_job_results.py::test_model_cache_load_is_atomic_under_concurrent_reads` — INV-3
- [x] `test_job_results.py::test_model_cache_respects_max_size`
- [x] `test_job_results.py::test_retired_globals_are_gone`
- [x] `test_jobs.py::test_job_store_load_model_raises_when_no_model_path`
- [x] Existing dispatch-helper tests migrated to the `cache`-taking signatures

Closes #235