### PR TITLE
test(e2e): add UI-driven Tune spec + shared helpers (#257 Phase 3)

### DIFF
--- a/frontend/tests/e2e/helpers/workspace-ui.ts
+++ b/frontend/tests/e2e/helpers/workspace-ui.ts
@@ -1,0 +1,119 @@
+import { expect, type Page, type TestInfo } from "@playwright/test";
+import type { APIRequestContext } from "@playwright/test";
+import { isMobileProject, openWorkspaceSectionIfMobile } from "./mobile";
+import { dismissOnboarding } from "./onboarding";
+
+/**
+ * Shared UI-driven setup boilerplate for workspace E2E specs.
+ *
+ * Rationale (Issue #257): Scenario A / B in workspace-fit.spec.ts, the
+ * Scenario T in workspace-tune.spec.ts (Tune), and any future Retune /
+ * Inference UI specs all share the same opening sequence: dismiss
+ * onboarding, load data via the Path source, pick the target column,
+ * and wait for the ConfigForm to be ready. Keeping this in one place
+ * means future layout tweaks (e.g. onboarding copy change, Data Source
+ * segment rename) only need one edit.
+ *
+ * The helper deliberately uses the UI Path flow (not a direct
+ * ``request.post(/workspace/data/path)``) because the regression class
+ * we want to lock is the full ``ConfigForm onChange -> PUT /config``
+ * write path. Seeding via API bypasses the exact code paths Issue #253
+ * touched.
+ */
+
+export interface SeedUiWorkspaceOptions {
+  /** Path to the CSV that will be typed into the Data Source "Path" input. */
+  csvPath: string;
+  /** Name of the target column to pick via the combobox. Default "target". */
+  target?: string;
+  /** Expected row count used to wait for data-loaded confirmation. */
+  expectedRows?: number;
+}
+
+/**
+ * Drive the UI through "dismiss onboarding -> goto / -> switch to Path
+ * data source -> type CSV path -> Load -> pick target -> open Model
+ * section". Returns once the ConfigForm is in a state where the primary
+ * action button (Fit / Tune) should be reachable.
+ *
+ * On mobile viewports, the caller must still open the Model section
+ * again AFTER switching Fit/Tune tabs if the layout collapses between
+ * them. For desktop chromium (the primary project), the Model section
+ * stays open.
+ */
+export async function seedUiWorkspace(
+  page: Page,
+  testInfo: TestInfo,
+  { csvPath, target = "target", expectedRows = 100 }: SeedUiWorkspaceOptions,
+): Promise<void> {
+  await dismissOnboarding(page);
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+  await openWorkspaceSectionIfMobile(page, testInfo, "data");
+
+  // Switch the Data Source segment from the default Upload to Path and
+  // load the synthetic CSV. ``15s`` matches the schema-load budget used
+  // by the original inline specs.
+  await page.getByRole("radio", { name: "Path" }).click();
+  await page.getByPlaceholder("/path/to/data.csv").fill(csvPath);
+  await page.getByRole("button", { name: "Load" }).click();
+  await expect(
+    page.getByText(new RegExp(`${expectedRows} rows × \\d+ columns`)),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // Pick the target column. The combobox is disabled until
+  // useTargetSelection resolves the column analysis request, so wait
+  // explicitly before clicking.
+  const targetCombo = page.getByRole("combobox", {
+    name: /target column/i,
+  });
+  await expect(targetCombo).toBeEnabled({ timeout: 15_000 });
+  await targetCombo.click();
+  await page.getByRole("option", { name: target }).click();
+
+  // On mobile the Model panel collapses; re-open it so the caller can
+  // interact with Fit/Tune controls. On desktop this is a no-op.
+  await openWorkspaceSectionIfMobile(page, testInfo, "model");
+}
+
+/** Re-export mobile guard so specs don't need two imports. */
+export { isMobileProject };
+
+export interface PollJobOptions {
+  /** Max wait in ms. Default 90s (45 iterations × 2s). */
+  timeoutMs?: number;
+  /** Interval between polls in ms. Default 2s. */
+  intervalMs?: number;
+}
+
+/**
+ * Poll ``GET /api/jobs/{id}`` until the job hits any terminal status
+ * (``completed`` / ``failed`` / ``cancelled``) or the timeout expires.
+ * Returns the last body seen. All three UI Scenarios (A / B / T) share
+ * this so a ``cancelled`` status doesn't silently burn the full
+ * timeout budget before the caller asserts ``=== "completed"``.
+ */
+export async function pollJobUntilTerminal(
+  request: APIRequestContext,
+  jobId: string,
+  { timeoutMs = 90_000, intervalMs = 2_000 }: PollJobOptions = {},
+): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + timeoutMs;
+  let last: Record<string, unknown> | null = null;
+  while (Date.now() < deadline) {
+    const res = await request.get(
+      `http://localhost:8501/api/jobs/${jobId}`,
+    );
+    expect(res.status()).toBe(200);
+    last = (await res.json()) as Record<string, unknown>;
+    const status = last.status as string;
+    if (status === "completed" || status === "failed" || status === "cancelled") {
+      return last;
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(
+    `Job ${jobId} did not reach a terminal status within ${timeoutMs}ms ` +
+      `(last status=${last?.status ?? "<no response>"}).`,
+  );
+}

--- a/frontend/tests/e2e/workspace-fit.spec.ts
+++ b/frontend/tests/e2e/workspace-fit.spec.ts
@@ -5,12 +5,19 @@ import {
   openWorkspaceSectionIfMobile,
 } from "./helpers/mobile";
 import { dismissOnboarding } from "./helpers/onboarding";
+import {
+  pollJobUntilTerminal,
+  seedUiWorkspace,
+} from "./helpers/workspace-ui";
 
 const API = "http://localhost:8501/api";
 
 /**
  * Create a synthetic CSV with 100 rows for binary classification.
  * Includes numeric + categorical features and a binary target column.
+ *
+ * Kept local (vs. the shared helper) because the API-only specs at the
+ * top of this file reuse the same file path to avoid a redundant write.
  */
 function createTestCsv(): string {
   const csvPath = "/tmp/e2e_fit_test.csv";
@@ -292,32 +299,7 @@ test.describe("Workspace Fit Flow", () => {
     }
 
     const csvPath = createTestCsv();
-
-    await dismissOnboarding(page);
-    await page.goto("/");
-    await page.waitForLoadState("networkidle");
-    await openWorkspaceSectionIfMobile(page, testInfo, "data");
-
-    // Use the UI Path flow (more faithful to user behaviour than
-    // pre-seeding via API). The Data Source segment defaults to
-    // Upload; switch to Path, type the CSV path, and click Load.
-    await page.getByRole("radio", { name: "Path" }).click();
-    const pathInput = page.getByPlaceholder("/path/to/data.csv");
-    await pathInput.fill(csvPath);
-    await page.getByRole("button", { name: "Load" }).click();
-    await expect(
-      page.getByText(/100 rows × \d+ columns/),
-    ).toBeVisible({ timeout: 15_000 });
-
-    // Pick the target column so the UI can assemble a complete config.
-    const targetCombo = page.getByRole("combobox", {
-      name: /target column/i,
-    });
-    await expect(targetCombo).toBeEnabled({ timeout: 15_000 });
-    await targetCombo.click();
-    await page.getByRole("option", { name: "target" }).click();
-
-    await openWorkspaceSectionIfMobile(page, testInfo, "model");
+    await seedUiWorkspace(page, testInfo, { csvPath });
 
     // The Fit button enables once target is set and config is synced.
     const fitButton = page.getByRole("button", { name: "Fit", exact: true });
@@ -343,17 +325,14 @@ test.describe("Workspace Fit Flow", () => {
     expect(fitBody.job_id).toBeTruthy();
 
     // Poll until the job completes so the regression net covers the
-    // full lifecycle, not just the accept-on-submit moment.
-    let status = "";
-    for (let i = 0; i < 45; i++) {
-      const jobRes = await request.get(`${API}/jobs/${fitBody.job_id}`);
-      expect(jobRes.status()).toBe(200);
-      const job = await jobRes.json();
-      status = job.status;
-      if (status === "completed" || status === "failed") break;
-      await page.waitForTimeout(2000);
-    }
-    expect(status).toBe("completed");
+    // full lifecycle, not just the accept-on-submit moment. Uses the
+    // shared helper so ``cancelled`` short-circuits instead of burning
+    // the full 90s budget before the final ``=== "completed"`` assert.
+    const jobBody = await pollJobUntilTerminal(
+      request,
+      fitBody.job_id as string,
+    );
+    expect(jobBody.status).toBe("completed");
   });
 
   /**
@@ -381,28 +360,7 @@ test.describe("Workspace Fit Flow", () => {
     }
 
     const csvPath = createTestCsv();
-
-    await dismissOnboarding(page);
-    await page.goto("/");
-    await page.waitForLoadState("networkidle");
-    await openWorkspaceSectionIfMobile(page, testInfo, "data");
-
-    // Same data-seeding flow as Scenario A.
-    await page.getByRole("radio", { name: "Path" }).click();
-    await page.getByPlaceholder("/path/to/data.csv").fill(csvPath);
-    await page.getByRole("button", { name: "Load" }).click();
-    await expect(
-      page.getByText(/100 rows × \d+ columns/),
-    ).toBeVisible({ timeout: 15_000 });
-
-    const targetCombo = page.getByRole("combobox", {
-      name: /target column/i,
-    });
-    await expect(targetCombo).toBeEnabled({ timeout: 15_000 });
-    await targetCombo.click();
-    await page.getByRole("option", { name: "target" }).click();
-
-    await openWorkspaceSectionIfMobile(page, testInfo, "model");
+    await seedUiWorkspace(page, testInfo, { csvPath });
 
     // Wait for the ConfigForm to finish seeding; the Calibration section
     // only appears once the model accordion is populated.
@@ -469,16 +427,11 @@ test.describe("Workspace Fit Flow", () => {
 
     // Poll to completion so backend actually runs with the calibrated
     // config (any schema mismatch on the extra field surfaces here, not
-    // only at accept-time).
-    let status = "";
-    for (let i = 0; i < 45; i++) {
-      const jobRes = await request.get(`${API}/jobs/${fitBody.job_id}`);
-      expect(jobRes.status()).toBe(200);
-      const job = await jobRes.json();
-      status = job.status;
-      if (status === "completed" || status === "failed") break;
-      await page.waitForTimeout(2000);
-    }
-    expect(status).toBe("completed");
+    // only at accept-time). Shared helper breaks on any terminal state.
+    const jobBody = await pollJobUntilTerminal(
+      request,
+      fitBody.job_id as string,
+    );
+    expect(jobBody.status).toBe("completed");
   });
 });

--- a/frontend/tests/e2e/workspace-tune.spec.ts
+++ b/frontend/tests/e2e/workspace-tune.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@playwright/test";
 import * as fs from "node:fs";
+import { isMobileProject } from "./helpers/mobile";
+import {
+  pollJobUntilTerminal,
+  seedUiWorkspace,
+} from "./helpers/workspace-ui";
 
 const API = "http://localhost:8501/api";
 
@@ -251,5 +256,81 @@ test.describe("Workspace tune flow", () => {
     // ZIP magic bytes: PK\x03\x04
     expect(body[0]).toBe(0x50); // P
     expect(body[1]).toBe(0x4b); // K
+  });
+
+  /**
+   * Issue #257 Phase 3 — UI-driven Tune happy path.
+   *
+   * Parallel to the UI-Fit Scenario A in workspace-fit.spec.ts. Drives
+   * the real frontend path: seed data via the Path input, pick target,
+   * switch to the Tune tab, click the Tune button, assert POST
+   * /workspace/tune returns 200 and the job completes.
+   *
+   * TuneTab auto-populates a default search space from
+   * ``catalog_entries.default_range`` (see TuneTab.tsx:62-86), so a
+   * user-driven Tune with no manual search-space edits still submits a
+   * valid config. This spec locks that contract.
+   */
+  test("UI: load data -> pick target -> Tune tab -> click Tune -> tune returns 200", async ({
+    page,
+    request,
+  }, testInfo) => {
+    // Same budget as the UI-Fit scenarios (15s schema load + 15s combo
+    // enable + 30s tune accept + 90s poll), plus a margin for Optuna
+    // overhead on the first trial.
+    test.setTimeout(180_000);
+    if (isMobileProject(testInfo)) {
+      // Mobile layout collapses the Tune tab behind the tab nav;
+      // covered separately by ui-improvements specs.
+      test.skip(true, "Mobile layout path is covered elsewhere");
+    }
+
+    const csvPath = createTestCsv();
+    await seedUiWorkspace(page, testInfo, { csvPath });
+
+    // Switch to the Tune tab. Radix Tabs uses role="tab" for triggers.
+    await page.getByRole("tab", { name: "Tune" }).click();
+    const tuneButton = page.getByRole("button", { name: "Tune", exact: true });
+    await expect(tuneButton).toBeEnabled({ timeout: 15_000 });
+
+    // Arm the response listener BEFORE the click so we don't miss the
+    // fast accept-on-submit path.
+    const tuneResponsePromise = page.waitForResponse(
+      (res) =>
+        res.url().endsWith("/api/workspace/tune") &&
+        res.request().method() === "POST",
+      { timeout: 30_000 },
+    );
+
+    await tuneButton.click();
+
+    const tuneResponse = await tuneResponsePromise;
+    expect(
+      tuneResponse.status(),
+      `POST /workspace/tune must succeed for default UI flow (got ${tuneResponse.status()}). ` +
+        `Body: ${await tuneResponse.text()}`,
+    ).toBe(200);
+    const tuneBody = await tuneResponse.json();
+    expect(tuneBody.job_id).toBeTruthy();
+
+    // Poll until the job completes. Tune walltime is dominated by the
+    // number of trials; TuneTab's default n_trials comes from the
+    // backend ui_schema. The shared helper caps at 90s and breaks on
+    // any terminal status (``cancelled`` included) so a cancel in-flight
+    // surfaces with a clear status rather than timing out.
+    const terminalBody = await pollJobUntilTerminal(
+      request,
+      tuneBody.job_id as string,
+    );
+    expect(terminalBody.status).toBe("completed");
+
+    // Sanity-check the tune_result shape so a "200 OK but garbage
+    // result" regression is also caught.
+    const tuneResult = terminalBody.tune_result as
+      | Record<string, unknown>
+      | null;
+    expect(tuneResult).toBeTruthy();
+    expect(tuneResult).toHaveProperty("best_params");
+    expect(tuneResult).toHaveProperty("best_score");
   });
 });


### PR DESCRIPTION
## Summary

Phase 3 of Issue #257. Closes the last acceptance criterion from the original proposal — "Added helper in `tests/e2e/helpers/` for the 'seed data → pick target → wait for config form' boilerplate so future specs can reuse" — and adds the **UI-driven Tune** scenario on top.

- **New helper** `frontend/tests/e2e/helpers/workspace-ui.ts` exposes:
  - `seedUiWorkspace(page, testInfo, { csvPath, target?, expectedRows? })` — the shared opening dance (dismiss onboarding, goto `/`, switch to Path, Load, pick target, reopen Model on mobile).
  - `pollJobUntilTerminal(request, jobId, opts?)` — polls `GET /api/jobs/{id}` until `completed` / `failed` / `cancelled` (breaks on any terminal status so a `cancelled` doesn't silently burn the 90s budget before the final assert).
- **Scenarios A and B** in `workspace-fit.spec.ts` refactored to call the helpers. Pure extraction, no assertion loss; ~40 lines of duplication removed.
- **New Scenario T** in `workspace-tune.spec.ts`: `UI: load data → pick target → Tune tab → click Tune → tune returns 200`. Drives the Tune path through the real UI (Radix `role=tab name=Tune` switch, TuneTab's auto-populated default search space), asserts `POST /workspace/tune` is 200, polls to `completed`, and sanity-checks `tune_result.best_params` / `tune_result.best_score`.

## Invariants (Issue #257)

- **INV-1**: `PUT /workspace/config` body immediately preceding Fit/Tune is a complete, valid config. Locked by A, B, T (all three go through `seedUiWorkspace` and then click the real primary action).
- **INV-2**: No UI interaction sequence produces 4xx at `/fit` or `/tune`. Asserted directly by A, B, T.

## Failure Paths Covered

- [x] Defaults round-trip (A).
- [x] UI edit before Fit (B — toggle Calibration).
- [x] Defaults round-trip for Tune (T).
- [x] Job reaches a terminal status other than `completed` — helper surfaces `cancelled` with a clear status instead of timing out.

## Test Plan

- [x] `pnpm test` — 1655 pass, 2 skipped.
- [x] `pnpm test:e2e --project=chromium --grep-invert "@visual|@a11y|@ci-flaky" --ignore-snapshots` — 77 pass, 1 skipped (Phase 2 was 76; +1 from Scenario T).
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy src/lizystudio/` — clean.
- [x] `pnpm check` / `pnpm build` — clean.
- [x] Re-ran targeted E2E (A + B + T) after the post-review polling refactor to confirm no behavioural regression: 3 passed.

## Deferred to a later phase (still on #257)

- Scenario C (Config Validation error message propagation) — needs a concrete repro before it makes sense as a regression lock; Issue #257 body flagged this as "may start as a follow-up".
- Retune UI spec.
- Inference UI spec.

## Code Review

One review round via the code-reviewer agent surfaced:
- HIGH: a dead `createBinaryTestCsv` export I initially added but none of the specs call — **removed in a follow-up commit**; the two existing local `createTestCsv` helpers stay because they share `/tmp` paths with API-only specs in the same files.
- MEDIUM: polling loops previously break only on `completed`/`failed`; `cancelled` would silently wait out the full timeout. **Fixed** by consolidating polling into the shared `pollJobUntilTerminal` helper.
- Other findings were stylistic and left as-is.

Refs #257
