### PR TITLE
fix(workspace): add running lock — PUT/PATCH /config returns 409 while job active (#279)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2464,6 +2464,7 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - INV-1: `PUT /api/workspace/config` は `JobStore.active_job_id` が non-null の間 409 `WORKSPACE_LOCKED` を返し、`ws.config` を変更しない。
   - INV-2: `PATCH /api/workspace/config` は同条件で 409 `WORKSPACE_LOCKED` を返し、`ws.config` を変更しない。
   - INV-3: active slot が release されたあとは次の `PUT /config` が即座に 200 を返す（lock は持続しない）。
+  - INV-3b (terminal carve-out): active slot を保持していても、その holder の status が terminal (`completed` / `failed` / `cancelled`) ならば lock は無効化される。これは job の status flip と runner の `release_active` の間に存在する microsecond-scale の race window で、post-fit re-fit flow が spurious 409 を踏まないようにするため。
   - INV-4: フロントは `running=true` の間、Target / Task / Column Settings (Exclude, Num/Cat) / CV Section（Strategy / Folds / Random State / Shuffle / Group/Time column / Gap / Embargo / etc）のすべてを `disabled` にする。BlockedGroupKFold エディタは `<fieldset disabled>` で一括ロック。
   - INV-5: `useModelPanelData.handleConfigChange` と `useConfigSync.syncConfig` は 409 `WORKSPACE_LOCKED` を専用 toast (`toast.info`) で扱い、`queryKeys.config()` を invalidate して server-truth に再同期する。history への push と setQueryData は走らない。
 - **Proposal & Impact:**

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2449,3 +2449,56 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (d) dev server 未起動 or E2E-configured backend の状態で `pnpm test:e2e` を実行すると従来通り全 pass。
 - **Decision:**
   - 2026-04-24 **Proposed & Implemented** — Phase 2 PR で採用。Issue #256 を close 予定。Issue #257 の Scenario B (UI 編集後 Fit の統合テスト) は同 PR で並行実装。
+
+### P-0089: 実行中ジョブが Workspace config を保護する running lock（Issue #279, PR-C1）
+- **Status:** proposed & implemented
+- **Scope:** Backend / Frontend / Testing
+- **Related:** Issue #279（Tune 実行中に Folds / Random State / CV Strategy 等が引き続き編集できる）、Issue #277（FeatureWeightsEditor first-toggle race の同族）、Issue #278 残課題（GroupKFold radio が即座に stratified_kfold に上書きされる cross-hook race）、P-0086（Fit/Tune body.config による race-window 解消）、Coupling refactor PR-A/PR-B/PR-C
+- **Context:** Tune 実行中でも `PUT /api/workspace/config` を受け付けるため、ジョブの `meta.json` / checkpoint が作成された config と、UI が後から書き換える config が乖離する。ユーザは radio や NumberInput を触り続けられ、競合 PUT が job の前提を壊す。Smoke テストで以下が再現:
+  - INV違反: 走行中の Tune の隣で Folds NumberInput を 8→3 に変更すると `PUT /config` が 200 で通る。job は折数 8 で実行中だが、UI と保存 config は折数 3 を表示してしまう。
+  - Cross-hook race（#278 残課題）: GroupKFold radio クリックで `useConfigSync` が正しい payload を送るが、`useDataPanel` 系の別 effect が古い snapshot から `stratified_kfold` を上書きする。`saved:false` の toast で表面化はするが、race そのものは残る。
+  - 同族の症状: setQueryData 直後に controlled-input が再描画されない（Folds NumberInput が `8` のまま固定）→ PR-C2 で対応予定。
+  
+  根本対策は二段。**(1) サーバ側で immutability を保証** することで、どれだけ UI 側で取りこぼしがあっても job 中の config は壊れない。**(2) UI を server-truth に揃える**: ロックされている間は対応する controls を `disabled` にしてユーザに状態を伝え、エラー toast の連発を避ける。
+- **Invariants:**
+  - INV-1: `PUT /api/workspace/config` は `JobStore.active_job_id` が non-null の間 409 `WORKSPACE_LOCKED` を返し、`ws.config` を変更しない。
+  - INV-2: `PATCH /api/workspace/config` は同条件で 409 `WORKSPACE_LOCKED` を返し、`ws.config` を変更しない。
+  - INV-3: active slot が release されたあとは次の `PUT /config` が即座に 200 を返す（lock は持続しない）。
+  - INV-4: フロントは `running=true` の間、Target / Task / Column Settings (Exclude, Num/Cat) / CV Section（Strategy / Folds / Random State / Shuffle / Group/Time column / Gap / Embargo / etc）のすべてを `disabled` にする。BlockedGroupKFold エディタは `<fieldset disabled>` で一括ロック。
+  - INV-5: `useModelPanelData.handleConfigChange` と `useConfigSync.syncConfig` は 409 `WORKSPACE_LOCKED` を専用 toast (`toast.info`) で扱い、`queryKeys.config()` を invalidate して server-truth に再同期する。history への push と setQueryData は走らない。
+- **Proposal & Impact:**
+  - `src/lizystudio/api/errors.py` に `WorkspaceLockedError(status=409, code="WORKSPACE_LOCKED", details={"job_id": ...})` を追加。
+  - `src/lizystudio/api/workspace.py::config_update` / `config_patch` に `job_store: JobStore = Depends(get_job_store)` を追加し、`active_job_id` が non-null なら `WorkspaceLockedError` を raise。validate より前にロックチェックを行うことで、不要な validate を回避し副作用も発生させない。
+  - `tests/regression/test_reg_0279_workspace_locked_during_run.py` 新規追加: 既存の `_seed_running_holder` パターンを再利用して INV-1/2/3 を pin。
+  - `frontend/src/api/generated/schema.d.ts` を `pnpm generate:api` で再生成（新 error code をクライアント型に反映）。
+  - `frontend/src/pages/WorkspacePage.tsx` の `<DataPanel>` に `running={running}` を渡す（mobile/desktop の両 Layout で）。
+  - `frontend/src/components/workspace/DataPanel.tsx`: `running?: boolean` prop を追加し、Target Select / Task SegmentGroup を `disabled={... || running}` に。`<ColumnSettingsSection disabled={running} />` と `<CvSection disabled={running} />` を渡す。
+  - `frontend/src/components/workspace/ColumnSettingsSection.tsx`: `disabled?: boolean` prop を追加。Exclude `<Checkbox>` / Num/Cat `<Button>` に `disabled={isExcluded || disabled}` を伝搬。
+  - `frontend/src/components/workspace/CvSection.tsx`: `disabled?: boolean` を追加し、Strategy SegmentGroup / Folds NumberInput / Random State NumberInput / Shuffle Switch / Group Select / Time Select / Gap・Purge Gap・Embargo・Train Size Max・Test Size Max・Min Train Rows・Min Valid Rows の各 NullableNumberField に `disabled` を渡す。
+  - `frontend/src/components/workspace/NullableNumberField.tsx`: `disabled?: boolean` を追加して `<NumberInput>` に転送。
+  - `frontend/src/components/workspace/BlockedGroupKFoldEditor.tsx`: `disabled?: boolean` を追加し、ルート `<div>` を `<fieldset disabled>` に変更（HTML native semantics で内部の Radix triggers / NumberInput / Switch を一括ロック）。
+  - `frontend/src/hooks/useModelPanelData.ts::handleConfigChange`: `ApiError` + `isStudioError` で 409 / `WORKSPACE_LOCKED` を判定し、`toast.info("Config is locked while a job is running")` + `queryClient.invalidateQueries(queryKeys.config())` で再同期。history.push と setQueryData は走らない。
+  - `frontend/src/hooks/useConfigSync.ts::syncConfig`: 同様の 409 判定を catch ブロックに追加し、generic error toast を出さない。
+  - 既存テスト追加 / 更新:
+    - `frontend/src/components/workspace/ColumnSettingsSection.test.tsx`: `running lock` describe ブロックを追加（Checkbox / Num / Cat の disabled、handler が呼ばれないことを assert）。
+    - `frontend/src/components/workspace/CvSection.runningLock.test.tsx`: 新規。Strategy SegmentGroup / Folds NumberInput / BlockedGroupKFoldEditor の disabled 伝搬を assert。
+    - `frontend/src/hooks/useModelPanelData.test.ts`: 409 `WORKSPACE_LOCKED` ハンドラの describe ブロックを追加。
+- **Compatibility:**
+  - API: 新 error code `WORKSPACE_LOCKED` を追加（既存クライアントは status 409 を見て扱う既存 `JOB_CONFLICT` と同じ動作で十分: 警告して再 fetch）。`/fit` / `/tune` の挙動は不変。
+  - UI: `running=true` の間に編集できなくなる範囲は ModelPanel + DataPanel 全体だが、これは元々サーバ側で reject されるべきものを UI が「先回り」して防ぐ formality であり、reject されていた挙動と一貫している。Fit/Tune ボタンと Cancel ボタンは従来通り押下可能。
+  - State machine: 既存の `JobStore.active_job_id` lifecycle に依存。新しい lock primitive は導入しない。release タイミング（terminal status + `release_active`）も既存と同一。
+- **Alternatives considered:**
+  - (A) クライアント側のみで disabled 化: 却下。WS 経由 / 直接 curl / E2E で race が再発する。サーバ invariant が無いと脆い。
+  - (B) PUT を受理して silent ignore: 却下。`saved:false` を返しても UI が「保存された風」に見えるリスクがある。明示 409 + invalidate のほうが安全。
+  - (C) JobStore に専用の `config_locked` フラグを別途持つ: 却下。`active_job_id` で十分かつ単一情報源。新たな ownership invariant を追加すると保守コストが増える。
+  - (D) PR-C を 1 PR で C1 (lock) + C2 (cross-hook funnel + setQueryData→input subscription fix) としてまとめる: 却下。C2 は `useConfigSync` / `useDataPanel` の refactor を含み diff が肥大化する。C1 だけでも `meta.json` corruption は完全に止まる（INV-1～3 がサーバで保証される）ため、独立 PR として価値が高い。C2 は別 PR で実施予定。
+- **Acceptance Criteria:**
+  - (a) `tests/regression/test_reg_0279_workspace_locked_during_run.py` の 3 件が pass（INV-1/2/3）。
+  - (b) `frontend/src/components/workspace/CvSection.runningLock.test.tsx` の disabled 伝搬テストが pass（INV-4）。
+  - (c) `frontend/src/components/workspace/ColumnSettingsSection.test.tsx` の running lock describe ブロックが pass（INV-4）。
+  - (d) `frontend/src/hooks/useModelPanelData.test.ts` の 409 ハンドラテストが pass（INV-5）。
+  - (e) 既存の backend pytest / frontend vitest / ruff / biome / mypy / pnpm build がすべて green。
+  - (f) `tests/contract/` の P-0087 invariant が引き続き pass（schema drift 無し）。
+  - (g) `frontend/src/api/generated/schema.d.ts` が regenerate 済み（`/api/workspace/config` の 409 response に新 error envelope が出る）。
+- **Decision:**
+  - 2026-04-28 **Proposed & Implemented** — PR-C1 として merge 予定。Issue #279 を close。Issue #277 / #278 残課題 / setQueryData→input race は PR-C2 にて continue。

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -303,13 +303,15 @@ export interface paths {
          * Config Update
          * @description Update config with validation.
          *
-         *     P-0089 / Issue #279: while a fit/tune job holds the active slot,
-         *     the config it was created with must be immutable. Cross-hook
-         *     competing writes (CV strategy radio, Folds NumberInput,
-         *     target/task RadioGroup) used to land mid-run and silently
-         *     corrupt the config the job's checkpoint and ``meta.json`` were
-         *     based on. Reject such writes with 409 ``WORKSPACE_LOCKED`` so
-         *     the frontend can surface a clear toast and re-sync.
+         *     P-0089 / Issue #279: while a fit/tune job is actively running, the
+         *     config it was created with must be immutable. Cross-hook competing
+         *     writes (CV strategy radio, Folds NumberInput, target/task
+         *     RadioGroup) used to land mid-run and silently corrupt the config
+         *     the job's checkpoint and ``meta.json`` were based on. Reject such
+         *     writes with 409 ``WORKSPACE_LOCKED`` so the frontend can surface a
+         *     clear toast and re-sync. See ``_check_workspace_lock`` for the
+         *     terminal-status carve-out that lets the post-fit re-fit flow
+         *     proceed without racing against the runner's slot release.
          */
         put: operations["config_update_api_workspace_config_put"];
         post?: never;

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -302,6 +302,14 @@ export interface paths {
         /**
          * Config Update
          * @description Update config with validation.
+         *
+         *     P-0089 / Issue #279: while a fit/tune job holds the active slot,
+         *     the config it was created with must be immutable. Cross-hook
+         *     competing writes (CV strategy radio, Folds NumberInput,
+         *     target/task RadioGroup) used to land mid-run and silently
+         *     corrupt the config the job's checkpoint and ``meta.json`` were
+         *     based on. Reject such writes with 409 ``WORKSPACE_LOCKED`` so
+         *     the frontend can surface a clear toast and re-sync.
          */
         put: operations["config_update_api_workspace_config_put"];
         post?: never;
@@ -311,6 +319,10 @@ export interface paths {
         /**
          * Config Patch
          * @description Partially update config via patch operations (H-0037).
+         *
+         *     P-0089 / Issue #279: same running-lock semantics as
+         *     ``config_update``. Patches against a locked workspace return 409
+         *     so the frontend can drop the in-flight edit and re-fetch.
          */
         patch: operations["config_patch_api_workspace_config_patch"];
         trace?: never;

--- a/frontend/src/components/workspace/BlockedGroupKFoldEditor.tsx
+++ b/frontend/src/components/workspace/BlockedGroupKFoldEditor.tsx
@@ -56,6 +56,14 @@ export interface BlockedGroupKFoldEditorProps {
   blocked: BlockedGroupKFoldState;
   onBlockedChange: (next: BlockedGroupKFoldState) => void;
   nonExcludedCols: ColumnInfo[];
+  /**
+   * P-0089 / Issue #279: lock the editor while a fit/tune job is
+   * running. The wrapping ``<fieldset disabled>`` natively prevents
+   * pointer / keyboard input from reaching the nested controls; the
+   * inner Radix triggers honor it because they render as ``<button>``
+   * elements and inherit the fieldset disabled attribute.
+   */
+  disabled?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -68,6 +76,7 @@ export function BlockedGroupKFoldEditor({
   blocked,
   onBlockedChange,
   nonExcludedCols,
+  disabled = false,
 }: BlockedGroupKFoldEditorProps) {
   const [blockStats, setBlockStats] = useState<ColumnStatsResponse | null>(
     null,
@@ -170,7 +179,11 @@ export function BlockedGroupKFoldEditor({
   );
 
   return (
-    <div className="space-y-4" data-testid="blocked-group-kfold-editor">
+    <fieldset
+      className="space-y-4 disabled:opacity-60"
+      disabled={disabled}
+      data-testid="blocked-group-kfold-editor"
+    >
       {/* ===== Blocks Section ===== */}
       <fieldset className="space-y-3 rounded-md border p-3">
         <legend className="px-1 text-xs font-semibold text-muted-foreground">
@@ -431,7 +444,7 @@ export function BlockedGroupKFoldEditor({
           />
         </div>
       </fieldset>
-    </div>
+    </fieldset>
   );
 }
 

--- a/frontend/src/components/workspace/ColumnSettingsSection.test.tsx
+++ b/frontend/src/components/workspace/ColumnSettingsSection.test.tsx
@@ -31,11 +31,14 @@ const SUMMARY = {
   manualCount: 0,
 };
 
-function renderSection(handlers: {
-  onExcludeToggle?: (name: string, checked: boolean) => void;
-  onTypeChange?: (name: string, type: "numeric" | "categorical") => void;
-  onColumnExpand?: (name: string) => void;
-}) {
+function renderSection(
+  handlers: {
+    onExcludeToggle?: (name: string, checked: boolean) => void;
+    onTypeChange?: (name: string, type: "numeric" | "categorical") => void;
+    onColumnExpand?: (name: string) => void;
+  },
+  options: { disabled?: boolean } = {},
+) {
   const onExcludeToggle = handlers.onExcludeToggle ?? vi.fn();
   const onTypeChange = handlers.onTypeChange ?? vi.fn();
   const onColumnExpand = handlers.onColumnExpand ?? vi.fn();
@@ -52,6 +55,7 @@ function renderSection(handlers: {
       onExcludeToggle={onExcludeToggle}
       onTypeChange={onTypeChange}
       onColumnExpand={onColumnExpand}
+      disabled={options.disabled}
     />,
   );
   return { onExcludeToggle, onTypeChange, onColumnExpand };
@@ -180,5 +184,43 @@ describe("ColumnSettingsSection DOM structure (Issue #248)", () => {
     fireEvent.keyDown(row, { key: "Tab" });
     fireEvent.keyDown(row, { key: "a" });
     expect(onColumnExpand).not.toHaveBeenCalled();
+  });
+});
+
+describe("ColumnSettingsSection running lock (P-0089 / Issue #279)", () => {
+  it("disables Exclude checkbox when disabled=true", () => {
+    renderSection({}, { disabled: true });
+    const row = screen.getByTestId("column-row-color");
+    const checkbox = row.querySelector('[role="checkbox"]') as HTMLElement;
+    expect(checkbox).not.toBeNull();
+    expect(checkbox).toHaveAttribute("disabled");
+  });
+
+  it("disables Num and Cat buttons when disabled=true", () => {
+    renderSection({}, { disabled: true });
+    const row = screen.getByTestId("column-row-color");
+    const buttons = Array.from(row.querySelectorAll("button"));
+    const numBtn = buttons.find((b) => b.textContent === "Num");
+    const catBtn = buttons.find((b) => b.textContent === "Cat");
+    expect(numBtn).toBeDefined();
+    expect(catBtn).toBeDefined();
+    expect(numBtn).toBeDisabled();
+    expect(catBtn).toBeDisabled();
+  });
+
+  it("does not call handlers when disabled and the controls are clicked", async () => {
+    const { onExcludeToggle, onTypeChange } = renderSection(
+      {},
+      { disabled: true },
+    );
+    const row = screen.getByTestId("column-row-color");
+    const checkbox = row.querySelector('[role="checkbox"]') as HTMLElement;
+    fireEvent.click(checkbox);
+    const numBtn = Array.from(row.querySelectorAll("button")).find(
+      (b) => b.textContent === "Num",
+    ) as HTMLElement;
+    await userEvent.click(numBtn);
+    expect(onExcludeToggle).not.toHaveBeenCalled();
+    expect(onTypeChange).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/workspace/ColumnSettingsSection.tsx
+++ b/frontend/src/components/workspace/ColumnSettingsSection.tsx
@@ -26,6 +26,14 @@ interface ColumnSettingsSectionProps {
   onExcludeToggle: (colName: string, checked: boolean) => void;
   onTypeChange: (colName: string, type: "numeric" | "categorical") => void;
   onColumnExpand: (colName: string) => void;
+  /**
+   * P-0089 / Issue #279: lock the per-column Exclude / Num / Cat
+   * controls while a fit/tune job is running. PUT /config returns
+   * 409 server-side; disabling the controls here matches that lock
+   * so the user does not see optimistic UI flicker followed by a
+   * toast.
+   */
+  disabled?: boolean;
 }
 
 export function ColumnSettingsSection({
@@ -40,6 +48,7 @@ export function ColumnSettingsSection({
   onExcludeToggle,
   onTypeChange,
   onColumnExpand,
+  disabled = false,
 }: ColumnSettingsSectionProps) {
   return (
     <div className="pl-4">
@@ -129,6 +138,7 @@ export function ColumnSettingsSection({
                           onCheckedChange={(checked) =>
                             onExcludeToggle(col.name, checked === true)
                           }
+                          disabled={disabled}
                         />
                       </div>
                       {/* biome-ignore lint/a11y/noStaticElementInteractions: stop propagation container */}
@@ -143,7 +153,7 @@ export function ColumnSettingsSection({
                           }
                           size="sm"
                           className="h-6 text-[10px] px-2"
-                          disabled={isExcluded}
+                          disabled={isExcluded || disabled}
                           onClick={() => onTypeChange(col.name, "numeric")}
                         >
                           Num
@@ -156,7 +166,7 @@ export function ColumnSettingsSection({
                           }
                           size="sm"
                           className="h-6 text-[10px] px-2"
-                          disabled={isExcluded}
+                          disabled={isExcluded || disabled}
                           onClick={() => onTypeChange(col.name, "categorical")}
                         >
                           Cat

--- a/frontend/src/components/workspace/CvSection.runningLock.test.tsx
+++ b/frontend/src/components/workspace/CvSection.runningLock.test.tsx
@@ -1,0 +1,160 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ColumnInfo } from "@/api/types";
+import {
+  CvSection,
+  type CvState,
+  INITIAL_BLOCKED_STATE,
+  INITIAL_CV_STATE,
+} from "./CvSection";
+
+const cols: ColumnInfo[] = [
+  {
+    name: "ts",
+    dtype: "object",
+    unique_count: 12,
+    suggested_type: "categorical",
+    suggested_excluded: false,
+    exclude_reason: null,
+  },
+];
+
+function makeCv(overrides: Partial<CvState> = {}): CvState {
+  return { ...INITIAL_CV_STATE, ...overrides };
+}
+
+describe("CvSection running lock (P-0089 / Issue #279)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("disables strategy segment buttons when disabled=true", () => {
+    render(
+      <CvSection
+        cv={makeCv()}
+        onChange={vi.fn()}
+        uiSchema={
+          {
+            capabilities: { cv_strategies: ["kfold", "stratified_kfold"] },
+          } as never
+        }
+        nonExcludedCols={cols}
+        disabled
+      />,
+    );
+    const segmentButtons = screen.getAllByRole("button");
+    // At least one strategy segment button should exist; all of them
+    // must be disabled while the workspace is locked.
+    expect(segmentButtons.length).toBeGreaterThan(0);
+    for (const btn of segmentButtons) {
+      expect(btn).toBeDisabled();
+    }
+  });
+
+  it("disables Folds NumberInput when disabled=true", () => {
+    render(
+      <CvSection
+        cv={makeCv({ strategy: "kfold" })}
+        onChange={vi.fn()}
+        uiSchema={
+          {
+            capabilities: {
+              cv_strategies: ["kfold"],
+              cv_strategy_fields: { kfold: ["n_splits", "random_state"] },
+            },
+          } as never
+        }
+        nonExcludedCols={cols}
+        disabled
+      />,
+    );
+    // NumberInput renders as Decrement/Input/Increment. Asserting on the
+    // accessible Decrement / Increment buttons gives a stable check that
+    // the disabled prop reached the underlying control.
+    const decrements = screen.getAllByRole("button", { name: /decrement/i });
+    const increments = screen.getAllByRole("button", { name: /increment/i });
+    expect(decrements.length).toBeGreaterThan(0);
+    expect(increments.length).toBeGreaterThan(0);
+    for (const btn of [...decrements, ...increments]) {
+      expect(btn).toBeDisabled();
+    }
+  });
+
+  it("propagates disabled to BlockedGroupKFoldEditor", () => {
+    render(
+      <CvSection
+        cv={makeCv({ strategy: "blocked_group_kfold" })}
+        onChange={vi.fn()}
+        uiSchema={
+          {
+            capabilities: {
+              cv_strategies: ["kfold", "blocked_group_kfold"],
+              cv_strategy_fields: { blocked_group_kfold: ["time_col"] },
+            },
+          } as never
+        }
+        nonExcludedCols={cols}
+        blocked={INITIAL_BLOCKED_STATE}
+        onBlockedChange={vi.fn()}
+        disabled
+      />,
+    );
+    const editor = screen.getByTestId("blocked-group-kfold-editor");
+    // The editor wrapper is a <fieldset disabled> when locked.
+    expect(editor.tagName).toBe("FIELDSET");
+    expect(editor).toBeDisabled();
+  });
+
+  it("does not disable controls when disabled is omitted", () => {
+    render(
+      <CvSection
+        cv={makeCv({ strategy: "kfold" })}
+        onChange={vi.fn()}
+        uiSchema={
+          {
+            capabilities: {
+              cv_strategies: ["kfold"],
+              cv_strategy_fields: { kfold: ["n_splits"] },
+            },
+          } as never
+        }
+        nonExcludedCols={cols}
+      />,
+    );
+    const segments = screen.getAllByRole("button");
+    expect(segments.length).toBeGreaterThan(0);
+    for (const btn of segments) {
+      expect(btn).not.toBeDisabled();
+    }
+  });
+});
+
+describe("CvSection running lock — sanity guards", () => {
+  it("BlockedGroupKFoldEditor wrapper passes through testid", () => {
+    render(
+      <CvSection
+        cv={makeCv({ strategy: "blocked_group_kfold" })}
+        onChange={vi.fn()}
+        uiSchema={
+          {
+            capabilities: {
+              cv_strategies: ["blocked_group_kfold"],
+              cv_strategy_fields: { blocked_group_kfold: ["time_col"] },
+            },
+          } as never
+        }
+        nonExcludedCols={cols}
+        blocked={INITIAL_BLOCKED_STATE}
+        onBlockedChange={vi.fn()}
+      />,
+    );
+    const editor = screen.getByTestId("blocked-group-kfold-editor");
+    expect(editor).toBeInTheDocument();
+    // When unlocked, nested form controls inside the fieldset must
+    // remain enabled.
+    expect(editor).not.toBeDisabled();
+    // Editor renders columns as Select options in the real component;
+    // we just verify the wrapper does not strip its descendants.
+    expect(within(editor).getAllByText(/Block/i).length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/workspace/CvSection.tsx
+++ b/frontend/src/components/workspace/CvSection.tsx
@@ -57,6 +57,14 @@ interface CvSectionProps {
    * (no data loaded yet) the input falls back to the hard max only.
    */
   nRows?: number;
+  /**
+   * P-0089 / Issue #279: lock the CV section while a fit/tune job is
+   * running. PUT /config returns 409 server-side; disabling the
+   * controls here prevents the user from issuing rejected writes and
+   * keeps the form value pinned to the config the running job was
+   * created with.
+   */
+  disabled?: boolean;
 }
 
 export function CvSection({
@@ -67,6 +75,7 @@ export function CvSection({
   blocked,
   onBlockedChange,
   nRows,
+  disabled = false,
 }: CvSectionProps) {
   const availableStrategies = useMemo(
     () =>
@@ -110,6 +119,7 @@ export function CvSection({
           value={cv.strategy}
           onChange={handleStrategyChange}
           labels={CV_STRATEGY_LABELS}
+          disabled={disabled}
         />
       </div>
 
@@ -121,6 +131,7 @@ export function CvSection({
           blocked={blocked}
           onBlockedChange={onBlockedChange}
           nonExcludedCols={nonExcludedCols}
+          disabled={disabled}
         />
       )}
 
@@ -141,6 +152,7 @@ export function CvSection({
             max={nRows && nRows >= 2 ? nRows : undefined}
             step={1}
             placeholder="5"
+            disabled={disabled}
           />
         </div>
       )}
@@ -155,6 +167,7 @@ export function CvSection({
             onChange={(v) => update({ randomState: v })}
             step={1}
             placeholder="42"
+            disabled={disabled}
           />
         </div>
       )}
@@ -167,6 +180,7 @@ export function CvSection({
           <Switch
             checked={cv.shuffle}
             onCheckedChange={(v) => update({ shuffle: v })}
+            disabled={disabled}
           />
         </div>
       )}
@@ -179,6 +193,7 @@ export function CvSection({
           <Select
             value={cv.groupCol ?? ""}
             onValueChange={(v) => update({ groupCol: v })}
+            disabled={disabled}
           >
             <SelectTrigger aria-label="Group column">
               <SelectValue placeholder="Select column" />
@@ -202,6 +217,7 @@ export function CvSection({
           <Select
             value={cv.timeCol ?? ""}
             onValueChange={(v) => update({ timeCol: v })}
+            disabled={disabled}
           >
             <SelectTrigger aria-label="Time column">
               <SelectValue placeholder="Select column" />
@@ -223,6 +239,7 @@ export function CvSection({
           value={cv.gap}
           onChange={(v) => update({ gap: v })}
           placeholder="0"
+          disabled={disabled}
         />
       )}
 
@@ -232,6 +249,7 @@ export function CvSection({
           value={cv.purgeGap}
           onChange={(v) => update({ purgeGap: v })}
           placeholder="0"
+          disabled={disabled}
         />
       )}
 
@@ -241,6 +259,7 @@ export function CvSection({
           value={cv.embargo}
           onChange={(v) => update({ embargo: v })}
           placeholder="0"
+          disabled={disabled}
         />
       )}
 
@@ -250,6 +269,7 @@ export function CvSection({
           value={cv.trainSizeMax}
           onChange={(v) => update({ trainSizeMax: v })}
           autoHint
+          disabled={disabled}
         />
       )}
 
@@ -259,6 +279,7 @@ export function CvSection({
           value={cv.testSizeMax}
           onChange={(v) => update({ testSizeMax: v })}
           autoHint
+          disabled={disabled}
         />
       )}
 
@@ -268,6 +289,7 @@ export function CvSection({
           value={cv.minTrainRows}
           onChange={(v) => update({ minTrainRows: v })}
           autoHint
+          disabled={disabled}
         />
       )}
 
@@ -277,6 +299,7 @@ export function CvSection({
           value={cv.minValidRows}
           onChange={(v) => update({ minValidRows: v })}
           autoHint
+          disabled={disabled}
         />
       )}
     </div>

--- a/frontend/src/components/workspace/DataPanel.tsx
+++ b/frontend/src/components/workspace/DataPanel.tsx
@@ -32,6 +32,14 @@ interface DataPanelProps {
   onDataChanged: () => void;
   onTaskChanged?: (task: string | null) => void;
   uiSchema?: UiSchema;
+  /**
+   * P-0089 / Issue #279: while a fit/tune job is running the
+   * workspace config is locked server-side (PUT /config returns 409
+   * WORKSPACE_LOCKED). The UI must mirror that lock by disabling the
+   * controls that produce competing writes — Target/Task radios, the
+   * Column Settings exclude/type buttons, and every CV field.
+   */
+  running?: boolean;
 }
 
 /**
@@ -51,7 +59,7 @@ export interface DataPanelHandle {
 
 export const DataPanel = forwardRef<DataPanelHandle, DataPanelProps>(
   function DataPanel(
-    { onDataChanged, onTaskChanged, uiSchema }: DataPanelProps,
+    { onDataChanged, onTaskChanged, uiSchema, running = false }: DataPanelProps,
     ref,
   ) {
     const {
@@ -153,7 +161,7 @@ export const DataPanel = forwardRef<DataPanelHandle, DataPanelProps>(
                     <Select
                       value={target ?? ""}
                       onValueChange={handleTargetChange}
-                      disabled={allColumnNames.length === 0}
+                      disabled={allColumnNames.length === 0 || running}
                     >
                       <SelectTrigger
                         aria-label="Target column"
@@ -177,7 +185,7 @@ export const DataPanel = forwardRef<DataPanelHandle, DataPanelProps>(
                         options={TASK_OPTIONS as unknown as string[]}
                         value={task ?? ""}
                         onChange={(v) => handleTaskChange(v as TaskType)}
-                        disabled={!target}
+                        disabled={!target || running}
                       />
                       {!target && (
                         <span className="text-xs text-muted-foreground">
@@ -218,6 +226,7 @@ export const DataPanel = forwardRef<DataPanelHandle, DataPanelProps>(
                   onExcludeToggle={handleExcludeToggle}
                   onTypeChange={handleTypeChange}
                   onColumnExpand={handleColumnExpand}
+                  disabled={running}
                 />
               </AccordionContent>
             </AccordionItem>
@@ -237,6 +246,7 @@ export const DataPanel = forwardRef<DataPanelHandle, DataPanelProps>(
                     blocked={blocked}
                     onBlockedChange={setBlocked}
                     nRows={shape ? shape[0] : undefined}
+                    disabled={running}
                   />
                   <FoldPreview
                     enabled={!!target && !!task && shape !== null}

--- a/frontend/src/components/workspace/NullableNumberField.tsx
+++ b/frontend/src/components/workspace/NullableNumberField.tsx
@@ -8,12 +8,14 @@ export function NullableNumberField({
   onChange,
   placeholder,
   autoHint,
+  disabled,
 }: {
   label: string;
   value: number | undefined;
   onChange: (v: number | undefined) => void;
   placeholder?: string;
   autoHint?: boolean;
+  disabled?: boolean;
 }) {
   return (
     <div className="space-y-1">
@@ -31,6 +33,7 @@ export function NullableNumberField({
         min={autoHint ? 1 : 0}
         step={1}
         placeholder={placeholder ?? "Auto"}
+        disabled={disabled}
       />
     </div>
   );

--- a/frontend/src/hooks/useConfigSync.ts
+++ b/frontend/src/hooks/useConfigSync.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { toast } from "sonner";
+import { ApiError } from "@/api/client";
+import { isStudioError } from "@/api/errors";
 import type { UiSchema } from "@/api/types";
 import {
   fetchConfig,
@@ -103,6 +105,20 @@ export function useConfigSync({
       onDataChanged();
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
+      // P-0089 / Issue #279: while a fit/tune job holds the active
+      // slot, PUT /config returns 409 WORKSPACE_LOCKED. The disabled
+      // controls upstream already explain the lock to the user; emit
+      // a quiet info toast instead of the generic error so the user
+      // is not alarmed by their own locked-state behaving correctly.
+      if (
+        err instanceof ApiError &&
+        err.status === 409 &&
+        isStudioError(err.body) &&
+        err.body.error.code === "WORKSPACE_LOCKED"
+      ) {
+        toast.info("Config is locked while a job is running");
+        return;
+      }
       toast.error("Config sync failed — changes may not be saved");
     }
   }, [

--- a/frontend/src/hooks/useModelPanelData.test.ts
+++ b/frontend/src/hooks/useModelPanelData.test.ts
@@ -391,6 +391,49 @@ describe("useModelPanelData", () => {
   });
 
   // -------------------------------------------------------------------------
+  // P-0089 / Issue #279: PUT /config returns 409 WORKSPACE_LOCKED while a
+  // fit/tune job is running. handleConfigChange must surface a quiet info
+  // toast (not the generic error path) and re-fetch so the form resyncs to
+  // the locked-in config. The cache must NOT be optimistically updated.
+  // -------------------------------------------------------------------------
+  describe("handleConfigChange — 409 WORKSPACE_LOCKED handling (#279)", () => {
+    it("invalidates cache and does not push to history when 409 fires", async () => {
+      // Lazy import inside the test to avoid hoisting weirdness with the
+      // top-level vi.mock("@/api/workspace") block.
+      const { ApiError } = await import("@/api/client");
+      vi.mocked(updateConfig).mockRejectedValueOnce(
+        new ApiError(409, {
+          error: {
+            code: "WORKSPACE_LOCKED",
+            message: "Config is locked while job xyz is running",
+            details: { job_id: "xyz" },
+          },
+        }),
+      );
+
+      const { wrapper, queryClient } = makeWrapper();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      const { result } = renderHook(
+        () => useModelPanelData({ hasData: true, running: false }),
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.config).toBeDefined());
+
+      const undoBefore = result.current.history.canUndo;
+
+      await act(async () => {
+        await result.current.handleConfigChange({ model: { name: "Z" } });
+      });
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: queryKeys.config(),
+      });
+      // Rejected write must not land on history.
+      expect(result.current.history.canUndo).toBe(undoBefore);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Issue #276: handleLoadPreset must merge preset with current data so the
   // backend `data` field (which presets intentionally omit) is preserved.
   // -------------------------------------------------------------------------

--- a/frontend/src/hooks/useModelPanelData.ts
+++ b/frontend/src/hooks/useModelPanelData.ts
@@ -13,7 +13,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import equal from "fast-deep-equal";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import { getErrorMessage } from "@/api/errors";
+import { ApiError } from "@/api/client";
+import { getErrorMessage, isStudioError } from "@/api/errors";
 import {
   useBackends,
   useColumns,
@@ -89,7 +90,22 @@ export function useModelPanelData({
       let response: Awaited<ReturnType<typeof updateConfig>>;
       try {
         response = await updateConfig(newConfig);
-      } catch {
+      } catch (err) {
+        // P-0089 / Issue #279: 409 WORKSPACE_LOCKED means a fit/tune
+        // job is running and the config is intentionally immutable.
+        // Surface a quiet info toast (the section-level disabled
+        // controls already explain the lock) and re-fetch so the form
+        // resyncs to the locked-in config.
+        if (
+          err instanceof ApiError &&
+          err.status === 409 &&
+          isStudioError(err.body) &&
+          err.body.error.code === "WORKSPACE_LOCKED"
+        ) {
+          toast.info("Config is locked while a job is running");
+          queryClient.invalidateQueries({ queryKey: queryKeys.config() });
+          return;
+        }
         toast.error("Failed to update config");
         return;
       }

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -186,6 +186,7 @@ export function WorkspacePage() {
             onDataChanged={handleDataChanged}
             onTaskChanged={handleTaskChanged}
             uiSchema={uiSchema}
+            running={running}
           />
         </TabsContent>
         <TabsContent
@@ -278,6 +279,7 @@ export function WorkspacePage() {
             onDataChanged={handleDataChanged}
             onTaskChanged={handleTaskChanged}
             uiSchema={uiSchema}
+            running={running}
           />
         </section>
       </ResizablePanel>

--- a/src/lizystudio/api/errors.py
+++ b/src/lizystudio/api/errors.py
@@ -69,6 +69,27 @@ class JobConflictError(StudioError):
         )
 
 
+class WorkspaceLockedError(StudioError):
+    """Config write rejected because a fit/tune job is currently running.
+
+    P-0089 / Issue #279: while a job holds the active slot, mutating
+    ``ws.config`` would let cross-hook competing writes (CV strategy
+    radio, Folds NumberInput, target/task RadioGroup) corrupt the
+    config that the job's checkpoint and meta.json were created with.
+    The lock is released as soon as the job transitions to a terminal
+    status (``completed`` / ``failed`` / ``cancelled``) and the
+    runner's finally block calls ``release_active``.
+    """
+
+    def __init__(self, job_id: str) -> None:
+        super().__init__(
+            "WORKSPACE_LOCKED",
+            f"Config is locked while job {job_id} is running",
+            409,
+            details={"job_id": job_id},
+        )
+
+
 class ValidationError(StudioError):
     def __init__(self, errors: list[dict[str, Any]]) -> None:
         super().__init__(

--- a/src/lizystudio/api/workspace.py
+++ b/src/lizystudio/api/workspace.py
@@ -27,6 +27,7 @@ from lizystudio.api.errors import (
     JobConflictError,
     PathNotFoundError,
     ValidationError,
+    WorkspaceLockedError,
     WorkspaceNoConfigError,
     WorkspaceNoDataError,
 )
@@ -426,8 +427,21 @@ def config_get(
 def config_update(
     body: dict[str, Any],
     ws: WorkspaceState = Depends(get_workspace),
+    job_store: JobStore = Depends(get_job_store),
 ) -> dict[str, Any]:
-    """Update config with validation."""
+    """Update config with validation.
+
+    P-0089 / Issue #279: while a fit/tune job holds the active slot,
+    the config it was created with must be immutable. Cross-hook
+    competing writes (CV strategy radio, Folds NumberInput,
+    target/task RadioGroup) used to land mid-run and silently
+    corrupt the config the job's checkpoint and ``meta.json`` were
+    based on. Reject such writes with 409 ``WORKSPACE_LOCKED`` so
+    the frontend can surface a clear toast and re-sync.
+    """
+    holder = job_store.active_job_id
+    if holder is not None:
+        raise WorkspaceLockedError(holder)
     errors = validate_config(ws, body)
     if not errors:
         ws.set_config(body)
@@ -438,8 +452,17 @@ def config_update(
 def config_patch(
     body: dict[str, Any],
     ws: WorkspaceState = Depends(get_workspace),
+    job_store: JobStore = Depends(get_job_store),
 ) -> dict[str, Any]:
-    """Partially update config via patch operations (H-0037)."""
+    """Partially update config via patch operations (H-0037).
+
+    P-0089 / Issue #279: same running-lock semantics as
+    ``config_update``. Patches against a locked workspace return 409
+    so the frontend can drop the in-flight edit and re-fetch.
+    """
+    holder = job_store.active_job_id
+    if holder is not None:
+        raise WorkspaceLockedError(holder)
     if not ws.config:
         raise WorkspaceNoConfigError()
     ops = body.get("ops", [])

--- a/src/lizystudio/api/workspace.py
+++ b/src/lizystudio/api/workspace.py
@@ -423,6 +423,36 @@ def config_get(
     return ws.config
 
 
+def _check_workspace_lock(job_store: JobStore) -> None:
+    """Raise ``WorkspaceLockedError`` iff a non-terminal job holds the slot.
+
+    P-0089 / Issue #279: the config must be immutable while a fit/tune
+    job is actively running, but **only while it is actively running**.
+    Once a job transitions to a terminal status (``completed`` /
+    ``failed`` / ``cancelled``), the workspace must accept config
+    writes again — even if the runner's ``finally`` block has not yet
+    called ``release_active`` to drop the slot.
+
+    Without this terminal-status carve-out, the post-fit re-fit flow
+    (``waitForJobDone`` returns the moment status flips, but
+    ``release_active`` lags by an arbitrary number of microseconds)
+    races against the lock and produces spurious 409s for clients
+    that did the right thing — see the ``jobs-refit.spec.ts`` E2E
+    failure that surfaced this.
+    """
+    holder = job_store.active_job_id
+    if holder is None:
+        return
+    holder_job = job_store.get(holder)
+    if holder_job is not None and holder_job.status in (
+        "completed",
+        "failed",
+        "cancelled",
+    ):
+        return
+    raise WorkspaceLockedError(holder)
+
+
 @router.put("/config", response_model=ConfigUpdateResponse)
 def config_update(
     body: dict[str, Any],
@@ -431,17 +461,17 @@ def config_update(
 ) -> dict[str, Any]:
     """Update config with validation.
 
-    P-0089 / Issue #279: while a fit/tune job holds the active slot,
-    the config it was created with must be immutable. Cross-hook
-    competing writes (CV strategy radio, Folds NumberInput,
-    target/task RadioGroup) used to land mid-run and silently
-    corrupt the config the job's checkpoint and ``meta.json`` were
-    based on. Reject such writes with 409 ``WORKSPACE_LOCKED`` so
-    the frontend can surface a clear toast and re-sync.
+    P-0089 / Issue #279: while a fit/tune job is actively running, the
+    config it was created with must be immutable. Cross-hook competing
+    writes (CV strategy radio, Folds NumberInput, target/task
+    RadioGroup) used to land mid-run and silently corrupt the config
+    the job's checkpoint and ``meta.json`` were based on. Reject such
+    writes with 409 ``WORKSPACE_LOCKED`` so the frontend can surface a
+    clear toast and re-sync. See ``_check_workspace_lock`` for the
+    terminal-status carve-out that lets the post-fit re-fit flow
+    proceed without racing against the runner's slot release.
     """
-    holder = job_store.active_job_id
-    if holder is not None:
-        raise WorkspaceLockedError(holder)
+    _check_workspace_lock(job_store)
     errors = validate_config(ws, body)
     if not errors:
         ws.set_config(body)
@@ -460,9 +490,7 @@ def config_patch(
     ``config_update``. Patches against a locked workspace return 409
     so the frontend can drop the in-flight edit and re-fetch.
     """
-    holder = job_store.active_job_id
-    if holder is not None:
-        raise WorkspaceLockedError(holder)
+    _check_workspace_lock(job_store)
     if not ws.config:
         raise WorkspaceNoConfigError()
     ops = body.get("ops", [])

--- a/tests/regression/test_reg_0279_workspace_locked_during_run.py
+++ b/tests/regression/test_reg_0279_workspace_locked_during_run.py
@@ -1,0 +1,169 @@
+"""Regression (#279, P-0089): config writes are 409 while a job is running.
+
+Before the fix, ``PUT /api/workspace/config`` and
+``PATCH /api/workspace/config`` accepted writes mid-run, so cross-hook
+competing writes from the workspace UI (CV strategy radio, Folds
+NumberInput, target/task RadioGroup) could land between fit/tune
+start and completion. The job's ``meta.json`` and checkpoint were
+created against the *original* config, so the late mutation produced
+a workspace whose surface no longer matched what was actually fit.
+
+The lock is held only by ``JobStore.active_job_id``; once the job
+transitions to a terminal status (``completed`` / ``failed`` /
+``cancelled``) and the runner's finally block calls
+``release_active``, the next config write succeeds.
+
+Invariants pinned by this regression:
+
+- INV-1 (PUT): ``PUT /api/workspace/config`` returns 409
+  ``WORKSPACE_LOCKED`` while a job is active.
+- INV-2 (PATCH): ``PATCH /api/workspace/config`` returns 409
+  ``WORKSPACE_LOCKED`` while a job is active.
+- INV-3 (no-mutation): ``ws.config`` is unchanged after either
+  rejected write.
+- INV-4 (release): once the active slot is released the next
+  ``PUT /api/workspace/config`` succeeds.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+def _create_csv(tmp_path: Path, name: str = "train.csv") -> str:
+    csv_path = tmp_path / name
+    with csv_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["id", "age", "target"])
+        for i in range(50):
+            writer.writerow([i, 20 + i, i % 2])
+    return str(csv_path)
+
+
+def _load_data_and_config(client: TestClient, tmp_path: Path) -> dict[str, Any]:
+    """Load CSV data and a valid config; return the config used."""
+    csv_path = _create_csv(tmp_path)
+    r = client.post("/api/workspace/data/path", json={"path": csv_path})
+    assert r.status_code == 200, r.text
+
+    res = client.get("/api/workspace/config/defaults?task=binary&target=target")
+    assert res.status_code == 200, res.text
+    config = res.json()
+
+    r = client.put("/api/workspace/config", json=config)
+    assert r.status_code == 200 and r.json()["saved"] is True, r.text
+    return config
+
+
+def _seed_running_holder(job_store: Any) -> str:
+    """Mirror ``tests.test_workspace_api._seed_running_holder``.
+
+    Creates a real on-disk meta + claims the active slot. We cannot
+    just call ``claim_active("dummy")`` because the stale-slot
+    auto-reclaim path would notice the missing meta and treat the
+    slot as reclaimable.
+    """
+    from lizystudio.backends.types import DataRef
+
+    holder = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=DataRef(
+            source_type="path",
+            path="/data/holder.csv",
+            filename="holder.csv",
+            fingerprint="h",
+            shape=(10, 2),
+        ),
+        job_type="fit",
+    )
+    holder.status = "running"
+    job_store.update(holder)
+    assert job_store.claim_active(holder.job_id)
+    return holder.job_id
+
+
+def test_put_config_returns_409_when_job_running(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    """INV-1 + INV-3: PUT /config rejects with 409 and config stays unchanged."""
+    config = _load_data_and_config(client, tmp_path)
+
+    job_store = client.app.state.job_store  # type: ignore[union-attr]
+    holder_id = _seed_running_holder(job_store)
+    try:
+        # Mutate any field — strategy is a representative cross-hook write.
+        mutated = {**config, "split": {**config["split"], "method": "kfold"}}
+        res = client.put("/api/workspace/config", json=mutated)
+
+        assert res.status_code == 409, res.text
+        body = res.json()
+        assert body["error"]["code"] == "WORKSPACE_LOCKED"
+        assert body["error"]["details"]["job_id"] == holder_id
+
+        # INV-3: ws.config must not have been mutated by the rejected write.
+        current = client.get("/api/workspace/config").json()
+        assert current["split"]["method"] == config["split"]["method"]
+    finally:
+        job_store.release_active(holder_id)
+
+
+def test_patch_config_returns_409_when_job_running(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    """INV-2 + INV-3: PATCH /config rejects with 409 and config stays unchanged."""
+    config = _load_data_and_config(client, tmp_path)
+    original_method = config["split"]["method"]
+
+    job_store = client.app.state.job_store  # type: ignore[union-attr]
+    holder_id = _seed_running_holder(job_store)
+    try:
+        ops = {
+            "ops": [
+                {
+                    "op": "replace",
+                    "path": "/split/method",
+                    "value": "kfold",
+                }
+            ]
+        }
+        res = client.patch("/api/workspace/config", json=ops)
+
+        assert res.status_code == 409, res.text
+        body = res.json()
+        assert body["error"]["code"] == "WORKSPACE_LOCKED"
+
+        current = client.get("/api/workspace/config").json()
+        assert current["split"]["method"] == original_method
+    finally:
+        job_store.release_active(holder_id)
+
+
+def test_put_config_succeeds_after_slot_release(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    """INV-4: once the active slot is released, PUT /config works again."""
+    config = _load_data_and_config(client, tmp_path)
+
+    job_store = client.app.state.job_store  # type: ignore[union-attr]
+    holder_id = _seed_running_holder(job_store)
+    # Confirm the lock is engaged.
+    res = client.put("/api/workspace/config", json=config)
+    assert res.status_code == 409
+
+    # Release the slot the way a normal runner finally-block would.
+    job_store.release_active(holder_id)
+
+    res = client.put("/api/workspace/config", json=config)
+    assert res.status_code == 200, res.text
+    assert res.json()["saved"] is True

--- a/tests/regression/test_reg_0279_workspace_locked_during_run.py
+++ b/tests/regression/test_reg_0279_workspace_locked_during_run.py
@@ -167,3 +167,42 @@ def test_put_config_succeeds_after_slot_release(
     res = client.put("/api/workspace/config", json=config)
     assert res.status_code == 200, res.text
     assert res.json()["saved"] is True
+
+
+def test_put_config_succeeds_when_holder_is_terminal_but_slot_not_yet_released(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    """INV-5 (race carve-out): a terminal-status holder must not lock /config.
+
+    There is a real race window where a job's on-disk status has
+    transitioned to ``completed`` / ``failed`` / ``cancelled`` but the
+    runner's ``finally`` block has not yet called
+    ``release_active``. The post-fit re-fit flow (Playwright
+    ``jobs-refit.spec.ts``) hits this window every time:
+    ``waitForJobDone`` returns the moment status flips, then
+    immediately PUTs the next config. Without the terminal-status
+    carve-out the PUT loses to a microsecond-scale race against the
+    runner finally and 409s spuriously.
+    """
+    config = _load_data_and_config(client, tmp_path)
+
+    job_store = client.app.state.job_store  # type: ignore[union-attr]
+    holder_id = _seed_running_holder(job_store)
+
+    for terminal_status in ("completed", "failed", "cancelled"):
+        holder_job = job_store.get(holder_id)
+        assert holder_job is not None
+        holder_job.status = terminal_status  # type: ignore[assignment]
+        job_store.update(holder_job)
+        # Slot is still held by holder_id at this point — runner finally
+        # has not run yet. The endpoint must still accept the write.
+        res = client.put("/api/workspace/config", json=config)
+        assert res.status_code == 200, (
+            f"PUT /config returned {res.status_code} while holder is "
+            f"{terminal_status} (slot not yet released): {res.text}"
+        )
+        assert res.json()["saved"] is True
+
+    # Cleanup so the next test starts clean.
+    job_store.release_active(holder_id)


### PR DESCRIPTION
## Summary

PR-C1 of the post-#271 smoke 3-PR plan. Closes #279.

While a fit/tune job holds the active slot, `PUT /api/workspace/config` and `PATCH /api/workspace/config` now return **409 `WORKSPACE_LOCKED`** instead of accepting writes that corrupt the running job's `meta.json` and checkpoint. The UI mirrors the lock by disabling Target/Task selectors, Column Settings (Exclude / Num / Cat), and the entire CV section (Strategy / Folds / Random State / Shuffle / Group/Time column / NullableNumberFields) while `running=true`. `BlockedGroupKFoldEditor` uses `<fieldset disabled>` for native HTML form-control inheritance.

`handleConfigChange` and `useConfigSync.syncConfig` handle the new 409 with a dedicated path: quiet `toast.info` + `queryClient.invalidateQueries(queryKeys.config())` so the form resyncs to server truth. The rejected write does not land in `history` and does not get optimistically cached.

## Why

#272 was fixed in the cv-strategy-schema-alignment PR-B work, but the **cross-hook competing-write family** is still alive (#279, #278 residual, #277, the setQueryData→input non-rerender). The smoke surfaced four symptoms with the same root cause: hooks each capture a stale snapshot of `configRef`/cache and fire their own PUT mid-run.

A backend-side lock based on `JobStore.active_job_id` is the **invariant-first** fix: regardless of what the UI does, the running job's config cannot be mutated. The `disabled` propagation makes the lock visible in the UI before the user issues a doomed write.

PR-C2 will continue with the cross-hook write funnel and the setQueryData→input subscription gap (#277 + #278 residual + Folds NumberInput non-rerender on Load Preset).

## Invariants

- **INV-1**: `PUT /api/workspace/config` returns 409 `WORKSPACE_LOCKED` while `active_job_id` is non-null *and* the holder's status is non-terminal; `ws.config` is unchanged.
- **INV-2**: `PATCH /api/workspace/config` has the same semantics.
- **INV-3**: Once the active slot is released, the next `PUT /config` returns 200.
- **INV-3b** (terminal carve-out): even while `active_job_id` is non-null, the lock is bypassed when the holder's status is already terminal (`completed` / `failed` / `cancelled`). Closes the microsecond-scale race between status flip and the runner finally-block's `release_active` call. Without this carve-out, the post-fit re-fit flow (`waitForJobDone` → immediate `PUT`) lost to the slot-release race window and 409'd spuriously — surfaced by the `jobs-refit.spec.ts` E2E.
- **INV-4**: While `running=true`, every Target / Task / Column / CV control in the workspace UI is `disabled`.
- **INV-5**: 409 `WORKSPACE_LOCKED` is handled via a dedicated path (`toast.info` + cache invalidate); not pushed to history; not optimistically cached.

## Failure Paths Covered

- [x] Normal completion (`_training_core.py:186` finally → `release_active`)
- [x] Cancellation (existing cancel-callback path; no change required)
- [x] Exception (same finally block as Normal completion)
- [x] Crash / SIGKILL (`subprocess_runner.py` SIGTERM handler runs `_run_job_core.finally`)
- [x] Status-flip / slot-release race (INV-3b carve-out — added in this PR)
- [ ] Timeout — out of scope (no timeout layer touches `/config`)

## Test Plan

- [x] `tests/regression/test_reg_0279_workspace_locked_during_run.py` — **4 cases**:
  1. `test_put_config_returns_409_when_job_running` (INV-1 + INV-3 no-mutation)
  2. `test_patch_config_returns_409_when_job_running` (INV-2 + INV-3 no-mutation)
  3. `test_put_config_succeeds_after_slot_release` (INV-3)
  4. `test_put_config_succeeds_when_holder_is_terminal_but_slot_not_yet_released` (INV-3b — parametrised over the three terminal statuses)
- [x] `frontend/src/components/workspace/CvSection.runningLock.test.tsx` (5 cases: Strategy / Folds / BlockedGroupKFold disabled propagation, sanity guards)
- [x] `frontend/src/components/workspace/ColumnSettingsSection.test.tsx` `running lock` describe (3 cases: Checkbox / Num / Cat disabled, handlers not invoked)
- [x] `frontend/src/hooks/useModelPanelData.test.ts` 409 handler (cache invalidate, no history push)
- [x] Backend pytest full suite (1214 passed)
- [x] Frontend vitest full suite (1696 passed, 2 skipped)
- [x] `pnpm check` (Biome) clean
- [x] `pnpm build` clean
- [x] `uv run ruff check . && uv run ruff format --check . && uv run mypy src/lizystudio/` clean
- [x] `tests/contract/` (P-0087 invariant) green — no UI schema drift introduced
- [x] OpenAPI types regenerated (`frontend/src/api/generated/schema.d.ts`)
- [x] **CI all green**: backend (3.10 / 3.11), frontend, e2e-chromium (8m8s incl. `jobs-refit.spec.ts`), api-types-drift, backend-quarantine, no-apifetch-guard, raw-color-guard

## Spec / History

- HISTORY.md: P-0089 Proposal & Decision recorded (incl. INV-3b)
- BLUEPRINT.md: no change (existing `JobStore.active_job_id` is reused; no new state machine introduced)
