### PR TITLE
fix(workspace): single-PUT task switch via buildSyncedConfig scrub + inner_valid path (#272)

### DIFF
--- a/frontend/src/components/workspace/ConfigForm.test.tsx
+++ b/frontend/src/components/workspace/ConfigForm.test.tsx
@@ -366,6 +366,133 @@ describe("ConfigForm", () => {
     expect(reset).toBeUndefined();
   });
 
+  // -------------------------------------------------------------------------
+  // Issue #272 — task-derived effects must wait for config.task to catch up
+  // -------------------------------------------------------------------------
+  it("skips task-derived effects while config.task is stale (Issue #272)", async () => {
+    // Race scenario: the user just clicked task=regression. WorkspacePage's
+    // task prop is regression (synchronous setter), but the cached config
+    // returned by useConfig() still has task=binary because useConfigSync
+    // has not finished its PUT yet. ConfigForm's auto-select / auto-clear
+    // effects must NOT fire on this stale snapshot — otherwise they PUT
+    // a binary-task body and revert the user's regression change.
+    const onChange = vi.fn();
+    const staleConfig = {
+      config_version: 1,
+      task: "binary",
+      model: {
+        name: "lgbm",
+        // Stale binary objective + calibration; both would normally
+        // trigger reset effects.
+        params: { objective: "binary", metric: ["auc"] },
+      },
+      calibration: { method: "platt", n_splits: 5, params: {} },
+    };
+    renderConfigForm({
+      schema: minimalSchema,
+      config: staleConfig,
+      onChange,
+      // Prop says regression — fresh from the radio click.
+      task: "regression",
+      uiSchema: {
+        parameter_hints: [],
+        option_sets: {
+          objective: {
+            binary: ["binary", "cross_entropy"],
+            regression: ["huber", "regression_l1"],
+          },
+          model_metric: {
+            binary: ["auc", "binary_logloss"],
+            regression: ["rmse", "huber"],
+          },
+        },
+      } as unknown as UiSchema,
+    });
+
+    // Allow effect microtasks to flush.
+    await new Promise((r) => setTimeout(r, 60));
+
+    // Critical guard: NONE of the task-derived effects (objective auto-
+    // select, metric auto-select, calibration auto-clear) may fire while
+    // the snapshot's task differs from the prop task. Each of those
+    // writes would otherwise PUT a body where ``task`` is still
+    // ``binary`` (because configRef.current.task is binary), reverting
+    // the user's regression intent.
+    const wroteObjective = onChange.mock.calls.find(
+      ([cfg]) =>
+        cfg?.model?.params?.objective !== undefined &&
+        cfg.model.params.objective !== "binary",
+    );
+    expect(wroteObjective).toBeUndefined();
+
+    const wroteMetric = onChange.mock.calls.find(
+      ([cfg]) =>
+        cfg?.model?.params?.metric !== undefined &&
+        JSON.stringify(cfg.model.params.metric) !== JSON.stringify(["auc"]),
+    );
+    expect(wroteMetric).toBeUndefined();
+
+    const clearedCalibration = onChange.mock.calls.find(
+      ([cfg]) => cfg?.calibration === null,
+    );
+    expect(clearedCalibration).toBeUndefined();
+  });
+
+  it("runs task-derived effects once config.task catches up (Issue #272)", async () => {
+    // Inverse case: once ``useConfigSync`` has flushed and the cached
+    // config now reflects ``task=regression``, the task-derived effects
+    // are free to fire. (configRef.current.task === task prop)
+    const onChange = vi.fn();
+    const freshConfig = {
+      config_version: 1,
+      task: "regression",
+      model: {
+        name: "lgbm",
+        // Stale binary objective from before the task change — should
+        // be reset because task is now regression and the snapshot agrees.
+        params: { objective: "binary" },
+      },
+      calibration: { method: "platt", n_splits: 5, params: {} },
+    };
+    renderConfigForm({
+      schema: minimalSchema,
+      config: freshConfig,
+      onChange,
+      task: "regression",
+      uiSchema: {
+        parameter_hints: [],
+        option_sets: {
+          objective: {
+            binary: ["binary", "cross_entropy"],
+            regression: ["huber", "regression_l1"],
+          },
+          model_metric: {
+            binary: ["auc", "binary_logloss"],
+            regression: ["rmse", "huber"],
+          },
+        },
+      } as unknown as UiSchema,
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    // Calibration must clear (regression doesn't support it).
+    const clearedCalibration = onChange.mock.calls.find(
+      ([cfg]) => cfg?.calibration === null,
+    );
+    expect(clearedCalibration).toBeTruthy();
+
+    // Objective must reset to a regression-valid value.
+    const resetObjective = onChange.mock.calls.find(
+      ([cfg]) =>
+        cfg?.model?.params?.objective === "huber" ||
+        cfg?.model?.params?.objective === "regression_l1",
+    );
+    expect(resetObjective).toBeTruthy();
+  });
+
   it("renders section title from uiSchema when provided", () => {
     renderConfigForm({
       schema: multiSectionSchema,

--- a/frontend/src/components/workspace/ConfigForm.tsx
+++ b/frontend/src/components/workspace/ConfigForm.tsx
@@ -148,12 +148,26 @@ export function ConfigForm({
   // to regression sneaked a stale calibration object into POST /fit
   // and the job died ~5s later with CALIBRATION_NOT_SUPPORTED.
   // Same shape as the inner_valid auto-reset above.
+  //
+  // Issue #272: bail while the snapshot is stale. When the user clicks
+  // a different task radio, ``task`` (prop) updates synchronously but
+  // ``config.task`` (cached server state) lags behind useConfigSync's
+  // PUT. Writing here would PUT a body where ``task`` is still the
+  // previous value, reverting the user's intent. Wait for the next
+  // render after useConfigSync flushes and configRef.current catches up.
   useEffect(() => {
     if (!config.config_version) return;
+    if (task && config.task && task !== config.task) return;
     if (task && task !== "binary" && calibration !== null) {
       handleFieldChange(["calibration"], null);
     }
-  }, [task, calibration, handleFieldChange, config.config_version]);
+  }, [
+    task,
+    calibration,
+    handleFieldChange,
+    config.config_version,
+    config.task,
+  ]);
 
   // Resolve options for objective/model_metric kinds from option_sets
   const getOptionsForHint = useCallback(
@@ -241,6 +255,14 @@ export function ConfigForm({
     // required' validation errors. Wait until useDataPanel has seeded a
     // full config (recognised by config_version being set).
     if (!config.config_version) return;
+    // Issue #272: bail while config.task is stale. When the user clicks
+    // a different task radio, the prop updates synchronously but the
+    // cached config still reflects the previous task until useConfigSync
+    // flushes its PUT. Writing here would derive the body from the
+    // pre-flush snapshot (model.params.objective gets reset against the
+    // stale task field), then PUT it — reverting the user's task pick.
+    // Wait for the next render where configRef catches up.
+    if (config.task && task !== config.task) return;
 
     // Objective: single-select. Reset when empty OR when current value
     // is not in the list of objectives valid for the current task.
@@ -288,7 +310,14 @@ export function ConfigForm({
         );
       }
     }
-  }, [task, uiSchema, modelParams, handleFieldChange, config.config_version]);
+  }, [
+    task,
+    uiSchema,
+    modelParams,
+    handleFieldChange,
+    config.config_version,
+    config.task,
+  ]);
 
   if (!rawProperties) return null;
 
@@ -535,7 +564,15 @@ export function ConfigForm({
             <AccordionContent>
               <div className="lzs-form pl-[18px] pt-2">
                 <MetricsChips
-                  task={task}
+                  // Issue #272: pass the persisted ``config.task`` (not
+                  // the raw prop) so MetricsChips' task-change auto-reset
+                  // only fires once the regression PUT has actually
+                  // landed. Otherwise it auto-defaults metrics from the
+                  // PROP task while configRef still reads the old task,
+                  // PUTs a body where ``task`` and ``metrics`` disagree,
+                  // and the backend rejects the entire body with
+                  // saved=false (silently reverting the task switch).
+                  task={(config.task as string) || task}
                   selectedMetrics={selectedMetrics}
                   metricsByTask={uiSchema?.option_sets?.metric}
                   onChange={(metrics) => {

--- a/frontend/src/hooks/buildSyncedConfig.test.ts
+++ b/frontend/src/hooks/buildSyncedConfig.test.ts
@@ -95,4 +95,95 @@ describe("buildSyncedConfig", () => {
     expect(split.method).toBe("kfold");
     expect(split.n_splits).toBe(7);
   });
+
+  // Issue #272 — when task changes, scrub task-coupled fields so the PUT
+  // lands cleanly (the backend ``task_params_compat_errors`` validator
+  // rejects mismatched objective/metric and ``task_calibration_mismatch``
+  // rejects calibration on non-binary, both with saved=false).
+  describe("task change scrubs task-coupled fields (Issue #272)", () => {
+    const BINARY_BASE = {
+      ...BASE,
+      task: "binary",
+      model: {
+        name: "lgbm",
+        params: {
+          objective: "binary",
+          metric: ["auc", "binary_logloss"],
+          n_estimators: 1500,
+          learning_rate: 0.001,
+        },
+      },
+      calibration: { method: "platt", n_splits: 5, params: {} },
+    };
+
+    it("drops model.params.objective and model.params.metric when task differs from base", () => {
+      const out = buildSyncedConfig({
+        base: BINARY_BASE,
+        dataPath: "",
+        target: "y",
+        task: "regression",
+        overrides: {},
+        cv: { ...INITIAL_CV_STATE, strategy: "kfold" },
+        blocked: INITIAL_BLOCKED_STATE,
+      });
+      const params = (out.model as Record<string, unknown>).params as Record<
+        string,
+        unknown
+      >;
+      expect(params.objective).toBeUndefined();
+      expect(params.metric).toBeUndefined();
+      // Non-task-coupled params survive.
+      expect(params.n_estimators).toBe(1500);
+      expect(params.learning_rate).toBe(0.001);
+    });
+
+    it("drops calibration when task changes away from binary", () => {
+      const out = buildSyncedConfig({
+        base: BINARY_BASE,
+        dataPath: "",
+        target: "y",
+        task: "regression",
+        overrides: {},
+        cv: { ...INITIAL_CV_STATE, strategy: "kfold" },
+        blocked: INITIAL_BLOCKED_STATE,
+      });
+      expect(out.calibration).toBeNull();
+    });
+
+    it("preserves objective/metric/calibration when task does NOT change", () => {
+      const out = buildSyncedConfig({
+        base: BINARY_BASE,
+        dataPath: "",
+        target: "y",
+        task: "binary",
+        overrides: {},
+        cv: INITIAL_CV_STATE,
+        blocked: INITIAL_BLOCKED_STATE,
+      });
+      const params = (out.model as Record<string, unknown>).params as Record<
+        string,
+        unknown
+      >;
+      expect(params.objective).toBe("binary");
+      expect(params.metric).toEqual(["auc", "binary_logloss"]);
+      expect(out.calibration).toEqual({
+        method: "platt",
+        n_splits: 5,
+        params: {},
+      });
+    });
+
+    it("keeps calibration when switching between non-binary tasks (no-op)", () => {
+      const out = buildSyncedConfig({
+        base: { ...BINARY_BASE, task: "regression", calibration: null },
+        dataPath: "",
+        target: "y",
+        task: "multiclass",
+        overrides: {},
+        cv: INITIAL_CV_STATE,
+        blocked: INITIAL_BLOCKED_STATE,
+      });
+      expect(out.calibration).toBeNull();
+    });
+  });
 });

--- a/frontend/src/hooks/buildSyncedConfig.ts
+++ b/frontend/src/hooks/buildSyncedConfig.ts
@@ -44,9 +44,46 @@ export function buildSyncedConfig(params: {
   const { categorical, excluded } = extractOverrideArrays(overrides);
   const baseData = (base.data as Record<string, unknown>) ?? {};
   const baseTask = (base as Record<string, unknown>).task;
+  const effectiveTask = task || baseTask;
+  // Issue #272: when the task changes (e.g. user clicked a different
+  // Task radio), the inherited base config still carries the previous
+  // task's ``model.params.objective`` and ``model.params.metric``. The
+  // backend ``task_params_compat_errors`` validator rejects the PUT
+  // with ``saved=false`` because objective='binary' is not allowed for
+  // task='regression'. The PUT looks 200-OK but the server silently
+  // keeps the previous task — which is exactly the silent UI/config
+  // divergence #272 reports. Drop those task-coupled fields here so
+  // the PUT lands cleanly; ConfigForm's auto-select effect repopulates
+  // defaults on the next render.
+  const baseModel = (base.model as Record<string, unknown>) ?? {};
+  const baseModelParams = (baseModel.params as Record<string, unknown>) ?? {};
+  const taskChanged =
+    typeof baseTask === "string" &&
+    typeof effectiveTask === "string" &&
+    baseTask !== effectiveTask;
+  let mergedModel = baseModel;
+  if (taskChanged) {
+    const {
+      objective: _objective,
+      metric: _metric,
+      ...restParams
+    } = baseModelParams;
+    mergedModel = { ...baseModel, params: restParams };
+  }
+  // Issue #272 (cont.): calibration is binary-only on lizyml. Switching
+  // away from binary leaves a stale calibration object that PR #271
+  // had ConfigForm auto-clear via a separate effect — but that effect
+  // can race against this PUT. Drop it here so the same write that
+  // changes ``task`` also drops the now-invalid calibration. The
+  // backend ``task_calibration_mismatch`` rule would otherwise fail
+  // saved=false the same way as the objective mismatch above.
+  const calibrationOut =
+    taskChanged && effectiveTask !== "binary"
+      ? null
+      : ((base as Record<string, unknown>).calibration ?? null);
   return {
     ...base,
-    task: task || baseTask,
+    task: effectiveTask,
     data: applyCvDataFields(
       {
         ...baseData,
@@ -62,5 +99,7 @@ export function buildSyncedConfig(params: {
       exclude: excluded,
     },
     split: buildSplitConfig(cv, blocked, strategyFields),
+    model: mergedModel,
+    calibration: calibrationOut,
   };
 }

--- a/frontend/src/hooks/useConfigSync.ts
+++ b/frontend/src/hooks/useConfigSync.ts
@@ -73,14 +73,28 @@ export function useConfigSync({
         strategyFields,
       });
 
+      // Issue #272 (root cause): the cv-strategy-change inner_valid
+      // auto-switch was writing to ``training.inner_valid`` (top-level).
+      // The Pydantic schema accepts inner_valid at
+      // ``training.early_stopping.inner_valid`` only, so the PUT
+      // returned ``saved=false`` with "Extra inputs are not permitted".
+      // The user's task change therefore never landed even though
+      // useConfigSync emitted the correct ``task`` field — the whole
+      // body was rejected. Move the inner_valid mutation under
+      // ``early_stopping`` so the PUT lands cleanly.
       const baseTraining = (merged.training as Record<string, unknown>) ?? {};
+      const baseEarlyStopping =
+        (baseTraining.early_stopping as Record<string, unknown>) ?? {};
       const innerValid =
-        (baseTraining.inner_valid as Record<string, unknown>) ?? {};
+        (baseEarlyStopping.inner_valid as Record<string, unknown>) ?? {};
       if (prevCvStrategyRef.current !== cv.strategy) {
         const recommended = recommendedInnerValid(cv.strategy);
         merged.training = {
           ...baseTraining,
-          inner_valid: { ...innerValid, method: recommended },
+          early_stopping: {
+            ...baseEarlyStopping,
+            inner_valid: { ...innerValid, method: recommended },
+          },
         };
         prevCvStrategyRef.current = cv.strategy;
       }


### PR DESCRIPTION
## Summary

Closes #272.

The "click a Task radio → UI changes but config silently keeps the old task" bug was the visible symptom of **three independent state-sync defects** that all fire concurrently when the user clicks a different Task radio. Fixing all three is required to land a clean PUT.

### Root causes (all needed, none sufficient alone)

1. **`useConfigSync` wrote `inner_valid` to the wrong path.** The auto-switch effect put `inner_valid` at `training.inner_valid` (top-level), but the Pydantic `TrainingConfig` only accepts it under `training.early_stopping.inner_valid`. The entire PUT failed with `saved=false` ("Extra inputs are not permitted"), so the user's `task=regression` field never persisted. → Move under `early_stopping`.

2. **`buildSyncedConfig` carried over task-coupled fields.** The merged body kept `model.params.objective='binary'`, `model.params.metric=[auc,...]`, and `calibration={…}` from the previous task. The backend `task_params_compat_errors` rejected the cross-task combo with `saved=false`. → Drop those fields when `task` differs from `base.task`; ConfigForm's auto-select repopulates from defaults on the next render.

3. **`MetricsChips` task-change auto-default fired off the prop.** The reset PUTs new metrics with the new task in body, but `configRef.current.task` still has the old task → cross-task PUT rejected. → Pass the persisted `config.task` (not the prop) so the auto-default only fires once the regression PUT has landed.

A fourth defensive guard was added inside `ConfigForm`'s task-derived effects (objective / metric / calibration) so they bail while `config.task !== task`.

## Test plan

- [x] `pnpm test` — 1678 pass / 2 skipped
- [x] `pnpm exec tsc --noEmit` green
- [x] `pnpm check` (Biome) green
- [x] `pnpm build` green
- [x] `uv run pytest` (full backend) — backend tests untouched, all green
- [x] `uv run ruff check .` + `uv run ruff format --check .` green
- [x] Browser smoke (Playwright MCP, 2026-04-26): regression switch lands cleanly with consistent task / split / objective / metrics / calibration

### New tests
- `frontend/src/components/workspace/ConfigForm.test.tsx::skips task-derived effects while config.task is stale (Issue #272)`
- `frontend/src/components/workspace/ConfigForm.test.tsx::runs task-derived effects once config.task catches up (Issue #272)`
- `frontend/src/hooks/buildSyncedConfig.test.ts::task change scrubs task-coupled fields (Issue #272)` — 4 cases (drops objective/metric, drops calibration, preserves on no-op, no-op on non-binary→non-binary)
