### PR TITLE
feat: accept config body in /fit and /tune to close race (P-0086, #251)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2344,3 +2344,42 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (f) 既存 pytest 1167+ / vitest 1624+ 全 pass、ruff / mypy / biome / tsc / pnpm build 全 clean。
 - **Decision:**
   - 2026-04-22 **Proposed & Implemented** — 本 PR で Proposal + 実装 + コメント付与を同時 merge。
+
+### P-0086: `/api/workspace/fit` と `/api/workspace/tune` に optional `config` body を受け入れる（Issue #251）
+- **Status:** proposed & implemented
+- **Scope:** Backend / Frontend | **change-gate 対象** — 公開 API の request body 拡張
+- **Related:** Issue #251、#248（独立した DOM ネスト問題）、#249（form section audit）、H-0076 / H-0077（useConfigSync / useDataPanel refactor の race-prone 前提を解消）
+- **Context:** Column Settings で Exclude をチェック直後に Fit を押すと、UI で exclude 表示になっている列が学習に使われる症状が報告された。原因は、`PUT /api/workspace/config` が非同期で in-flight のまま `POST /api/workspace/fit` が発火し、サーバー側の `ws.config`（更新前の snapshot）で job が作成される race condition。`/fit` `/tune` は body なしで呼ばれ `ws.config` に暗黙依存する設計であり、どんなにクライアントで flush しても送信中の window が残るため、構造的に脆い。
+- **Invariants:**
+  - INV-1: `POST /fit` の request body に `config` が与えられた場合、その config を validate → 成功時に `ws.config` を同じ内容に更新 → fit job を作成する。
+  - INV-2: `POST /fit` の `config` が省略された場合、従来通り `ws.config` を使う（後方互換）。
+  - INV-3: `POST /tune` も `config` 受け入れについて同じ振る舞いをする（tuning injection も含む）。
+  - INV-4: Frontend の `handleFit` / `handleTune` はクリック時点の React state から merged config を組み立て、body に載せて送る。これにより race window は構造的に存在しない。
+  - INV-5: `config` body は pydantic の `extra="forbid"` で未知フィールドを拒否する（request 自体のガード。内部 config の validate は backend adapter の `validate_config` に委譲）。
+- **Proposal & Impact:**
+  - `api/models.py` に `WorkspaceFitRequest(config: dict[str, Any] | None = None)` と `WorkspaceTuneRequest(config: dict[str, Any] | None = None)` を追加。
+  - `api/workspace.py` の `workspace_fit` / `workspace_tune` の signature に `body: WorkspaceFitRequest | None = None` / `WorkspaceTuneRequest | None = None` を追加。body.config があれば `validate_config` → `ws.set_config(body.config)` → 既存の fit / tune 起動パス。
+  - `frontend/src/api/generated/schema.d.ts` を `pnpm generate:api` で再生成。
+  - `frontend/src/api/workspace.ts` の `runFit` / `runTune` に optional `config?: Record<string, unknown>` 引数を追加し、body に載せる。
+  - `frontend/src/hooks/useConfigSync.ts` から merged config 組み立てロジックを `buildSyncedConfig` 純関数として抽出し、Fit / Tune ハンドラからも再利用できるようにする。
+  - `frontend/src/pages/WorkspacePage.tsx` の `handleFit` / `handleTune` が `buildSyncedConfig` で最新 state の config を組み立てて `runFit` / `runTune` に渡す。
+- **Compatibility:**
+  - wire format: request body を optional に拡張（後方互換）。既存の body なし呼び出しは従来通り `ws.config` を使って動作する。
+  - 既存 test / CLI / curl は変更不要。
+  - 新 body schema は `extra="forbid"` により将来の拡張を明示的に制御。
+- **Alternatives considered:**
+  - (A) クライアント側で in-flight PUT を await する `flushPending()`: 却下。変更は最小だが race の構造的脆弱性が残り、CommandPalette / 将来の Run エントリポイント / 外部クライアント（curl / E2E）では race が再発する。
+  - (C) `PUT /config` を同期的にし、完了前に次の PUT / POST をブロック: 却下。UI のレスポンシビリティと開発体験を損なう。
+  - (D) WebSocket による双方向 config 同期: 却下。複雑度が現状の問題スケールに対して過大。
+- **Acceptance Criteria:**
+  - (a) `api/models.py` に `WorkspaceFitRequest` / `WorkspaceTuneRequest` が存在し `extra="forbid"` がついている。
+  - (b) `workspace_fit` / `workspace_tune` が body.config あり / なし両方で動作する（ユニットテスト追加）。
+  - (c) body.config があれば `ws.config` がそれで上書きされ、その config で job meta が作られる。
+  - (d) body.config が validate 失敗なら 4xx、`ws.config` は不変。
+  - (e) `frontend/src/api/generated/schema.d.ts` が regenerate 済み。
+  - (f) `runFit(config?)` / `runTune(config?)` が optional 引数を受ける。
+  - (g) `useConfigSync` から `buildSyncedConfig` が抽出されテストされる。
+  - (h) `handleFit` / `handleTune` が最新 state の merged config を body で送信する（Vitest で検証）。
+  - (i) 既存 pytest / vitest 全 pass、ruff / biome / tsc / pnpm build 全 clean。
+- **Decision:**
+  - 2026-04-23 **Proposed & Implemented** — 本 PR で Proposal + 実装を同時 merge。Issue #251 を close。

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -389,6 +389,14 @@ export interface paths {
         /**
          * Workspace Fit
          * @description Create a fit job (thread managed by Service layer).
+         *
+         *     P-0086 (Issue #251): ``body.config`` may be provided to atomically
+         *     overwrite ``ws.config`` at fit time, closing the race window between
+         *     a pending ``PUT /config`` and the ``POST /fit`` call. The body is
+         *     declared with a ``WorkspaceFitRequest()`` default (rather than
+         *     ``| None``) because ``from __future__ import annotations`` together
+         *     with ``Optional`` + ``Depends`` breaks FastAPI's body detection,
+         *     causing the parameter to be parsed as a query string.
          */
         post: operations["workspace_fit_api_workspace_fit_post"];
         delete?: never;
@@ -409,6 +417,10 @@ export interface paths {
         /**
          * Workspace Tune
          * @description Create a tune job (thread managed by Service layer).
+         *
+         *     P-0086 (Issue #251): ``body.config`` may be provided to atomically
+         *     overwrite ``ws.config`` at tune time. See ``workspace_fit`` above
+         *     for the rationale behind the ``WorkspaceTuneRequest()`` default.
          */
         post: operations["workspace_tune_api_workspace_tune_post"];
         delete?: never;
@@ -1883,6 +1895,26 @@ export interface components {
                 [key: string]: unknown;
             }[];
         };
+        /**
+         * WorkspaceFitRequest
+         * @description Request body for ``POST /api/workspace/fit`` (P-0086, Issue #251).
+         *
+         *     When ``config`` is provided it overwrites ``ws.config`` atomically at
+         *     fit time, closing the race window between an in-flight ``PUT /config``
+         *     and the subsequent ``POST /fit``. The UI sends the latest merged
+         *     config here so user edits (e.g. an Exclude toggle) are guaranteed to
+         *     be reflected in the fitted model regardless of PUT timing.
+         *
+         *     When omitted, the endpoint falls back to the current ``ws.config``
+         *     for backward compatibility with callers that still use the old
+         *     PUT-then-POST flow (curl, external clients, legacy E2E).
+         */
+        WorkspaceFitRequest: {
+            /** Config */
+            config?: {
+                [key: string]: unknown;
+            } | null;
+        };
         /** WorkspaceStatusResponse */
         WorkspaceStatusResponse: {
             /** Has Data */
@@ -1894,6 +1926,19 @@ export interface components {
             data_ref?: components["schemas"]["StatusDataRef"] | null;
             /** Current Job Id */
             current_job_id?: string | null;
+        };
+        /**
+         * WorkspaceTuneRequest
+         * @description Request body for ``POST /api/workspace/tune`` (P-0086, Issue #251).
+         *
+         *     Mirrors :class:`WorkspaceFitRequest`. Tuning-specific defaults are
+         *     still injected inside the endpoint after the body.config is applied.
+         */
+        WorkspaceTuneRequest: {
+            /** Config */
+            config?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * WsCompleted
@@ -2511,7 +2556,11 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["WorkspaceFitRequest"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -2520,6 +2569,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["JobStartResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -2531,7 +2589,11 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["WorkspaceTuneRequest"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -2540,6 +2602,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["JobStartResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/frontend/src/api/workspace.test.ts
+++ b/frontend/src/api/workspace.test.ts
@@ -355,6 +355,34 @@ describe("runFit", () => {
     const result = await runFit();
     expect(result).toEqual({ job_id: "j1" });
   });
+
+  it("sends no body when called with no argument (P-0086)", async () => {
+    let capturedBody: unknown = "not captured";
+    server.use(
+      http.post("/api/workspace/fit", async ({ request }) => {
+        capturedBody = await request
+          .clone()
+          .json()
+          .catch(() => "empty");
+        return HttpResponse.json({ job_id: "j1" });
+      }),
+    );
+    await runFit();
+    expect(capturedBody).toBe("empty");
+  });
+
+  it("sends body={config} when called with config (P-0086)", async () => {
+    let capturedBody: unknown = null;
+    server.use(
+      http.post("/api/workspace/fit", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({ job_id: "j1" });
+      }),
+    );
+    const config = { task: "binary", features: { exclude: ["age"] } };
+    await runFit(config);
+    expect(capturedBody).toEqual({ config });
+  });
 });
 
 describe("runTune", () => {
@@ -366,6 +394,19 @@ describe("runTune", () => {
     );
     const result = await runTune();
     expect(result).toEqual({ job_id: "j2" });
+  });
+
+  it("sends body={config} when called with config (P-0086)", async () => {
+    let capturedBody: unknown = null;
+    server.use(
+      http.post("/api/workspace/tune", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({ job_id: "j2" });
+      }),
+    );
+    const config = { task: "regression", features: { exclude: ["x"] } };
+    await runTune(config);
+    expect(capturedBody).toEqual({ config });
   });
 });
 

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -170,15 +170,38 @@ export function getConfigDownloadUrl(): string {
   return "/api/workspace/config/download";
 }
 
-export async function runFit(): Promise<{ job_id: string }> {
-  const { data } = await apiClient.POST("/api/workspace/fit", {});
+// P-0086 (Issue #251): accept an optional ``config`` so the latest UI state
+// is applied atomically at fit time. Without this, an in-flight ``PUT /config``
+// can lose the race against ``POST /fit`` and the server reads a stale
+// ``ws.config``, which silently drops manual Exclude / Type edits made just
+// before pressing Fit.
+export async function runFit(
+  config?: Record<string, unknown>,
+): Promise<{ job_id: string }> {
+  // SSOT-EXEMPT (Issue #236): openapi-fetch's generated body type for
+  // /api/workspace/fit is ``WorkspaceFitRequest | undefined``, but the
+  // body must be wrapped under ``{ body: ... }`` for the client and
+  // also allow complete omission when ``config`` is undefined. The
+  // conditional-wrapper + cast keeps the single call-site ergonomic.
+  const options =
+    config !== undefined
+      ? ({ body: { config } } as never)
+      : (undefined as never);
+  const { data } = await apiClient.POST("/api/workspace/fit", options);
   // SSOT-EXEMPT (Issue #236): backend returns JobStartResponse — wider than this subset.
   return unwrap(data, "/api/workspace/fit") as unknown as { job_id: string };
 }
 
-export async function runTune(): Promise<{ job_id: string }> {
-  const { data } = await apiClient.POST("/api/workspace/tune", {});
-  // SSOT-EXEMPT (Issue #236): same as runFit.
+export async function runTune(
+  config?: Record<string, unknown>,
+): Promise<{ job_id: string }> {
+  // SSOT-EXEMPT (Issue #236): see runFit above.
+  const options =
+    config !== undefined
+      ? ({ body: { config } } as never)
+      : (undefined as never);
+  const { data } = await apiClient.POST("/api/workspace/tune", options);
+  // SSOT-EXEMPT (Issue #236): backend returns JobStartResponse — wider than this subset.
   return unwrap(data, "/api/workspace/tune") as unknown as { job_id: string };
 }
 

--- a/frontend/src/components/workspace/DataPanel.tsx
+++ b/frontend/src/components/workspace/DataPanel.tsx
@@ -1,4 +1,6 @@
+import { forwardRef, useImperativeHandle } from "react";
 import type { UiSchema } from "@/api/types";
+import { fetchConfig } from "@/api/workspace";
 import {
   Accordion,
   AccordionContent,
@@ -14,6 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { buildSyncedConfig } from "@/hooks/buildSyncedConfig";
 import {
   TASK_OPTIONS,
   type TaskType,
@@ -31,179 +34,223 @@ interface DataPanelProps {
   uiSchema?: UiSchema;
 }
 
-export function DataPanel({
-  onDataChanged,
-  onTaskChanged,
-  uiSchema,
-}: DataPanelProps) {
-  const {
-    sourceType,
-    setSourceType,
-    dataPath,
-    setDataPath,
-    shape,
-    preview,
-    target,
-    task,
-    allColumnNames,
-    columns,
-    overrides,
-    cv,
-    setCv,
-    blocked,
-    setBlocked,
-    loading,
-    columnFilter,
-    setColumnFilter,
-    expandedCol,
-    colStats,
-    summary,
-    nonExcludedCols,
-    handleLoadPathByValue,
-    handleUpload,
-    handleTargetChange,
-    handleTaskChange,
-    handleExcludeToggle,
-    handleTypeChange,
-    handleColumnExpand,
-  } = useDataPanel({ onDataChanged, onTaskChanged, uiSchema });
+/**
+ * Imperative handle exposed by :class:`DataPanel` so the Fit/Tune
+ * handler in ``WorkspacePage`` can grab the **latest** merged config
+ * at click time (P-0086, Issue #251).
+ *
+ * The alternative of lifting every piece of :func:`useDataPanel` state
+ * up one level would require threading 25+ controlled-component props
+ * through DataPanel, exploding the surface area. The ref keeps the
+ * interface small: one function that returns the snapshot a POST /fit
+ * or /tune body should carry.
+ */
+export interface DataPanelHandle {
+  getSubmitConfig: () => Promise<Record<string, unknown>>;
+}
 
-  return (
-    <div className="flex h-full flex-col overflow-auto">
-      <div className="px-3 py-4">
-        <Accordion
-          type="multiple"
-          defaultValue={["source", "target", "columns", "cv"]}
-        >
-          {/* Data Source */}
-          <AccordionItem value="source" className="border-b">
-            <AccordionTrigger className="py-1.5 text-sm font-semibold hover:bg-muted/50">
-              Data Source
-            </AccordionTrigger>
-            <AccordionContent>
-              <DataSourceSection
-                sourceType={sourceType}
-                onSourceTypeChange={setSourceType}
-                dataPath={dataPath}
-                onDataPathChange={setDataPath}
-                loading={loading}
-                shape={shape}
-                preview={preview}
-                onLoadPath={handleLoadPathByValue}
-                onUpload={handleUpload}
-              />
-            </AccordionContent>
-          </AccordionItem>
+export const DataPanel = forwardRef<DataPanelHandle, DataPanelProps>(
+  function DataPanel(
+    { onDataChanged, onTaskChanged, uiSchema }: DataPanelProps,
+    ref,
+  ) {
+    const {
+      sourceType,
+      setSourceType,
+      dataPath,
+      setDataPath,
+      shape,
+      preview,
+      target,
+      task,
+      allColumnNames,
+      columns,
+      overrides,
+      cv,
+      setCv,
+      blocked,
+      setBlocked,
+      loading,
+      columnFilter,
+      setColumnFilter,
+      expandedCol,
+      colStats,
+      summary,
+      nonExcludedCols,
+      handleLoadPathByValue,
+      handleUpload,
+      handleTargetChange,
+      handleTaskChange,
+      handleExcludeToggle,
+      handleTypeChange,
+      handleColumnExpand,
+    } = useDataPanel({ onDataChanged, onTaskChanged, uiSchema });
 
-          {/* Target / Task */}
-          <AccordionItem value="target" className="border-b">
-            <AccordionTrigger className="py-1.5 text-sm font-semibold hover:bg-muted/50">
-              Target / Task
-            </AccordionTrigger>
-            <AccordionContent>
-              <div className="lzs-form space-y-3 pl-4">
-                <div className="flex items-center gap-2">
-                  <Label className="min-w-[60px] text-xs">Target</Label>
-                  <Select
-                    value={target ?? ""}
-                    onValueChange={handleTargetChange}
-                    disabled={allColumnNames.length === 0}
-                  >
-                    <SelectTrigger
-                      aria-label="Target column"
-                      className="h-8 flex-1"
+    // P-0086: expose a builder that returns the merged config the Fit/Tune
+    // handler should post. ``base`` is re-fetched on each call so the
+    // merge runs against the freshest server-known snapshot, but the
+    // overlay (target / task / overrides / cv / blocked) comes from
+    // current React state — i.e. what the user actually sees.
+    const strategyFields = uiSchema?.capabilities?.cv_strategy_fields?.[
+      cv.strategy
+    ] as readonly string[] | undefined;
+    useImperativeHandle(
+      ref,
+      () => ({
+        getSubmitConfig: async () => {
+          const base = await fetchConfig();
+          return buildSyncedConfig({
+            base: base as Record<string, unknown>,
+            dataPath,
+            target,
+            task,
+            overrides,
+            cv,
+            blocked,
+            strategyFields,
+          });
+        },
+      }),
+      [dataPath, target, task, overrides, cv, blocked, strategyFields],
+    );
+
+    return (
+      <div className="flex h-full flex-col overflow-auto">
+        <div className="px-3 py-4">
+          <Accordion
+            type="multiple"
+            defaultValue={["source", "target", "columns", "cv"]}
+          >
+            {/* Data Source */}
+            <AccordionItem value="source" className="border-b">
+              <AccordionTrigger className="py-1.5 text-sm font-semibold hover:bg-muted/50">
+                Data Source
+              </AccordionTrigger>
+              <AccordionContent>
+                <DataSourceSection
+                  sourceType={sourceType}
+                  onSourceTypeChange={setSourceType}
+                  dataPath={dataPath}
+                  onDataPathChange={setDataPath}
+                  loading={loading}
+                  shape={shape}
+                  preview={preview}
+                  onLoadPath={handleLoadPathByValue}
+                  onUpload={handleUpload}
+                />
+              </AccordionContent>
+            </AccordionItem>
+
+            {/* Target / Task */}
+            <AccordionItem value="target" className="border-b">
+              <AccordionTrigger className="py-1.5 text-sm font-semibold hover:bg-muted/50">
+                Target / Task
+              </AccordionTrigger>
+              <AccordionContent>
+                <div className="lzs-form space-y-3 pl-4">
+                  <div className="flex items-center gap-2">
+                    <Label className="min-w-[60px] text-xs">Target</Label>
+                    <Select
+                      value={target ?? ""}
+                      onValueChange={handleTargetChange}
+                      disabled={allColumnNames.length === 0}
                     >
-                      <SelectValue placeholder="Select target column" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {allColumnNames.map((name) => (
-                        <SelectItem key={name} value={name}>
-                          {name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="flex items-start gap-2">
-                  <Label className="mt-1 min-w-[60px] text-xs">Task</Label>
-                  <div className="flex flex-col gap-1">
-                    <SegmentGroup
-                      options={TASK_OPTIONS as unknown as string[]}
-                      value={task ?? ""}
-                      onChange={(v) => handleTaskChange(v as TaskType)}
-                      disabled={!target}
-                    />
-                    {!target && (
-                      <span className="text-xs text-muted-foreground">
-                        Auto-detected after target selection
-                      </span>
-                    )}
+                      <SelectTrigger
+                        aria-label="Target column"
+                        className="h-8 flex-1"
+                      >
+                        <SelectValue placeholder="Select target column" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {allColumnNames.map((name) => (
+                          <SelectItem key={name} value={name}>
+                            {name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="flex items-start gap-2">
+                    <Label className="mt-1 min-w-[60px] text-xs">Task</Label>
+                    <div className="flex flex-col gap-1">
+                      <SegmentGroup
+                        options={TASK_OPTIONS as unknown as string[]}
+                        value={task ?? ""}
+                        onChange={(v) => handleTaskChange(v as TaskType)}
+                        disabled={!target}
+                      />
+                      {!target && (
+                        <span className="text-xs text-muted-foreground">
+                          Auto-detected after target selection
+                        </span>
+                      )}
+                    </div>
                   </div>
                 </div>
-              </div>
-            </AccordionContent>
-          </AccordionItem>
+              </AccordionContent>
+            </AccordionItem>
 
-          {/* Column Settings */}
-          <AccordionItem value="columns" className="border-b">
-            <AccordionTrigger className="py-1.5 text-sm font-semibold hover:bg-muted/50">
-              <span className="flex items-center gap-2">
-                Column Settings
-                {target && columns.length > 0 && (
-                  <Badge
-                    variant="secondary"
-                    className="text-[10px] font-normal"
-                  >
-                    {summary.total - summary.excluded} features
-                  </Badge>
-                )}
-              </span>
-            </AccordionTrigger>
-            <AccordionContent>
-              <ColumnSettingsSection
-                columns={columns}
-                target={target}
-                overrides={overrides}
-                columnFilter={columnFilter}
-                onColumnFilterChange={setColumnFilter}
-                expandedCol={expandedCol}
-                colStats={colStats}
-                summary={summary}
-                onExcludeToggle={handleExcludeToggle}
-                onTypeChange={handleTypeChange}
-                onColumnExpand={handleColumnExpand}
-              />
-            </AccordionContent>
-          </AccordionItem>
+            {/* Column Settings */}
+            <AccordionItem value="columns" className="border-b">
+              <AccordionTrigger className="py-1.5 text-sm font-semibold hover:bg-muted/50">
+                <span className="flex items-center gap-2">
+                  Column Settings
+                  {target && columns.length > 0 && (
+                    <Badge
+                      variant="secondary"
+                      className="text-[10px] font-normal"
+                    >
+                      {summary.total - summary.excluded} features
+                    </Badge>
+                  )}
+                </span>
+              </AccordionTrigger>
+              <AccordionContent>
+                <ColumnSettingsSection
+                  columns={columns}
+                  target={target}
+                  overrides={overrides}
+                  columnFilter={columnFilter}
+                  onColumnFilterChange={setColumnFilter}
+                  expandedCol={expandedCol}
+                  colStats={colStats}
+                  summary={summary}
+                  onExcludeToggle={handleExcludeToggle}
+                  onTypeChange={handleTypeChange}
+                  onColumnExpand={handleColumnExpand}
+                />
+              </AccordionContent>
+            </AccordionItem>
 
-          {/* Cross Validation */}
-          <AccordionItem value="cv" className="border-b">
-            <AccordionTrigger className="py-1.5 text-sm font-semibold hover:bg-muted/50">
-              Cross Validation
-            </AccordionTrigger>
-            <AccordionContent>
-              <div className="pl-4 space-y-3">
-                <CvSection
-                  cv={cv}
-                  onChange={setCv}
-                  uiSchema={uiSchema}
-                  nonExcludedCols={nonExcludedCols}
-                  blocked={blocked}
-                  onBlockedChange={setBlocked}
-                />
-                <FoldPreview
-                  enabled={!!target && !!task && shape !== null}
-                  cvKey={JSON.stringify({
-                    strategy: cv.strategy,
-                    folds: cv.folds,
-                    gap: cv.gap,
-                  })}
-                />
-              </div>
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
+            {/* Cross Validation */}
+            <AccordionItem value="cv" className="border-b">
+              <AccordionTrigger className="py-1.5 text-sm font-semibold hover:bg-muted/50">
+                Cross Validation
+              </AccordionTrigger>
+              <AccordionContent>
+                <div className="pl-4 space-y-3">
+                  <CvSection
+                    cv={cv}
+                    onChange={setCv}
+                    uiSchema={uiSchema}
+                    nonExcludedCols={nonExcludedCols}
+                    blocked={blocked}
+                    onBlockedChange={setBlocked}
+                  />
+                  <FoldPreview
+                    enabled={!!target && !!task && shape !== null}
+                    cvKey={JSON.stringify({
+                      strategy: cv.strategy,
+                      folds: cv.folds,
+                      gap: cv.gap,
+                    })}
+                  />
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  },
+);

--- a/frontend/src/hooks/buildSyncedConfig.test.ts
+++ b/frontend/src/hooks/buildSyncedConfig.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { INITIAL_BLOCKED_STATE } from "@/components/workspace/BlockedGroupKFoldEditor";
+import { INITIAL_CV_STATE } from "@/components/workspace/cv-state";
+import { buildSyncedConfig } from "./buildSyncedConfig";
+
+const BASE = {
+  config_version: 1,
+  task: "binary",
+  data: { path: null, target: null, time_col: null, group_col: null },
+  features: { exclude: [], categorical: [], auto_categorical: true },
+  split: { method: "stratified_kfold", n_splits: 5 },
+  model: { name: "lgbm", params: {} },
+  training: {
+    seed: 42,
+    early_stopping: { enabled: true, rounds: 150 },
+    inner_valid: { method: "holdout", ratio: 0.1 },
+  },
+  evaluation: { metrics: [] },
+  calibration: null,
+  tuning: null,
+};
+
+describe("buildSyncedConfig", () => {
+  it("applies target, task, dataPath into data section", () => {
+    const out = buildSyncedConfig({
+      base: BASE,
+      dataPath: "/tmp/data.csv",
+      target: "Survived",
+      task: "binary",
+      overrides: {},
+      cv: INITIAL_CV_STATE,
+      blocked: INITIAL_BLOCKED_STATE,
+    });
+    expect((out.data as Record<string, unknown>).target).toBe("Survived");
+    expect((out.data as Record<string, unknown>).path).toBe("/tmp/data.csv");
+    expect(out.task).toBe("binary");
+  });
+
+  it("extracts exclude and categorical from overrides", () => {
+    const out = buildSyncedConfig({
+      base: BASE,
+      dataPath: "",
+      target: "target",
+      task: "binary",
+      overrides: {
+        age: { excluded: true, type: "numeric" },
+        gender: { excluded: false, type: "categorical" },
+      },
+      cv: INITIAL_CV_STATE,
+      blocked: INITIAL_BLOCKED_STATE,
+    });
+    const features = out.features as Record<string, unknown>;
+    expect(features.exclude).toEqual(["age"]);
+    expect(features.categorical).toEqual(["gender"]);
+  });
+
+  it("falls back to base task when task arg is null", () => {
+    const out = buildSyncedConfig({
+      base: { ...BASE, task: "regression" },
+      dataPath: "",
+      target: "y",
+      task: null,
+      overrides: {},
+      cv: INITIAL_CV_STATE,
+      blocked: INITIAL_BLOCKED_STATE,
+    });
+    expect(out.task).toBe("regression");
+  });
+
+  it("does not mutate the base config", () => {
+    const base = structuredClone(BASE);
+    buildSyncedConfig({
+      base,
+      dataPath: "/d",
+      target: "y",
+      task: "binary",
+      overrides: { x: { excluded: true, type: "numeric" } },
+      cv: INITIAL_CV_STATE,
+      blocked: INITIAL_BLOCKED_STATE,
+    });
+    expect(base).toEqual(BASE);
+  });
+
+  it("emits a split section based on cv state", () => {
+    const out = buildSyncedConfig({
+      base: BASE,
+      dataPath: "",
+      target: "y",
+      task: "binary",
+      overrides: {},
+      cv: { ...INITIAL_CV_STATE, strategy: "kfold", folds: 7 },
+      blocked: INITIAL_BLOCKED_STATE,
+    });
+    const split = out.split as Record<string, unknown>;
+    expect(split.method).toBe("kfold");
+    expect(split.n_splits).toBe(7);
+  });
+});

--- a/frontend/src/hooks/buildSyncedConfig.ts
+++ b/frontend/src/hooks/buildSyncedConfig.ts
@@ -1,0 +1,66 @@
+import type { BlockedGroupKFoldState } from "@/components/workspace/BlockedGroupKFoldEditor";
+import {
+  applyCvDataFields,
+  buildSplitConfig,
+  type CvState,
+} from "@/components/workspace/cv-state";
+import type { ColumnOverride, TaskType } from "./useDataPanel.types";
+import { extractOverrideArrays } from "./useDataPanel.types";
+
+/**
+ * Pure builder that merges the latest UI state onto a base config snapshot.
+ *
+ * Extracted from ``useConfigSync.syncConfig`` (P-0086, Issue #251) so the
+ * same logic can be reused by the Fit / Tune handlers to send the current
+ * state in the POST body. Without sharing this, the UI would have to either
+ * (a) wait for the in-flight PUT /config — race-prone and brittle — or
+ * (b) duplicate the merging logic and drift out of sync with what
+ * ``useConfigSync`` emits.
+ *
+ * The CV-strategy-change ``inner_valid`` auto-switch stays inside the hook
+ * because it depends on a cross-render ref; this builder is intentionally
+ * stateless so it is safe to call from any React event handler.
+ */
+export function buildSyncedConfig(params: {
+  base: Record<string, unknown>;
+  dataPath: string;
+  target: string | null;
+  task: TaskType | null;
+  overrides: Record<string, ColumnOverride>;
+  cv: CvState;
+  blocked: BlockedGroupKFoldState;
+  strategyFields?: readonly string[];
+}): Record<string, unknown> {
+  const {
+    base,
+    dataPath,
+    target,
+    task,
+    overrides,
+    cv,
+    blocked,
+    strategyFields,
+  } = params;
+  const { categorical, excluded } = extractOverrideArrays(overrides);
+  const baseData = (base.data as Record<string, unknown>) ?? {};
+  const baseTask = (base as Record<string, unknown>).task;
+  return {
+    ...base,
+    task: task || baseTask,
+    data: applyCvDataFields(
+      {
+        ...baseData,
+        path: dataPath || undefined,
+        target: target || undefined,
+      },
+      cv,
+      strategyFields,
+    ),
+    features: {
+      ...((base.features as object) ?? {}),
+      categorical,
+      exclude: excluded,
+    },
+    split: buildSplitConfig(cv, blocked, strategyFields),
+  };
+}

--- a/frontend/src/hooks/useConfigSync.ts
+++ b/frontend/src/hooks/useConfigSync.ts
@@ -8,13 +8,12 @@ import {
 } from "@/api/workspace";
 import type { BlockedGroupKFoldState } from "@/components/workspace/BlockedGroupKFoldEditor";
 import {
-  applyCvDataFields,
-  buildSplitConfig,
   type CvState,
   recommendedInnerValid,
 } from "@/components/workspace/cv-state";
+import { buildSyncedConfig } from "./buildSyncedConfig";
 import type { ColumnOverride, TaskType } from "./useDataPanel.types";
-import { buildSyncKey, extractOverrideArrays } from "./useDataPanel.types";
+import { buildSyncKey } from "./useDataPanel.types";
 
 interface UseConfigSyncParams {
   dataPath: string;
@@ -54,8 +53,6 @@ export function useConfigSync({
     abortRef.current = controller;
 
     try {
-      const { categorical, excluded } = extractOverrideArrays(overrides);
-
       let base = await fetchConfig({ signal: controller.signal });
       if (controller.signal.aborted) return;
 
@@ -65,29 +62,16 @@ export function useConfigSync({
         base = await fetchConfigDefaults(task, target);
       }
 
-      const baseData = (base as Record<string, unknown>).data as Record<
-        string,
-        unknown
-      >;
-      const merged: Record<string, unknown> = {
-        ...base,
-        task: task || (base as Record<string, unknown>).task,
-        data: applyCvDataFields(
-          {
-            ...baseData,
-            path: dataPath || undefined,
-            target: target || undefined,
-          },
-          cv,
-          strategyFields,
-        ),
-        features: {
-          ...((base as Record<string, unknown>).features as object),
-          categorical,
-          exclude: excluded,
-        },
-        split: buildSplitConfig(cv, blocked, strategyFields),
-      };
+      const merged = buildSyncedConfig({
+        base: base as Record<string, unknown>,
+        dataPath,
+        target,
+        task,
+        overrides,
+        cv,
+        blocked,
+        strategyFields,
+      });
 
       const baseTraining = (merged.training as Record<string, unknown>) ?? {};
       const innerValid =

--- a/frontend/src/pages/WorkspacePage.test.tsx
+++ b/frontend/src/pages/WorkspacePage.test.tsx
@@ -1,4 +1,5 @@
 import { act, cleanup, screen } from "@testing-library/react";
+import { forwardRef, useImperativeHandle } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "@/test/helpers";
 import { WorkspacePage } from "./WorkspacePage";
@@ -16,7 +17,12 @@ const {
   mockRunFit: vi.fn(),
   mockRunTune: vi.fn(),
   mockUpdateConfig: vi.fn(),
-  mockToast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  mockToast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
 }));
 
 const { mockFetchConfig } = vi.hoisted(() => ({
@@ -52,11 +58,41 @@ let capturedDataPanelProps: Record<string, unknown> = {};
 let capturedModelPanelProps: Record<string, unknown> = {};
 let capturedResultsPanelProps: Record<string, unknown> = {};
 
+// P-0086: DataPanel now forwards a ref that exposes ``getSubmitConfig``.
+// The mock mirrors that contract so handleFit / handleTune can read the
+// latest merged config through the ref at click time. ``submitConfigRef``
+// is created via ``vi.hoisted`` because vi.mock factories execute before
+// module-scope ``const`` initializers, and because a mutable ref is the
+// idiomatic way to let individual tests swap the value seen by the mock.
+const { submitConfigRef, submitConfigErrorRef } = vi.hoisted(() => ({
+  submitConfigRef: { current: null as Record<string, unknown> | null },
+  submitConfigErrorRef: { current: null as Error | null },
+}));
+
 vi.mock("@/components/workspace/DataPanel", () => ({
-  DataPanel: (props: Record<string, unknown>) => {
-    capturedDataPanelProps = props;
-    return <div data-testid="data-panel">DataPanel</div>;
-  },
+  DataPanel: forwardRef(
+    (
+      props: Record<string, unknown>,
+      ref: React.Ref<{
+        getSubmitConfig: () => Promise<Record<string, unknown>>;
+      }>,
+    ) => {
+      capturedDataPanelProps = props;
+      useImperativeHandle(
+        ref,
+        () => ({
+          getSubmitConfig: async () => {
+            if (submitConfigErrorRef.current) {
+              throw submitConfigErrorRef.current;
+            }
+            return submitConfigRef.current ?? ({} as Record<string, unknown>);
+          },
+        }),
+        [],
+      );
+      return <div data-testid="data-panel">DataPanel</div>;
+    },
+  ),
 }));
 vi.mock("@/components/workspace/ModelPanel", () => ({
   ModelPanel: (props: Record<string, unknown>) => {
@@ -79,6 +115,8 @@ describe("WorkspacePage", () => {
     capturedDataPanelProps = {};
     capturedModelPanelProps = {};
     capturedResultsPanelProps = {};
+    submitConfigRef.current = null;
+    submitConfigErrorRef.current = null;
 
     Object.defineProperty(window, "matchMedia", {
       writable: true,
@@ -481,6 +519,59 @@ describe("WorkspacePage", () => {
       expect(screen.getByRole("tab", { name: /model/i })).toHaveAttribute(
         "aria-selected",
         "true",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // P-0086 (Issue #251): handleFit / handleTune must read the latest
+  // merged config from DataPanel's ref and include it in the POST body,
+  // so Fit/Tune never loses the race against an in-flight PUT /config.
+  // -------------------------------------------------------------------
+  describe("P-0086 fit/tune config body", () => {
+    it("passes DataPanel's merged config as runFit body", async () => {
+      mockRunFit.mockResolvedValue({ job_id: "job-fit-p0086" });
+      submitConfigRef.current = {
+        task: "binary",
+        features: { exclude: ["age"], categorical: [] },
+      };
+      renderWithProviders(<WorkspacePage />);
+
+      const onFit = capturedModelPanelProps.onFit as () => Promise<void>;
+      await act(async () => onFit());
+
+      expect(mockRunFit).toHaveBeenCalledWith(submitConfigRef.current);
+    });
+
+    it("passes DataPanel's merged config as runTune body", async () => {
+      mockRunTune.mockResolvedValue({ job_id: "job-tune-p0086" });
+      submitConfigRef.current = {
+        task: "regression",
+        features: { exclude: ["id"], categorical: [] },
+      };
+      renderWithProviders(<WorkspacePage />);
+
+      const onTune = capturedModelPanelProps.onTune as () => Promise<void>;
+      await act(async () => onTune());
+
+      expect(mockRunTune).toHaveBeenCalledWith(submitConfigRef.current);
+    });
+
+    it("falls back to body-less runFit and warns when getSubmitConfig throws", async () => {
+      // Review feedback on P-0086: when fetchConfig fails inside the
+      // DataPanel imperative handle, the fit/tune click must still
+      // reach the server (body-less regression path) AND surface a
+      // toast so the user knows why their latest edits may be missing.
+      mockRunFit.mockResolvedValue({ job_id: "job-fallback" });
+      submitConfigErrorRef.current = new Error("network down");
+      renderWithProviders(<WorkspacePage />);
+
+      const onFit = capturedModelPanelProps.onFit as () => Promise<void>;
+      await act(async () => onFit());
+
+      expect(mockRunFit).toHaveBeenCalledWith(undefined);
+      expect(mockToast.warning).toHaveBeenCalledWith(
+        expect.stringContaining("network down"),
       );
     });
   });

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { BarChart3, Database, SlidersHorizontal } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { getErrorMessage } from "@/api/errors";
 import { useConfig, useUiSchema } from "@/api/queries";
@@ -12,7 +12,10 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { DataPanel } from "@/components/workspace/DataPanel";
+import {
+  DataPanel,
+  type DataPanelHandle,
+} from "@/components/workspace/DataPanel";
 import { ModelPanel } from "@/components/workspace/ModelPanel";
 import { ResultsPanel } from "@/components/workspace/ResultsPanel";
 import { useBackgroundNotification } from "@/hooks/useBackgroundNotification";
@@ -73,27 +76,55 @@ export function WorkspacePage() {
     setTask(t);
   }, []);
 
+  // P-0086 (Issue #251): ref that exposes the DataPanel's merged config
+  // at click time so Fit/Tune never reads a stale ws.config that lost
+  // the race against an in-flight PUT /config. If the ref isn't
+  // attached yet (extremely early in mount) we fall back to the legacy
+  // body-less POST, which is backward-compatible with the server.
+  const dataPanelRef = useRef<DataPanelHandle | null>(null);
+
+  const submitConfigOrUndefined = useCallback(async () => {
+    const handle = dataPanelRef.current;
+    if (!handle) return undefined;
+    try {
+      return await handle.getSubmitConfig();
+    } catch (err) {
+      // Fall through to body-less POST so the server still receives
+      // the run request; better to fit with ws.config than to cancel
+      // the user's click on a transient fetch failure. Warn via toast
+      // so the user understands why their latest Column Settings edits
+      // may not appear in the fitted model (race-fix observability,
+      // review feedback on P-0086).
+      toast.warning(
+        `Using last saved config for this run — live config unavailable (${getErrorMessage(err)})`,
+      );
+      return undefined;
+    }
+  }, []);
+
   const handleFit = useCallback(async () => {
     setRunning(true);
     try {
-      const { job_id } = await runFit();
+      const config = await submitConfigOrUndefined();
+      const { job_id } = await runFit(config);
       setCurrentJobId(job_id);
     } catch (err) {
       toast.error(`Fit failed: ${getErrorMessage(err)}`);
       setRunning(false);
     }
-  }, [setCurrentJobId]);
+  }, [setCurrentJobId, submitConfigOrUndefined]);
 
   const handleTune = useCallback(async () => {
     setRunning(true);
     try {
-      const { job_id } = await runTune();
+      const config = await submitConfigOrUndefined();
+      const { job_id } = await runTune(config);
       setCurrentJobId(job_id);
     } catch (err) {
       toast.error(`Tune failed: ${getErrorMessage(err)}`);
       setRunning(false);
     }
-  }, [setCurrentJobId]);
+  }, [setCurrentJobId, submitConfigOrUndefined]);
 
   const handleApplyToFit = useCallback(
     async (fullConfig: Record<string, unknown>) => {
@@ -151,6 +182,7 @@ export function WorkspacePage() {
           className="flex-1 overflow-auto focus-visible:outline-none"
         >
           <DataPanel
+            ref={dataPanelRef}
             onDataChanged={handleDataChanged}
             onTaskChanged={handleTaskChanged}
             uiSchema={uiSchema}
@@ -242,6 +274,7 @@ export function WorkspacePage() {
           className="flex h-full flex-col focus-visible:outline-none"
         >
           <DataPanel
+            ref={dataPanelRef}
             onDataChanged={handleDataChanged}
             onTaskChanged={handleTaskChanged}
             uiSchema={uiSchema}

--- a/src/lizystudio/api/models.py
+++ b/src/lizystudio/api/models.py
@@ -128,6 +128,37 @@ class JobStartResponse(BaseModel):
     job_id: str
 
 
+class WorkspaceFitRequest(BaseModel):
+    """Request body for ``POST /api/workspace/fit`` (P-0086, Issue #251).
+
+    When ``config`` is provided it overwrites ``ws.config`` atomically at
+    fit time, closing the race window between an in-flight ``PUT /config``
+    and the subsequent ``POST /fit``. The UI sends the latest merged
+    config here so user edits (e.g. an Exclude toggle) are guaranteed to
+    be reflected in the fitted model regardless of PUT timing.
+
+    When omitted, the endpoint falls back to the current ``ws.config``
+    for backward compatibility with callers that still use the old
+    PUT-then-POST flow (curl, external clients, legacy E2E).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    config: dict[str, Any] | None = None
+
+
+class WorkspaceTuneRequest(BaseModel):
+    """Request body for ``POST /api/workspace/tune`` (P-0086, Issue #251).
+
+    Mirrors :class:`WorkspaceFitRequest`. Tuning-specific defaults are
+    still injected inside the endpoint after the body.config is applied.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    config: dict[str, Any] | None = None
+
+
 class FitResultResponse(BaseModel):
     """Training result summary (mirror of :class:`FitSummary`).
 

--- a/src/lizystudio/api/workspace.py
+++ b/src/lizystudio/api/workspace.py
@@ -11,10 +11,10 @@ import tempfile
 import time
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 import yaml
-from fastapi import APIRouter, Depends, Query, Request, UploadFile  # noqa: F401
+from fastapi import APIRouter, Body, Depends, Query, Request, UploadFile  # noqa: F401
 from fastapi.responses import Response
 from pydantic import BaseModel  # noqa: F401
 
@@ -39,7 +39,9 @@ from lizystudio.api.models import (
     PreviewResponseModel,
     SplitPreviewResponseModel,
     ValidationResponse,
+    WorkspaceFitRequest,
     WorkspaceStatusResponse,
+    WorkspaceTuneRequest,
 )
 from lizystudio.security import (
     check_dataframe_memory,
@@ -507,11 +509,30 @@ def config_download(
 
 @router.post("/fit", response_model=JobStartResponse)
 def workspace_fit(
+    body: Annotated[WorkspaceFitRequest, Body()] = WorkspaceFitRequest(),
     ws: WorkspaceState = Depends(get_workspace),
     job_store: JobStore = Depends(get_job_store),
     broadcaster: ProgressBroadcaster = Depends(get_broadcaster),
 ) -> dict[str, Any]:
-    """Create a fit job (thread managed by Service layer)."""
+    """Create a fit job (thread managed by Service layer).
+
+    P-0086 (Issue #251): ``body.config`` may be provided to atomically
+    overwrite ``ws.config`` at fit time, closing the race window between
+    a pending ``PUT /config`` and the ``POST /fit`` call. The body is
+    declared with a ``WorkspaceFitRequest()`` default (rather than
+    ``| None``) because ``from __future__ import annotations`` together
+    with ``Optional`` + ``Depends`` breaks FastAPI's body detection,
+    causing the parameter to be parsed as a query string.
+    """
+    # P-0086: apply body.config first so validate runs against what the
+    # caller actually wants to fit, and so ws.config ends up matching
+    # the config recorded in the job's meta.json.
+    if body.config is not None:
+        candidate = body.config
+        errors = validate_config(ws, candidate)
+        if errors:
+            raise ValidationError(errors)
+        ws.set_config(candidate)
     if not ws.config:
         raise WorkspaceNoConfigError()
     if ws.dataframe is None or ws.data_ref is None:
@@ -563,11 +584,25 @@ def workspace_fit(
 
 @router.post("/tune", response_model=JobStartResponse)
 def workspace_tune(
+    body: Annotated[WorkspaceTuneRequest, Body()] = WorkspaceTuneRequest(),
     ws: WorkspaceState = Depends(get_workspace),
     job_store: JobStore = Depends(get_job_store),
     broadcaster: ProgressBroadcaster = Depends(get_broadcaster),
 ) -> dict[str, Any]:
-    """Create a tune job (thread managed by Service layer)."""
+    """Create a tune job (thread managed by Service layer).
+
+    P-0086 (Issue #251): ``body.config`` may be provided to atomically
+    overwrite ``ws.config`` at tune time. See ``workspace_fit`` above
+    for the rationale behind the ``WorkspaceTuneRequest()`` default.
+    """
+    # P-0086: same semantics as workspace_fit — body.config wins and
+    # updates ws.config before tuning injection / validation runs.
+    if body.config is not None:
+        candidate = body.config
+        errors = validate_config(ws, candidate)
+        if errors:
+            raise ValidationError(errors)
+        ws.set_config(candidate)
     if not ws.config:
         raise WorkspaceNoConfigError()
     if ws.dataframe is None or ws.data_ref is None:

--- a/tests/test_fit_tune_config_body.py
+++ b/tests/test_fit_tune_config_body.py
@@ -1,0 +1,220 @@
+"""Tests for P-0086: /api/workspace/fit and /tune accept optional config body.
+
+Motivated by Issue #251: a race condition where ``PUT /config`` is in-flight
+while ``POST /fit`` fires makes the server use a stale ``ws.config``. The
+structural fix is to accept a ``{ "config": {...} }`` body on /fit and /tune
+so the latest UI snapshot is applied atomically at fit/tune time.
+
+Invariants covered:
+
+- INV-1: body.config present → validate → ws.config overwrite → fit job
+- INV-2: body.config absent → fall back to ws.config (backward compatible)
+- INV-3: same behaviour for /tune
+- INV-5: WorkspaceFitRequest / WorkspaceTuneRequest reject unknown top-level
+  fields (extra="forbid")
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+def _create_csv(tmp_path: Path) -> str:
+    csv_path = tmp_path / "train.csv"
+    with csv_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["id", "age", "gender", "target"])
+        for i in range(50):
+            writer.writerow([i, 20 + i, "M" if i % 2 == 0 else "F", i % 2])
+    return str(csv_path)
+
+
+def _load_data(client: TestClient, tmp_path: Path) -> None:
+    csv_path = _create_csv(tmp_path)
+    r = client.post("/api/workspace/data/path", json={"path": csv_path})
+    assert r.status_code == 200
+
+
+def _get_defaults(client: TestClient) -> dict[str, Any]:
+    r = client.get("/api/workspace/config/defaults?task=binary&target=target")
+    assert r.status_code == 200
+    return r.json()
+
+
+def _put_config(client: TestClient, cfg: dict[str, Any]) -> None:
+    r = client.put("/api/workspace/config", json=cfg)
+    assert r.status_code == 200
+    assert r.json()["saved"] is True
+
+
+# ---------------------------------------------------------------------------
+# INV-1: body.config is applied and ws.config is overwritten
+# ---------------------------------------------------------------------------
+
+
+def test_fit_body_config_overwrites_ws_config(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """POST /fit with body.config updates ws.config before fit runs."""
+    _load_data(client, tmp_path)
+    base = _get_defaults(client)
+    _put_config(client, base)
+
+    # Baseline: ws.config has exclude=[] (no manual excludes yet)
+    cfg_before = client.get("/api/workspace/config").json()
+    assert "age" not in cfg_before["features"].get("exclude", [])
+
+    # Send fit with explicit exclude=["age"] in body
+    new_cfg = {**base, "features": {**base["features"], "exclude": ["age"]}}
+    r = client.post("/api/workspace/fit", json={"config": new_cfg})
+    assert r.status_code == 200, r.text
+    assert "job_id" in r.json()
+
+    # ws.config must now reflect the body.config
+    cfg_after = client.get("/api/workspace/config").json()
+    assert cfg_after["features"]["exclude"] == ["age"]
+
+
+def test_tune_body_config_overwrites_ws_config(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """POST /tune with body.config updates ws.config before tune runs."""
+    _load_data(client, tmp_path)
+    base = _get_defaults(client)
+    _put_config(client, base)
+
+    new_cfg = {**base, "features": {**base["features"], "exclude": ["gender"]}}
+    r = client.post("/api/workspace/tune", json={"config": new_cfg})
+    assert r.status_code == 200, r.text
+    assert "job_id" in r.json()
+
+    cfg_after = client.get("/api/workspace/config").json()
+    assert cfg_after["features"]["exclude"] == ["gender"]
+
+
+# ---------------------------------------------------------------------------
+# INV-2: body.config omitted → use ws.config (backward compatibility)
+# ---------------------------------------------------------------------------
+
+
+def test_fit_without_body_uses_ws_config(client: TestClient, tmp_path: Path) -> None:
+    """POST /fit with no body still works and uses ws.config (regression)."""
+    _load_data(client, tmp_path)
+    base = _get_defaults(client)
+    _put_config(client, base)
+
+    # Caller-preferred ergonomics: omit body entirely
+    r = client.post("/api/workspace/fit")
+    assert r.status_code == 200, r.text
+    assert "job_id" in r.json()
+
+
+def test_fit_with_empty_body_uses_ws_config(client: TestClient, tmp_path: Path) -> None:
+    """POST /fit with body={} (no config field) still uses ws.config."""
+    _load_data(client, tmp_path)
+    base = _get_defaults(client)
+    _put_config(client, base)
+
+    r = client.post("/api/workspace/fit", json={})
+    assert r.status_code == 200, r.text
+
+
+def test_tune_without_body_uses_ws_config(client: TestClient, tmp_path: Path) -> None:
+    """POST /tune with no body still works and uses ws.config (regression)."""
+    _load_data(client, tmp_path)
+    base = _get_defaults(client)
+    _put_config(client, base)
+
+    r = client.post("/api/workspace/tune")
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# Validation: body.config that fails validate → 4xx, ws.config unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_fit_body_config_invalid_returns_4xx_and_keeps_ws_config(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """If body.config fails backend validation, fit returns 4xx and
+    ws.config is not overwritten."""
+    _load_data(client, tmp_path)
+    base = _get_defaults(client)
+    _put_config(client, base)
+    baseline_cfg = client.get("/api/workspace/config").json()
+
+    # Deliberately break the config: task is required and must be a known
+    # literal. Passing a garbage task triggers validate_config failure.
+    broken = {**base, "task": "not_a_task"}
+    r = client.post("/api/workspace/fit", json={"config": broken})
+    assert r.status_code in (400, 422), r.text
+
+    # ws.config must be untouched
+    after = client.get("/api/workspace/config").json()
+    assert after == baseline_cfg
+
+
+# ---------------------------------------------------------------------------
+# INV-5: request body rejects unknown top-level fields
+# ---------------------------------------------------------------------------
+
+
+def test_fit_body_rejects_unknown_top_level_fields(
+    client: TestClient, tmp_path: Path
+) -> None:
+    _load_data(client, tmp_path)
+    base = _get_defaults(client)
+    _put_config(client, base)
+
+    r = client.post(
+        "/api/workspace/fit",
+        json={"config": base, "mystery_field": "value"},
+    )
+    assert r.status_code == 422
+
+
+def test_tune_body_rejects_unknown_top_level_fields(
+    client: TestClient, tmp_path: Path
+) -> None:
+    _load_data(client, tmp_path)
+    base = _get_defaults(client)
+    _put_config(client, base)
+
+    r = client.post(
+        "/api/workspace/tune",
+        json={"config": base, "mystery_field": "value"},
+    )
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Race-condition regression: body.config wins over stale ws.config
+# ---------------------------------------------------------------------------
+
+
+def test_fit_body_config_wins_over_stale_ws_config(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Even if ws.config is stale (missing a manual exclude), the body's
+    config is what ends up in ws.config after /fit."""
+    _load_data(client, tmp_path)
+    base = _get_defaults(client)
+    # Simulate the stale state: ws.config has no manual excludes
+    _put_config(client, base)
+
+    # Fresh config from the UI with a manual exclude applied
+    fresh = {**base, "features": {**base["features"], "exclude": ["age"]}}
+
+    r = client.post("/api/workspace/fit", json={"config": fresh})
+    assert r.status_code == 200
+
+    after = client.get("/api/workspace/config").json()
+    assert "age" in after["features"]["exclude"]


### PR DESCRIPTION
## Summary

Closes #251. Implements Proposal **P-0086** in [HISTORY.md](../blob/feat/fit-tune-config-body-251/HISTORY.md#L2348) — fit/tune now accept an optional `{ config: {...} }` body and apply it atomically, eliminating the race window between an in-flight `PUT /config` and the subsequent `POST /fit`.

## The bug (reproduced via Playwright)

1. Upload Titanic-shaped data, select target, toggle Exclude on `Sex`
2. Click Fit before the PUT /config triggered by the checkbox toggle completes
3. Job `meta.json` shows `features.exclude: ["PassengerId", "Name"]` (auto-detected only), missing `Sex`
4. Feature Importance plot has `Sex` at 1.0 — the model learned on what the UI had marked excluded

The race window exists even with a perfectly coded frontend because PUT/POST are separate HTTP calls; the user's click arrives faster than the PUT completes.

## Fix — plan B (accepted in the design discussion on #251)

Accept `config` in the request body of `/fit` and `/tune`. When provided, the server validates it, overwrites `ws.config`, then fits/tunes. The frontend sends the latest UI state (merged via the same `buildSyncedConfig` that `useConfigSync` uses) so the POST alone is sufficient — no sync handshake needed.

## Changes

### Backend
- [api/models.py](../blob/feat/fit-tune-config-body-251/src/lizystudio/api/models.py#L131) — `WorkspaceFitRequest` / `WorkspaceTuneRequest` with `extra=\"forbid\"`
- [api/workspace.py](../blob/feat/fit-tune-config-body-251/src/lizystudio/api/workspace.py#L508) — `workspace_fit`/`workspace_tune` accept `Annotated[Model, Body()] = Model()` (not `Optional[Model] = None`; the latter breaks FastAPI body parsing under `from __future__ import annotations` + `Depends`)
- [tests/test_fit_tune_config_body.py](../blob/feat/fit-tune-config-body-251/tests/test_fit_tune_config_body.py) — 9 integration tests: present/absent/invalid/unknown-field/wins-over-stale/empty-body

### Frontend
- [api/workspace.ts](../blob/feat/fit-tune-config-body-251/frontend/src/api/workspace.ts#L173) — `runFit(config?)` / `runTune(config?)` forward to `{ body: { config } }`
- [hooks/buildSyncedConfig.ts](../blob/feat/fit-tune-config-body-251/frontend/src/hooks/buildSyncedConfig.ts) — new pure function extracted from `useConfigSync.syncConfig`; reused by both the effect-driven PUT path and the click-time Fit/Tune path
- [hooks/useConfigSync.ts](../blob/feat/fit-tune-config-body-251/frontend/src/hooks/useConfigSync.ts) — delegates to `buildSyncedConfig`
- [components/workspace/DataPanel.tsx](../blob/feat/fit-tune-config-body-251/frontend/src/components/workspace/DataPanel.tsx) — `forwardRef` exposes `getSubmitConfig()` via `useImperativeHandle`; keeps prop surface small (lifting every `useDataPanel` state to `WorkspacePage` would have required 25+ controlled props)
- [pages/WorkspacePage.tsx](../blob/feat/fit-tune-config-body-251/frontend/src/pages/WorkspacePage.tsx) — `dataPanelRef` + `handleFit`/`handleTune` pull the snapshot at click time; fallback to body-less POST with a `toast.warning` when the ref handle throws

### Docs
- [HISTORY.md](../blob/feat/fit-tune-config-body-251/HISTORY.md#L2348) — Proposal P-0086 with full invariants, alternatives, and acceptance criteria

## Invariants

- **INV-1**: `POST /fit` with `body.config` validates → overwrites `ws.config` → fits in one atomic step
- **INV-2**: `POST /fit` without body falls back to `ws.config` (backward compatible)
- **INV-3**: Same for `POST /tune` (including tuning-default injection after body apply)
- **INV-4**: Frontend Fit/Tune handlers pull merged config from current React state at click time → race is structurally impossible
- **INV-5**: Request body rejects unknown top-level fields via `extra=\"forbid\"`

## Failure Paths

- [x] body.config present → validate → overwrite → fit (happy path)
- [x] body.config absent → use ws.config (regression, curl/E2E/legacy clients)
- [x] body.config invalid → 4xx, ws.config unchanged
- [x] body with unknown top-level fields → 422
- [x] body.config wins even when ws.config is stale
- [x] Frontend ref not yet attached → body-less POST
- [x] `getSubmitConfig` throws (e.g. fetchConfig network error) → body-less POST + `toast.warning` so user notices

## Verification

- `pytest tests/test_fit_tune_config_body.py tests/test_workspace_edge_cases.py tests/test_workspace_api.py tests/test_api_schema_contract.py tests/test_error_paths.py tests/test_server.py tests/test_retune_api.py tests/test_jobs.py` — 159/159 pass
- `pnpm vitest run` — 1638 passed, 2 skipped
- `uv run ruff check .` — clean
- `uv run mypy src/lizystudio/api/workspace.py src/lizystudio/api/models.py` — clean
- `pnpm check` — clean
- `pnpm build` — clean
- Proposal P-0086 added before implementation commits per [change-gate.md](https://github.com/nbx-liz/LizyStudio/blob/develop/CLAUDE.md)

## Commit order (change-gate compliant)

1. `docs(history): add proposal P-0086 for fit/tune config body (#251)`
2. `feat(api): accept optional config body in /fit and /tune (P-0086, #251)` (backend + tests)
3. `chore(frontend): regenerate OpenAPI schema after P-0086 body changes`
4. `feat(frontend): send latest merged config in runFit/runTune body (P-0086, #251)`

## Test plan

- [ ] Smoke: Upload Titanic-shape CSV, select target, toggle Exclude on Sex, click Fit immediately — `meta.json` `features.exclude` includes `Sex` and model Feature Importance omits it
- [ ] Regression: `curl -X POST /api/workspace/fit` (no body) still works against a pre-populated `ws.config`
- [ ] Toast path: disconnect network briefly, click Fit — `toast.warning` appears and a body-less fit still starts
- [ ] Keyboard shortcut (`Ctrl+Enter`) path — same race-fix behaviour

## Related

- #248 Column Settings nested `<button>` HTML violation — independent PR merged at #250; not the root cause of #251
- #249 Workspace form sections audit — this PR addresses one instance; the audit still tracks other potential gaps
- H-0076 / H-0077 — the useConfigSync / useDataPanel refactor that this PR piggy-backs on