### PR TITLE
fix(workspace): surface silent-late validation failures (#268, #269, #270)

### DIFF
--- a/frontend/src/components/workspace/ConfigForm.test.tsx
+++ b/frontend/src/components/workspace/ConfigForm.test.tsx
@@ -3,6 +3,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
   within,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -310,6 +311,59 @@ describe("ConfigForm", () => {
     });
 
     expect(screen.queryByText("Calibration")).not.toBeInTheDocument();
+  });
+
+  it("auto-clears stale calibration when task is not binary (Issue #269)", async () => {
+    // Reproduces the silent state bug from #269: calibration was set
+    // while task=binary, then the user switched to regression and the
+    // Calibration UI hid itself but the value lingered, causing a
+    // ~5s LightGBM error after Fit. The auto-reset effect must
+    // immediately write calibration=null on render with task!=binary.
+    const onChange = vi.fn();
+    const staleConfig = {
+      ...minimalConfig,
+      config_version: 1,
+      calibration: { method: "platt", n_splits: 5, params: {} },
+    };
+    renderConfigForm({
+      schema: minimalSchema,
+      config: staleConfig,
+      onChange,
+      task: "regression",
+    });
+
+    // Allow the effect to flush.
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+    // The reset write must zero the calibration field (immutably).
+    const calls = onChange.mock.calls.map((c) => c[0]);
+    const cleared = calls.find(
+      (c) => c && (c as { calibration?: unknown }).calibration === null,
+    );
+    expect(cleared).toBeTruthy();
+  });
+
+  it("does not auto-clear calibration on binary task", async () => {
+    const onChange = vi.fn();
+    const config = {
+      ...minimalConfig,
+      config_version: 1,
+      calibration: { method: "platt", n_splits: 5, params: {} },
+    };
+    renderConfigForm({
+      schema: minimalSchema,
+      config,
+      onChange,
+      task: "binary",
+    });
+
+    // Brief wait — binary must NOT trigger the reset effect.
+    await new Promise((r) => setTimeout(r, 50));
+    const reset = onChange.mock.calls.find(
+      (c) => c[0] && (c[0] as { calibration?: unknown }).calibration === null,
+    );
+    expect(reset).toBeUndefined();
   });
 
   it("renders section title from uiSchema when provided", () => {

--- a/frontend/src/components/workspace/ConfigForm.tsx
+++ b/frontend/src/components/workspace/ConfigForm.tsx
@@ -141,6 +141,20 @@ export function ConfigForm({
       ? (config.calibration as Record<string, unknown> | null)
       : null;
 
+  // Issue #269: lizyml only supports calibration for task="binary".
+  // The Calibration UI hides itself for other tasks via
+  // ``conditional_visibility``, but until now the underlying value was
+  // left alone — a user enabling calibration on binary then switching
+  // to regression sneaked a stale calibration object into POST /fit
+  // and the job died ~5s later with CALIBRATION_NOT_SUPPORTED.
+  // Same shape as the inner_valid auto-reset above.
+  useEffect(() => {
+    if (!config.config_version) return;
+    if (task && task !== "binary" && calibration !== null) {
+      handleFieldChange(["calibration"], null);
+    }
+  }, [task, calibration, handleFieldChange, config.config_version]);
+
   // Resolve options for objective/model_metric kinds from option_sets
   const getOptionsForHint = useCallback(
     (hint: import("@/api/types").ParameterHint): string[] => {

--- a/frontend/src/components/workspace/CvSection.component.test.tsx
+++ b/frontend/src/components/workspace/CvSection.component.test.tsx
@@ -55,11 +55,13 @@ vi.mock("./NumberInput", () => ({
     value,
     onChange,
     min,
+    max,
     placeholder,
   }: {
     value: number | undefined;
     onChange: (v: number | undefined) => void;
     min?: number;
+    max?: number;
     step?: number;
     placeholder?: string;
   }) => (
@@ -68,6 +70,7 @@ vi.mock("./NumberInput", () => ({
       type="number"
       value={value ?? ""}
       min={min}
+      max={max}
       onChange={(e) => {
         const v = e.target.value === "" ? undefined : Number(e.target.value);
         onChange(v);
@@ -653,5 +656,48 @@ describe("CvSection", () => {
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({ groupCol: "col_a" }),
     );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #268: Folds NumberInput max
+  // ---------------------------------------------------------------------------
+  describe("Folds max (Issue #268)", () => {
+    it("passes nRows as the max attribute on the Folds NumberInput", () => {
+      render(
+        <CvSection
+          cv={makeCvState({ strategy: "kfold", folds: 5 })}
+          onChange={mockOnChange}
+          nonExcludedCols={sampleCols}
+          nRows={42}
+        />,
+      );
+      const folds = screen.getByTestId("number-input-5");
+      expect(folds.getAttribute("max")).toBe("42");
+    });
+
+    it("omits max when nRows is undefined (no data loaded yet)", () => {
+      render(
+        <CvSection
+          cv={makeCvState({ strategy: "kfold", folds: 5 })}
+          onChange={mockOnChange}
+          nonExcludedCols={sampleCols}
+        />,
+      );
+      const folds = screen.getByTestId("number-input-5");
+      expect(folds.getAttribute("max")).toBeNull();
+    });
+
+    it("omits max when nRows < 2 (a single-row dataset cannot be split)", () => {
+      render(
+        <CvSection
+          cv={makeCvState({ strategy: "kfold", folds: 5 })}
+          onChange={mockOnChange}
+          nonExcludedCols={sampleCols}
+          nRows={1}
+        />,
+      );
+      const folds = screen.getByTestId("number-input-5");
+      expect(folds.getAttribute("max")).toBeNull();
+    });
   });
 });

--- a/frontend/src/components/workspace/CvSection.tsx
+++ b/frontend/src/components/workspace/CvSection.tsx
@@ -51,6 +51,12 @@ interface CvSectionProps {
   nonExcludedCols: ColumnInfo[];
   blocked?: BlockedGroupKFoldState;
   onBlockedChange?: (next: BlockedGroupKFoldState) => void;
+  /**
+   * Issue #268: dataset row count threaded down so the Folds NumberInput
+   * can clamp to ``min(n_rows, hard_max)``. Optional — when undefined
+   * (no data loaded yet) the input falls back to the hard max only.
+   */
+  nRows?: number;
 }
 
 export function CvSection({
@@ -60,6 +66,7 @@ export function CvSection({
   nonExcludedCols,
   blocked,
   onBlockedChange,
+  nRows,
 }: CvSectionProps) {
   const availableStrategies = useMemo(
     () =>
@@ -127,6 +134,11 @@ export function CvSection({
             value={cv.folds}
             onChange={(v) => update({ folds: v ?? 5 })}
             min={2}
+            // Issue #268: cap Folds at the dataset row count so the user
+            // gets feedback in the input instead of a 5-second silent
+            // failure after Fit. Backend validator catches the YAML
+            // import / preset path on top of this.
+            max={nRows && nRows >= 2 ? nRows : undefined}
             step={1}
             placeholder="5"
           />

--- a/frontend/src/components/workspace/DataPanel.tsx
+++ b/frontend/src/components/workspace/DataPanel.tsx
@@ -236,6 +236,7 @@ export const DataPanel = forwardRef<DataPanelHandle, DataPanelProps>(
                     nonExcludedCols={nonExcludedCols}
                     blocked={blocked}
                     onBlockedChange={setBlocked}
+                    nRows={shape ? shape[0] : undefined}
                   />
                   <FoldPreview
                     enabled={!!target && !!task && shape !== null}

--- a/src/lizystudio/backends/lizyml/config_compat.py
+++ b/src/lizystudio/backends/lizyml/config_compat.py
@@ -201,4 +201,26 @@ def task_params_compat_errors(config: dict[str, Any]) -> list[dict[str, Any]]:
                 }
             )
 
+    # Issue #269: lizyml only supports calibration for task="binary" and
+    # raises CALIBRATION_NOT_SUPPORTED at fit time otherwise. The UI
+    # hides the Calibration section under conditional_visibility but
+    # leaves the value on the config when the user changes the task,
+    # so the stale calibration sneaks past Pydantic and dies ~5s after
+    # Fit. Catching it in the workspace validator surfaces the issue
+    # in the existing "Fix validation errors first" banner instead.
+    calibration = config.get("calibration")
+    if calibration is not None and task != "binary":
+        errors.append(
+            {
+                "type": "task_calibration_mismatch",
+                "loc": ("calibration",),
+                "msg": (
+                    f"calibration is only supported for task='binary'; "
+                    f"got task={task!r}. Clear the calibration block or "
+                    f"switch the task to 'binary'."
+                ),
+                "input": calibration,
+            }
+        )
+
     return errors

--- a/src/lizystudio/services/data.py
+++ b/src/lizystudio/services/data.py
@@ -108,13 +108,19 @@ def analyze_columns(
             )
         )
 
-    # Auto-detect task from target column (BLUEPRINT §4.2.1)
+    # Auto-detect task from target column (BLUEPRINT §4.2.1).
+    # Issue #270: a single-class target is ill-posed (no signal to predict),
+    # so we leave suggested_task=None and let the user pick a different
+    # target. Otherwise the previous heuristic would suggest "multiclass"
+    # for an all-zero target and trigger a confusing LightGBM failure.
     suggested_task: Literal["binary", "multiclass", "regression"] | None = None
     if target and target in df.columns:
         target_series = df[target]
         target_unique = int(target_series.nunique())
         threshold = max(20, int(n_rows * 0.05))
-        if target_unique == 2:
+        if target_unique < 2:
+            suggested_task = None
+        elif target_unique == 2:
             suggested_task = "binary"
         elif target_series.dtype == "object" or target_series.dtype.name == "category":
             # Object/category dtype is always multiclass (BLUEPRINT §4.2.1)

--- a/src/lizystudio/services/workspace.py
+++ b/src/lizystudio/services/workspace.py
@@ -157,7 +157,48 @@ def validate_config(ws: WorkspaceState, config: dict[str, Any]) -> list[dict[str
         message = err.get("msg", err.get("message", ""))
         if path or message:
             normalized.append({"path": path, "message": message})
+    # Issue #268: workspace-aware validation. n_splits > n_rows is
+    # accepted by Pydantic (no row-count knowledge inside the schema)
+    # but explodes ~5s after Fit with sklearn's
+    # "Cannot have number of splits greater than the number of samples".
+    # Surfacing it here lets the existing "Fix validation errors first"
+    # banner block the user before they even click Fit.
+    normalized.extend(_workspace_split_errors(ws, config))
     return normalized
+
+
+def _workspace_split_errors(
+    ws: WorkspaceState, config: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Return ``{path, message}`` errors for split.n_splits > n_rows.
+
+    Returns an empty list when the workspace has no data loaded yet, or
+    when the config is malformed in ways the Pydantic layer already
+    flagged (defensive to avoid raising AttributeError on top of an
+    unrelated validation failure).
+    """
+    data_ref = ws.data_ref
+    if data_ref is None:
+        return []
+    n_rows = data_ref.shape[0]
+    split = config.get("split") if isinstance(config, dict) else None
+    if not isinstance(split, dict):
+        return []
+    n_splits_raw = split.get("n_splits")
+    if not isinstance(n_splits_raw, int) or isinstance(n_splits_raw, bool):
+        return []
+    if n_splits_raw <= n_rows:
+        return []
+    return [
+        {
+            "path": "split.n_splits",
+            "message": (
+                f"n_splits={n_splits_raw} is greater than the number of "
+                f"samples in the loaded dataset (n_rows={n_rows}). "
+                f"Reduce Folds to at most {n_rows}."
+            ),
+        }
+    ]
 
 
 def load_config_from_file(

--- a/tests/test_backends_lizyml.py
+++ b/tests/test_backends_lizyml.py
@@ -198,6 +198,75 @@ def test_adapter_validate_config_does_not_crash_on_non_dict_params() -> None:
     assert isinstance(errors, list)
 
 
+def test_adapter_validate_config_rejects_regression_with_calibration() -> None:
+    """Issue #269: lizyml only supports calibration for task='binary'
+    and raises ``CALIBRATION_NOT_SUPPORTED`` ~5s after Fit otherwise.
+    The compat helper must surface that mismatch up-front so the
+    'Fix validation errors first' banner blocks the run.
+    """
+    adapter = LizyMLAdapter()
+    cfg: dict[str, Any] = {
+        "config_version": 1,
+        "task": "regression",
+        "data": {"target": "y"},
+        "model": {"name": "lgbm", "params": {"objective": "huber"}},
+        "split": {"method": "kfold"},
+        "calibration": {"method": "platt", "n_splits": 5, "params": {}},
+    }
+    errors = adapter.validate_config(cfg)
+    assert any(
+        e.get("type") == "task_calibration_mismatch"
+        or "calibration" in str(e.get("loc", ()))
+        for e in errors
+    ), errors
+
+
+def test_adapter_validate_config_rejects_multiclass_with_calibration() -> None:
+    """Same guard for multiclass — calibration is binary-only."""
+    adapter = LizyMLAdapter()
+    cfg: dict[str, Any] = {
+        "config_version": 1,
+        "task": "multiclass",
+        "data": {"target": "y"},
+        "model": {"name": "lgbm", "params": {"objective": "multiclass"}},
+        "split": {"method": "stratified_kfold"},
+        "calibration": {"method": "platt", "n_splits": 5, "params": {}},
+    }
+    errors = adapter.validate_config(cfg)
+    assert any(e.get("type") == "task_calibration_mismatch" for e in errors), errors
+
+
+def test_adapter_validate_config_accepts_binary_with_calibration() -> None:
+    """Sanity check: calibration with task='binary' must NOT trigger the
+    new compat error."""
+    adapter = LizyMLAdapter()
+    cfg = _valid_binary_config()
+    cfg["calibration"] = {"method": "platt", "n_splits": 5, "params": {}}
+    errors = adapter.validate_config(cfg)
+    compat = [e for e in errors if e.get("type") == "task_calibration_mismatch"]
+    assert compat == []
+
+
+def test_adapter_validate_config_accepts_null_calibration_for_any_task() -> None:
+    """``calibration: null`` is the explicit 'off' state — must never
+    trigger the calibration compat error regardless of task."""
+    adapter = LizyMLAdapter()
+    for task in ("binary", "multiclass", "regression"):
+        cfg: dict[str, Any] = {
+            "config_version": 1,
+            "task": task,
+            "data": {"target": "y"},
+            "model": {"name": "lgbm"},
+            "split": {
+                "method": "stratified_kfold" if task != "regression" else "kfold"
+            },
+            "calibration": None,
+        }
+        errors = adapter.validate_config(cfg)
+        compat = [e for e in errors if e.get("type") == "task_calibration_mismatch"]
+        assert compat == [], (task, errors)
+
+
 def test_adapter_load_config_yaml() -> None:
     adapter = LizyMLAdapter()
     content = b"task: binary\nmodel:\n  name: lightgbm"

--- a/tests/test_data_api.py
+++ b/tests/test_data_api.py
@@ -402,6 +402,25 @@ def test_analyze_columns_target_not_in_columns() -> None:
     assert result.suggested_task is None
 
 
+def test_analyze_columns_single_class_target_returns_none() -> None:
+    """Issue #270: a target column with a single unique value is ill-posed
+    (no signal to predict). The suggestion engine must NOT propose
+    ``multiclass`` for an all-zero target — that fed a confusing
+    ``LightGBM n_classes=1`` failure ~5s after Fit. Returning None makes
+    the UI prompt the user to pick a different target instead.
+    """
+    df = pd.DataFrame({"x": range(50), "target": [0] * 50})
+    result = analyze_columns(df, target="target")
+    assert result.suggested_task is None
+
+
+def test_analyze_columns_single_class_object_target_returns_none() -> None:
+    """Issue #270: same guard for an object-dtype constant column."""
+    df = pd.DataFrame({"x": range(50), "target": ["only"] * 50})
+    result = analyze_columns(df, target="target")
+    assert result.suggested_task is None
+
+
 # ---------------------------------------------------------------------------
 # API: data/upload with parquet
 # ---------------------------------------------------------------------------

--- a/tests/test_workspace_api.py
+++ b/tests/test_workspace_api.py
@@ -112,6 +112,63 @@ def test_status_has_config_true_after_put(client: TestClient) -> None:
     assert res.json()["has_config"] is True
 
 
+def test_validate_flags_n_splits_greater_than_n_rows(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    """Issue #268: a 50-row dataset with n_splits=1000 used to pass
+    validate, get accepted by POST /fit, and fail ~5s later with
+    sklearn's "Cannot have number of splits greater than the number of
+    samples". The workspace-aware validator now flags it up-front so
+    the existing 'Fix validation errors first' banner blocks the run.
+    """
+    _load_data_and_config(client, tmp_path)
+    config = _load_valid_config(client)
+    config["split"]["n_splits"] = 1000
+    res = client.post("/api/workspace/config/validate", json=config)
+    assert res.status_code == 200
+    errors = res.json()["errors"]
+    assert any(
+        "n_splits" in (err.get("path") or "") and "1000" in (err.get("message") or "")
+        for err in errors
+    ), errors
+
+
+def test_validate_does_not_flag_n_splits_when_no_data_loaded(
+    client: TestClient,
+) -> None:
+    """Without a loaded dataset the workspace cannot enforce a row-count
+    cap. The validator must short-circuit instead of raising.
+    """
+    config = _load_valid_config(client)
+    config["split"]["n_splits"] = 999_999
+    res = client.post("/api/workspace/config/validate", json=config)
+    assert res.status_code == 200
+    errors = res.json()["errors"]
+    assert not any("n_splits" in (err.get("path") or "") for err in errors)
+
+
+def test_put_config_saved_false_when_n_splits_exceeds_n_rows(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    """Issue #268: an over-large n_splits arriving via PUT /config must
+    flip ``saved=false`` (errors prevent the write) so the user sees the
+    state mismatch instead of a healthy-looking PUT followed by a 5-s
+    Fit failure.
+    """
+    _load_data_and_config(client, tmp_path)
+    config = _load_valid_config(client)
+    config["split"]["n_splits"] = 1000
+    res = client.put("/api/workspace/config", json=config)
+    assert res.status_code == 200
+    body = res.json()
+    assert body["saved"] is False
+    assert any("n_splits" in (err.get("path") or "") for err in body["errors"]), body[
+        "errors"
+    ]
+
+
 def test_status_no_disk_restore(
     client: TestClient,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

Closes #268, closes #269, closes #270.

Three sibling bugs from the post-#265/#266 audit. All match the same UX-failure shape: **validate passes → Fit accepted → job dies in ~5s with a runtime error from lizyml/sklearn/LightGBM**. Surfacing them as synchronous validation errors keeps the failure mode in the editor instead of in the job log.

### Issue #268 — `n_splits > n_rows` accepted by validate

A 50-row CSV with `n_splits=1000` previously round-tripped through `POST /api/workspace/config/validate` with `errors: []`, the Fit was accepted, and ~5 s later sklearn raised `Cannot have number of splits greater than the number of samples`.

**Fix**:
- Backend: new helper `services.workspace._workspace_split_errors(ws, config)` runs after Pydantic in `validate_config(ws, config)`. It compares `config.split.n_splits` against `ws.data_ref.shape[0]` and returns a `{path: "split.n_splits", message: ...}` error if exceeded. No-op when no data is loaded.
- Frontend: `CvSection` now accepts an `nRows` prop and forwards it to the Folds `NumberInput` as `max=`. `DataPanel` reads `shape[0]` from the workspace and threads it through. Catches the input the moment the user blurs.

### Issue #269 — Stale calibration after `task` switch

User enabled Calibration on `task=binary`, switched to `regression`, the section vanished (gated by `conditional_visibility`) but the value lingered. Pydantic accepted, lizyml raised `CALIBRATION_NOT_SUPPORTED` ~5 s after Fit.

**Fix**:
- Frontend (preferred path): a new `useEffect` in `ConfigForm` mirrors the existing inner_valid auto-reset — when `task !== "binary"` and `calibration !== null`, it writes `calibration: null`.
- Backend (defence in depth): `task_params_compat_errors` now emits `task_calibration_mismatch` for any `task != "binary" && calibration != null`. Catches the YAML import / preset load path that bypasses the React effect.

### Issue #270 — Single-class target → `suggested_task: "multiclass"`

`analyze_columns` previously suggested `multiclass` for an all-zero column because the only branch that returned `None` was "no target / target not in df". This fed a confusing LightGBM `n_classes=1` failure downstream.

**Fix**: `services.data.analyze_columns` now returns `suggested_task=None` when `target.nunique() < 2`. The UI prompts the user to pick a different target instead of accepting a clearly wrong default.

## Test plan

- [x] `uv run pytest` (full suite, 1209 pass; one unrelated WSL2-flaky SIGTERM regression test that passes in isolation)
- [x] `pnpm test` — 1663 pass / 2 skipped (one unrelated worker-exit env issue from #267 era)
- [x] `pnpm exec tsc --noEmit` green
- [x] `pnpm check` (Biome) green
- [x] `pnpm build` green
- [x] `uv run ruff check . && uv run ruff format --check .` green

### New tests
- `tests/test_data_api.py::test_analyze_columns_single_class_target_returns_none`
- `tests/test_data_api.py::test_analyze_columns_single_class_object_target_returns_none`
- `tests/test_backends_lizyml.py::test_adapter_validate_config_rejects_regression_with_calibration`
- `tests/test_backends_lizyml.py::test_adapter_validate_config_rejects_multiclass_with_calibration`
- `tests/test_backends_lizyml.py::test_adapter_validate_config_accepts_binary_with_calibration`
- `tests/test_backends_lizyml.py::test_adapter_validate_config_accepts_null_calibration_for_any_task`
- `tests/test_workspace_api.py::test_validate_flags_n_splits_greater_than_n_rows`
- `tests/test_workspace_api.py::test_validate_does_not_flag_n_splits_when_no_data_loaded`
- `tests/test_workspace_api.py::test_put_config_saved_false_when_n_splits_exceeds_n_rows`
- `frontend/src/components/workspace/ConfigForm.test.tsx`: calibration auto-clear (non-binary fires reset, binary is no-op)
- `frontend/src/components/workspace/CvSection.component.test.tsx::Folds max (Issue #268)`: 3 cases (nRows present, undefined, <2)
