### PR TITLE
fix(workspace): observe saved:false on PUT /config + merge data into preset Load (#276)

### DIFF
--- a/frontend/src/api/api-contract.test.ts
+++ b/frontend/src/api/api-contract.test.ts
@@ -171,15 +171,27 @@ describe("PreviewResponse", () => {
 // ConfigUpdateResponse + ConfigError
 // ---------------------------------------------------------------------------
 describe("ConfigUpdateResponse", () => {
-  it("has config and errors", () => {
+  it("has config, errors, and saved", () => {
     const err: ConfigError = { path: "model.name", message: "required" };
     const resp: ConfigUpdateResponse = {
       config: { model: { name: "lgbm" } },
       errors: [err],
+      saved: false,
     };
     assertDefined(resp.config, "config");
     expect(resp.errors).toHaveLength(1);
     expect(resp.errors[0].path).toBe("model.name");
+    expect(resp.saved).toBe(false);
+  });
+
+  it("saved=true means the backend persisted the PUT body (Issue #276)", () => {
+    const resp: ConfigUpdateResponse = {
+      config: { model: { name: "lgbm" } },
+      errors: [],
+      saved: true,
+    };
+    expect(resp.saved).toBe(true);
+    expect(resp.errors).toHaveLength(0);
   });
 });
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -89,10 +89,16 @@ export type ColumnsResponse = components["schemas"]["ColumnsResponseModel"];
  * ConfigUpdateResponse — hand-written because generated type has
  * `errors: {[key: string]: unknown}[]` whereas we use the structured
  * `ConfigError` type, and the generated type includes an index signature.
+ *
+ * `saved` is the backend's authoritative answer to "did this PUT
+ * actually persist?" — false when validation rejected the body.
+ * Callers must observe it (Issue #276); silently dropping it leads to
+ * UI ↔ backend divergence.
  */
 export interface ConfigUpdateResponse {
   config: Record<string, unknown>;
   errors: ConfigError[];
+  saved: boolean;
 }
 
 export interface ConfigError {

--- a/frontend/src/hooks/useModelPanelData.test.ts
+++ b/frontend/src/hooks/useModelPanelData.test.ts
@@ -11,7 +11,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { queryKeys } from "@/api/queryKeys";
 import { useModelPanelData } from "./useModelPanelData";
 
@@ -28,7 +28,11 @@ vi.mock("@/api/workspace", () => ({
   fetchConfigSchema: vi.fn().mockResolvedValue({ type: "object" }),
   fetchUiSchema: vi.fn().mockResolvedValue({}),
   getConfigDownloadUrl: vi.fn().mockReturnValue("/api/config/download"),
-  updateConfig: vi.fn().mockResolvedValue(undefined),
+  // PUT /config returns { config, errors, saved } per ConfigUpdateResponse.
+  // Default mock simulates a successful save so existing tests keep working.
+  updateConfig: vi
+    .fn()
+    .mockResolvedValue({ config: {}, errors: [], saved: true }),
   uploadConfig: vi.fn().mockResolvedValue({ errors: [] }),
   validateConfig: vi.fn().mockResolvedValue({ errors: [] }),
 }));
@@ -263,6 +267,203 @@ describe("useModelPanelData", () => {
     });
 
     expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #276: handleConfigChange must observe `saved:false` from the
+  // backend and not silently swallow the rejection.
+  //
+  // Invariants under test:
+  //   INV-A1: when updateConfig returns saved=false, the cached query data
+  //           is NOT updated (frontend stays consistent with backend).
+  //   INV-A2: when updateConfig returns saved=false, the rejection errors
+  //           surface on the hook's `errors` state.
+  //   INV-A3: when updateConfig returns saved=false, the change is NOT
+  //           pushed to history (undo/redo would otherwise re-apply the
+  //           unsaved config).
+  // -------------------------------------------------------------------------
+  describe("handleConfigChange — saved:false observation (#276)", () => {
+    it("does not write to cache when backend returns saved=false", async () => {
+      vi.mocked(updateConfig).mockResolvedValueOnce({
+        config: { model: {} },
+        errors: [{ path: "data", message: "Field required" }],
+        saved: false,
+        // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+      } as any);
+
+      const { wrapper, queryClient } = makeWrapper();
+      const { result } = renderHook(
+        () => useModelPanelData({ hasData: true, running: false }),
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.config).toBeDefined());
+
+      const before = queryClient.getQueryData(queryKeys.config());
+      await act(async () => {
+        await result.current.handleConfigChange({ model: { name: "X" } });
+      });
+
+      // Cache stays at backend's true state (not the rejected payload).
+      expect(queryClient.getQueryData(queryKeys.config())).toEqual(before);
+    });
+
+    it("surfaces backend errors on the errors state when saved=false", async () => {
+      const rejectionErrors = [
+        { path: "data", message: "Field required" },
+        { path: "split.method", message: "Invalid value" },
+      ];
+      vi.mocked(updateConfig).mockResolvedValueOnce({
+        config: { model: {} },
+        errors: rejectionErrors,
+        saved: false,
+        // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+      } as any);
+
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(
+        () => useModelPanelData({ hasData: true, running: false }),
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.config).toBeDefined());
+
+      await act(async () => {
+        await result.current.handleConfigChange({ model: { name: "X" } });
+      });
+
+      expect(result.current.errors).toEqual(rejectionErrors);
+    });
+
+    it("does not push rejected config onto history (undo would otherwise re-apply it)", async () => {
+      vi.mocked(updateConfig).mockResolvedValueOnce({
+        config: { model: {} },
+        errors: [{ path: "data", message: "Field required" }],
+        saved: false,
+        // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+      } as any);
+
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(
+        () => useModelPanelData({ hasData: true, running: false }),
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.config).toBeDefined());
+
+      const undoBefore = result.current.history.canUndo;
+      await act(async () => {
+        await result.current.handleConfigChange({ model: { name: "X" } });
+      });
+      // Rejected change must not have been recorded in history.
+      expect(result.current.history.canUndo).toBe(undoBefore);
+    });
+
+    it("clears errors when a subsequent successful change comes through", async () => {
+      vi.mocked(updateConfig)
+        .mockResolvedValueOnce({
+          config: { model: {} },
+          errors: [{ path: "data", message: "Field required" }],
+          saved: false,
+          // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+        } as any)
+        .mockResolvedValueOnce({
+          config: { model: { name: "Y" } },
+          errors: [],
+          saved: true,
+          // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+        } as any);
+
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(
+        () => useModelPanelData({ hasData: true, running: false }),
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.config).toBeDefined());
+
+      await act(async () => {
+        await result.current.handleConfigChange({ model: { name: "X" } });
+      });
+      expect(result.current.errors.length).toBeGreaterThan(0);
+
+      await act(async () => {
+        await result.current.handleConfigChange({ model: { name: "Y" } });
+      });
+      expect(result.current.errors).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #276: handleLoadPreset must merge preset with current data so the
+  // backend `data` field (which presets intentionally omit) is preserved.
+  // -------------------------------------------------------------------------
+  describe("handleLoadPreset — merges preset with current data (#276)", () => {
+    afterEach(() => {
+      localStorage.clear();
+    });
+
+    it("preserves data.path / data.target from current config when applying a preset", async () => {
+      // Pre-populate localStorage with a data-stripped preset (this is
+      // what useConfigPresets.save would have written — sanitizeConfig
+      // strips the `data` and `features` keys before serialising).
+      // useConfigPresets reads from localStorage at hook-init time, so
+      // the preset must exist BEFORE the hook mounts.
+      localStorage.setItem(
+        "lizystudio-config-presets",
+        JSON.stringify([
+          {
+            name: "p1",
+            config: {
+              config_version: 1,
+              task: "binary",
+              split: { method: "stratified_kfold", n_splits: 5 },
+              model: { name: "lgbm", params: {} },
+            },
+            createdAt: "2026-01-01T00:00:00.000Z",
+          },
+        ]),
+      );
+
+      vi.mocked(fetchConfig).mockResolvedValueOnce({
+        config_version: 1,
+        task: "binary",
+        data: {
+          path: "/tmp/train.csv",
+          target: "Survived",
+          time_col: null,
+          group_col: null,
+        },
+        split: { method: "kfold", n_splits: 3 },
+        // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+      } as any);
+
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(
+        () => useModelPanelData({ hasData: true, running: false }),
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.config).toBeDefined());
+
+      await act(async () => {
+        result.current.handleLoadPreset("p1");
+        // wait for the async handleConfigChange chain
+        await new Promise((r) => setTimeout(r, 10));
+      });
+
+      // updateConfig must have received a body that includes the current
+      // data field (merged from the cached config), not undefined.
+      const lastCall = vi.mocked(updateConfig).mock.calls.at(-1)?.[0];
+      expect(lastCall).toBeDefined();
+      expect((lastCall as Record<string, unknown>).data).toEqual({
+        path: "/tmp/train.csv",
+        target: "Survived",
+        time_col: null,
+        group_col: null,
+      });
+      // And the preset's split.method is what gets sent (not the prior
+      // config's split.method).
+      expect((lastCall as Record<string, unknown>).split).toEqual({
+        method: "stratified_kfold",
+        n_splits: 5,
+      });
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/frontend/src/hooks/useModelPanelData.ts
+++ b/frontend/src/hooks/useModelPanelData.ts
@@ -82,14 +82,32 @@ export function useModelPanelData({
       if (cached && equal(cached, newConfig)) {
         return;
       }
+      // INV-A1/A2/A3 (Issue #276): observe `saved` from PUT /config and
+      // do not silently swallow validation rejections. When saved=false
+      // the backend kept the prior config, so the cache, history, and
+      // errors state must reflect that — not the rejected payload.
+      let response: Awaited<ReturnType<typeof updateConfig>>;
       try {
-        await updateConfig(newConfig);
-        queryClient.setQueryData(queryKeys.config(), newConfig);
-        history.push(newConfig);
+        response = await updateConfig(newConfig);
       } catch {
         toast.error("Failed to update config");
         return;
       }
+      if (response?.saved === false) {
+        const errs = response.errors ?? [];
+        setErrors(errs);
+        const summary =
+          errs[0]?.message ?? "Config rejected by backend validation";
+        toast.error(`Config not saved: ${summary}`);
+        // Re-fetch the actual backend state so the UI reflects truth,
+        // not the rejected payload the caller tried to apply.
+        queryClient.invalidateQueries({ queryKey: queryKeys.config() });
+        return;
+      }
+      queryClient.setQueryData(queryKeys.config(), newConfig);
+      history.push(newConfig);
+      // Successful save clears any prior rejection errors.
+      setErrors([]);
 
       clearTimeout(validateTimer.current);
       validateTimer.current = setTimeout(async () => {
@@ -162,10 +180,25 @@ export function useModelPanelData({
     (name: string) => {
       const preset = loadPreset(name);
       if (!preset) return;
-      handleConfigChange(preset);
+      // Issue #276: presets intentionally omit data-bound fields (path,
+      // target, time_col, group_col, output_dir). Merging them from the
+      // current config ensures the resulting PUT body is valid; without
+      // the merge, backend `validate_config` rejects with
+      // `data: Field required` and silently keeps the prior config.
+      const current = queryClient.getQueryData<Record<string, unknown>>(
+        queryKeys.config(),
+      );
+      const merged: Record<string, unknown> = { ...preset };
+      if (current?.data && merged.data === undefined) {
+        merged.data = current.data;
+      }
+      if (current?.output_dir && merged.output_dir === undefined) {
+        merged.output_dir = current.output_dir;
+      }
+      handleConfigChange(merged);
       toast.success(`Preset "${name}" loaded`);
     },
-    [loadPreset, handleConfigChange],
+    [loadPreset, handleConfigChange, queryClient],
   );
 
   // --------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes the silent-rejection root cause behind #276 (Preset Load) and the same family of bugs blocking #278 (CV strategy schema drift): `handleConfigChange` now reads the backend's `saved` flag on `PUT /config` instead of optimistically updating the cache regardless. Also merges `data` / `output_dir` into preset bodies so Load Preset stops sending validation-failing payloads.

This is **PR-A of the 3-PR plan** outlined in the post-#271 smoke session. PR-B (CV strategy payload alignment) and PR-C (running-lock + backend 409) build on this response-contract fix.

## Fix

### 1. `ConfigUpdateResponse` gains `saved: boolean`
- `frontend/src/api/types.ts` — add the field to the hand-written type. Backend already returns it at [api/workspace.py:434](src/lizystudio/api/workspace.py#L434).
- `frontend/src/api/api-contract.test.ts` — golden tests cover both `saved:true` and `saved:false` shapes.

### 2. `handleConfigChange` observes `saved`
- `frontend/src/hooks/useModelPanelData.ts:76-127` — when `saved=false`:
  - Surface `errors[]` to the hook's `errors` state
  - Show an error toast with the first message
  - **Do not** update `queryClient.setQueryData` (cache stays consistent with backend truth)
  - **Do not** push to `history` (undo/redo would otherwise re-apply the rejected config)
  - `invalidateQueries` to force a fresh `GET /config`

### 3. `handleLoadPreset` merges `data` + `output_dir`
- `useConfigPresets` strips `data` and `features` on save (XSS-safe localStorage). Without merging the current values back in on Load, the PUT body is missing `data: Field required` and the backend rejects it.
- `useModelPanelData.ts:174-198` reads the cached current config and copies `data` / `output_dir` into the preset payload before sending.

## Invariants

- **INV-A1:** `queryClient` cache is updated **only** when `saved=true`.
- **INV-A2:** `errors` state reflects the latest PUT's `errors[]` (cleared on subsequent success).
- **INV-A3:** `history` is pushed **only** on successful saves; undo/redo cannot replay a rejected config.

## Tests

**RED → GREEN, in order:**
- `useModelPanelData.test.ts` — 4 new tests for the saved=false path:
  - cache untouched
  - errors surface
  - history not pushed
  - errors clear on subsequent success
- `useModelPanelData.test.ts` — 1 new test for preset merge:
  - localStorage holds a data-stripped preset
  - after `handleLoadPreset`, `updateConfig` receives a body whose `data` matches the cached current config and whose `split` matches the preset
- `api-contract.test.ts` — `ConfigUpdateResponse` golden test updated for the `saved` field

**Suite:** 1686 passed / 2 skipped (Vitest full).
**Build:** Biome / tsc / `pnpm build` all clean.

## Browser verification (round-trip)

| Step | Folds | Backend |
|---|---|---|
| Save Preset (n_splits=5) | 5 | 5 |
| Edit Folds 5→8 | 8 | 8 |
| Load Preset | (UI input still 8 — see follow-up) | **5 ✅** |
| Page reload after Load | 5 | 5 |

Backend round-trip works. The form-input UI sync issue (NumberInput not re-rendering after `setQueryData`) is documented as out of scope and will be addressed alongside #277's first-toggle race in a follow-up — same controlled-input subscription bug.

## Test plan
- [x] Vitest unit tests (4 new + 1 contract update)
- [x] `pnpm check` (Biome clean)
- [x] `tsc --noEmit` (clean)
- [x] `pnpm build` (clean)
- [x] Manual repro: Preset Load round-trips correctly on backend; silent-reject toast surfaces on direct rejected PUT.

## Audit context
PR-A of the 3-PR plan derived from Phase 2/3 of post-#271 smoke (`project_smoke_test_plan_post_271.md`). Closes the response-contract gap that masks #276 / #278 / parts of #277 / #279.

Closes #276 (root cause); leaves #277 form-sync, #278 schema drift, #279 running-lock for the follow-up PRs.