### PR TITLE
fix(workspace): nest blocks/groups in BlockedGroupKFold split payload (#278)

### DIFF
--- a/frontend/src/components/workspace/cv-section.test.ts
+++ b/frontend/src/components/workspace/cv-section.test.ts
@@ -302,47 +302,19 @@ describe("buildSplitConfig", () => {
   });
 
   describe("blocked_group_kfold", () => {
-    it("includes min_train_rows and min_valid_rows", () => {
+    // Issue #278: BlockedGroupKFoldConfig requires nested `blocks` and
+    // `groups` sub-objects (BlocksConfig + GroupCVConfig in
+    // lizyml.config.schema). Flat `mode`/`train_window` at the split
+    // level are rejected by `extra="forbid"`.
+    it("nests block-axis fields under split.blocks (not flat)", () => {
       const cv: CvState = {
         ...INITIAL_CV_STATE,
         strategy: "blocked_group_kfold",
         folds: 5,
         timeCol: "date",
-        groupCol: "block",
+        groupCol: "entity",
         minTrainRows: 100,
         minValidRows: 50,
-      };
-      const result = buildSplitConfig(cv);
-      expect(result.min_train_rows).toBe(100);
-      expect(result.min_valid_rows).toBe(50);
-    });
-
-    it("omits undefined optional cv fields and does not emit n_splits (Pydantic rejects it)", () => {
-      // Issue #258 / #259: BlockedGroupKFoldConfig has no `n_splits`
-      // field and rejects extras. buildSplitConfig must gate n_splits
-      // on the active fields list (which excludes it for this strategy).
-      const cv: CvState = {
-        ...INITIAL_CV_STATE,
-        strategy: "blocked_group_kfold",
-        folds: 3,
-        minTrainRows: undefined,
-        minValidRows: undefined,
-      };
-      const result = buildSplitConfig(cv);
-      expect(result).toEqual({
-        method: "blocked_group_kfold",
-        mode: "expanding",
-        train_window: 1,
-      });
-      expect(result).not.toHaveProperty("n_splits");
-    });
-
-    it("includes blocked state fields (mode, train_window, cutoffs, stratify)", () => {
-      const cv: CvState = {
-        ...INITIAL_CV_STATE,
-        strategy: "blocked_group_kfold",
-        folds: 5,
-        minTrainRows: 100,
       };
       const blocked: BlockedGroupKFoldState = {
         cutoffs: ["2023-01", "2023-06"],
@@ -351,67 +323,125 @@ describe("buildSplitConfig", () => {
         stratify: "on",
       };
       const result = buildSplitConfig(cv, blocked);
-      expect(result.mode).toBe("sliding");
-      expect(result.train_window).toBe(3);
-      expect(result.cutoffs).toEqual(["2023-01", "2023-06"]);
-      expect(result.stratify).toBe(true);
-      expect(result.min_train_rows).toBe(100);
+      expect(result.method).toBe("blocked_group_kfold");
+      expect(result.blocks).toBeDefined();
+      expect(result.blocks).toMatchObject({
+        col: "date",
+        cutoffs: ["2023-01", "2023-06"],
+        mode: "sliding",
+        train_window: 3,
+      });
+      // Flat fields must NOT exist at the split level.
+      expect(result).not.toHaveProperty("mode");
+      expect(result).not.toHaveProperty("train_window");
+      expect(result).not.toHaveProperty("cutoffs");
     });
 
-    it("omits cutoffs when empty", () => {
+    it("nests group-axis fields under split.groups (not flat)", () => {
       const cv: CvState = {
         ...INITIAL_CV_STATE,
         strategy: "blocked_group_kfold",
         folds: 4,
+        timeCol: "period",
+        groupCol: "entity",
+      };
+      const blocked: BlockedGroupKFoldState = {
+        ...INITIAL_BLOCKED_STATE,
+        cutoffs: ["2024-01"],
+        stratify: "on",
+      };
+      const result = buildSplitConfig(cv, blocked);
+      expect(result.groups).toBeDefined();
+      expect(result.groups).toMatchObject({
+        col: "entity",
+        n_splits: 4,
+        stratify: true,
+      });
+      // No flat group fields.
+      expect(result).not.toHaveProperty("stratify");
+      expect(result).not.toHaveProperty("group_col");
+    });
+
+    it("sets groups.stratify=false when blocked.stratify=off", () => {
+      const cv: CvState = {
+        ...INITIAL_CV_STATE,
+        strategy: "blocked_group_kfold",
+        folds: 4,
+        timeCol: "date",
+        groupCol: "entity",
+      };
+      const blocked: BlockedGroupKFoldState = {
+        ...INITIAL_BLOCKED_STATE,
+        cutoffs: ["2023-01"],
+        stratify: "off",
+      };
+      const result = buildSplitConfig(cv, blocked);
+      expect((result.groups as Record<string, unknown>).stratify).toBe(false);
+    });
+
+    it('sets groups.stratify="auto" when blocked.stratify=auto', () => {
+      const cv: CvState = {
+        ...INITIAL_CV_STATE,
+        strategy: "blocked_group_kfold",
+        folds: 4,
+        timeCol: "date",
+        groupCol: "entity",
+      };
+      const blocked: BlockedGroupKFoldState = {
+        ...INITIAL_BLOCKED_STATE,
+        cutoffs: ["2023-01"],
+        stratify: "auto",
+      };
+      const result = buildSplitConfig(cv, blocked);
+      expect((result.groups as Record<string, unknown>).stratify).toBe("auto");
+    });
+
+    it("includes min_train_rows and min_valid_rows at the split top level", () => {
+      const cv: CvState = {
+        ...INITIAL_CV_STATE,
+        strategy: "blocked_group_kfold",
+        folds: 5,
+        timeCol: "date",
+        groupCol: "entity",
+        minTrainRows: 100,
+        minValidRows: 50,
+      };
+      const result = buildSplitConfig(cv);
+      expect(result.min_train_rows).toBe(100);
+      expect(result.min_valid_rows).toBe(50);
+    });
+
+    it("omits n_splits at split level (BlockedGroupKFoldConfig has no top-level n_splits)", () => {
+      const cv: CvState = {
+        ...INITIAL_CV_STATE,
+        strategy: "blocked_group_kfold",
+        folds: 3,
+        timeCol: "date",
+        groupCol: "entity",
+      };
+      const result = buildSplitConfig(cv);
+      expect(result).not.toHaveProperty("n_splits");
+    });
+
+    it("omits cutoffs from blocks when blocked.cutoffs is empty", () => {
+      const cv: CvState = {
+        ...INITIAL_CV_STATE,
+        strategy: "blocked_group_kfold",
+        folds: 4,
+        timeCol: "date",
+        groupCol: "entity",
       };
       const blocked: BlockedGroupKFoldState = {
         ...INITIAL_BLOCKED_STATE,
         cutoffs: [],
       };
       const result = buildSplitConfig(cv, blocked);
-      expect(result).not.toHaveProperty("cutoffs");
-      expect(result.mode).toBe("expanding");
-    });
-
-    it("omits stratify when set to auto", () => {
-      const cv: CvState = {
-        ...INITIAL_CV_STATE,
-        strategy: "blocked_group_kfold",
-        folds: 4,
-      };
-      const blocked: BlockedGroupKFoldState = {
-        ...INITIAL_BLOCKED_STATE,
-        stratify: "auto",
-      };
-      const result = buildSplitConfig(cv, blocked);
-      expect(result).not.toHaveProperty("stratify");
-    });
-
-    it("sets stratify=false when off", () => {
-      const cv: CvState = {
-        ...INITIAL_CV_STATE,
-        strategy: "blocked_group_kfold",
-        folds: 4,
-      };
-      const blocked: BlockedGroupKFoldState = {
-        ...INITIAL_BLOCKED_STATE,
-        stratify: "off",
-      };
-      const result = buildSplitConfig(cv, blocked);
-      expect(result.stratify).toBe(false);
-    });
-
-    it("falls back to INITIAL_BLOCKED_STATE when blocked is undefined", () => {
-      const cv: CvState = {
-        ...INITIAL_CV_STATE,
-        strategy: "blocked_group_kfold",
-        folds: 5,
-      };
-      const result = buildSplitConfig(cv);
-      expect(result.mode).toBe("expanding");
-      expect(result.train_window).toBe(1);
-      expect(result).not.toHaveProperty("cutoffs");
-      expect(result).not.toHaveProperty("stratify");
+      const blocks = result.blocks as Record<string, unknown>;
+      // BlocksConfig requires cutoffs (min_length=1) — so when the user
+      // hasn't picked any, we must omit `blocks` entirely so the user sees
+      // a clear validation error rather than a confusing "min_length=1"
+      // trap. Same shape as the rest of the optional emission.
+      expect(blocks).toBeUndefined();
     });
 
     it("ignores blocked state for non-blocked strategies", () => {
@@ -429,9 +459,24 @@ describe("buildSplitConfig", () => {
         stratify: "on",
       };
       const result = buildSplitConfig(cv, blocked);
-      expect(result).not.toHaveProperty("mode");
-      expect(result).not.toHaveProperty("train_window");
-      expect(result).not.toHaveProperty("cutoffs");
+      expect(result).not.toHaveProperty("blocks");
+      expect(result).not.toHaveProperty("groups");
+    });
+
+    it("omits blocks/groups when timeCol/groupCol are not set (so the user sees clear errors)", () => {
+      const cv: CvState = {
+        ...INITIAL_CV_STATE,
+        strategy: "blocked_group_kfold",
+        folds: 4,
+        timeCol: null,
+        groupCol: null,
+      };
+      const result = buildSplitConfig(cv);
+      // Without col values, BlocksConfig / GroupCVConfig would fail to
+      // construct anyway. Emitting nothing keeps the rejection cleanly
+      // localised to "blocks: Field required" / "groups: Field required".
+      expect(result).not.toHaveProperty("blocks");
+      expect(result).not.toHaveProperty("groups");
     });
   });
 
@@ -638,7 +683,12 @@ describe("applyCvDataFields", () => {
     expect(result).not.toHaveProperty("group_col");
   });
 
-  it("injects blocks_col and groups_col for blocked_group_kfold (not time_col/group_col)", () => {
+  it("does NOT inject blocks_col/groups_col into data for blocked_group_kfold (Issue #278)", () => {
+    // Issue #278: BlockedGroupKFoldConfig owns the col names inside
+    // split.blocks.col and split.groups.col, not at the data level.
+    // applyCvDataFields must therefore leave the data object untouched
+    // for this strategy — buildSplitConfig is the single source of
+    // truth for the blocks/groups fields.
     const data = { path: "/data.csv", target: "y" };
     const cv: CvState = {
       ...INITIAL_CV_STATE,
@@ -647,13 +697,15 @@ describe("applyCvDataFields", () => {
       groupCol: "entity",
     };
     const result = applyCvDataFields(data, cv);
-    expect(result.blocks_col).toBe("period");
-    expect(result.groups_col).toBe("entity");
+    expect(result).not.toHaveProperty("blocks_col");
+    expect(result).not.toHaveProperty("groups_col");
     expect(result).not.toHaveProperty("time_col");
     expect(result).not.toHaveProperty("group_col");
+    // data passes through unchanged
+    expect(result).toEqual(data);
   });
 
-  it("does not inject blocks_col/groups_col when null", () => {
+  it("does not mutate data when timeCol/groupCol are null for blocked_group_kfold", () => {
     const data = { path: "/data.csv" };
     const cv: CvState = {
       ...INITIAL_CV_STATE,
@@ -662,7 +714,6 @@ describe("applyCvDataFields", () => {
       groupCol: null,
     };
     const result = applyCvDataFields(data, cv);
-    expect(result).not.toHaveProperty("blocks_col");
-    expect(result).not.toHaveProperty("groups_col");
+    expect(result).toEqual(data);
   });
 });

--- a/frontend/src/components/workspace/cv-state.ts
+++ b/frontend/src/components/workspace/cv-state.ts
@@ -229,16 +229,39 @@ export function buildSplitConfig(
   if (active.includes("min_valid_rows") && cv.minValidRows !== undefined) {
     split.min_valid_rows = cv.minValidRows;
   }
-  // blocked_group_kfold-specific fields from the dedicated editor state
+  // Issue #278: BlockedGroupKFoldConfig requires nested `blocks` and
+  // `groups` sub-objects (BlocksConfig + GroupCVConfig). Flat fields at
+  // the split level are rejected by `extra="forbid"`. Only emit the
+  // nested objects when the user has supplied the col values + at least
+  // one cutoff — otherwise omit them so the rejection localises cleanly
+  // to "blocks: Field required" / "groups: Field required" instead of a
+  // confusing "min_length=1" deep-nested message.
   if (cv.strategy === "blocked_group_kfold") {
     const b = blocked ?? INITIAL_BLOCKED_STATE;
-    split.mode = b.blockMode;
-    split.train_window = b.trainWindow;
-    if (b.cutoffs.length > 0) {
-      split.cutoffs = b.cutoffs;
+    if (cv.timeCol && b.cutoffs.length > 0) {
+      const blocks: Record<string, unknown> = {
+        col: cv.timeCol,
+        cutoffs: b.cutoffs,
+        mode: b.blockMode,
+      };
+      // BlocksConfig.train_window is None when expanding (server-side
+      // warning emitted otherwise), int when sliding.
+      if (b.blockMode === "sliding") {
+        blocks.train_window = b.trainWindow;
+      } else {
+        blocks.train_window = null;
+      }
+      split.blocks = blocks;
     }
-    if (b.stratify !== "auto") {
-      split.stratify = b.stratify === "on";
+    if (cv.groupCol) {
+      const groups: Record<string, unknown> = {
+        col: cv.groupCol,
+        n_splits: cv.folds,
+        // GroupCVConfig.stratify is "auto" | bool. The UI tristate maps
+        // to those: auto → "auto", on → true, off → false.
+        stratify: b.stratify === "auto" ? "auto" : b.stratify === "on",
+      };
+      split.groups = groups;
     }
   }
   return split;
@@ -256,14 +279,11 @@ export function applyCvDataFields(
 ): Record<string, unknown> {
   const active = resolveFields(cv.strategy, fields);
   const result = { ...data };
-  // blocked_group_kfold uses blocks_col/groups_col instead of time_col/group_col
+  // Issue #278: BlockedGroupKFoldConfig owns the col names inside
+  // split.blocks.col and split.groups.col (handled by
+  // {@link buildSplitConfig}); they do NOT live at the data level.
+  // Pass the data object through unchanged for this strategy.
   if (cv.strategy === "blocked_group_kfold") {
-    if (cv.timeCol) {
-      result.blocks_col = cv.timeCol;
-    }
-    if (cv.groupCol) {
-      result.groups_col = cv.groupCol;
-    }
     return result;
   }
   if (active.includes("group_col") && cv.groupCol) {

--- a/tests/contract/test_ui_schema_matches_pydantic.py
+++ b/tests/contract/test_ui_schema_matches_pydantic.py
@@ -179,6 +179,51 @@ def test_frontend_fallback_matches_backend_cv_strategy_fields() -> None:
     )
 
 
+def test_blocked_group_kfold_payload_shape() -> None:
+    """Issue #278: BlockedGroupKFoldConfig requires nested ``blocks`` and
+    ``groups`` sub-objects. Lock the contract here so any refactor of the
+    Pydantic model that flattens those fields fails this test, and any
+    frontend regression that re-flattens the payload is caught by the
+    cv-section unit tests on the other side.
+
+    This is a structural assertion: it asserts the Pydantic side of the
+    contract that the frontend's ``buildSplitConfig`` is built against.
+    """
+    from lizyml.config.schema import LizyMLConfig
+
+    defs = LizyMLConfig.model_json_schema().get("$defs", {})
+
+    bgk = defs.get("BlockedGroupKFoldConfig") or {}
+    bgk_props = set((bgk.get("properties") or {}).keys())
+    assert "blocks" in bgk_props, (
+        "BlockedGroupKFoldConfig must expose a `blocks` sub-object "
+        f"(got {sorted(bgk_props)})"
+    )
+    assert "groups" in bgk_props, (
+        "BlockedGroupKFoldConfig must expose a `groups` sub-object "
+        f"(got {sorted(bgk_props)})"
+    )
+    # Flat axis fields must NOT live at the split level — those belong
+    # inside `blocks` / `groups`.
+    for forbidden in ("col", "cutoffs", "mode", "train_window", "stratify"):
+        assert forbidden not in bgk_props, (
+            f"BlockedGroupKFoldConfig must NOT expose `{forbidden}` at "
+            "the split level — it belongs inside `blocks` or `groups`."
+        )
+
+    blocks = defs.get("BlocksConfig") or {}
+    blocks_props = set((blocks.get("properties") or {}).keys())
+    assert blocks_props == {"col", "cutoffs", "mode", "train_window"}, (
+        f"BlocksConfig field set drifted: {sorted(blocks_props)}"
+    )
+
+    groups = defs.get("GroupCVConfig") or {}
+    groups_props = set((groups.get("properties") or {}).keys())
+    assert groups_props == {"col", "n_splits", "stratify", "shuffle"}, (
+        f"GroupCVConfig field set drifted: {sorted(groups_props)}"
+    )
+
+
 def test_parameter_hints_do_not_shadow_smart_params() -> None:
     """Issue #265 regression guard.
 


### PR DESCRIPTION
## Summary
Closes part of #278 (the BlockedGroupKFold schema-drift slice). The frontend CvSection was sending a flat split payload for the `blocked_group_kfold` strategy (`split.{mode,train_window}` + `data.{blocks_col,groups_col}`), but the backend Pydantic schema requires nested `split.blocks` + `split.groups` sub-objects. The mismatch combined with the silent-reject swallow (fixed in #280) caused users clicking BlockedGroup to see the UI flip while the backend silently kept the prior strategy.

This is **PR-B of the 3-PR plan** outlined in the post-#271 smoke session. PR-A (#280) shipped the `saved:false` observation that now surfaces these mismatches as user-visible toast errors; this PR fixes the actual payload so BlockedGroup round-trips cleanly. PR-C will tackle the remaining running-lock + competing-write issues (#279, plus the non-Default-CV-revert race seen in Phase 3-2).

## What changed

### 1. `buildSplitConfig` emits nested `split.blocks` + `split.groups`
[frontend/src/components/workspace/cv-state.ts](frontend/src/components/workspace/cv-state.ts)

```ts
// Before: flat fields rejected by extra="forbid"
split: { method: "blocked_group_kfold", mode, train_window }

// After: nested per backend BlockedGroupKFoldConfig
split: {
  method: "blocked_group_kfold",
  blocks: { col, cutoffs, mode, train_window },
  groups: { col, n_splits, stratify },
  min_train_rows, min_valid_rows,
}
```

- The blocked editor's tristate `stratify` (`"auto" | "on" | "off"`) maps to backend's `"auto" | true | false`.
- `train_window` is `null` in `expanding` mode (server warns otherwise) and the user's integer in `sliding` mode.
- When `timeCol`/`groupCol` are unset, `blocks` / `groups` are omitted entirely so the rejection localises to a clean `"blocks: Field required"` instead of a confusing `min_length=1` deep-nested error.

### 2. `applyCvDataFields` no longer injects `blocks_col` / `groups_col`
The col names live exclusively inside `split.blocks.col` / `split.groups.col` now. The data object passes through untouched for this strategy.

### 3. New contract test
[tests/contract/test_ui_schema_matches_pydantic.py](tests/contract/test_ui_schema_matches_pydantic.py)

`test_blocked_group_kfold_payload_shape` locks the Pydantic side:
- `BlockedGroupKFoldConfig` must keep `blocks` and `groups` properties
- `BlocksConfig` field set must equal `{col, cutoffs, mode, train_window}`
- `GroupCVConfig` field set must equal `{col, n_splits, stratify, shuffle}`

Mirrors the existing UI-schema / FALLBACK_CV_STRATEGY_FIELDS contracts.

### 4. cv-section.test.ts updated for nested expectations
- 5 existing blocked_group_kfold tests updated (RED → GREEN) to assert the nested shape
- 2 new tests added: `groups.stratify="auto"` passthrough; `timeCol/groupCol`-null omission

## Test plan
- [x] Vitest: 1687 passed / 2 skipped (full)
- [x] pytest: 1220 passed (full backend, including new contract test)
- [x] `pnpm check` (Biome) clean
- [x] `tsc --noEmit` clean
- [x] `pnpm build` clean
- [x] Browser smoke: BlockedGroup radio → Block Column "Age" + Group Column "Pclass" → `GET /config` returns:
  ```json
  {
    "method": "blocked_group_kfold",
    "blocks": { "col": "Age", "cutoffs": [...], "mode": "expanding", "train_window": null },
    "groups": { "col": "Pclass", "n_splits": 5, "stratify": "auto" }
  }
  ```
  with `saved:true` (was silent-reject + revert before).

## Out of scope
- The non-default-CV-revert race observed in Phase 3-2 (other strategies like GroupKFold / TimeSeriesSplit also reverted to stratified_kfold). PR-A's `saved:false` observation now surfaces these as toasts; the underlying competing-write race is tracked separately in PR-C's running-lock work alongside #279.

## Audit context
PR-B of the 3-PR plan derived from Phase 2/3 of post-#271 smoke (`project_smoke_test_plan_post_271.md`). Closes the BlockedGroupKFold schema drift documented in #278; same family as P-0087 Phase 2 (UI ↔ Pydantic invariant).

Closes part of #278.