### PR TITLE
fix(workspace): close cross-hook competing-write race + setQueryData input back-sync (P-0090, #278 residual)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2503,3 +2503,41 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (g) `frontend/src/api/generated/schema.d.ts` が regenerate 済み（`/api/workspace/config` の 409 response に新 error envelope が出る）。
 - **Decision:**
   - 2026-04-28 **Proposed & Implemented** — PR-C1 として merge 予定。Issue #279 を close。Issue #277 / #278 残課題 / setQueryData→input race は PR-C2 にて continue。
+
+### P-0090: cross-hook 競合書き込みの構造的解消（Issue #278 残課題, PR-C2）
+- **Status:** proposed & implemented
+- **Scope:** Frontend / Testing
+- **Related:** Issue #278（CV strategy radios for BlockedGroup / TimeSeries / GroupKFold are silently rejected — UI state diverges from backend）の残課題、Issue #279（PR-C1 で running lock 化済み）、setQueryData→controlled-input non-rerender（PR-A の post-#271 smoke で観測された Folds NumberInput stuck-at-8 after Load Preset）、P-0089（PR-C1 running lock）。Issue #277（FeatureWeightsEditor first-toggle）は PR-C3 にて別途対応。
+- **Context:** PR-C1（P-0089）でサーバ invariant が確立したため、走行中ジョブの config 破壊は構造的に防げるようになった。一方、走行中でないときの**クライアント側 cross-hook 競合書き込み**は残存しており、symptom として:
+  - **#278 残課題**: ユーザが GroupKFold / TimeSeries / GroupTimeSeries の radio を click → `useConfigSync` が正しい payload (`split.method=group_kfold`) で PUT を発火 → `useModelPanelData.handleConfigChange` 経由で ConfigForm の `inner_valid` reset effect / `calibration` auto-clear effect が**古い**キャッシュ snapshot から `setNestedValue` を計算 → 別 PUT が `split.method=stratified_kfold` で上書き → server 状態が radio click 前に巻き戻る。
+  - **setQueryData → controlled-input non-rerender**: handleLoadPreset 経由で cache に `split.n_splits=5` が書かれても、`useDataPanel` の local `cv.folds` は preset Load 前の値（例: 8）のまま。Folds NumberInput はそれにバインドしているのでページリロードまで再描画されない。
+  
+  両者の root cause は同じ: **`useConfigSync` の PUT 後の cache 更新が非対称**（`onDataChanged` 経由の `invalidateQueries` で eventual fetch を待つだけで、`setQueryData` で即時反映していない）。これにより ConfigForm が PR-C1 と同様の race window で古い snapshot を見て競合 PUT を撃つ。さらに `useDataPanel.cv` は cache に subscribe していないので外部書き込みを受け取れない。
+- **Invariants:**
+  - INV-1: `useConfigSync.syncConfig` は `await updateConfig(merged)` 成功時、`onDataChanged()` の前に `queryClient.setQueryData(queryKeys.config(), merged)` を呼ぶ。これにより ConfigForm の次 render が merged config を見て、stale-snapshot effects が no-op 化または正しい上書き構成に変化する。
+  - INV-2: `updateConfig` が失敗（reject / abort）した場合は `setQueryData` を呼ばない（partial cache 汚染の防止）。
+  - INV-3: `useDataPanel` は `queryKeys.config()` cache に subscribe し、外部書き込み（preset Load / undo / useConfigSync の新 setQueryData path）が起きたら `parseSplitToCv` で local `cv` を reconcile する。差分があるフィールドのみ更新し、全一致なら no-op（render 抑制）。
+  - INV-4: back-sync effect は cache の echo（自分の syncConfig が書いた値）でも fire するが、parseSplitToCv → 差分チェックで no-op になり、PUT の無限ループは発生しない。
+  - INV-5: `parseSplitToCv` は wire format（snake_case fields）→ CvState（camelCase）の対称な逆変換で、`buildSplitConfig` が emit するすべてのフィールドを read 可能。
+- **Proposal & Impact:**
+  - `frontend/src/hooks/useConfigSync.ts`: `useQueryClient` を追加し、`syncConfig` の `await updateConfig(merged)` 成功直後に `queryClient.setQueryData(queryKeys.config(), merged)` を呼ぶ。エラーパスは現状維持（cache 不変）。
+  - `frontend/src/components/workspace/cv-state.ts`: `parseSplitToCv(split, data)` 関数を新規追加。`buildSplitConfig` の wire format 出力を `Partial<CvState>` に逆変換。`split.blocks.col` / `split.groups.col` / `data.group_col` / `data.time_col` も含む。
+  - `frontend/src/hooks/useDataPanel.ts`: `useQueryClient` + `useEffect` で `QueryCache.subscribe()` し、`queryKeys.config()` の更新 event で `parseSplitToCv` の出力を局所 `cv` state にマージ（差分があるフィールドだけ）。`cvRef` で stale closure 回避。
+  - `frontend/src/hooks/useConfigSync.test.ts`: `QueryClientProvider` wrapper を追加し、既存の renderHook 呼び出しを wrapper 付きに移行（13 件）。新規 describe `setQueryData cache update on success (#278 residual)` で 2 ケース追加（成功時に cache が書かれる / 失敗時に cache が書かれない）。
+  - `frontend/src/hooks/useDataPanel.test.ts`: 新規 describe `back-sync from config cache` で 3 ケース追加（n_splits 更新 → cv.folds 更新 / strategy 更新 → cv.strategy 更新 / 更新が PUT を発火しないこと）。
+- **Compatibility:**
+  - API: 変更なし（クライアント側 only）。
+  - UI: 既存の編集フローは不変。Preset Load 後に Folds 入力が即時更新されるようになる（regression ではなく fix）。
+  - State machine: `useDataPanel.cv` の局所 state が cache の従属に近づくが、ユーザ入力は依然として setCv 経由で先に local state を更新（その後 useConfigSync が PUT → setQueryData → cache → back-sync → no-op）。illegal な書き戻しループは差分チェックで防止。
+- **Alternatives considered:**
+  - (A) ConfigForm の effects（inner_valid reset, calibration auto-clear）から `configRef.current` を読まず、毎回 cache を再取得: 却下。configRef は stale-write 防止で導入された設計（HIGH-5）で、外すと別の race を再発させる。
+  - (B) `useConfigSync` 経由ではなく、ConfigForm の effects 自体を `useConfigSync.syncConfig` に集約: refactor が大きく PR-C2 のスコープを超える。スキーマ・field-renderer 側に effects が分散しているので、まず cache の対称化で症状を消すほうが Reach/Effort 比が高い。
+  - (C) `useDataPanel` で `useConfig({ enabled: false })` を subscribe: TanStack 上は等価だが、observer が増えると `useConfig` の `enabled` トグル時に再検証が走る等の副作用があるため、`QueryCache.subscribe()` で event-only 購読のほうが副作用最小。
+- **Acceptance Criteria:**
+  - (a) `frontend/src/hooks/useConfigSync.test.ts` の `setQueryData cache update on success` 2 ケースが pass（INV-1, INV-2）。
+  - (b) `frontend/src/hooks/useDataPanel.test.ts` の `back-sync from config cache` 3 ケースが pass（INV-3, INV-4）。
+  - (c) 既存の vitest / pytest / ruff / biome / mypy / pnpm build がすべて green（regression なし）。
+  - (d) Manual smoke: Tune 未走行の状態で BlockedGroupKFold radio を click → 1 click で `split.method=blocked_group_kfold` が server に lands し、ConfigForm の表示も追従する（再 click 不要）。
+  - (e) Manual smoke: Load Preset で `n_splits=5` の preset を読み込むと、Folds NumberInput が即時に 5 表示になる（reload 不要）。
+- **Decision:**
+  - 2026-04-28 **Proposed & Implemented** — PR-C2 として merge 予定。Issue #278 残課題を close。Issue #277 (FeatureWeightsEditor first-toggle) は initial-value handling の別問題なので PR-C3 で対応。

--- a/frontend/src/components/workspace/cv-state.ts
+++ b/frontend/src/components/workspace/cv-state.ts
@@ -294,3 +294,55 @@ export function applyCvDataFields(
   }
   return result;
 }
+
+/** Inverse of {@link buildSplitConfig} — read the CvState slice that an
+ * external write has stored in the cached config back into local state.
+ *
+ * Used by ``useDataPanel`` (P-0090 / Issue #278 residual) to reconcile
+ * its controlled inputs with the TanStack Query cache after preset
+ * Load, undo/redo, or any other path that writes to ``queryKeys.config()``
+ * without going through the normal user-edit flow. The function returns
+ * a partial CvState — only fields that are present in the input ``split``
+ * are returned, so callers can spread the result onto their existing
+ * state without erasing fields that the cached config does not declare.
+ */
+export function parseSplitToCv(
+  split: Record<string, unknown> | undefined | null,
+  data?: Record<string, unknown> | undefined | null,
+): Partial<CvState> {
+  if (!split) return {};
+  const out: Partial<CvState> = {};
+  if (typeof split.method === "string") out.strategy = split.method;
+  if (typeof split.n_splits === "number") out.folds = split.n_splits;
+  if (typeof split.random_state === "number")
+    out.randomState = split.random_state;
+  if (typeof split.shuffle === "boolean") out.shuffle = split.shuffle;
+  if (typeof split.gap === "number") out.gap = split.gap;
+  if (typeof split.purge_gap === "number") out.purgeGap = split.purge_gap;
+  if (typeof split.embargo === "number") out.embargo = split.embargo;
+  if (typeof split.train_size_max === "number")
+    out.trainSizeMax = split.train_size_max;
+  if (typeof split.test_size_max === "number")
+    out.testSizeMax = split.test_size_max;
+  if (typeof split.min_train_rows === "number")
+    out.minTrainRows = split.min_train_rows;
+  if (typeof split.min_valid_rows === "number")
+    out.minValidRows = split.min_valid_rows;
+  // group_col / time_col live in `data` for non-blocked strategies and
+  // inside split.blocks/groups for blocked_group_kfold (handled by a
+  // dedicated parser if needed). Read from data here so the simple
+  // cases — Load Preset on a kfold/group_kfold/time_series config —
+  // resync the column dropdowns too.
+  if (data) {
+    if (typeof data.group_col === "string") out.groupCol = data.group_col;
+    if (typeof data.time_col === "string") out.timeCol = data.time_col;
+  }
+  // BlockedGroupKFold: read the nested split.blocks/groups col fields
+  // when present so the editor shows what was loaded. The full
+  // BlockedGroupKFoldState (cutoffs etc.) is parsed by a separate path.
+  const blocks = split.blocks as Record<string, unknown> | undefined;
+  const groups = split.groups as Record<string, unknown> | undefined;
+  if (typeof blocks?.col === "string") out.timeCol = blocks.col;
+  if (typeof groups?.col === "string") out.groupCol = groups.col;
+  return out;
+}

--- a/frontend/src/hooks/useConfigSync.test.ts
+++ b/frontend/src/hooks/useConfigSync.test.ts
@@ -1,4 +1,6 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -28,10 +30,23 @@ vi.mock("sonner", () => ({
   },
 }));
 
+import { queryKeys } from "@/api/queryKeys";
 import { INITIAL_BLOCKED_STATE } from "@/components/workspace/BlockedGroupKFoldEditor";
 import { INITIAL_CV_STATE } from "@/components/workspace/cv-state";
 import { useConfigSync } from "./useConfigSync";
 import type { ColumnOverride, TaskType } from "./useDataPanel.types";
+
+function makeQueryWrapper() {
+  // gcTime > 0 so setQueryData survives long enough for assertions; the
+  // hook under test has no observer for queryKeys.config() so a 0-gcTime
+  // would tombstone the entry immediately on insert.
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 60_000 } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { queryClient, wrapper };
+}
 
 function defaultParams(
   partial: Partial<Parameters<typeof useConfigSync>[0]> = {},
@@ -65,29 +80,38 @@ const defaultsConfig = {
 };
 
 describe("useConfigSync", () => {
+  let testWrapper: ReturnType<typeof makeQueryWrapper>;
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.fetchConfig.mockResolvedValue(baseConfig);
     mocks.fetchConfigDefaults.mockResolvedValue(defaultsConfig);
     mocks.updateConfig.mockResolvedValue({});
+    testWrapper = makeQueryWrapper();
   });
 
   it("returns the public API shape", () => {
-    const { result } = renderHook(() => useConfigSync(defaultParams()));
+    const { result } = renderHook(() => useConfigSync(defaultParams()), {
+      wrapper: testWrapper.wrapper,
+    });
     expect(result.current.syncConfig).toBeInstanceOf(Function);
     expect(result.current.setSyncSuppressed).toBeInstanceOf(Function);
     expect(result.current.preseedSyncKey).toBeInstanceOf(Function);
   });
 
   it("skips sync when target is null", () => {
-    renderHook(() => useConfigSync(defaultParams({ target: null })));
+    renderHook(() => useConfigSync(defaultParams({ target: null })), {
+      wrapper: testWrapper.wrapper,
+    });
     expect(mocks.fetchConfig).not.toHaveBeenCalled();
     expect(mocks.updateConfig).not.toHaveBeenCalled();
   });
 
   it("runs sync on mount when target is set and writes the merged config", async () => {
     const onDataChanged = vi.fn();
-    renderHook(() => useConfigSync(defaultParams({ onDataChanged })));
+    renderHook(() => useConfigSync(defaultParams({ onDataChanged })), {
+      wrapper: testWrapper.wrapper,
+    });
 
     await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalledTimes(1));
     const [payload] = mocks.updateConfig.mock.calls[0];
@@ -99,7 +123,9 @@ describe("useConfigSync", () => {
 
   it("falls back to fetchConfigDefaults when the existing config lacks config_version", async () => {
     mocks.fetchConfig.mockResolvedValue({ data: {}, features: {} });
-    renderHook(() => useConfigSync(defaultParams()));
+    renderHook(() => useConfigSync(defaultParams()), {
+      wrapper: testWrapper.wrapper,
+    });
 
     await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalled());
     expect(mocks.fetchConfigDefaults).toHaveBeenCalledWith("binary", "y");
@@ -107,7 +133,10 @@ describe("useConfigSync", () => {
 
   it("skips the defaults fallback when task or target is missing and config has no version", async () => {
     mocks.fetchConfig.mockResolvedValue({ data: {}, features: {} });
-    renderHook(() => useConfigSync(defaultParams({ task: null, target: "y" })));
+    renderHook(
+      () => useConfigSync(defaultParams({ task: null, target: "y" })),
+      { wrapper: testWrapper.wrapper },
+    );
 
     // target is set so sync still runs, but fetchConfigDefaults requires
     // both task and target — so it must not be called.
@@ -121,7 +150,9 @@ describe("useConfigSync", () => {
       region: { excluded: false, type: "categorical" },
       leaky: { excluded: true, type: "numeric" },
     };
-    renderHook(() => useConfigSync(defaultParams({ overrides })));
+    renderHook(() => useConfigSync(defaultParams({ overrides })), {
+      wrapper: testWrapper.wrapper,
+    });
 
     await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalled());
     const [payload] = mocks.updateConfig.mock.calls[0];
@@ -131,7 +162,9 @@ describe("useConfigSync", () => {
 
   it("does not re-run sync when inputs are unchanged between renders", async () => {
     const params = defaultParams();
-    const { rerender } = renderHook(() => useConfigSync(params));
+    const { rerender } = renderHook(() => useConfigSync(params), {
+      wrapper: testWrapper.wrapper,
+    });
     await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalledTimes(1));
 
     rerender();
@@ -148,7 +181,7 @@ describe("useConfigSync", () => {
     const { rerender, result } = renderHook(
       ({ params }: { params: ReturnType<typeof defaultParams> }) =>
         useConfigSync(params),
-      { initialProps: { params: initialParams } },
+      { initialProps: { params: initialParams }, wrapper: testWrapper.wrapper },
     );
     await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalledTimes(1));
 
@@ -164,7 +197,10 @@ describe("useConfigSync", () => {
     const { result, rerender } = renderHook(
       ({ params }: { params: ReturnType<typeof defaultParams> }) =>
         useConfigSync(params),
-      { initialProps: { params: defaultParams({ target: null }) } },
+      {
+        initialProps: { params: defaultParams({ target: null }) },
+        wrapper: testWrapper.wrapper,
+      },
     );
 
     // Pre-seed the sync key to match what the effect would compute
@@ -184,7 +220,9 @@ describe("useConfigSync", () => {
 
   it("reports an error toast when updateConfig throws a non-AbortError", async () => {
     mocks.updateConfig.mockRejectedValue(new Error("500 server"));
-    renderHook(() => useConfigSync(defaultParams()));
+    renderHook(() => useConfigSync(defaultParams()), {
+      wrapper: testWrapper.wrapper,
+    });
 
     await waitFor(() =>
       expect(mocks.toastError).toHaveBeenCalledWith(
@@ -196,10 +234,48 @@ describe("useConfigSync", () => {
   it("swallows AbortError silently (no toast)", async () => {
     const abort = new DOMException("aborted", "AbortError");
     mocks.fetchConfig.mockRejectedValueOnce(abort);
-    renderHook(() => useConfigSync(defaultParams()));
+    renderHook(() => useConfigSync(defaultParams()), {
+      wrapper: testWrapper.wrapper,
+    });
 
     // Give the async handler a chance to run.
     await new Promise((r) => setTimeout(r, 10));
     expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // P-0090 / Issue #278 residual: useConfigSync must update the TanStack
+  // Query cache atomically with its successful PUT, not only invalidate via
+  // onDataChanged. Otherwise ConfigForm's stale-snapshot effects (inner_valid
+  // reset, calibration auto-clear) read the pre-PUT cache, recompute against
+  // the old `split.method`, and fire a competing PUT through
+  // useModelPanelData.handleConfigChange that reverts the user's strategy
+  // change. setQueryData closes the race window structurally — ConfigForm
+  // sees the merged config on the very next render, so its effects either
+  // no-op (no inconsistency) or compose correctly on top of the new state.
+  // -------------------------------------------------------------------------
+  describe("setQueryData cache update on success (#278 residual)", () => {
+    it("writes the merged config to the React Query cache after a successful PUT", async () => {
+      const { queryClient, wrapper } = testWrapper;
+      renderHook(() => useConfigSync(defaultParams()), { wrapper });
+
+      await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalledTimes(1));
+      const [payload] = mocks.updateConfig.mock.calls[0];
+      expect(queryClient.getQueryData(queryKeys.config())).toEqual(payload);
+    });
+
+    it("does not pollute the cache when updateConfig rejects", async () => {
+      mocks.updateConfig.mockRejectedValue(new Error("boom"));
+      const { queryClient, wrapper } = testWrapper;
+      renderHook(() => useConfigSync(defaultParams()), { wrapper });
+
+      await waitFor(() =>
+        expect(mocks.toastError).toHaveBeenCalledWith(
+          "Config sync failed — changes may not be saved",
+        ),
+      );
+      // No setQueryData on failure — cache must remain untouched.
+      expect(queryClient.getQueryData(queryKeys.config())).toBeUndefined();
+    });
   });
 });

--- a/frontend/src/hooks/useConfigSync.ts
+++ b/frontend/src/hooks/useConfigSync.ts
@@ -1,7 +1,9 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { ApiError } from "@/api/client";
 import { isStudioError } from "@/api/errors";
+import { queryKeys } from "@/api/queryKeys";
 import type { UiSchema } from "@/api/types";
 import {
   fetchConfig,
@@ -38,6 +40,7 @@ export function useConfigSync({
   uiSchema,
   onDataChanged,
 }: UseConfigSyncParams) {
+  const queryClient = useQueryClient();
   const abortRef = useRef<AbortController | null>(null);
   const prevCvStrategyRef = useRef<string>(cv.strategy);
   const skipNextSyncRef = useRef(false);
@@ -102,6 +105,18 @@ export function useConfigSync({
       }
       await updateConfig(merged, { signal: controller.signal });
       if (controller.signal.aborted) return;
+      // P-0090 / Issue #278 residual: write the merged config to the
+      // cache atomically with the PUT so ConfigForm's stale-snapshot
+      // effects (inner_valid reset, calibration auto-clear) don't race
+      // a second PUT through useModelPanelData.handleConfigChange that
+      // reverts the user's just-applied CV strategy or task. Without
+      // this setQueryData, ConfigForm reads the pre-PUT cache, computes
+      // setNestedValue against the OLD split.method, and the resulting
+      // PUT silently overwrites the user's intent. Updating the cache
+      // here means ConfigForm's next render sees the merged config and
+      // its effects either no-op (already consistent) or compose
+      // correctly on top of the new state.
+      queryClient.setQueryData(queryKeys.config(), merged);
       onDataChanged();
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
@@ -130,6 +145,7 @@ export function useConfigSync({
     blocked,
     strategyFields,
     onDataChanged,
+    queryClient,
   ]);
 
   // H-0076: key suffix that makes the dedup guard resync when

--- a/frontend/src/hooks/useDataPanel.test.ts
+++ b/frontend/src/hooks/useDataPanel.test.ts
@@ -369,6 +369,89 @@ describe("useDataPanel", () => {
 
     expect(result.current.cv.strategy).toBe("time_series");
   });
+
+  // -------------------------------------------------------------------------
+  // P-0090 / Issue #278 residual: when an external write updates the cached
+  // config (e.g. handleLoadPreset → setQueryData with n_splits=5), the
+  // controlled inputs in CvSection must re-render to the new value. The
+  // inputs are bound to useDataPanel's local `cv` state, which has no
+  // subscription to the config cache, so without an explicit back-sync the
+  // Folds NumberInput stays stuck at the pre-preset value (8) until a full
+  // page reload re-derives the state. The hook subscribes to the
+  // queryKeys.config() cache and reconciles cv.folds / cv.strategy / etc.
+  // when the cache value diverges from local state.
+  // -------------------------------------------------------------------------
+  describe("back-sync from config cache (#278 residual / setQueryData input race)", () => {
+    it("updates cv.folds when an external setQueryData writes a new n_splits", async () => {
+      const { wrapper, queryClient } = createWrapper();
+      const { result } = renderHook(
+        () => useDataPanel({ onDataChanged: vi.fn() }),
+        { wrapper },
+      );
+
+      // Initial state: defaults — folds=5 (per CV_FIELD_DEFAULTS).
+      expect(result.current.cv.folds).toBe(5);
+
+      // Simulate an external write (e.g. preset Load or
+      // useConfigSync's new setQueryData path) that drops a new
+      // config into the TanStack Query cache.
+      act(() => {
+        queryClient.setQueryData(queryKeys.config(), {
+          config_version: 1,
+          task: "binary",
+          split: { method: "stratified_kfold", n_splits: 8, random_state: 42 },
+        });
+      });
+
+      await waitFor(() => expect(result.current.cv.folds).toBe(8));
+      expect(result.current.cv.strategy).toBe("stratified_kfold");
+    });
+
+    it("updates cv.strategy when external config switches the CV method", async () => {
+      const { wrapper, queryClient } = createWrapper();
+      const { result } = renderHook(
+        () => useDataPanel({ onDataChanged: vi.fn() }),
+        { wrapper },
+      );
+
+      act(() => {
+        queryClient.setQueryData(queryKeys.config(), {
+          config_version: 1,
+          task: "regression",
+          split: { method: "time_series", n_splits: 4 },
+        });
+      });
+
+      await waitFor(() =>
+        expect(result.current.cv.strategy).toBe("time_series"),
+      );
+      expect(result.current.cv.folds).toBe(4);
+    });
+
+    it("does not write back to the cache when reconciling from external state", async () => {
+      const { wrapper, queryClient } = createWrapper();
+      renderHook(() => useDataPanel({ onDataChanged: vi.fn() }), { wrapper });
+
+      // Reset call count so we observe only post-back-sync writes.
+      mocks.updateConfig.mockClear();
+
+      act(() => {
+        queryClient.setQueryData(queryKeys.config(), {
+          config_version: 1,
+          task: "binary",
+          split: { method: "kfold", n_splits: 7 },
+        });
+      });
+
+      // Allow the back-sync effect to run and any erroneous useConfigSync
+      // re-fire to settle.
+      await new Promise((r) => setTimeout(r, 30));
+      // Back-sync must not echo the cached value back to the server —
+      // that would loop infinitely. Without target set the sync effect
+      // is gated, so updateConfig should remain at zero calls.
+      expect(mocks.updateConfig).not.toHaveBeenCalled();
+    });
+  });
 });
 
 // --- Issue #128: pure helper unit tests ---

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -1,4 +1,6 @@
-import { useCallback, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { queryKeys } from "@/api/queryKeys";
 import type { ColumnInfo, UiSchema } from "@/api/types";
 import {
   type BlockedGroupKFoldState,
@@ -8,6 +10,7 @@ import {
   type CvState,
   getEffectiveCvStrategy,
   INITIAL_CV_STATE,
+  parseSplitToCv,
   resetCvState,
 } from "@/components/workspace/cv-state";
 import { useColumnOverrides } from "./useColumnOverrides";
@@ -105,6 +108,57 @@ export function useDataPanel({
     },
     [onTaskChanged, uiSchema],
   );
+
+  // P-0090 / Issue #278 residual: subscribe to the cached config and
+  // back-sync local cv/blocked state whenever an external write
+  // (handleLoadPreset, undo/redo, useConfigSync's new setQueryData
+  // path) drops a different value into the cache. Without this the
+  // controlled inputs in CvSection stay pinned to the pre-external-
+  // write snapshot and only resync on a full page reload.
+  //
+  // The subscription is via QueryCache.subscribe() so we observe
+  // updates without triggering a fetch (the cache is read-only here).
+  // A signature ref guards against the obvious feedback loop where
+  // useConfigSync's PUT-then-setQueryData echoes back into setCv —
+  // we only call setCv when the parsed split actually differs from
+  // current local state.
+  const queryClient = useQueryClient();
+  const cvRef = useRef(cv);
+  cvRef.current = cv;
+  useEffect(() => {
+    const cache = queryClient.getQueryCache();
+    const reconcile = () => {
+      const cached = queryClient.getQueryData<Record<string, unknown>>(
+        queryKeys.config(),
+      );
+      if (!cached) return;
+      const split = cached.split as Record<string, unknown> | undefined;
+      const data = cached.data as Record<string, unknown> | undefined;
+      const parsed = parseSplitToCv(split, data);
+      if (Object.keys(parsed).length === 0) return;
+      const current = cvRef.current as unknown as Record<string, unknown>;
+      // Only update fields that actually differ — bail if everything
+      // matches so we never trigger an unnecessary render.
+      let changed = false;
+      const next: Record<string, unknown> = { ...current };
+      for (const [k, v] of Object.entries(parsed)) {
+        if (current[k] !== v) {
+          next[k] = v;
+          changed = true;
+        }
+      }
+      if (changed) setCv(next as unknown as CvState);
+    };
+    // Initial reconcile in case the cache is already populated when
+    // this effect mounts (e.g. after Load Preset in another panel).
+    reconcile();
+    const unsubscribe = cache.subscribe((event) => {
+      if (event.type === "updated" && event.query.queryKey[0] === "config") {
+        reconcile();
+      }
+    });
+    return unsubscribe;
+  }, [queryClient]);
 
   return {
     sourceType: dataLoad.sourceType,


### PR DESCRIPTION
## Summary

PR-C2 of the post-#271 smoke 3-PR plan. Closes residual scope of #278 and the setQueryData→input non-rerender race observed in PR-A's manual smoke. PR-C1 (#282, P-0089) handled #279 with the running lock; this PR addresses the cross-hook competing-write family that remains *outside* the running lock — i.e. when no job is active.

Two structural fixes:

### 1. `useConfigSync` cache update on success (#278 residual)

After `await updateConfig(merged)`, the hook now calls `queryClient.setQueryData(queryKeys.config(), merged)` atomically before `onDataChanged()`. This closes the race where ConfigForm's stale-snapshot effects (inner_valid reset, calibration auto-clear) read the pre-PUT cache, recompute against the OLD `split.method`, and fire a competing PUT through `useModelPanelData.handleConfigChange` that silently reverts the user's just-applied CV strategy or task.

Concrete repro before this PR:
1. User clicks **GroupKFold** radio in CvSection.
2. `useConfigSync` PUTs `split.method=group_kfold` ✅
3. `onDataChanged` invalidates the cache → background refetch starts.
4. Before the refetch lands, ConfigForm re-renders with the OLD cached config and its `inner_valid` reset effect computes `setNestedValue(staleConfig, ...)` — staleConfig has `split.method=stratified_kfold`.
5. The effect's `onChange` reaches `useModelPanelData.handleConfigChange`, which PUTs the WHOLE staleConfig with the inner_valid tweak.
6. Server now has `split.method=stratified_kfold`. User's intent silently reverted.

After this PR, ConfigForm's next render sees the merged config (`split.method=group_kfold`) directly from cache, so its effects either no-op (already consistent) or compose correctly on top of the new state.

### 2. `useDataPanel` back-sync from config cache (setQueryData→input race)

A `QueryCache.subscribe()` effect reconciles local `cv` state with external cache writes (handleLoadPreset, undo/redo, useConfigSync's new setQueryData path). The Folds NumberInput no longer stays stuck at the pre-preset value (e.g. 8) after Load Preset writes `n_splits=5` — `parseSplitToCv` extracts the wire-format slice, a diff check prevents render thrash and PUT echo-loops, and a `cvRef` avoids stale-closure issues.

A new `parseSplitToCv(split, data)` helper in `cv-state.ts` is the symmetric inverse of `buildSplitConfig` — it reads every field the build side emits, including the BlockedGroupKFold nested `blocks.col` / `groups.col` and the data-level `group_col` / `time_col`.

## Why these belong together

Same root cause: **asymmetric cache update**. `useModelPanelData.handleConfigChange` already does `setQueryData(merged)` on success, but `useConfigSync.syncConfig` only invalidates via `onDataChanged`. The two paths write to the same backend through different cache contracts, so any time the two hooks share state (CV strategy, target, task), the cache lags and downstream effects race against eventual consistency. INV-1 fixes the producer (writer); INV-3 fixes the consumer (reader) so a single canonical invariant — *the cache mirrors server state immediately after a write* — is restored across the workspace.

#277 (FeatureWeightsEditor first-toggle) is **not** in this PR. Its symptom traces to initial-value handling on the editor side, not cross-hook racing. Deferred to PR-C3.

## Invariants

- **INV-1**: `useConfigSync.syncConfig` calls `queryClient.setQueryData(queryKeys.config(), merged)` after a successful `updateConfig(merged)`, before `onDataChanged()`.
- **INV-2**: `setQueryData` is NOT called when `updateConfig` rejects (no partial cache pollution).
- **INV-3**: `useDataPanel` subscribes to `queryKeys.config()` and reconciles local `cv` via `parseSplitToCv` whenever the cache value diverges from local state.
- **INV-4**: Back-sync diff-checks every field. No `setCv` when nothing changed → no infinite PUT loop when `useConfigSync` writes its own merged config back.
- **INV-5**: `parseSplitToCv` reads every field that `buildSplitConfig` emits (perfect symmetry; a future field added on the build side without a parser update gets caught by the existing snapshot tests).

## Failure Paths Covered

- [x] Successful PUT → cache mirrors merged config (INV-1)
- [x] Rejected PUT → cache untouched (INV-2)
- [x] External `setQueryData` (preset Load, undo, useConfigSync echo) → local `cv` reconciles (INV-3)
- [x] Echo loop (own setQueryData → back-sync subscription → setCv) → no-op via diff check (INV-4)
- [ ] Concurrent rapid edits during preset Load — out of scope (PR-C1 running lock covers job-active concurrency; rapid-edit non-running race is not in scope here, deferred to PR-C3 if observed)

## Test Plan

- [x] `frontend/src/hooks/useConfigSync.test.ts` — `setQueryData cache update on success (#278 residual)` describe (2 cases):
  - Writes the merged config to the cache after a successful PUT.
  - Does not pollute the cache when `updateConfig` rejects.
- [x] All 11 existing useConfigSync tests migrated to `QueryClientProvider` wrapper (no behavioural changes).
- [x] `frontend/src/hooks/useDataPanel.test.ts` — `back-sync from config cache (#278 residual / setQueryData input race)` describe (3 cases):
  - Updates `cv.folds` when an external write changes `n_splits`.
  - Updates `cv.strategy` when external config switches the CV method.
  - Does not echo cached values back to the server (no infinite loop).
- [x] Backend pytest full suite (1215 passed)
- [x] Frontend vitest full suite (1701 passed, 2 skipped)
- [x] `pnpm check` (Biome) clean
- [x] `pnpm build` clean
- [x] `uv run ruff check . && uv run ruff format --check . && uv run mypy src/lizystudio/` clean
- [x] `tests/contract/` (P-0087 invariant) green — no UI schema drift introduced
- [x] OpenAPI types unchanged (frontend-only PR)

## Spec / History

- HISTORY.md: P-0090 Proposal & Decision recorded.
- BLUEPRINT.md: no change (no new state machine; `useDataPanel.cv` semantics unchanged from the user's perspective — back-sync only resolves an existing inconsistency).
