### PR TITLE
fix(workspace): exclude target + features.exclude from FeatureWeightsEditor picker (P-0091, #277)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2541,3 +2541,37 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (e) Manual smoke: Load Preset で `n_splits=5` の preset を読み込むと、Folds NumberInput が即時に 5 表示になる（reload 不要）。
 - **Decision:**
   - 2026-04-28 **Proposed & Implemented** — PR-C2 として merge 予定。Issue #278 残課題を close。Issue #277 (FeatureWeightsEditor first-toggle) は initial-value handling の別問題なので PR-C3 で対応。
+
+### P-0091: FeatureWeightsEditor の `nonExcludedColumns` から target / 除外 features を除く（Issue #277, PR-C3）
+- **Status:** proposed & implemented
+- **Scope:** Frontend / Testing
+- **Related:** Issue #277（FeatureWeightsEditor: editor body not rendered on first toggle ON; columns prop empty so 'Add feature' never appears）、P-0089（PR-C1 running lock）、P-0090（PR-C2 cross-hook race fix）
+- **Context:** post-#271 smoke で報告された 2 つの症状のうち、(1) "first toggle ON does not expand the editor body" は PR-C2 (P-0090) の `useConfigSync.setQueryData` で解消済み（実機 Playwright 検証済）。残る (2) "columns prop empty so 'Add feature' never appears" は実際には**逆**で、`nonExcludedColumns` に target column （Survived 等）と user-excluded features までが含まれている状態だった。これにより:
+  - FeatureWeightsEditor の "Add feature" picker に target column が candidate として表示され、ユーザが target に weight を割り当ててしまう（無意味な操作で backend に reject される）。
+  - Column Settings で除外した features も Picker に表示され、weight を付けても backend が無視する dead-end UX。
+  
+  根本原因は `useModelPanelData.useColumns({ enabled: hasData })` が target を渡さず `fetchColumns()` を呼ぶため、backend の `analyze_columns` が target を含めた全 column を返すこと。さらに `nonExcludedColumns` の filter は `suggested_excluded` のみで、target / `features.exclude` は filter していなかった。
+- **Invariants:**
+  - INV-1: `useModelPanelData.nonExcludedColumns` は `cached config.data.target` に一致する column を必ず除く。
+  - INV-2: `nonExcludedColumns` は `cached config.features.exclude` に列挙された column も除く。
+  - INV-3: `cached config` が未 seed（`config_version` なし、`data` なし）の場合、`suggested_excluded` のみによる従来の filter にフォールバックする（regression なし）。
+  - INV-4: 上記の filter 順序は冪等で、各 filter は集合演算（差集合）として可換に振る舞う。
+- **Proposal & Impact:**
+  - `frontend/src/hooks/useModelPanelData.ts`: `nonExcludedColumns` の `useMemo` を拡張。`config?.data?.target` で target を、`config?.features?.exclude` (Array) で user-excluded を除外。`config` を deps に追加。
+  - `frontend/src/hooks/useModelPanelData.test.ts`: 新規 describe `nonExcludedColumns filters target + features.exclude (#277)` で 3 case 追加（target filter、features.exclude filter、未 seed 時のフォールバック）。
+  - 上位の Issue #277 における "first toggle empty body" は P-0090 で構造的に解消済みのため、PR-C3 では新たな修正は不要（実機 Playwright で確認、本 Proposal の context に記録）。
+- **Compatibility:**
+  - API: 変更なし。
+  - UI: FeatureWeightsEditor の "Add feature" picker から target / user-excluded features が消える（regression ではなく仕様準拠化）。
+  - Backend: 変更なし。`fetchColumns()` の signature は既に `target?: string` を受け付けるが、PR-C3 では client-side filter のみで対処（`useColumns` cache key を target で複雑化しない方針）。将来的に target-aware cache が必要になれば別 PR で。
+- **Alternatives considered:**
+  - (A) `useColumns` を target-aware にして cache key に含める: client-side filter より厳密だが、cache key が target 変更で完全に invalidate されるため、target を変えるたびに full re-fetch が走る。target は頻繁に変わらないので overhead は小さいが、現状の client-side filter で十分な情報量があり追加実装は不要と判断。
+  - (B) Backend `analyze_columns` を呼ぶたびに target を渡すよう `useColumns` の signature を変える: 同上、client-side filter で十分。
+  - (C) `nonExcludedColumns` を `useColumnOverrides.nonExcludedCols` (Data 側の既存 helper) に統合: Model 側と Data 側で `target` の保持位置が異なる（Data: useDataPanel.target / Model: cached config.data.target）。SoT を分けるほうがレイヤ設計として clean。
+- **Acceptance Criteria:**
+  - (a) `useModelPanelData.test.ts` の `nonExcludedColumns filters target + features.exclude (#277)` 3 case が pass（INV-1, INV-2, INV-3）。
+  - (b) 既存の `nonExcludedColumns` test が引き続き pass（regression なし）。
+  - (c) frontend vitest / biome / build / backend pytest / ruff / mypy がすべて green。
+  - (d) Manual smoke: target=Survived の状態で Feature Weights を ON にし、"Add feature" picker に Survived が **含まれない** ことを確認（実機 Playwright）。
+- **Decision:**
+  - 2026-04-28 **Proposed & Implemented** — PR-C3 として merge 予定。Issue #277 を close。post-#271 smoke 3-PR plan (PR-C1 / PR-C2 / PR-C3) はこれで完了。

--- a/frontend/src/hooks/useModelPanelData.test.ts
+++ b/frontend/src/hooks/useModelPanelData.test.ts
@@ -84,6 +84,98 @@ describe("useModelPanelData", () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // Issue #277 / P-0091: nonExcludedColumns must NOT contain the target
+  // column or any column the user explicitly excluded via Column Settings.
+  // FeatureWeightsEditor consumes this list — if target / excluded columns
+  // leak in, the user can attach a weight to the prediction target or to a
+  // feature the backend ignores, both of which the backend either rejects
+  // at fit-time or silently drops.
+  // -------------------------------------------------------------------------
+  describe("nonExcludedColumns filters target + features.exclude (#277)", () => {
+    it("filters target out when config.data.target is set", async () => {
+      vi.mocked(fetchColumns).mockResolvedValueOnce({
+        columns: [
+          { name: "Pclass", suggested_excluded: false },
+          { name: "Survived", suggested_excluded: false },
+          { name: "Age", suggested_excluded: false },
+        ],
+        // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+      } as any);
+      vi.mocked(fetchConfig).mockResolvedValueOnce({
+        config_version: 1,
+        task: "binary",
+        data: { target: "Survived" },
+        features: { exclude: [], categorical: [] },
+        model: {},
+      });
+
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(
+        () => useModelPanelData({ hasData: true }),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.nonExcludedColumns).toEqual(["Pclass", "Age"]);
+      });
+    });
+
+    it("filters columns listed in config.features.exclude", async () => {
+      vi.mocked(fetchColumns).mockResolvedValueOnce({
+        columns: [
+          { name: "Pclass", suggested_excluded: false },
+          { name: "Ticket", suggested_excluded: false },
+          { name: "Cabin", suggested_excluded: false },
+          { name: "Age", suggested_excluded: false },
+        ],
+        // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+      } as any);
+      vi.mocked(fetchConfig).mockResolvedValueOnce({
+        config_version: 1,
+        task: "binary",
+        data: { target: "Survived" },
+        features: { exclude: ["Ticket", "Cabin"], categorical: [] },
+        model: {},
+      });
+
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(
+        () => useModelPanelData({ hasData: true }),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.nonExcludedColumns).toEqual(["Pclass", "Age"]);
+      });
+    });
+
+    it("falls back to suggested_excluded only when config is not yet seeded", async () => {
+      vi.mocked(fetchColumns).mockResolvedValueOnce({
+        columns: [
+          { name: "a", suggested_excluded: false },
+          { name: "b", suggested_excluded: true },
+          { name: "c", suggested_excluded: false },
+        ],
+        // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+      } as any);
+      // No config_version / data.target — pre-seeding state.
+      vi.mocked(fetchConfig).mockResolvedValueOnce({
+        model: {},
+      });
+
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(
+        () => useModelPanelData({ hasData: true }),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.nonExcludedColumns).toEqual(["a", "c"]);
+      });
+    });
+  });
+
   it("does NOT fetch columns until hasData is true", async () => {
     const { wrapper } = makeWrapper();
     renderHook(() => useModelPanelData({ hasData: false }), { wrapper });

--- a/frontend/src/hooks/useModelPanelData.ts
+++ b/frontend/src/hooks/useModelPanelData.ts
@@ -57,12 +57,35 @@ export function useModelPanelData({
   const { data: uiSchema } = useUiSchema();
   const { data: columnsData } = useColumns({ enabled: hasData });
 
+  // P-0091 / Issue #277: nonExcludedColumns is the source list for
+  // FeatureWeightsEditor's "Add feature" picker (and any other model-side
+  // consumer that needs the user-selectable feature names). It must
+  // exclude:
+  //   1. The target column — weighting the prediction target is
+  //      semantically nonsensical and gets dropped server-side.
+  //   2. User-excluded features (config.features.exclude) — the backend
+  //      will not see those columns at fit time, so allowing the user
+  //      to weight them is a confusing dead-end.
+  //   3. Auto-suggested excluded columns (id-like / constant) — same
+  //      class of dead-end as #2.
+  // The cached config is the source of truth for #1 and #2; columnsData
+  // covers #3 via ``suggested_excluded``.
   const nonExcludedColumns = useMemo(() => {
     if (!columnsData?.columns) return [];
+    const target = (config?.data as { target?: string } | undefined)?.target;
+    const excludedRaw = (config?.features as { exclude?: unknown } | undefined)
+      ?.exclude;
+    const userExcluded = new Set<string>(
+      Array.isArray(excludedRaw)
+        ? excludedRaw.filter((v): v is string => typeof v === "string")
+        : [],
+    );
     return columnsData.columns
       .filter((c) => !c.suggested_excluded)
+      .filter((c) => c.name !== target)
+      .filter((c) => !userExcluded.has(c.name))
       .map((c) => c.name);
-  }, [columnsData]);
+  }, [columnsData, config]);
 
   // --------------------------------------------------------------------
   // Debounced validation on change


### PR DESCRIPTION
## Summary

PR-C3 of the post-#271 smoke 3-PR plan. Closes #277. Closes the plan.

Issue #277 reported two symptoms:
1. **First toggle ON does not expand the editor body** — already resolved by PR #286 (P-0090 useConfigSync.setQueryData on success), confirmed via Playwright reproduction on the current dev build.
2. **`columns` prop empty so 'Add feature' never appears** — the actual symptom was the inverse: the prop contained TOO MANY columns, including the **target** (e.g. `Survived`) and **user-excluded features**. The dropdown was visible all along; it was just polluted with semantically invalid candidates.

### Root cause (#2)

`useModelPanelData.nonExcludedColumns` filtered only by `suggested_excluded`, not by `config.data.target` or `config.features.exclude`. As a result:

- FeatureWeightsEditor's "Add feature" picker showed the prediction target as a candidate weight. Selecting it produces `model.feature_weights = {Survived: 1.0}` which the backend silently drops at fit time.
- Columns the user explicitly excluded via Column Settings (e.g. `Ticket`, `Cabin` for ID-like leakage) were also offered as candidates, even though the backend never sees them.

### Fix

Extend the `useMemo` in `useModelPanelData.ts` to also subtract the cached config's `data.target` and `features.exclude` entries. Falls back to `suggested_excluded`-only when the config is not yet seeded (preserves initial-render behaviour).

This is a client-side filter — `useColumns` still calls `fetchColumns()` without target. The cache key stays simple. If a future use case demands target-aware backend caching, that's a separate refactor.

## Why #1 was already fixed

The browser repro (Playwright) showed:
- Switch toggled ON → `aria-checked=true` ✅
- `model.feature_weights = {}` written to backend ✅
- `[aria-label="Add feature"]` selector present in DOM ✅
- Body `.mt-2.space-y-1.5` div rendered ✅

PR-C2's `useConfigSync.setQueryData(merged)` closed the cache stale window where ConfigForm's stale-snapshot effects could clobber `feature_weights: {}` back to `null` between the PUT and the next render. Without that fix, the body would render briefly and then disappear when the competing PUT landed, matching the reporter's "absent on first toggle" observation.

## Invariants

- **INV-1**: `nonExcludedColumns` excludes `config.data.target`.
- **INV-2**: `nonExcludedColumns` excludes columns listed in `config.features.exclude`.
- **INV-3**: Falls back to `suggested_excluded`-only when the config is not yet seeded (no regression on initial render).
- **INV-4**: Filter order is idempotent — set-difference operations are commutative.

## Failure Paths Covered

- [x] Target set, no manual excludes → target hidden from picker (INV-1)
- [x] Target set + manual excludes → both hidden (INV-1 + INV-2)
- [x] Config not seeded → fallback to suggested_excluded only (INV-3)
- [x] `features.exclude` is non-array (malformed) → safely treated as empty
- [x] Manual smoke (Playwright): target column removed from picker; feature_weights body renders correctly on first toggle ON (the latter was already true post-PR-C2)

## Test Plan

- [x] `frontend/src/hooks/useModelPanelData.test.ts` — `nonExcludedColumns filters target + features.exclude (#277)` describe (3 cases):
  - Filters target out when `config.data.target` is set.
  - Filters columns listed in `config.features.exclude`.
  - Falls back to `suggested_excluded`-only when config is not yet seeded.
- [x] Existing `nonExcludedColumns` test still passes (no regression on the original filter behaviour).
- [x] Backend pytest full suite (1215 passed)
- [x] Frontend vitest full suite (1704 passed, 2 skipped)
- [x] `pnpm check` (Biome) clean
- [x] `pnpm build` clean
- [x] `uv run ruff check . && uv run ruff format --check . && uv run mypy src/lizystudio/` clean

## Spec / History

- HISTORY.md: P-0091 Proposal & Decision recorded.
- BLUEPRINT.md: no change.
- post-#271 smoke 3-PR plan **complete**: PR-C1 (P-0089 running lock, #279) → PR-C2 (P-0090 cross-hook race, #278 residual) → PR-C3 (P-0091 FeatureWeightsEditor target leakage, #277).
