### PR TITLE
fix(workspace): replace SearchSpaceRow button wrapper with div[role=button] (#274)

### DIFF
--- a/frontend/src/components/workspace/SearchSpaceRow.test.tsx
+++ b/frontend/src/components/workspace/SearchSpaceRow.test.tsx
@@ -515,6 +515,48 @@ describe("SearchSpaceRow – precision_at_k row", () => {
 });
 
 // ---------------------------------------------------------------------------
+// HTML structural validity (no nested buttons — see #274)
+// ---------------------------------------------------------------------------
+
+describe("SearchSpaceRow – HTML validity", () => {
+  it("does not render a real <button> as the row wrapper", () => {
+    // The row wrapper must not be a <button> element because it contains
+    // interactive descendants (SegmentGroup radio buttons, stepper icon
+    // buttons), which would violate the HTML5 content model and trigger
+    // React hydration warnings (#274).
+    const { container } = renderWithQuery(<SearchSpaceRow {...makeProps()} />);
+    const wrapper = container.querySelector('[role="button"]');
+    expect(wrapper).toBeTruthy();
+    expect(wrapper?.tagName).toBe("DIV");
+  });
+
+  it("does not nest any <button> inside another <button>", () => {
+    // When rendered in range mode (expandable) with onModelParamChange
+    // present, the row contains both SegmentGroup radio buttons and stepper
+    // icon buttons. Walk every <button> and assert none of them has a
+    // <button> ancestor inside the same row.
+    const onModelParamChange = vi.fn();
+    const { container } = renderWithQuery(
+      <SearchSpaceRow
+        {...makeProps({
+          space: {
+            learning_rate: { type: "float", low: 0.001, high: 0.1, log: false },
+          },
+          modelParams: { learning_rate: 0.01 },
+          onModelParamChange,
+        })}
+      />,
+    );
+    const buttons = container.querySelectorAll("button");
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const btn of Array.from(buttons)) {
+      const ancestorButton = btn.parentElement?.closest("button");
+      expect(ancestorButton).toBeNull();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Keyboard event stopPropagation (lines 77, 97)
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/components/workspace/SearchSpaceRow.tsx
+++ b/frontend/src/components/workspace/SearchSpaceRow.tsx
@@ -50,13 +50,28 @@ export function SearchSpaceRow({
   const isInteger = param.type === "integer";
   const availableModes = param.modes ?? ["fixed", "range"];
 
+  const handleSummaryActivate = () => {
+    if (isExpandable) onToggleExpand(param.key);
+  };
+
   return (
     <div key={param.key} className="border-b last:border-b-0">
-      {/* Summary line */}
-      <button
-        type="button"
+      {/* Summary line — div+role=button avoids nesting interactive descendants
+          (SegmentGroup buttons, NumberInput steppers) inside a real <button>
+          which is invalid HTML and triggers React hydration warnings. */}
+      {/* biome-ignore lint/a11y/useSemanticElements: native <button> would nest interactive descendants (#274) */}
+      <div
+        role="button"
+        tabIndex={isExpandable ? 0 : -1}
+        aria-expanded={isExpandable ? isExpanded : undefined}
         className="flex w-full items-center px-3 py-2 hover:bg-muted/30 cursor-pointer text-left"
-        onClick={() => isExpandable && onToggleExpand(param.key)}
+        onClick={handleSummaryActivate}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleSummaryActivate();
+          }
+        }}
       >
         <span className="w-6 flex-shrink-0">
           {isExpandable &&
@@ -171,7 +186,7 @@ export function SearchSpaceRow({
             )
           )}
         </span>
-      </button>
+      </div>
 
       {/* Range detail */}
       {isRange && isExpanded && entry && (

--- a/frontend/src/components/workspace/SearchSpaceTable.test.tsx
+++ b/frontend/src/components/workspace/SearchSpaceTable.test.tsx
@@ -189,7 +189,7 @@ describe("SearchSpaceTable", () => {
     render(<SearchSpaceTable {...defaultProps} space={space} />);
 
     // Click the row to expand
-    const row = screen.getByText("learning_rate").closest("button");
+    const row = screen.getByText("learning_rate").closest('[role="button"]');
     if (row) fireEvent.click(row);
 
     // Expanded row shows Min, Max, Distribution
@@ -221,7 +221,7 @@ describe("SearchSpaceTable", () => {
     );
 
     // Expand the row
-    const row = screen.getByText("n_estimators").closest("button");
+    const row = screen.getByText("n_estimators").closest('[role="button"]');
     if (row) fireEvent.click(row);
 
     expect(screen.getByText("Step")).toBeInTheDocument();
@@ -837,7 +837,7 @@ describe("SearchSpaceTable", () => {
         />,
       );
       // Click the row to expand choice mode
-      const row = screen.getByText("objective").closest("button");
+      const row = screen.getByText("objective").closest('[role="button"]');
       if (row) fireEvent.click(row);
 
       // ChoiceInput should be visible after expanding
@@ -1191,7 +1191,7 @@ describe("SearchSpaceTable", () => {
         <SearchSpaceTable {...defaultProps} space={{}} onChange={onChange} />,
       );
       // No range entry exists, so toggling expansion has no effect
-      const row = screen.getByText("learning_rate").closest("button");
+      const row = screen.getByText("learning_rate").closest('[role="button"]');
       if (row) fireEvent.click(row);
       // onChange should not have been called by row click alone
       expect(onChange).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
Closes #274. The Tune tab's `SearchSpaceRow` wrapped each row in a `<button>` while also rendering interactive descendants (SegmentGroup mode toggles, NumberInput stepper icons). This is invalid HTML and triggers a React hydration warning every time the Tune tab is opened.

## Fix
- Replace the outer `<button>` with `<div role="button" tabIndex={0}>` plus explicit Enter/Space `onKeyDown` handling and `aria-expanded` for screen readers.
- Inner cells (mode segment, fixed-value editor) already used `stopPropagation()` to keep wrapper click handling separate; that logic continues to work unchanged.
- Add Biome ignore for `lint/a11y/useSemanticElements` since the lint rule recommends `<button>` precisely the choice that caused the bug — comment cites #274.

## Tests
**New (RED → GREEN)**
- `SearchSpaceRow.test.tsx`: assert wrapper is a `<div>` (not `<button>`), and no `<button>` in the rendered row has a `<button>` ancestor.

**Updated**
- `SearchSpaceTable.test.tsx`: `.closest("button")` → `.closest('[role="button"]')` (4 sites) so existing row-click tests keep finding the wrapper.

**Suite**
- Vitest: 1680 passed / 2 skipped (full).
- Biome: clean. tsc: clean. `pnpm build`: clean.

## Browser verification
- Open Workspace → load data → pick target → switch to Tune tab.
- Before: console logged `In HTML, <button> cannot be a descendant of <button>. This will cause a hydration error.` every mount.
- After: 0 console errors / 0 warnings on Tune tab mount.
- Mode toggle (Fixed → Range), row expand/collapse via row click, Range value editing all verified working.

## Test plan
- [x] Vitest unit/component (1680 passed)
- [x] `pnpm check` (Biome clean)
- [x] `tsc --noEmit` (clean)
- [x] `pnpm build` (clean)
- [x] Browser smoke: Tune tab opens with 0 console errors; mode segment, expand/collapse, and Range editing all functional.

## Audit context
Discovered during Phase 1 of post-#271 systematic smoke (`project_smoke_test_plan_post_271.md`). Phase 1 found this single new bug; all 6 main-screen golden-path scenarios (Fit binary/regression, Tune, Re-Tune, Jobs page, Inference) passed otherwise.

Closes #274