### PR TITLE
test(e2e): add UI-driven Retune and Inference specs (#263)

### DIFF
--- a/frontend/tests/e2e/inference-flow.spec.ts
+++ b/frontend/tests/e2e/inference-flow.spec.ts
@@ -227,4 +227,86 @@ test.describe("Inference flow", () => {
     expect(record.has_ground_truth).toBe(false);
     expect(record.row_count).toBe(50);
   });
+
+  /**
+   * Issue #263 — UI-driven Inference happy path.
+   *
+   * Drives the full user flow on /inference: complete a Fit via API
+   * (the parent setup is well-covered by Fit specs already), navigate
+   * to the Inference page, select the completed job from the combobox,
+   * type the data path, click Run Inference, and assert
+   * ``POST /api/inference/run`` returns 200 with a non-empty
+   * ``inf_id`` and the predictions endpoint is reachable for the new
+   * record.
+   *
+   * This locks the regression class where the Inference page builds a
+   * malformed body (missing ``job_id``, wrong source_type, omitted
+   * ``return_shap`` / ``evaluate``) — the API-only specs above cannot
+   * detect such a bug because they craft the body in TypeScript.
+   */
+  test("UI: select model -> set path -> Run Inference -> inference returns 200", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(180_000);
+
+    // Seed a completed Fit job via API; the UI flow we're locking is the
+    // inference page itself, not Fit (covered separately).
+    const csvPath = createTestCsv(100);
+    const jobId = await setupAndFit(request, csvPath);
+    await waitForJobDone(request, jobId);
+
+    await dismissOnboarding(page);
+    await page.goto("/inference");
+    await page.waitForLoadState("networkidle");
+
+    // Pick the completed job from the model combobox.
+    const modelCombo = page.getByRole("combobox", {
+      name: "Select completed job",
+    });
+    await expect(modelCombo).toBeEnabled({ timeout: 15_000 });
+    await modelCombo.click();
+    // Scope the option lookup to the open listbox so unrelated
+    // comboboxes (now or future) cannot leak their options into the
+    // .first() pick. Radix sets ``role="listbox"`` on the open
+    // SelectContent. The first option is the most recent job
+    // (newest-first ordering is locked by jobs.py:282 ``reverse=True``).
+    const openListbox = page.getByRole("listbox");
+    await openListbox.getByRole("option").first().click();
+
+    // The data source defaults to "Path" — fill in the same CSV the fit
+    // job consumed (target column is present, so evaluate=true by
+    // default which exercises the with-ground-truth branch).
+    const pathInput = page.getByPlaceholder("/path/to/data.csv");
+    await pathInput.fill(csvPath);
+
+    const runButton = page.getByRole("button", { name: "Run Inference" });
+    await expect(runButton).toBeEnabled({ timeout: 5_000 });
+
+    const inferResponsePromise = page.waitForResponse(
+      (res) =>
+        res.url().endsWith("/api/inference/run") &&
+        res.request().method() === "POST",
+      { timeout: 30_000 },
+    );
+    await runButton.click();
+
+    const inferResponse = await inferResponsePromise;
+    expect(
+      inferResponse.status(),
+      `POST /inference/run must succeed for default UI flow ` +
+        `(got ${inferResponse.status()}). Body: ${await inferResponse.text()}`,
+    ).toBe(200);
+    const inferBody = await inferResponse.json();
+    expect(inferBody.inf_id).toBeTruthy();
+
+    // Sanity-check the new record is reachable so a "200 OK but the
+    // record never lands on disk" regression also fails this spec.
+    const recordRes = await request.get(
+      `${API}/inference/${inferBody.inf_id}?job_id=${jobId}`,
+    );
+    expect(recordRes.status()).toBe(200);
+    const record = await recordRes.json();
+    expect(record.row_count).toBe(100);
+  });
 });

--- a/frontend/tests/e2e/workspace-tune.spec.ts
+++ b/frontend/tests/e2e/workspace-tune.spec.ts
@@ -333,4 +333,105 @@ test.describe("Workspace tune flow", () => {
     expect(tuneResult).toHaveProperty("best_params");
     expect(tuneResult).toHaveProperty("best_score");
   });
+
+  /**
+   * Issue #263 — UI-driven Retune happy path.
+   *
+   * Drives the full user flow: complete a Tune via the UI (Scenario T
+   * shape), wait for the workspace ResultsCompletedView to render the
+   * "Re-tune (+N trials)" button (only shown for completed Tune jobs
+   * with tune_result, see ResultsCompletedView.tsx:85), open the
+   * dialog, click "Start Re-tune", and assert
+   * ``POST /api/jobs/{parent}/retune`` returns 200 with the parent_job_id
+   * threaded through.
+   *
+   * This locks the regression class where a UI re-tune produces a
+   * malformed body (e.g. missing parent_job_id, wrong n_trials shape)
+   * because the API-only specs already in this file cannot catch it —
+   * they craft the body in TypeScript by hand.
+   */
+  test("UI: complete Tune -> click Re-tune -> dialog -> Start -> retune returns 200", async ({
+    page,
+    request,
+  }, testInfo) => {
+    // Tune + Retune walltime stacks: seed (~30s) + parent poll (90s
+    // default) + child poll (capped to 60s below since a continued
+    // Optuna study is faster than a fresh one) = ~180s in the worst
+    // case. 300s leaves ~2× headroom for CI IO jitter.
+    test.setTimeout(300_000);
+    if (isMobileProject(testInfo)) {
+      test.skip(true, "Mobile layout path is covered elsewhere");
+    }
+
+    const csvPath = createTestCsv();
+    await seedUiWorkspace(page, testInfo, { csvPath });
+
+    // Drive the parent Tune through the UI (same as Scenario T).
+    await page.getByRole("tab", { name: "Tune" }).click();
+    const tuneButton = page.getByRole("button", { name: "Tune", exact: true });
+    await expect(tuneButton).toBeEnabled({ timeout: 15_000 });
+    const tuneResponsePromise = page.waitForResponse(
+      (res) =>
+        res.url().endsWith("/api/workspace/tune") &&
+        res.request().method() === "POST",
+      { timeout: 30_000 },
+    );
+    await tuneButton.click();
+    const tuneResponse = await tuneResponsePromise;
+    expect(tuneResponse.status()).toBe(200);
+    const { job_id: parentJobId } = await tuneResponse.json();
+
+    const parentBody = await pollJobUntilTerminal(request, parentJobId);
+    expect(parentBody.status).toBe("completed");
+
+    // Once parent is completed the workspace ResultsCompletedView
+    // renders the Re-tune button. ``aria-label="Re-tune with additional
+    // trials"`` is set in RetuneActionButton.tsx:99 — locator survives
+    // copy tweaks on the visible label.
+    const retuneTrigger = page.getByRole("button", {
+      name: "Re-tune with additional trials",
+    });
+    await expect(retuneTrigger).toBeVisible({ timeout: 15_000 });
+    await retuneTrigger.click();
+
+    // Dialog opens with default n_trials pre-filled. The Start button
+    // is the second button inside the dialog footer; lookup by role.
+    const startButton = page.getByRole("button", { name: "Start Re-tune" });
+    await expect(startButton).toBeEnabled({ timeout: 5_000 });
+
+    // Arm POST /jobs/{parentId}/retune capture before clicking Start.
+    const retuneResponsePromise = page.waitForResponse(
+      (res) =>
+        res.url().endsWith(`/api/jobs/${parentJobId}/retune`) &&
+        res.request().method() === "POST",
+      { timeout: 30_000 },
+    );
+    await startButton.click();
+
+    const retuneResponse = await retuneResponsePromise;
+    expect(
+      retuneResponse.status(),
+      `POST /jobs/${parentJobId}/retune must succeed for default UI flow ` +
+        `(got ${retuneResponse.status()}). Body: ${await retuneResponse.text()}`,
+    ).toBe(200);
+    const retuneBody = await retuneResponse.json();
+    expect(retuneBody.parent_job_id).toBe(parentJobId);
+    expect(retuneBody.job_id).toBeTruthy();
+
+    // Poll the child to terminal. Re-tune continues the existing study
+    // so it is typically faster than the parent — cap at 60s so a
+    // child stuck in ``running`` surfaces as a clear timeout rather
+    // than burning the test-level 300s budget.
+    const childBody = await pollJobUntilTerminal(
+      request,
+      retuneBody.job_id as string,
+      { timeoutMs: 60_000 },
+    );
+    expect(childBody.status).toBe("completed");
+    const childTuneResult = childBody.tune_result as
+      | Record<string, unknown>
+      | null;
+    expect(childTuneResult).toBeTruthy();
+    expect(childTuneResult).toHaveProperty("best_params");
+  });
 });


### PR DESCRIPTION
## Summary

Closes the remaining UI-driven happy-path coverage from #263 (the follow-up issue split out of #257).

- **Scenario R — UI Retune** (`workspace-tune.spec.ts`): complete a Tune via the UI (re-using the Scenario T pattern), click "Re-tune with additional trials" on the workspace results view, open the dialog, click Start Re-tune, assert `POST /api/jobs/{parent}/retune` returns 200 with `parent_job_id` threaded, poll the child Tune to completion, and sanity-check `tune_result.best_params`.
- **Scenario I — UI Inference** (`inference-flow.spec.ts`): API-seed a completed Fit job, navigate to `/inference`, pick the completed job from the model combobox (scoped to the open listbox so future comboboxes cannot leak), fill the data path, click Run Inference, assert `POST /api/inference/run` returns 200 with a non-empty `inf_id`, and verify the resulting record is reachable with the expected `row_count`.

Both reuse the `seedUiWorkspace` + `pollJobUntilTerminal` helpers introduced in PR #262 (Phase 3) — no opening-dance duplication.

## Scenario C (deferred)

The remaining piece from #263 was Scenario C: a UI E2E that locks the Config Validation error message propagating to the toast. **This PR explicitly does not add it**, because the same invariant is already covered at the Vitest layer:

- `frontend/src/pages/WorkspacePage.test.tsx:186` and `:351` assert `toast.error("Fit failed: ...")` is fired when `runFit` rejects.
- `frontend/src/api/error-handling.test.ts:99` covers `runFit` rejection on HTTP error.

An E2E equivalent would duplicate that without unique value, and would couple a Playwright test to the live backend's exact error wording. If a concrete reproduction of the user-reported "Config Validation" error surfaces later, file it as its own targeted regression spec rather than a generic Scenario C.

## Invariants (Issue #257 / #263)

- **INV-1**: PUT /workspace/config body immediately preceding Fit/Tune is a complete, valid config — locked by Scenarios A, B, T, R (all four go through `seedUiWorkspace`).
- **INV-2**: No UI interaction sequence produces 4xx at /fit, /tune, /retune, or /inference/run — locked by A, B, T, R, I.
- **INV-3**: Validation errors propagate to the UI — locked at Vitest (see Scenario C section).

## Failure Paths Covered

- [x] Defaults round-trip Fit (Scenario A, existing).
- [x] UI edit before Fit (Scenario B, existing).
- [x] Defaults round-trip Tune (Scenario T, existing).
- [x] UI Retune from completed Tune (R — new).
- [x] UI Inference from completed Fit (I — new).
- [x] Job reaches a terminal status other than `completed` — `pollJobUntilTerminal` surfaces it as a clear status check.

## Code Review

One review round via the code-reviewer agent surfaced 2 MEDIUM findings (no CRITICAL/HIGH); both **addressed in the same commit**:

- Scenario I's option lookup is now scoped to `role="listbox"` so a future second combobox cannot leak its options into `.first()`.
- Scenario R's child poll is capped at 60s (`pollJobUntilTerminal({ timeoutMs: 60_000 })`) and the test-level timeout bumped to 300s for ~2× CI headroom over the worst-case parent + child stacking.

Pre-existing LOW issues (legacy `pollJobUntilDone` / `waitForJobDone` duplicates not yet migrated to the shared helper, and an existing `toHaveScreenshot` call in an inference spec without a `@visual` tag) were noted but left for a separate refactor PR.

## Test Plan

- [x] `pnpm test` — 1655 pass, 2 skipped.
- [x] `pnpm test:e2e --project=chromium --grep-invert "@visual|@a11y|@ci-flaky" --ignore-snapshots` — 79 pass, 1 skipped (was 77 in Phase 3; +2 from R + I).
- [x] Targeted E2E re-run after review fixes — Scenario R + I both green.
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy src/lizystudio/` — clean.
- [x] `pnpm check` / `pnpm build` — clean.

Closes #263
