### PR TITLE
fix(workspace): remove duplicate Balanced toggle and gate empty Tune Choice (#265, #266)

### DIFF
--- a/frontend/src/components/workspace/ConfigEditorBody.test.tsx
+++ b/frontend/src/components/workspace/ConfigEditorBody.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Tests for ConfigEditorBody — the scrollable host for ConfigForm / TuneTab.
+ *
+ * Focus is on the validation/error banners. Body-level form rendering is
+ * already covered by ConfigForm.test.tsx and TuneTab.test.tsx.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ConfigEditorBody } from "./ConfigEditorBody";
+
+vi.mock("./ConfigForm", () => ({
+  ConfigForm: () => <div data-testid="config-form-stub" />,
+}));
+vi.mock("./TuneTab", () => ({
+  TuneTab: () => <div data-testid="tune-tab-stub" />,
+}));
+
+function renderBody(
+  props: Partial<React.ComponentProps<typeof ConfigEditorBody>> = {},
+) {
+  const baseProps: React.ComponentProps<typeof ConfigEditorBody> = {
+    activeTab: "tune",
+    hasData: true,
+    running: false,
+    errors: [],
+    schema: { type: "object" },
+    config: { model: {}, tuning: { optuna: { space: {} } } },
+    onChange: vi.fn(),
+    task: "binary",
+    uiSchema: {},
+    columns: [],
+    ...props,
+  };
+  return render(
+    <TooltipProvider>
+      <ConfigEditorBody {...baseProps} />
+    </TooltipProvider>,
+  );
+}
+
+describe("ConfigEditorBody — empty Choice banner (Issue #266)", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not render the banner when emptyChoiceKeys is empty", () => {
+    renderBody({ emptyChoiceKeys: [] });
+    expect(screen.queryByTestId("empty-choice-banner")).toBeNull();
+  });
+
+  it("does not render the banner on the Fit tab even with empty choices", () => {
+    renderBody({ activeTab: "fit", emptyChoiceKeys: ["objective"] });
+    expect(screen.queryByTestId("empty-choice-banner")).toBeNull();
+  });
+
+  it("renders the banner listing offending parameter keys on the Tune tab", () => {
+    renderBody({
+      activeTab: "tune",
+      emptyChoiceKeys: ["objective", "metric"],
+    });
+    const banner = screen.getByTestId("empty-choice-banner");
+    expect(banner).toBeInTheDocument();
+    expect(banner.textContent).toContain("objective");
+    expect(banner.textContent).toContain("metric");
+  });
+});

--- a/frontend/src/components/workspace/ConfigEditorBody.tsx
+++ b/frontend/src/components/workspace/ConfigEditorBody.tsx
@@ -16,6 +16,12 @@ export interface ConfigEditorBodyProps {
   hasData: boolean;
   running: boolean;
   errors: ConfigError[];
+  /**
+   * Search Space parameter keys that are in Choice (categorical) mode
+   * with no choices populated (Issue #266). Surfaced as a banner above
+   * the search space when activeTab === "tune".
+   */
+  emptyChoiceKeys?: string[];
   // biome-ignore lint/suspicious/noExplicitAny: JSON schema shape passes straight through to ConfigForm
   schema: any | undefined;
   config: Record<string, unknown> | undefined;
@@ -31,6 +37,7 @@ export function ConfigEditorBody({
   hasData,
   running,
   errors,
+  emptyChoiceKeys = [],
   schema,
   config,
   onChange,
@@ -39,6 +46,8 @@ export function ConfigEditorBody({
   columns,
 }: ConfigEditorBodyProps) {
   const visibleErrors = errors.filter((err) => err.path || err.message);
+  const showEmptyChoiceBanner =
+    activeTab === "tune" && emptyChoiceKeys.length > 0;
 
   return (
     // tabIndex=0 satisfies axe scrollable-region-focusable (WCAG 2.1.1)
@@ -68,6 +77,21 @@ export function ConfigEditorBody({
               {[err.path, err.message].filter(Boolean).join(": ")}
             </p>
           ))}
+        </div>
+      )}
+      {showEmptyChoiceBanner && (
+        <div
+          className="mb-4 rounded-md border border-destructive/50 bg-destructive/10 p-3"
+          data-testid="empty-choice-banner"
+          role="alert"
+        >
+          <p className="text-xs font-medium text-destructive">
+            Fix validation errors first
+          </p>
+          <p className="mt-1 text-xs text-destructive">
+            Choice mode with no choices: {emptyChoiceKeys.join(", ")}. Add at
+            least one choice to each parameter or switch the row back to Fixed.
+          </p>
         </div>
       )}
 

--- a/frontend/src/components/workspace/ModelPanel.tsx
+++ b/frontend/src/components/workspace/ModelPanel.tsx
@@ -40,6 +40,7 @@ export function ModelPanel({
     uiSchema,
     nonExcludedColumns,
     errors,
+    emptyChoiceKeys,
     presets,
     history,
     fitEnabled,
@@ -74,6 +75,7 @@ export function ModelPanel({
         hasData={hasData}
         running={running}
         errors={errors}
+        emptyChoiceKeys={emptyChoiceKeys}
         schema={schema}
         config={config}
         onChange={handleConfigChange}

--- a/frontend/src/components/workspace/search-space-utils.test.ts
+++ b/frontend/src/components/workspace/search-space-utils.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { findEmptyChoiceKeys } from "./search-space-utils";
+
+describe("findEmptyChoiceKeys (Issue #266)", () => {
+  it("returns empty list for empty space", () => {
+    expect(findEmptyChoiceKeys({})).toEqual([]);
+  });
+
+  it("ignores Range entries", () => {
+    const space = {
+      learning_rate: { type: "float", low: 0.001, high: 0.1, log: false },
+      n_estimators: { type: "int", low: 100, high: 1000, log: false },
+    };
+    expect(findEmptyChoiceKeys(space)).toEqual([]);
+  });
+
+  it("ignores Choice entries with at least one choice", () => {
+    const space = {
+      objective: { type: "categorical", choices: ["binary", "huber"] },
+      metric: { type: "categorical", choices: ["auc"] },
+    };
+    expect(findEmptyChoiceKeys(space)).toEqual([]);
+  });
+
+  it("flags Choice entries with empty choices array", () => {
+    const space = {
+      objective: { type: "categorical", choices: [] },
+    };
+    expect(findEmptyChoiceKeys(space)).toEqual(["objective"]);
+  });
+
+  it("flags Choice entries when choices is missing entirely", () => {
+    const space = {
+      objective: { type: "categorical" },
+    };
+    expect(findEmptyChoiceKeys(space)).toEqual(["objective"]);
+  });
+
+  it("flags multiple offending entries while ignoring valid ones", () => {
+    const space = {
+      learning_rate: { type: "float", low: 0.001, high: 0.1, log: false },
+      objective: { type: "categorical", choices: [] },
+      metric: { type: "categorical", choices: ["auc"] },
+      verbose: { type: "categorical", choices: [] },
+    };
+    expect(findEmptyChoiceKeys(space).sort()).toEqual(["objective", "verbose"]);
+  });
+
+  it("ignores non-object values without throwing", () => {
+    const space: Record<string, unknown> = {
+      a: null,
+      b: undefined,
+      c: 42,
+      d: "string",
+      objective: { type: "categorical", choices: [] },
+    };
+    expect(findEmptyChoiceKeys(space)).toEqual(["objective"]);
+  });
+});

--- a/frontend/src/components/workspace/search-space-utils.ts
+++ b/frontend/src/components/workspace/search-space-utils.ts
@@ -64,6 +64,26 @@ export function formatSummary(entry: SpaceEntry): string {
   return `${entry.low} ~ ${entry.high}${dist}`;
 }
 
+/**
+ * Find Search Space entries in Choice (categorical) mode with no choices
+ * (Issue #266). The backend rejects these with 422; surface them as a
+ * client-side validation error so the Tune button can be disabled before
+ * submission.
+ */
+export function findEmptyChoiceKeys(space: Record<string, unknown>): string[] {
+  const keys: string[] = [];
+  for (const [key, raw] of Object.entries(space)) {
+    if (raw == null || typeof raw !== "object") continue;
+    const obj = raw as Record<string, unknown>;
+    if (obj.type !== "categorical") continue;
+    const choices = obj.choices;
+    if (!Array.isArray(choices) || choices.length === 0) {
+      keys.push(key);
+    }
+  }
+  return keys;
+}
+
 /** Props for the SearchSpaceRow component. */
 export interface SearchSpaceRowProps {
   param: {

--- a/frontend/src/hooks/useModelPanelData.test.ts
+++ b/frontend/src/hooks/useModelPanelData.test.ts
@@ -35,6 +35,7 @@ vi.mock("@/api/workspace", () => ({
 
 import {
   fetchColumns,
+  fetchConfig,
   updateConfig,
   uploadConfig,
   validateConfig,
@@ -135,6 +136,73 @@ describe("useModelPanelData", () => {
     await waitFor(() => expect(result.current.config).toBeDefined());
     // default config has no tuning.optuna.space → tune disabled
     expect(result.current.tuneEnabled).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #266: empty Choice validation gate
+  // -------------------------------------------------------------------------
+  it("flags empty Choice search-space entries via emptyChoiceKeys", async () => {
+    vi.mocked(fetchConfig).mockResolvedValueOnce({
+      model: { name: "lgbm", params: {} },
+      tuning: {
+        optuna: {
+          space: {
+            objective: { type: "categorical", choices: [] },
+            learning_rate: { type: "float", low: 0.001, high: 0.1, log: false },
+            metric: { type: "categorical", choices: [] },
+          },
+        },
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+    } as any);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () =>
+        useModelPanelData({
+          hasData: true,
+          running: false,
+          activeTab: "tune",
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.config).toBeDefined());
+    expect(result.current.emptyChoiceKeys.sort()).toEqual([
+      "metric",
+      "objective",
+    ]);
+    expect(result.current.tuneEnabled).toBe(false);
+    expect(result.current.disabledReason).toContain("Add at least one choice");
+  });
+
+  it("does not flag Choice entries that have at least one choice", async () => {
+    vi.mocked(fetchConfig).mockResolvedValueOnce({
+      model: { name: "lgbm", params: {} },
+      tuning: {
+        optuna: {
+          space: {
+            objective: { type: "categorical", choices: ["binary"] },
+          },
+        },
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+    } as any);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () =>
+        useModelPanelData({
+          hasData: true,
+          running: false,
+          activeTab: "tune",
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.config).toBeDefined());
+    expect(result.current.emptyChoiceKeys).toEqual([]);
+    expect(result.current.tuneEnabled).toBe(true);
   });
 
   // -------------------------------------------------------------------------

--- a/frontend/src/hooks/useModelPanelData.ts
+++ b/frontend/src/hooks/useModelPanelData.ts
@@ -24,6 +24,7 @@ import {
 import { queryKeys } from "@/api/queryKeys";
 import type { ConfigError } from "@/api/types";
 import { updateConfig, uploadConfig, validateConfig } from "@/api/workspace";
+import { findEmptyChoiceKeys } from "@/components/workspace/search-space-utils";
 import { useConfigHistory } from "@/hooks/useConfigHistory";
 import { useConfigPresets } from "@/hooks/useConfigPresets";
 
@@ -179,14 +180,26 @@ export function useModelPanelData({
         | Record<string, unknown>
         | undefined
     )?.space as Record<string, unknown> | undefined) ?? {};
+  // Issue #266: any Choice-mode entry with no choices is rejected by the
+  // backend. Surface as a client-side block so the user gets a clear
+  // signal (banner + disabled Tune) instead of a 422 round-trip.
+  const emptyChoiceKeys = useMemo(
+    () => findEmptyChoiceKeys(tuningSpace),
+    [tuningSpace],
+  );
   const tuneEnabled =
-    fitEnabled && (allowEmptySpace || Object.keys(tuningSpace).length > 0);
+    fitEnabled &&
+    (allowEmptySpace || Object.keys(tuningSpace).length > 0) &&
+    emptyChoiceKeys.length === 0;
 
   const disabledReason = (() => {
     if (running) return "A job is currently running";
     if (!hasData) return "Load data first";
     if (!config) return "Loading configuration...";
     if (errors.length > 0) return "Fix validation errors first";
+    if (activeTab === "tune" && emptyChoiceKeys.length > 0) {
+      return `Add at least one choice to: ${emptyChoiceKeys.join(", ")}`;
+    }
     if (activeTab === "tune" && !tuneEnabled)
       return "Define a search space or enable empty space";
     return null;
@@ -199,6 +212,7 @@ export function useModelPanelData({
     uiSchema,
     nonExcludedColumns,
     errors,
+    emptyChoiceKeys,
     presets,
     history,
     fitEnabled,

--- a/frontend/tests/e2e/workspace-fit.spec.ts
+++ b/frontend/tests/e2e/workspace-fit.spec.ts
@@ -434,4 +434,69 @@ test.describe("Workspace Fit Flow", () => {
     );
     expect(jobBody.status).toBe("completed");
   });
+
+  /**
+   * Issue #265 — UI-driven Balanced switch lock.
+   *
+   * The Smart Params Balanced switch must propagate to ``model.balanced``
+   * (the LGBMConfig top-level field consumed by lizyml). Before the fix
+   * a duplicate parameter_hint rendered a second toggle in Advanced
+   * Model Params that wrote to ``model.params.balanced`` — silently
+   * dropped by lizyml. This spec locks the contract: only one Balanced
+   * switch is rendered, and toggling it reaches ``model.balanced`` in
+   * the next PUT body.
+   */
+  test("UI: toggle Balanced, verify model.balanced reaches PUT /config and only one toggle exists", async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(60_000);
+    if (isMobileProject(testInfo)) {
+      test.skip(true, "Mobile layout path is covered elsewhere");
+    }
+
+    const csvPath = createTestCsv();
+    await seedUiWorkspace(page, testInfo, { csvPath });
+
+    // Smart Params Balanced switch (role="switch") — distinct from any
+    // CompactToggle in Advanced Model Params. Locating by accessible
+    // name guarantees we hit the Switch primitive, not a sibling input.
+    const balancedSwitch = page.getByRole("switch", { name: "Balanced" });
+    await expect(balancedSwitch).toBeVisible({ timeout: 15_000 });
+
+    // Issue #265 root cause: a parameter_hint named "balanced" rendered
+    // a SECOND toggle in the Advanced section that wrote to the wrong
+    // path. Open Advanced and assert there is exactly one Balanced
+    // switch on the page.
+    await page.getByTestId("toggle-advanced-params").click();
+    const allBalanced = page.getByRole("switch", { name: "Balanced" });
+    await expect(allBalanced).toHaveCount(1);
+
+    // Arm a PUT listener that watches for ``model.balanced === true``.
+    const balancedPutPromise = page.waitForRequest(
+      (req) =>
+        req.url().endsWith("/api/workspace/config") &&
+        req.method() === "PUT" &&
+        (() => {
+          try {
+            const body = req.postDataJSON() as {
+              model?: { balanced?: unknown };
+            };
+            return body?.model?.balanced === true;
+          } catch {
+            return false;
+          }
+        })(),
+      { timeout: 15_000 },
+    );
+
+    await balancedSwitch.click();
+    const put = await balancedPutPromise;
+    const putBody = put.postDataJSON() as {
+      model: { balanced: unknown; params?: { balanced?: unknown } };
+    };
+    expect(putBody.model.balanced).toBe(true);
+    // model.params.balanced must NOT be set — that path is silently
+    // dropped by lizyml and is the wrong target.
+    expect(putBody.model.params?.balanced).toBeUndefined();
+  });
 });

--- a/frontend/tests/e2e/workspace-tune.spec.ts
+++ b/frontend/tests/e2e/workspace-tune.spec.ts
@@ -461,14 +461,21 @@ test.describe("Workspace tune flow", () => {
     await expect(tuneButton).toBeEnabled({ timeout: 15_000 });
 
     // Drive the SearchSpaceTable: switch the ``objective`` row to Choice.
-    // SegmentGroup renders mode buttons inside each row; locate the
-    // row by its parameter key text and click the "choice" segment.
-    const objectiveRow = page
-      .locator("div")
-      .filter({ has: page.locator("span", { hasText: /^objective$/ }) })
-      .first();
-    await expect(objectiveRow).toBeVisible({ timeout: 5_000 });
-    await objectiveRow.getByRole("button", { name: "choice" }).click();
+    // SearchSpaceRow renders the param key as ``<span class="font-mono">``
+    // and the mode segments as ``role="radio"`` with capitalized labels
+    // (Fixed / Range / Choice — see SegmentGroup.tsx + SearchSpaceRow.tsx).
+    // The row wrapper carries ``border-b`` AND ``last:border-b-0``;
+    // matching just ``border-b`` was too loose and resolved to the
+    // SearchSpaceTable header card. Anchor to the row by walking up
+    // from the param-key ``<span>`` to the closest ``<div>`` that
+    // contains the ``radiogroup``.
+    const objectiveKey = page.locator("span.font-mono", {
+      hasText: /^objective$/,
+    });
+    const objectiveRow = objectiveKey
+      .locator("xpath=ancestor::div[.//*[@role='radiogroup']][1]");
+    await expect(objectiveRow).toBeVisible({ timeout: 15_000 });
+    await objectiveRow.getByRole("radio", { name: "Choice" }).click();
 
     // The banner appears and the Tune button gates off.
     await expect(page.getByTestId("empty-choice-banner")).toBeVisible({
@@ -481,7 +488,7 @@ test.describe("Workspace tune flow", () => {
 
     // Reverting the row to Fixed must re-enable Tune and remove the
     // banner. This is the recovery path users will take.
-    await objectiveRow.getByRole("button", { name: "fixed" }).click();
+    await objectiveRow.getByRole("radio", { name: "Fixed" }).click();
     await expect(page.getByTestId("empty-choice-banner")).toHaveCount(0);
     await expect(tuneButton).toBeEnabled({ timeout: 5_000 });
   });

--- a/frontend/tests/e2e/workspace-tune.spec.ts
+++ b/frontend/tests/e2e/workspace-tune.spec.ts
@@ -434,4 +434,55 @@ test.describe("Workspace tune flow", () => {
     expect(childTuneResult).toBeTruthy();
     expect(childTuneResult).toHaveProperty("best_params");
   });
+
+  /**
+   * Issue #266 — empty-Choice Tune button gate.
+   *
+   * Switching a Search Space row to Choice mode without entering any
+   * choices used to produce ``{type:"categorical", choices:[]}`` and the
+   * backend rejected the resulting Tune with 422. This spec drives the
+   * UI through the offending sequence and asserts the Tune button is
+   * disabled with a banner pointing at the offending row, then re-
+   * enables once the user reverts the row to Fixed.
+   */
+  test("UI: empty Choice mode disables Tune button and shows a banner", async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(60_000);
+    if (isMobileProject(testInfo)) {
+      test.skip(true, "Mobile layout path is covered elsewhere");
+    }
+
+    const csvPath = createTestCsv();
+    await seedUiWorkspace(page, testInfo, { csvPath });
+
+    await page.getByRole("tab", { name: "Tune" }).click();
+    const tuneButton = page.getByRole("button", { name: "Tune", exact: true });
+    await expect(tuneButton).toBeEnabled({ timeout: 15_000 });
+
+    // Drive the SearchSpaceTable: switch the ``objective`` row to Choice.
+    // SegmentGroup renders mode buttons inside each row; locate the
+    // row by its parameter key text and click the "choice" segment.
+    const objectiveRow = page
+      .locator("div")
+      .filter({ has: page.locator("span", { hasText: /^objective$/ }) })
+      .first();
+    await expect(objectiveRow).toBeVisible({ timeout: 5_000 });
+    await objectiveRow.getByRole("button", { name: "choice" }).click();
+
+    // The banner appears and the Tune button gates off.
+    await expect(page.getByTestId("empty-choice-banner")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByTestId("empty-choice-banner")).toContainText(
+      "objective",
+    );
+    await expect(tuneButton).toBeDisabled();
+
+    // Reverting the row to Fixed must re-enable Tune and remove the
+    // banner. This is the recovery path users will take.
+    await objectiveRow.getByRole("button", { name: "fixed" }).click();
+    await expect(page.getByTestId("empty-choice-banner")).toHaveCount(0);
+    await expect(tuneButton).toBeEnabled({ timeout: 5_000 });
+  });
 });

--- a/src/lizystudio/backends/lizyml_ui_schema.py
+++ b/src/lizystudio/backends/lizyml_ui_schema.py
@@ -193,12 +193,6 @@ def build_ui_schema(
                 "default": -1,
             },
             {
-                "key": "balanced",
-                "label": "Balanced",
-                "kind": "boolean",
-                "default": True,
-            },
-            {
                 "key": "num_leaves",
                 "label": "Num Leaves",
                 "kind": "integer",

--- a/tests/contract/test_ui_schema_matches_pydantic.py
+++ b/tests/contract/test_ui_schema_matches_pydantic.py
@@ -177,3 +177,38 @@ def test_frontend_fallback_matches_backend_cv_strategy_fields() -> None:
         "FALLBACK_CV_STRATEGY_FIELDS in cv-state.ts does not match "
         "backend ui_schema.cv_strategy_fields:\n  " + "\n  ".join(diffs)
     )
+
+
+def test_parameter_hints_do_not_shadow_smart_params() -> None:
+    """Issue #265 regression guard.
+
+    ``parameter_hints`` drives the Advanced Model Params section, which
+    writes to ``model.params.<key>``. Smart Params (top-level fields on
+    ``LGBMConfig`` like ``balanced``, ``auto_num_leaves``) write to
+    ``model.<key>``. lizyml only reads Smart Params from ``model.<key>``
+    (see ``LGBMProvider.extract_smart_params``), so a hint shadowing a
+    Smart Params field renders a second toggle that silently drops the
+    user's value into the wrong path.
+
+    This test enumerates the LGBMConfig fields that are not native
+    LightGBM ``params`` (i.e. all properties except ``name`` and
+    ``params``) and asserts none of them appear as a parameter_hint key.
+    """
+    from lizyml.config.schema import LizyMLConfig
+
+    ui_schema = build_ui_schema(get_eval_metrics_by_task())
+    hint_keys = {h["key"] for h in ui_schema["parameter_hints"]}
+
+    defs = LizyMLConfig.model_json_schema().get("$defs", {})
+    lgbm = defs.get("LGBMConfig") or {}
+    lgbm_props = set((lgbm.get("properties") or {}).keys())
+    smart_param_keys = lgbm_props - {"name", "params"}
+
+    overlap = hint_keys & smart_param_keys
+    assert not overlap, (
+        "parameter_hints must not shadow LGBMConfig Smart Params fields. "
+        f"Found overlap: {sorted(overlap)}. These fields are written by "
+        "the Smart Params section to model.<key>; including them in "
+        "parameter_hints causes a duplicate Advanced toggle that writes "
+        "to model.params.<key> and is silently dropped by lizyml."
+    )

--- a/tests/test_ui_schema.py
+++ b/tests/test_ui_schema.py
@@ -326,11 +326,11 @@ class TestLizyMLAdapterUiSchema:
         hints = {h["key"]: h for h in schema["parameter_hints"]}
         assert hints["first_metric_only"]["default"] is False
 
-    def test_parameter_hint_balanced_default(self) -> None:
-        """balanced default must be True."""
+    def test_search_space_catalog_balanced_default(self) -> None:
+        """balanced default in search_space_catalog must be True (Issue #265)."""
         schema = LizyMLAdapter().get_ui_schema()
-        hints = {h["key"]: h for h in schema["parameter_hints"]}
-        assert hints["balanced"]["default"] is True
+        catalog = {e["key"]: e for e in schema["search_space_catalog"]}
+        assert catalog["balanced"]["default"] is True
 
     def test_search_space_catalog_seed_default(self) -> None:
         """search_space_catalog seed default must be 1120."""
@@ -426,12 +426,21 @@ class TestLizyMLAdapterUiSchema:
 
     # --- Phase 1: Expanded parameter coverage (Widget parity) ---
 
-    def test_parameter_hints_include_balanced(self) -> None:
-        """balanced must be in parameter_hints as a boolean kind."""
+    def test_parameter_hints_exclude_balanced(self) -> None:
+        """balanced must NOT be in parameter_hints (Issue #265).
+
+        balanced is a Smart Params field on LGBMConfig (writes to
+        ``model.balanced``). Including it in parameter_hints caused
+        a duplicate render in the Advanced Model Params section that
+        wrote to ``model.params.balanced`` — silently dropped by lizyml
+        because it reads from ``model_cfg.balanced`` only.
+        """
         schema = LizyMLAdapter().get_ui_schema()
         hints = {h["key"]: h for h in schema["parameter_hints"]}
-        assert "balanced" in hints
-        assert hints["balanced"]["kind"] == "boolean"
+        assert "balanced" not in hints, (
+            "balanced must be rendered exclusively via Smart Params "
+            "(model.balanced), not via parameter_hints (model.params.balanced)"
+        )
 
     def test_parameter_hints_include_num_leaves(self) -> None:
         """num_leaves must be in parameter_hints as an integer kind."""


### PR DESCRIPTION
## Summary

Closes #265, closes #266.

### Issue #265 — Balanced toggle UI/config divergence

`balanced` was registered twice in the lizyml UI schema:

| Render path | Writes to | Read by lizyml? |
|---|---|---|
| Smart Params Switch (LGBMConfig top-level) | `model.balanced` | ✅ via `LGBMProvider.extract_smart_params` |
| Advanced Model Params CompactToggle (parameter_hints) | `model.params.balanced` | ❌ silently dropped |

Toggling the *Advanced* toggle shows `aria-checked="true"` in the DOM but the user's intent never reaches the backend. The Fit job runs without the balanced flag and the user attributes the metric drift to randomness.

**Fix:** remove the duplicate `balanced` entry from `parameter_hints` so the field renders exclusively via Smart Params (single Switch on the correct path).

A contract test (`test_parameter_hints_do_not_shadow_smart_params`) locks the invariant — adding any LGBMConfig non-params field to `parameter_hints` will fail CI.

### Issue #266 — Empty Choice mode submits invalid Tune body

Switching a Search Space row to Choice mode without entering any choices produced `{type:"categorical", choices:[]}` and the backend rejected the Tune with 422. The UI showed a generic toast; the user had to inspect the network tab to find which parameter was malformed.

**Fix:**
- New helper `findEmptyChoiceKeys(space)` — pure function, returns the list of param keys with empty choices.
- `useModelPanelData` exposes `emptyChoiceKeys` and folds it into the existing `tuneEnabled` / `disabledReason` derivation.
- `ConfigEditorBody` shows an alert banner above the search space listing the offending parameters when `activeTab === "tune"`.
- Tune button is disabled while any Choice row has `choices.length === 0`. Reverting the row to Fixed re-enables it.

## Test plan

- [x] Backend: `uv run pytest` — 1210 pass.
- [x] Frontend unit/component: `pnpm test` — 1667 pass / 2 skipped.
- [x] `pnpm exec tsc --noEmit` — green.
- [x] `pnpm check` (Biome) — green.
- [x] `pnpm build` — green.
- [x] New unit tests
  - `search-space-utils.test.ts` — `findEmptyChoiceKeys` happy/edge paths.
  - `ConfigEditorBody.test.tsx` — banner visibility per tab + key list.
  - `useModelPanelData.test.ts` — `emptyChoiceKeys` derivation + Tune gating.
- [x] New contract test
  - `test_parameter_hints_do_not_shadow_smart_params` — regression guard for #265.
- [x] Updated backend tests
  - `test_parameter_hints_exclude_balanced` (was `..._include_balanced`).
  - `test_search_space_catalog_balanced_default` (replaces hint-based default test).
- [x] New E2E
  - `workspace-fit.spec.ts`: only one Balanced switch in the DOM, PUT carries `model.balanced=true` and not `model.params.balanced`.
  - `workspace-tune.spec.ts`: Choice with empty choices disables Tune + shows banner; reverting to Fixed re-enables.
- [x] Live UI verification (Playwright MCP) confirmed the duplicate Advanced Balanced was the silent path; after the fix only Smart Params Switch renders.
