### PR TITLE
fix(workspace): unnest buttons in Column Settings row (#248)

### DIFF
--- a/frontend/src/components/workspace/ColumnSettingsSection.test.tsx
+++ b/frontend/src/components/workspace/ColumnSettingsSection.test.tsx
@@ -1,0 +1,184 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { ColumnInfo } from "@/api/types";
+import { ColumnSettingsSection } from "./ColumnSettingsSection";
+
+const COLUMNS: ColumnInfo[] = [
+  {
+    name: "age",
+    dtype: "float64",
+    unique_count: 50,
+    suggested_type: "numeric",
+    suggested_excluded: false,
+  },
+  {
+    name: "color",
+    dtype: "object",
+    unique_count: 3,
+    suggested_type: "categorical",
+    suggested_excluded: false,
+  },
+];
+
+const SUMMARY = {
+  total: 1,
+  numeric: 1,
+  categorical: 0,
+  excluded: 0,
+  idCount: 0,
+  constCount: 0,
+  manualCount: 0,
+};
+
+function renderSection(handlers: {
+  onExcludeToggle?: (name: string, checked: boolean) => void;
+  onTypeChange?: (name: string, type: "numeric" | "categorical") => void;
+  onColumnExpand?: (name: string) => void;
+}) {
+  const onExcludeToggle = handlers.onExcludeToggle ?? vi.fn();
+  const onTypeChange = handlers.onTypeChange ?? vi.fn();
+  const onColumnExpand = handlers.onColumnExpand ?? vi.fn();
+  render(
+    <ColumnSettingsSection
+      columns={COLUMNS}
+      target="age"
+      overrides={{}}
+      columnFilter=""
+      onColumnFilterChange={() => {}}
+      expandedCol={null}
+      colStats={{}}
+      summary={SUMMARY}
+      onExcludeToggle={onExcludeToggle}
+      onTypeChange={onTypeChange}
+      onColumnExpand={onColumnExpand}
+    />,
+  );
+  return { onExcludeToggle, onTypeChange, onColumnExpand };
+}
+
+describe("ColumnSettingsSection DOM structure (Issue #248)", () => {
+  it("row container is not a <button> element (no nested interactive content)", () => {
+    renderSection({});
+    const row = screen.getByTestId("column-row-color");
+    expect(row.tagName).not.toBe("BUTTON");
+  });
+
+  it("row container is keyboard-focusable and exposes button role", () => {
+    renderSection({});
+    const row = screen.getByTestId("column-row-color");
+    expect(row.getAttribute("role")).toBe("button");
+    expect(row.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("row container is never a <button> that contains nested <button>s", () => {
+    // The previous implementation rendered <Checkbox> (Radix button) and
+    // Num / Cat <Button> inside an outer <button>, violating HTML and
+    // breaking click handling in real browsers. Guard against regression
+    // unconditionally — if the row ever becomes a <button> again, this
+    // assertion must fail.
+    renderSection({});
+    const row = screen.getByTestId("column-row-color");
+    if (row.tagName === "BUTTON") {
+      expect(row.querySelectorAll("button").length).toBe(0);
+    }
+    expect(row.tagName).toBe("DIV");
+  });
+
+  it("row exposes aria-expanded reflecting expanded state", () => {
+    renderSection({});
+    const row = screen.getByTestId("column-row-color");
+    expect(row.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("row exposes aria-label with the column name", () => {
+    renderSection({});
+    const row = screen.getByTestId("column-row-color");
+    expect(row.getAttribute("aria-label")).toBe("color");
+  });
+
+  it("clicking the exclude checkbox calls onExcludeToggle and not onColumnExpand", () => {
+    const { onExcludeToggle, onColumnExpand } = renderSection({});
+    const row = screen.getByTestId("column-row-color");
+    const checkbox = row.querySelector('[role="checkbox"]');
+    expect(checkbox).not.toBeNull();
+    fireEvent.click(checkbox as HTMLElement);
+    expect(onExcludeToggle).toHaveBeenCalledWith("color", true);
+    expect(onColumnExpand).not.toHaveBeenCalled();
+  });
+
+  it("clicking the Num button calls onTypeChange and not onColumnExpand", async () => {
+    const { onTypeChange, onColumnExpand } = renderSection({});
+    const row = screen.getByTestId("column-row-color");
+    const numButton = Array.from(row.querySelectorAll("button")).find(
+      (b) => b.textContent === "Num",
+    );
+    expect(numButton).toBeDefined();
+    await userEvent.click(numButton as HTMLElement);
+    expect(onTypeChange).toHaveBeenCalledWith("color", "numeric");
+    expect(onColumnExpand).not.toHaveBeenCalled();
+  });
+
+  it("clicking the Cat button calls onTypeChange and not onColumnExpand", async () => {
+    const { onTypeChange, onColumnExpand } = renderSection({});
+    const row = screen.getByTestId("column-row-color");
+    const catButton = Array.from(row.querySelectorAll("button")).find(
+      (b) => b.textContent === "Cat",
+    );
+    expect(catButton).toBeDefined();
+    await userEvent.click(catButton as HTMLElement);
+    expect(onTypeChange).toHaveBeenCalledWith("color", "categorical");
+    expect(onColumnExpand).not.toHaveBeenCalled();
+  });
+
+  it("clicking the row body calls onColumnExpand", async () => {
+    const { onColumnExpand } = renderSection({});
+    const row = screen.getByTestId("column-row-color");
+    await userEvent.click(row);
+    expect(onColumnExpand).toHaveBeenCalledWith("color");
+  });
+
+  it("pressing Enter on the focused row calls onColumnExpand", () => {
+    const { onColumnExpand } = renderSection({});
+    const row = screen.getByTestId("column-row-color");
+    row.focus();
+    fireEvent.keyDown(row, { key: "Enter" });
+    expect(onColumnExpand).toHaveBeenCalledWith("color");
+  });
+
+  it("pressing Space on the focused row calls onColumnExpand", () => {
+    const { onColumnExpand } = renderSection({});
+    const row = screen.getByTestId("column-row-color");
+    row.focus();
+    fireEvent.keyDown(row, { key: " " });
+    expect(onColumnExpand).toHaveBeenCalledWith("color");
+  });
+
+  it("pressing Space on the focused row prevents default scroll", () => {
+    renderSection({});
+    const row = screen.getByTestId("column-row-color");
+    row.focus();
+    const result = fireEvent.keyDown(row, { key: " " });
+    // fireEvent returns false when preventDefault was called on the event.
+    expect(result).toBe(false);
+  });
+
+  it("keydown on the checkbox container does not bubble up to the row", () => {
+    const { onColumnExpand } = renderSection({});
+    const row = screen.getByTestId("column-row-color");
+    const checkbox = row.querySelector('[role="checkbox"]');
+    expect(checkbox).not.toBeNull();
+    fireEvent.keyDown(checkbox as HTMLElement, { key: "Enter" });
+    fireEvent.keyDown(checkbox as HTMLElement, { key: " " });
+    expect(onColumnExpand).not.toHaveBeenCalled();
+  });
+
+  it("pressing a non-activation key on the row does not call onColumnExpand", () => {
+    const { onColumnExpand } = renderSection({});
+    const row = screen.getByTestId("column-row-color");
+    row.focus();
+    fireEvent.keyDown(row, { key: "Tab" });
+    fireEvent.keyDown(row, { key: "a" });
+    expect(onColumnExpand).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/workspace/ColumnSettingsSection.tsx
+++ b/frontend/src/components/workspace/ColumnSettingsSection.tsx
@@ -82,10 +82,27 @@ export function ColumnSettingsSection({
                 const stats = colStats[col.name];
                 return (
                   <div key={col.name}>
-                    <button
-                      type="button"
+                    {/* Issue #248: row must not be a <button> because it
+                        wraps other interactive controls (Checkbox, Num/Cat
+                        buttons). Real browsers hoist the inner <button>s
+                        out of the outer one, breaking click handling. Use
+                        role="button" + tabIndex + keyboard handler so the
+                        row stays activatable without nesting interactive
+                        content inside a <button>. */}
+                    {/* biome-ignore lint/a11y/useSemanticElements: cannot use <button> — nested interactive content */}
+                    <div
+                      role="button"
+                      tabIndex={0}
+                      aria-label={col.name}
+                      aria-expanded={isExpanded}
                       className={`grid w-full grid-cols-[1fr_60px_60px_100px] items-center gap-x-2 px-3 py-1.5 text-left hover:bg-muted/40 cursor-pointer ${idx % 2 === 1 ? "bg-muted/20" : ""}`}
                       onClick={() => onColumnExpand(col.name)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          onColumnExpand(col.name);
+                        }
+                      }}
                       data-testid={`column-row-${col.name}`}
                     >
                       <span className="text-xs truncate">
@@ -102,13 +119,16 @@ export function ColumnSettingsSection({
                         )}
                       </span>
                       <span className="text-xs">{col.unique_count}</span>
-                      <div>
+                      {/* biome-ignore lint/a11y/noStaticElementInteractions: stop propagation container */}
+                      <div
+                        onClick={(e) => e.stopPropagation()}
+                        onKeyDown={(e) => e.stopPropagation()}
+                      >
                         <Checkbox
                           checked={isExcluded}
                           onCheckedChange={(checked) =>
                             onExcludeToggle(col.name, checked === true)
                           }
-                          onClick={(e) => e.stopPropagation()}
                         />
                       </div>
                       {/* biome-ignore lint/a11y/noStaticElementInteractions: stop propagation container */}
@@ -142,7 +162,7 @@ export function ColumnSettingsSection({
                           Cat
                         </Button>
                       </div>
-                    </button>
+                    </div>
                     {isExpanded && stats && (
                       <div
                         className="px-3 py-2 bg-muted/10 border-t"


### PR DESCRIPTION
## Summary

Closes #248.

The row container in `ColumnSettingsSection` was a `<button>` wrapping three other `<button>` elements (Radix `<Checkbox>` + Num/Cat `<Button>`s). This violates the HTML spec — `<button>` cannot contain nested interactive content. React emits `Warning: <button> cannot contain a nested <button>`, and real browsers hoist the inner buttons out of the outer one, breaking click handling for Exclude/Type toggles. The result: Exclude checkbox toggles silently failed to reach `onCheckedChange`, so `features.exclude` in the config was never updated.

## Changes

- [ColumnSettingsSection.tsx](../blob/fix/column-settings-nested-button-248/frontend/src/components/workspace/ColumnSettingsSection.tsx):
  - Replace outer `<button type="button">` with `<div role="button" tabIndex={0}>`
  - Handle Enter/Space via `onKeyDown` with `preventDefault` (scroll prevention for Space)
  - Stop both `onClick` and `onKeyDown` propagation on the Checkbox and Num/Cat containers so keyboard activation on inner controls does not also trigger row expand
  - Add `aria-expanded` reflecting `isExpanded` state
  - Add `aria-label={col.name}` for screen reader context
- [ColumnSettingsSection.test.tsx](../blob/fix/column-settings-nested-button-248/frontend/src/components/workspace/ColumnSettingsSection.test.tsx) (new, 14 tests):
  - DOM structure: row is `<div>`, not `<button>`; has `role="button"`, `tabindex="0"`, `aria-label`, `aria-expanded`
  - Regression guard: unconditional assertion that row is `<div>` (if future refactor re-introduces `<button>`, test fails)
  - Click routing: checkbox → `onExcludeToggle` only; Num/Cat → `onTypeChange` only; row body → `onColumnExpand`
  - Keyboard routing: Enter/Space on row → `onColumnExpand`; Space `preventDefault` verified; Enter/Space bubbling from checkbox is stopped

## Verification

- 14/14 new component tests pass
- 54 pre-existing DataPanel tests still pass (unchanged `data-testid` works on `<div>`)
- `pnpm check` (Biome) clean
- `pnpm build` (tsc + vite) succeeds

## Invariants

- INV-1: The row element never nests another `<button>` inside it — HTML spec compliance
- INV-2: A keyboard or pointer activation on the Checkbox toggles exclude state without also triggering row expand
- INV-3: A keyboard or pointer activation on Num/Cat changes column type without also triggering row expand
- INV-4: Row expand is reachable via Enter, Space, and direct click on row body

## Failure Paths Covered

- [x] Click on checkbox → only onExcludeToggle fires (no onColumnExpand)
- [x] Click on Num/Cat → only onTypeChange fires (no onColumnExpand)
- [x] Click on row body → onColumnExpand fires
- [x] Enter/Space on focused row → onColumnExpand fires
- [x] Space on focused row → preventDefault prevents page scroll
- [x] Enter/Space bubbling from checkbox → does NOT fire onColumnExpand
- [x] Other keys (Tab, letter keys) → no-op

## Test Plan

- [ ] Load a dataset in dev (uv run lizystudio --reload), select a target, toggle Exclude on a column, verify `PUT /api/workspace/config` includes the column in `features.exclude`
- [ ] Verify Num/Cat switching is reflected in `features.categorical`
- [ ] Keyboard-only: Tab onto a row, press Enter → distribution panel expands; Space → scroll does not happen, panel expands
- [ ] Screen reader (VoiceOver/NVDA): row announces "<col-name>, collapsed button" / "expanded button" correctly

## Follow-ups

- #249 tracks a broader audit of Workspace form sections for similar nested-interactive / config-sync gaps