### PR TITLE
fix(workspace): align UI schema with Pydantic to close UI Fit 422 (P-0087, #258, #259)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2383,3 +2383,36 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (i) 既存 pytest / vitest 全 pass、ruff / biome / tsc / pnpm build 全 clean。
 - **Decision:**
   - 2026-04-23 **Proposed & Implemented** — 本 PR で Proposal + 実装を同時 merge。Issue #251 を close。
+
+### P-0087: UI schema と Pydantic の drift を contract test で禁止（Issue #258 / #259）
+- **Status:** proposed & implemented
+- **Scope:** Backend / Frontend / Testing
+- **Related:** Issue #258（UI Fit が defaults でも 422 で失敗）、Issue #259（umbrella: defaults round-trip invariant 欠如）、Issue #257（UI-driven E2E 不在）、P-0086
+- **Context:** `POST /api/workspace/fit` が defaults 由来の config でも 422 を返す regression が出た。root cause は `lizystudio/backends/lizyml_ui_schema.py` の `capabilities.cv_strategy_fields` が `stratified_kfold: [..., "shuffle"]` と宣言していたが、lizyml の `StratifiedKFoldConfig` は `shuffle` を受け付けない。フロント (`buildSyncedConfig`) は UI schema を信頼して `shuffle: true` を payload に注入し、`POST /fit` が reject。2 つのスキーマが手書きで育ち drift するクラスのバグで、層単位のユニットテストでは検出できない（defaults は Pydantic を通るので backend 単体は常に pass、フロントは自分の宣言を信じるので自己閉じた契約は常に pass）。
+- **Invariants:**
+  - INV-1: `ui_schema.capabilities.cv_strategy_fields[M]` が宣言する field は、対応する Pydantic CV variant（`<M>Config`）または `DataConfig` で accept されていなければならない。
+  - INV-2: `POST /config/validate` と `POST /fit` は同じ config に対し同じ verdict を返す（両方 accept か両方 reject）。
+  - INV-3: `GET /config/defaults` が返す config をそのまま `POST /fit` に渡すと 200 が返る（defaults round-trip）。
+  - INV-4: フロントの `FALLBACK_CV_STRATEGY_FIELDS` は backend `cv_strategy_fields` と一致する（boot 時の UI schema 未取得期でも drift させない）。
+- **Proposal & Impact:**
+  - `lizyml_ui_schema.py:515` の `stratified_kfold` から `shuffle` を削除、`blocked_group_kfold` から `n_splits` を削除、`stratified_group_kfold` に `shuffle` を追加（全て Pydantic 側と整合）。
+  - `frontend/src/components/workspace/cv-state.ts` の `FALLBACK_CV_STRATEGY_FIELDS` を同期。さらに `buildSplitConfig` の `n_splits` 無条件出力を active fields チェックで gate（code-review HIGH-1: `blocked_group_kfold` で依然 422 を起こしていた同クラスバグ）。
+  - 新規 `tests/contract/` ディレクトリを作成し以下を追加:
+    - `test_ui_schema_matches_pydantic.py` — INV-1 / INV-4 を lock。全 CV variant の field が Pydantic または DataConfig に存在すること、さらに frontend の `FALLBACK_CV_STRATEGY_FIELDS` が backend SSOT と一致することを assert。
+    - `test_validate_fit_symmetry.py` — INV-2 を lock。realistic な UI payload shape で parametrize し、validate / fit の verdict が一致することを assert。
+  - `tests/regression/test_reg_0258_defaults_roundtrip.py` — INV-3 を lock。binary / regression の defaults が `POST /fit` で 200 を返すことを assert。
+  - `frontend/tests/e2e/workspace-fit.spec.ts` に "UI: load data -> pick target -> click Fit -> fit returns 200" を追加（UI-driven Fit の golden path、Issue #257 の最小対応）。
+  - 既存 `tests/test_ui_schema.py::test_capabilities_cv_strategy_fields_ui_semantics`、`frontend/src/components/workspace/cv-section.test.ts`、`CvSection.component.test.tsx` の expected map を新 SSOT に合わせて更新。
+- **Compatibility:**
+  - UI-visible: `stratified_kfold` 選択時に Shuffle トグルが **表示されなくなる**（`CvSection.tsx` の `has("shuffle")` ゲートが自動で非表示化）。`kfold` では従来通り表示。将来 lizyml に `StratifiedKFoldConfig.shuffle` が追加されたら UI schema に戻すだけで復活する。
+  - API: 破壊的変更なし。defaults の shape 不変、fit / tune の受け入れ範囲は狭くなる方向（以前から reject されていた invalid payload を、フロントが作らなくなる）。
+- **Alternatives considered:**
+  - (A) lizyml 側の `StratifiedKFoldConfig` に `shuffle: bool = True` を追加: 将来検討。外部リポジトリの PR リードタイムが必要なため Phase 3 に繰り延べ。
+  - (C) backend でサーバー側 strip: 却下。invariant を守るのではなく symptom を隠すだけで、drift class は残る。
+- **Acceptance Criteria:**
+  - (a) `tests/contract/` の 2 suite + `tests/regression/test_reg_0258_defaults_roundtrip.py` が全て pass。
+  - (b) 既存 pytest / vitest / ruff / biome / build が全 pass。
+  - (c) UI-driven E2E "UI: load data -> pick target -> click Fit" が pass する（new spec）。
+  - (d) Issue #258 の再現手順を踏んでも 200 が返る（手動検証）。
+- **Decision:**
+  - 2026-04-23 **Proposed & Implemented** — Phase 1 PR で採用。#258 / #259 の最小止血 + 再発防止 contract を同梱。#257 は minimal happy path を今 PR で追加し、残りは Phase 2 PR で拡充。#259 の UI schema Pydantic 導出化は Phase 3 PR で別途検討。

--- a/frontend/src/components/workspace/CvSection.component.test.tsx
+++ b/frontend/src/components/workspace/CvSection.component.test.tsx
@@ -264,7 +264,10 @@ describe("CvSection", () => {
   // Additional strategy rendering tests
   // -------------------------------------------------------------------------
 
-  it("shows Folds, Random State, and Group column for stratified_group_kfold", () => {
+  it("shows Folds, Random State, Shuffle, and Group column for stratified_group_kfold", () => {
+    // Issue #258 / #259 / P-0087: StratifiedGroupKFoldConfig accepts
+    // `shuffle` (Pydantic default True). The UI now exposes it so the
+    // user can override the default without editing raw config.
     render(
       <CvSection
         cv={makeCvState({ strategy: "stratified_group_kfold" })}
@@ -274,8 +277,8 @@ describe("CvSection", () => {
     );
     expect(screen.getByText("Folds")).toBeInTheDocument();
     expect(screen.getByText("Random State")).toBeInTheDocument();
+    expect(screen.getByText("Shuffle")).toBeInTheDocument();
     expect(screen.getByText("Group column")).toBeInTheDocument();
-    expect(screen.queryByText("Shuffle")).not.toBeInTheDocument();
     expect(screen.queryByText("Time column")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/workspace/cv-section.test.ts
+++ b/frontend/src/components/workspace/cv-section.test.ts
@@ -19,9 +19,9 @@ import {
 // previously imported `CV_STRATEGY_FIELDS` from `./constants`.
 const CV_STRATEGY_FIELDS: Record<string, readonly string[]> = {
   kfold: ["n_splits", "random_state", "shuffle"],
-  stratified_kfold: ["n_splits", "random_state", "shuffle"],
+  stratified_kfold: ["n_splits", "random_state"],
   group_kfold: ["n_splits", "group_col"],
-  stratified_group_kfold: ["n_splits", "random_state", "group_col"],
+  stratified_group_kfold: ["n_splits", "random_state", "shuffle", "group_col"],
   time_series: [
     "n_splits",
     "time_col",
@@ -46,7 +46,6 @@ const CV_STRATEGY_FIELDS: Record<string, readonly string[]> = {
     "test_size_max",
   ],
   blocked_group_kfold: [
-    "n_splits",
     "time_col",
     "group_col",
     "min_train_rows",
@@ -168,7 +167,12 @@ describe("buildSplitConfig", () => {
       });
     });
 
-    it("stratified_kfold includes folds, random_state and shuffle when fields allow all three", () => {
+    it("stratified_kfold includes folds and random_state (no shuffle — see #258 / #259)", () => {
+      // Issue #258 / #259: stratified_kfold in the lizyml Pydantic
+      // schema does not accept `shuffle` (only `kfold` does). The UI
+      // schema was updated to match; buildSplitConfig must therefore
+      // drop `shuffle` for this strategy even though the UI toggle
+      // still exists in CvState.
       const cv: CvState = {
         ...INITIAL_CV_STATE,
         strategy: "stratified_kfold",
@@ -185,7 +189,6 @@ describe("buildSplitConfig", () => {
         method: "stratified_kfold",
         n_splits: 3,
         random_state: 0,
-        shuffle: true,
       });
     });
 
@@ -314,7 +317,10 @@ describe("buildSplitConfig", () => {
       expect(result.min_valid_rows).toBe(50);
     });
 
-    it("omits undefined optional cv fields but includes blocked defaults", () => {
+    it("omits undefined optional cv fields and does not emit n_splits (Pydantic rejects it)", () => {
+      // Issue #258 / #259: BlockedGroupKFoldConfig has no `n_splits`
+      // field and rejects extras. buildSplitConfig must gate n_splits
+      // on the active fields list (which excludes it for this strategy).
       const cv: CvState = {
         ...INITIAL_CV_STATE,
         strategy: "blocked_group_kfold",
@@ -325,10 +331,10 @@ describe("buildSplitConfig", () => {
       const result = buildSplitConfig(cv);
       expect(result).toEqual({
         method: "blocked_group_kfold",
-        n_splits: 3,
         mode: "expanding",
         train_window: 1,
       });
+      expect(result).not.toHaveProperty("n_splits");
     });
 
     it("includes blocked state fields (mode, train_window, cutoffs, stratify)", () => {

--- a/frontend/src/components/workspace/cv-state.ts
+++ b/frontend/src/components/workspace/cv-state.ts
@@ -28,11 +28,18 @@ export function getEffectiveCvStrategy(
  * behaviour). Keep this in sync with the backend SSOT — the shape is
  * asserted by `tests/test_ui_schema.py::test_capabilities_cv_strategy_fields_ui_semantics`.
  */
+// Issue #258 / #259: every field must match the backend Pydantic
+// variant (or DataConfig for target/time_col/group_col). A contract
+// test on the backend side
+// (``tests/contract/test_ui_schema_matches_pydantic.py``) locks this
+// invariant server-side; this fallback only applies before the live
+// UI schema is fetched, so keep it in sync to avoid the same drift
+// class at boot time.
 export const FALLBACK_CV_STRATEGY_FIELDS: Record<string, readonly string[]> = {
   kfold: ["n_splits", "random_state", "shuffle"],
-  stratified_kfold: ["n_splits", "random_state", "shuffle"],
+  stratified_kfold: ["n_splits", "random_state"],
   group_kfold: ["n_splits", "group_col"],
-  stratified_group_kfold: ["n_splits", "random_state", "group_col"],
+  stratified_group_kfold: ["n_splits", "random_state", "shuffle", "group_col"],
   time_series: [
     "n_splits",
     "time_col",
@@ -57,7 +64,6 @@ export const FALLBACK_CV_STRATEGY_FIELDS: Record<string, readonly string[]> = {
     "test_size_max",
   ],
   blocked_group_kfold: [
-    "n_splits",
     "time_col",
     "group_col",
     "min_train_rows",
@@ -188,8 +194,14 @@ export function buildSplitConfig(
   const active = resolveFields(cv.strategy, fields);
   const split: Record<string, unknown> = {
     method: cv.strategy,
-    n_splits: cv.folds,
   };
+  // Issue #258 / #259: n_splits is strategy-specific. Pydantic variants
+  // like BlockedGroupKFoldConfig have no n_splits field and reject it
+  // with extra="forbid". Gate the assignment on the active fields list
+  // (same pattern as every other split property below).
+  if (active.includes("n_splits")) {
+    split.n_splits = cv.folds;
+  }
   if (active.includes("random_state") && cv.randomState !== undefined) {
     split.random_state = cv.randomState;
   }

--- a/frontend/tests/e2e/workspace-fit.spec.ts
+++ b/frontend/tests/e2e/workspace-fit.spec.ts
@@ -265,4 +265,94 @@ test.describe("Workspace Fit Flow", () => {
 
     await expect(page).toHaveScreenshot("fit-data-loaded.png");
   });
+
+  /**
+   * Issue #257 / #258 / #259 — UI-driven Fit happy path.
+   *
+   * Before this spec, the E2E suite exercised Fit only through
+   * ``request.post``. The real frontend path — where
+   * ``buildSyncedConfig`` assembles a payload on top of backend defaults
+   * — was never run in CI, so drift between the UI schema helper and
+   * the lizyml Pydantic model (#258) could only be caught by live
+   * browser testing. This spec drives the minimal UI flow and fails if
+   * ``POST /api/workspace/fit`` comes back with anything other than 200.
+   */
+  test("UI: load data -> pick target -> click Fit -> fit returns 200", async ({
+    page,
+    request,
+  }, testInfo) => {
+    // 120s was too tight on slow CI (15s schema load + 15s combo enable +
+    // 30s fit accept + 90s poll) — 180s matches the existing API-only
+    // ``run fit, verify results`` spec.
+    test.setTimeout(180_000);
+    if (isMobileProject(testInfo)) {
+      // The mobile layout hides the Fit button behind the tab nav;
+      // covered separately by ui-improvements specs.
+      test.skip(true, "Mobile layout path is covered elsewhere");
+    }
+
+    const csvPath = createTestCsv();
+
+    await dismissOnboarding(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await openWorkspaceSectionIfMobile(page, testInfo, "data");
+
+    // Use the UI Path flow (more faithful to user behaviour than
+    // pre-seeding via API). The Data Source segment defaults to
+    // Upload; switch to Path, type the CSV path, and click Load.
+    await page.getByRole("radio", { name: "Path" }).click();
+    const pathInput = page.getByPlaceholder("/path/to/data.csv");
+    await pathInput.fill(csvPath);
+    await page.getByRole("button", { name: "Load" }).click();
+    await expect(
+      page.getByText(/100 rows × \d+ columns/),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Pick the target column so the UI can assemble a complete config.
+    const targetCombo = page.getByRole("combobox", {
+      name: /target column/i,
+    });
+    await expect(targetCombo).toBeEnabled({ timeout: 15_000 });
+    await targetCombo.click();
+    await page.getByRole("option", { name: "target" }).click();
+
+    await openWorkspaceSectionIfMobile(page, testInfo, "model");
+
+    // The Fit button enables once target is set and config is synced.
+    const fitButton = page.getByRole("button", { name: "Fit", exact: true });
+    await expect(fitButton).toBeEnabled({ timeout: 15_000 });
+
+    // Arm the response listener *before* clicking so we capture the
+    // POST /workspace/fit round trip the click triggers.
+    const fitResponsePromise = page.waitForResponse(
+      (res) =>
+        res.url().endsWith("/api/workspace/fit") && res.request().method() === "POST",
+      { timeout: 30_000 },
+    );
+
+    await fitButton.click();
+
+    const fitResponse = await fitResponsePromise;
+    expect(
+      fitResponse.status(),
+      `POST /workspace/fit must succeed for default UI flow (got ${fitResponse.status()}). ` +
+        `Body: ${await fitResponse.text()}`,
+    ).toBe(200);
+    const fitBody = await fitResponse.json();
+    expect(fitBody.job_id).toBeTruthy();
+
+    // Poll until the job completes so the regression net covers the
+    // full lifecycle, not just the accept-on-submit moment.
+    let status = "";
+    for (let i = 0; i < 45; i++) {
+      const jobRes = await request.get(`${API}/jobs/${fitBody.job_id}`);
+      expect(jobRes.status()).toBe(200);
+      const job = await jobRes.json();
+      status = job.status;
+      if (status === "completed" || status === "failed") break;
+      await page.waitForTimeout(2000);
+    }
+    expect(status).toBe("completed");
+  });
 });

--- a/src/lizystudio/backends/lizyml_ui_schema.py
+++ b/src/lizystudio/backends/lizyml_ui_schema.py
@@ -510,13 +510,20 @@ def build_ui_schema(
             # (top-to-bottom in the form). Consumers treat the list as
             # a set via ``.includes(...)`` / ``in`` — order has no
             # semantic effect on the wire payload.
+            # Issue #258 / #259: every field must exist on the matching
+            # Pydantic variant (or on DataConfig for target/time_col/
+            # group_col). The contract test
+            # ``tests/contract/test_ui_schema_matches_pydantic.py``
+            # locks this invariant. Do not add a field here without
+            # extending the corresponding Pydantic model first.
             "cv_strategy_fields": {
                 "kfold": ["n_splits", "random_state", "shuffle"],
-                "stratified_kfold": ["n_splits", "random_state", "shuffle"],
+                "stratified_kfold": ["n_splits", "random_state"],
                 "group_kfold": ["n_splits", "group_col"],
                 "stratified_group_kfold": [
                     "n_splits",
                     "random_state",
+                    "shuffle",
                     "group_col",
                 ],
                 "time_series": [
@@ -542,8 +549,11 @@ def build_ui_schema(
                     "train_size_max",
                     "test_size_max",
                 ],
+                # blocked_group_kfold has no `n_splits` — the two axes
+                # (period blocks, group KFold) are configured via
+                # ``blocks`` / ``groups`` sub-objects on the Pydantic
+                # model. The UI renders those via a dedicated editor.
                 "blocked_group_kfold": [
-                    "n_splits",
                     "time_col",
                     "group_col",
                     "min_train_rows",

--- a/tests/contract/__init__.py
+++ b/tests/contract/__init__.py
@@ -1,0 +1,7 @@
+"""Cross-layer contract tests.
+
+Each test here asserts an invariant that spans two or more layers (UI
+schema vs Pydantic, validate-endpoint vs fit-endpoint, defaults vs fit,
+etc.). Contract tests exist to catch class-of-bugs that unit tests at
+each layer miss by construction.
+"""

--- a/tests/contract/test_ui_schema_matches_pydantic.py
+++ b/tests/contract/test_ui_schema_matches_pydantic.py
@@ -1,0 +1,179 @@
+"""Contract: UI schema field lists must match the backend Pydantic schema.
+
+Issue #258 / #259 surfaced when ``cv_strategy_fields`` declared
+``stratified_kfold: [..., "shuffle"]`` but the lizyml ``StratifiedKFoldConfig``
+Pydantic model did not accept ``shuffle``. The frontend trusted the UI
+schema and appended ``shuffle: true`` to the payload, which ``POST /fit``
+then rejected with 422.
+
+This test locks the invariant: every field the UI schema claims a CV
+strategy accepts must be a field the matching Pydantic variant (or a
+sibling section like DataConfig for target/time_col/group_col) actually
+accepts. Adding a field to the UI schema without extending the Pydantic
+model fails this test.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from lizystudio.backends.lizyml_ui_schema import (
+    build_ui_schema,
+    get_eval_metrics_by_task,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _variant_fields_by_method(defs: dict[str, Any]) -> dict[str, set[str]]:
+    """Map each CV method constant to the set of fields its Pydantic
+    variant accepts (excluding the ``method`` discriminator itself).
+    """
+    out: dict[str, set[str]] = {}
+    for schema in defs.values():
+        props = schema.get("properties") or {}
+        method_prop = props.get("method") or {}
+        method_const = method_prop.get("const")
+        if not method_const:
+            continue
+        out[method_const] = {k for k in props if k != "method"}
+    return out
+
+
+def _data_fields(defs: dict[str, Any]) -> set[str]:
+    data = defs.get("DataConfig") or {}
+    props = data.get("properties") or {}
+    return set(props)
+
+
+def test_cv_strategy_fields_match_pydantic_or_data() -> None:
+    """Every field the UI schema declares for a CV strategy must be
+    accepted either by the matching Pydantic CV variant (``split``
+    payload) or by ``DataConfig`` (``data`` payload such as ``time_col``
+    / ``group_col``).
+    """
+    from lizyml.config.schema import LizyMLConfig
+
+    ui_schema = build_ui_schema(get_eval_metrics_by_task())
+    cv_strategy_fields = ui_schema["capabilities"]["cv_strategy_fields"]
+
+    defs = LizyMLConfig.model_json_schema().get("$defs", {})
+    variant_fields = _variant_fields_by_method(defs)
+    data_fields = _data_fields(defs)
+
+    errors: list[str] = []
+    for method, declared in cv_strategy_fields.items():
+        pydantic_accepts = variant_fields.get(method, set())
+        for field in declared:
+            if field in pydantic_accepts:
+                continue
+            if field in data_fields:
+                continue
+            errors.append(
+                f"ui_schema.cv_strategy_fields[{method!r}] declares "
+                f"{field!r}, but Pydantic variant accepts "
+                f"{sorted(pydantic_accepts)} and DataConfig accepts "
+                f"{sorted(data_fields)}."
+            )
+
+    assert not errors, "\n".join(errors)
+
+
+def test_every_ui_method_has_matching_pydantic_variant() -> None:
+    """Every method the UI schema references must correspond to a real
+    Pydantic variant. A typo or a deprecated method in
+    ``cv_strategy_fields`` fails this guard.
+    """
+    from lizyml.config.schema import LizyMLConfig
+
+    ui_schema = build_ui_schema(get_eval_metrics_by_task())
+    cv_strategy_fields = ui_schema["capabilities"]["cv_strategy_fields"]
+
+    defs = LizyMLConfig.model_json_schema().get("$defs", {})
+    variant_fields = _variant_fields_by_method(defs)
+
+    missing = [m for m in cv_strategy_fields if m not in variant_fields]
+    assert not missing, (
+        f"ui_schema.cv_strategy_fields references methods with no "
+        f"matching Pydantic variant: {missing}"
+    )
+
+
+def test_frontend_fallback_matches_backend_cv_strategy_fields() -> None:
+    """INV-4: The frontend boot-time fallback
+    ``FALLBACK_CV_STRATEGY_FIELDS`` must match the backend's runtime
+    ``cv_strategy_fields``. Without this lock, a backend-only edit
+    lets the frontend fallback drift until the next UI schema fetch,
+    and users who land on the page before fetch completes see a stale
+    (possibly drifting) field list.
+
+    The frontend fallback is declared in
+    ``frontend/src/components/workspace/cv-state.ts``. This test reads
+    it as text (string parsing is acceptable here because the file is
+    TypeScript that cannot be imported into Python) and compares each
+    strategy's list of fields to the backend SSOT.
+    """
+    import re
+    from pathlib import Path
+
+    ui_schema = build_ui_schema(get_eval_metrics_by_task())
+    backend = ui_schema["capabilities"]["cv_strategy_fields"]
+
+    ts_path = (
+        Path(__file__).resolve().parents[2]
+        / "frontend"
+        / "src"
+        / "components"
+        / "workspace"
+        / "cv-state.ts"
+    )
+    source = ts_path.read_text(encoding="utf-8")
+
+    # Locate the FALLBACK_CV_STRATEGY_FIELDS object literal body.
+    marker = "export const FALLBACK_CV_STRATEGY_FIELDS"
+    start = source.index(marker)
+    brace_open = source.index("{", start)
+    # Walk braces to find the matching close.
+    depth = 0
+    i = brace_open
+    while i < len(source):
+        ch = source[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                break
+        i += 1
+    body = source[brace_open + 1 : i]
+
+    # Parse ``strategy: [ "field1", "field2", ... ],`` entries.
+    entry_pattern = re.compile(
+        r"(\w+)\s*:\s*\[([^\]]*)\]",
+        flags=re.MULTILINE,
+    )
+    frontend: dict[str, list[str]] = {}
+    for match in entry_pattern.finditer(body):
+        strategy = match.group(1)
+        fields_src = match.group(2)
+        fields = re.findall(r'"([^"]+)"', fields_src)
+        frontend[strategy] = fields
+
+    diffs: list[str] = []
+    for strategy, expected in backend.items():
+        got = frontend.get(strategy)
+        if got is None:
+            diffs.append(f"missing in frontend: {strategy}")
+            continue
+        if list(got) != list(expected):
+            diffs.append(f"{strategy}: frontend={got} backend={list(expected)}")
+    extra = set(frontend) - set(backend)
+    if extra:
+        diffs.append(f"extra in frontend: {sorted(extra)}")
+
+    assert not diffs, (
+        "FALLBACK_CV_STRATEGY_FIELDS in cv-state.ts does not match "
+        "backend ui_schema.cv_strategy_fields:\n  " + "\n  ".join(diffs)
+    )

--- a/tests/contract/test_validate_fit_symmetry.py
+++ b/tests/contract/test_validate_fit_symmetry.py
@@ -1,0 +1,103 @@
+"""Contract: ``POST /config/validate`` and ``POST /fit`` must agree.
+
+Issue #259 observed that a payload where ``split.stratified_kfold`` had
+an extra ``shuffle`` field:
+
+* returned 200 with ``valid: true`` from ``POST /config/validate``
+* returned 422 from ``POST /fit``
+
+for the same body. That asymmetry lets the frontend cheerfully proceed
+past validation and hit the expensive operation before discovering the
+problem. This contract locks both endpoints to the same verdict.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def csv_path(tmp_path: Path) -> Iterator[Path]:
+    # /tmp prefix is required because the ``client`` fixture restricts
+    # file access to LIZYSTUDIO_FILES_ROOT=/tmp. Use pytest's tmp_path
+    # basename (already unique per test) under /tmp so parallel runs
+    # do not collide. pytest cleans up the parent tmp_path itself.
+    path = Path("/tmp") / f"{tmp_path.name}_contract_symmetry.csv"
+    rows = ["id,age,income,gender,target"]
+    for i in range(100):
+        rows.append(
+            f"{i},{20 + (i % 50)},{30000 + i * 100},"
+            f"{'M' if i % 2 == 0 else 'F'},{i % 2}"
+        )
+    path.write_text("\n".join(rows))
+    yield path
+    path.unlink(missing_ok=True)
+
+
+def _load_data(client: TestClient, csv: Path) -> None:
+    res = client.post("/api/workspace/data/path", json={"path": str(csv)})
+    assert res.status_code == 200, res.text
+
+
+def _defaults(client: TestClient) -> dict:
+    res = client.get(
+        "/api/workspace/config/defaults?task=binary&target=target",
+    )
+    assert res.status_code == 200
+    return res.json()
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda c: c, id="defaults_as_is"),
+        pytest.param(
+            lambda c: {**c, "split": {**c["split"], "shuffle": True}},
+            id="stratified_kfold_plus_shuffle",
+        ),
+        pytest.param(
+            lambda c: {**c, "split": {**c["split"], "bogus_field": 1}},
+            id="bogus_extra_field_in_split",
+        ),
+        pytest.param(
+            lambda c: {**c, "task": "not_a_real_task"},
+            id="invalid_task",
+        ),
+    ],
+)
+def test_validate_and_fit_agree(client: TestClient, csv_path: Path, mutate) -> None:
+    """For each config, ``/config/validate`` and ``/fit`` must return the
+    same verdict (both accept or both reject).
+
+    ``/validate`` exposes the verdict as ``response.json()["valid"]``.
+    ``/fit`` exposes it as ``response.status_code`` (200 success,
+    422 validation error).
+    """
+    _load_data(client, csv_path)
+    config = mutate(_defaults(client))
+
+    validate_res = client.post("/api/workspace/config/validate", json=config)
+    assert validate_res.status_code == 200, validate_res.text
+    validate_says_valid = validate_res.json()["valid"]
+
+    # POST /fit takes the config under ``body.config`` (P-0086)
+    fit_res = client.post("/api/workspace/fit", json={"config": config})
+    fit_accepts = fit_res.status_code == 200
+    fit_rejects = fit_res.status_code == 422
+
+    if validate_says_valid:
+        assert fit_accepts, (
+            f"/validate said valid=true but /fit returned "
+            f"{fit_res.status_code}: {fit_res.text}"
+        )
+    else:
+        assert fit_rejects, (
+            f"/validate said valid=false but /fit returned "
+            f"{fit_res.status_code} (expected 422): {fit_res.text}"
+        )

--- a/tests/regression/test_reg_0258_defaults_roundtrip.py
+++ b/tests/regression/test_reg_0258_defaults_roundtrip.py
@@ -1,0 +1,131 @@
+"""Regression (#258): defaults round-trip must reach ``POST /fit``.
+
+Before the fix, ``GET /api/workspace/config/defaults`` returned a
+Pydantic-validated config, but the frontend added ``shuffle: true`` (via
+``buildSyncedConfig`` reading ``ui_schema.cv_strategy_fields``) before
+PUTting it back. The resulting payload was then rejected by
+``POST /fit`` with 422 because ``StratifiedKFoldConfig`` does not accept
+``shuffle``.
+
+This regression test pins the invariant at the API layer directly: for
+every supported task, the defaults config returned by the backend must
+itself be accepted by ``POST /fit`` body. Any future drift (ui schema
+claims a field that Pydantic rejects, or defaults start emitting an
+unaccepted field) fails this test.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def binary_csv(tmp_path: Path) -> Iterator[Path]:
+    # /tmp prefix is required because the ``client`` fixture restricts
+    # file access to LIZYSTUDIO_FILES_ROOT=/tmp. Use tmp_path.name as a
+    # per-test-unique suffix so parallel runs cannot collide.
+    path = Path("/tmp") / f"{tmp_path.name}_reg_0258_binary.csv"
+    rows = ["id,age,income,gender,target"]
+    for i in range(100):
+        rows.append(
+            f"{i},{20 + (i % 50)},{30000 + i * 100},"
+            f"{'M' if i % 2 == 0 else 'F'},{i % 2}"
+        )
+    path.write_text("\n".join(rows))
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@pytest.fixture()
+def regression_csv(tmp_path: Path) -> Iterator[Path]:
+    path = Path("/tmp") / f"{tmp_path.name}_reg_0258_regression.csv"
+    rows = ["id,age,income,gender,target"]
+    for i in range(100):
+        rows.append(
+            f"{i},{20 + (i % 50)},{30000 + i * 100},"
+            f"{'M' if i % 2 == 0 else 'F'},{i * 1.5}"
+        )
+    path.write_text("\n".join(rows))
+    yield path
+    path.unlink(missing_ok=True)
+
+
+def _load(client: TestClient, csv: Path) -> None:
+    res = client.post("/api/workspace/data/path", json={"path": str(csv)})
+    assert res.status_code == 200, res.text
+
+
+def test_defaults_roundtrip_binary(client: TestClient, binary_csv: Path) -> None:
+    _load(client, binary_csv)
+    defaults_res = client.get(
+        "/api/workspace/config/defaults?task=binary&target=target",
+    )
+    assert defaults_res.status_code == 200
+    defaults = defaults_res.json()
+
+    fit_res = client.post("/api/workspace/fit", json={"config": defaults})
+    assert fit_res.status_code == 200, (
+        "defaults for task=binary must be accepted by POST /fit "
+        f"(got {fit_res.status_code}): {fit_res.text}"
+    )
+
+
+def test_defaults_roundtrip_regression(
+    client: TestClient, regression_csv: Path
+) -> None:
+    _load(client, regression_csv)
+    defaults_res = client.get(
+        "/api/workspace/config/defaults?task=regression&target=target",
+    )
+    assert defaults_res.status_code == 200
+    defaults = defaults_res.json()
+
+    fit_res = client.post("/api/workspace/fit", json={"config": defaults})
+    assert fit_res.status_code == 200, (
+        "defaults for task=regression must be accepted by POST /fit "
+        f"(got {fit_res.status_code}): {fit_res.text}"
+    )
+
+
+def test_defaults_plus_ui_shuffle_injection_is_rejected_symmetrically(
+    client: TestClient, binary_csv: Path
+) -> None:
+    """Regression probe for the specific #258 shape: frontend injects
+    ``shuffle: true`` on top of stratified_kfold defaults.
+
+    After the fix (shuffle removed from UI schema for stratified_kfold),
+    the frontend never produces this payload. If a future change
+    reintroduces it, this test locks the expected behaviour: both
+    validate and fit must reject consistently. Either:
+
+    - both accept (meaning shuffle was legitimately added to the
+      Pydantic StratifiedKFoldConfig), or
+    - both reject (status 422 on fit, valid=false on validate)
+
+    What must never happen again is validate=200/valid, fit=422.
+    """
+    _load(client, binary_csv)
+    defaults = client.get(
+        "/api/workspace/config/defaults?task=binary&target=target",
+    ).json()
+    injected = {**defaults, "split": {**defaults["split"], "shuffle": True}}
+
+    v = client.post("/api/workspace/config/validate", json=injected).json()
+    fit = client.post("/api/workspace/fit", json={"config": injected})
+
+    if v["valid"]:
+        assert fit.status_code == 200, (
+            "/validate accepted the payload but /fit rejected it; "
+            "validate/fit must agree."
+        )
+    else:
+        assert fit.status_code == 422, (
+            "/validate rejected the payload but /fit did not return 422; "
+            "validate/fit must agree."
+        )

--- a/tests/test_ui_schema.py
+++ b/tests/test_ui_schema.py
@@ -577,13 +577,19 @@ class TestLizyMLAdapterUiSchema:
         fields = schema["capabilities"]["cv_strategy_fields"]
 
         # Expected fields per strategy — SSOT for the frontend UI map.
+        # Issue #258 / #259: these lists must match the matching
+        # Pydantic variant (or DataConfig for target/time_col/
+        # group_col). The contract test
+        # ``tests/contract/test_ui_schema_matches_pydantic.py`` locks
+        # this invariant and is the source of truth.
         expected = {
             "kfold": ["n_splits", "random_state", "shuffle"],
-            "stratified_kfold": ["n_splits", "random_state", "shuffle"],
+            "stratified_kfold": ["n_splits", "random_state"],
             "group_kfold": ["n_splits", "group_col"],
             "stratified_group_kfold": [
                 "n_splits",
                 "random_state",
+                "shuffle",
                 "group_col",
             ],
             "time_series": [
@@ -610,7 +616,6 @@ class TestLizyMLAdapterUiSchema:
                 "test_size_max",
             ],
             "blocked_group_kfold": [
-                "n_splits",
                 "time_col",
                 "group_col",
                 "min_train_rows",


### PR DESCRIPTION
## Summary

- UI Fit returned 422 on the default happy path (Issue #258). Root cause: ``lizystudio/backends/lizyml_ui_schema.py`` declared CV strategy fields that the matching lizyml Pydantic variants (``extra='forbid'``) reject. Frontend ``buildSyncedConfig`` trusted the UI schema and injected those fields into PUT/POST payloads.
- Three drifts removed / aligned, plus one latent payload bug in ``buildSplitConfig`` fixed (HIGH-1 from code review).
- Five new invariant locks landed so this class of drift is caught in CI going forward (#259 umbrella).
- UI-driven Fit happy-path spec added (minimum for Issue #257) — this spec would have caught the bug in the first place.

## Changes

### Schema drift fixes (Pydantic is SSOT)
- `stratified_kfold`: drop `shuffle` (Pydantic has none)
- `blocked_group_kfold`: drop `n_splits` (Pydantic has none)
- `stratified_group_kfold`: add `shuffle` (Pydantic has it; was silently hidden from the UI)

### Payload bug fix (HIGH-1 from code review)
- `buildSplitConfig` wrote `n_splits` unconditionally. BlockedGroupKFoldConfig has no `n_splits` field, so the drift fix alone would have left ``blocked_group_kfold`` still producing 422 payloads. Gate the assignment on the active fields list (same pattern as every other field below).

### Invariant locks (Issue #259 umbrella)
- ``tests/contract/test_ui_schema_matches_pydantic.py``
  - INV-1: every declared field exists in the matching Pydantic variant or DataConfig.
  - INV-4: frontend ``FALLBACK_CV_STRATEGY_FIELDS`` equals the backend SSOT (cross-layer drift lock, parses cv-state.ts).
- ``tests/contract/test_validate_fit_symmetry.py``
  - INV-2: ``POST /config/validate`` and ``POST /fit`` return the same verdict for realistic UI payload shapes.
- ``tests/regression/test_reg_0258_defaults_roundtrip.py``
  - INV-3: ``GET /defaults`` → ``POST /fit`` returns 200 for binary + regression.
  - Symmetric probe for the shuffle-injection shape.
- ``frontend/tests/e2e/workspace-fit.spec.ts``
  - "UI: load data -> pick target -> click Fit -> fit returns 200" (Issue #257 minimum).

### Compatibility
- UI-visible: Shuffle toggle is now **hidden** for ``stratified_kfold`` (Pydantic had no field to write to) and **visible** for ``stratified_group_kfold`` (was previously hidden silently).
- API: no wire-format changes; the set of accepted payloads is a proper subset (invalid payloads the frontend used to generate are no longer generated).

## Invariants

Declared in ``HISTORY.md`` §P-0087:
- INV-1: ``ui_schema.cv_strategy_fields[M]`` ⊆ Pydantic ``<M>Config`` fields ∪ DataConfig fields
- INV-2: ``/validate`` and ``/fit`` agree on every config
- INV-3: ``/defaults`` → ``/fit`` returns 200 (defaults round-trip)
- INV-4: frontend ``FALLBACK_CV_STRATEGY_FIELDS`` equals backend ``cv_strategy_fields``

## Failure Paths Covered

- [x] Default binary flow → Fit 200 (regression test + E2E)
- [x] Default regression flow → Fit 200 (regression test)
- [x] Shuffle-injection shape → validate and fit agree (regression test)
- [x] Every declared method has a Pydantic variant (contract)
- [x] Every declared field is accepted by Pydantic (contract)
- [x] Cross-layer drift: frontend fallback vs backend SSOT (contract)

## Test Plan

- [x] `uv run pytest` — 1216 passed (was 1207; +9 new)
- [x] `pnpm test` — 1655 passed, 2 skipped
- [x] `pnpm check` + `pnpm build` — clean
- [x] New UI-Fit E2E spec passes (chromium, 4.3s)
- [x] ruff / mypy — clean
- [ ] CI Nightly visual goldens may need regeneration if the Shuffle toggle change shifts pixels (monitored on nightly after merge, memory: visual_goldens_tracking).

## Phases 2 and 3 (follow-up)

This PR is Phase 1 (immediate stop-bleed + invariant lock). Phase 2 will expand UI-driven E2E coverage for the other primary workflows (Tune, Inference, Retune) and fix the DX foot-gun in Issue #256. Phase 3 will derive the UI schema from the Pydantic model directly to eliminate the drift class (Issue #259 long-term), and propose lizyml upstream for any legitimate additions (e.g. if ``StratifiedKFoldConfig.shuffle`` is wanted, add it there then restore in UI).

Closes #258
Closes #259
Refs #257 (minimum landed here; rest in Phase 2)