### PR TITLE
test(e2e): add config-reflection helper + sample spec for split.n_splits

### DIFF
--- a/frontend/src/components/workspace/CvSection.tsx
+++ b/frontend/src/components/workspace/CvSection.tsx
@@ -153,6 +153,7 @@ export function CvSection({
             step={1}
             placeholder="5"
             disabled={disabled}
+            ariaLabel="Folds"
           />
         </div>
       )}

--- a/frontend/src/components/workspace/NumberInput.tsx
+++ b/frontend/src/components/workspace/NumberInput.tsx
@@ -13,6 +13,14 @@ interface NumberInputProps {
   disabled?: boolean;
   className?: string;
   id?: string;
+  /**
+   * Accessible name for the input element. Wrapping <Label> components
+   * in this codebase frequently omit `htmlFor`, so we expose `aria-label`
+   * here to give each input a stable name without requiring every call
+   * site to thread an `id`. E2E specs rely on this to drive the field
+   * via `getByRole("textbox", { name: ... })`.
+   */
+  ariaLabel?: string;
 }
 
 export function NumberInput({
@@ -25,6 +33,7 @@ export function NumberInput({
   disabled,
   className,
   id,
+  ariaLabel,
 }: NumberInputProps) {
   // Track raw text to allow intermediate input like "0." or "1.0"
   const [raw, setRaw] = useState(value == null ? "" : String(value));
@@ -115,6 +124,7 @@ export function NumberInput({
         onBlur={handleBlur}
         placeholder={placeholder}
         disabled={disabled}
+        aria-label={ariaLabel}
         className="h-7 w-20 text-center text-xs tabular-nums [appearance:textfield]"
       />
       <Button

--- a/frontend/tests/e2e/helpers/config-reflection.ts
+++ b/frontend/tests/e2e/helpers/config-reflection.ts
@@ -1,0 +1,146 @@
+import {
+  type APIRequestContext,
+  type Locator,
+  type Page,
+  type Request,
+  expect,
+} from "@playwright/test";
+import { API } from "./api";
+
+/**
+ * Config-reflection helper for E2E specs.
+ *
+ * Phase A scope (gui-e2e-plan.md): each UI control that maps to a
+ * field in the LizyML Config must drive a PUT /api/workspace/config
+ * with the correct wire field name and value, and the saved config
+ * (next GET /config) must reflect that value.
+ *
+ * Each spec line in `fixtures/config-fields.ts` declares the smallest
+ * unit needed to assert the four-step invariant:
+ *
+ *   1. baseline: GET /config -> defaultValue is observed at configPath
+ *   2. drive: invoke `uiAction(uiLocator, testValue)` from the spec
+ *   3. observe: the next PUT /config carries `testValue` at configPath
+ *   4. confirm: GET /config returns `testValue` at configPath
+ *
+ * The helper does not own the UI seeding step — callers are expected
+ * to drive `seedUiWorkspace(...)` (or an equivalent) before invoking
+ * `assertConfigReflection`, because the precondition surface (which
+ * accordion is open, which Strategy is active) is spec-specific.
+ */
+
+export interface ConfigFieldSpec<TValue> {
+  /** Human-readable name shown in the test title. */
+  name: string;
+  /** Dotted path on the saved config (e.g. "split.n_splits"). */
+  configPath: string;
+  /** Value expected at `configPath` BEFORE the UI action runs. */
+  defaultValue: TValue;
+  /** Value to drive into the UI control. */
+  testValue: TValue;
+  /** Locator factory resolved against the page once preconditions hold. */
+  uiLocator: (page: Page) => Locator;
+  /** Action that writes `testValue` into the UI control. */
+  uiAction: (locator: Locator, value: TValue) => Promise<void>;
+}
+
+/**
+ * Read the current saved config and pluck the value at `configPath`.
+ * Throws if the GET fails, since callers always expect a 200 here.
+ */
+export async function readSavedConfig(
+  request: APIRequestContext,
+): Promise<Record<string, unknown>> {
+  const res = await request.get(`${API}/workspace/config`);
+  expect(res.status()).toBe(200);
+  return (await res.json()) as Record<string, unknown>;
+}
+
+/**
+ * Walk a dotted path through a JSON object. Returns `undefined` if any
+ * segment is missing — callers compare against the expected value
+ * directly, so a missing field surfaces as a clear `undefined !==
+ * <expected>` failure instead of throwing.
+ */
+export function deepGet(
+  obj: unknown,
+  path: string,
+): unknown {
+  const parts = path.split(".");
+  let cursor: unknown = obj;
+  for (const key of parts) {
+    if (cursor === null || cursor === undefined) return undefined;
+    if (typeof cursor !== "object") return undefined;
+    cursor = (cursor as Record<string, unknown>)[key];
+  }
+  return cursor;
+}
+
+/**
+ * Wait for the very next PUT /api/workspace/config that the page
+ * issues, returning the parsed JSON body. The matcher anchors on the
+ * exact path and HTTP method so we do not pick up unrelated PATCH or
+ * sibling routes (e.g. /config/validate).
+ *
+ * Caller is responsible for invoking the UI action AFTER this promise
+ * is created — Playwright's `waitForRequest` is one-shot, so racing
+ * the action before subscribing drops the event.
+ */
+export async function nextPutConfigBody(
+  page: Page,
+): Promise<Record<string, unknown>> {
+  const req = await page.waitForRequest((r: Request) => {
+    if (r.method() !== "PUT") return false;
+    return r.url().endsWith("/api/workspace/config");
+  });
+  const body = req.postDataJSON();
+  return body as Record<string, unknown>;
+}
+
+/**
+ * Assert the four-step config-reflection invariant for a single field.
+ *
+ * Preconditions: the caller has driven the workspace UI to a state
+ * where `spec.uiLocator(page)` resolves and `spec.uiAction` can write
+ * `spec.testValue`. The function is intentionally agnostic to Section
+ * (Data Source / CV / Model / etc.) because the precondition surface
+ * differs per field.
+ */
+export async function assertConfigReflection<TValue>(
+  page: Page,
+  request: APIRequestContext,
+  spec: ConfigFieldSpec<TValue>,
+): Promise<void> {
+  // (1) baseline: confirm the saved config currently holds the
+  //     declared default. If this fails the spec data is wrong (or
+  //     the precondition seeding leaked state) — fail fast with a
+  //     specific message rather than a generic deep-equal mismatch.
+  const before = await readSavedConfig(request);
+  expect(
+    deepGet(before, spec.configPath),
+    `baseline mismatch at ${spec.configPath}`,
+  ).toEqual(spec.defaultValue);
+
+  // (2)+(3) drive the UI and observe the immediate PUT body. The
+  // promise is created BEFORE the UI action so we don't drop the
+  // request — Playwright's waitForRequest is a one-shot subscription.
+  const locator = spec.uiLocator(page);
+  await expect(locator).toBeVisible();
+  const putPromise = nextPutConfigBody(page);
+  await spec.uiAction(locator, spec.testValue);
+  const putBody = await putPromise;
+  expect(
+    deepGet(putBody, spec.configPath),
+    `PUT body mismatch at ${spec.configPath}`,
+  ).toEqual(spec.testValue);
+
+  // (4) confirm the saved config reflects the new value. useConfigSync
+  //     calls setQueryData on success so a subsequent GET returns the
+  //     server view; we assert the server view directly to avoid any
+  //     client-cache illusion.
+  const after = await readSavedConfig(request);
+  expect(
+    deepGet(after, spec.configPath),
+    `saved config mismatch at ${spec.configPath}`,
+  ).toEqual(spec.testValue);
+}

--- a/frontend/tests/e2e/workspace-config-reflection.spec.ts
+++ b/frontend/tests/e2e/workspace-config-reflection.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "@playwright/test";
+import * as fs from "node:fs";
+import { API, createTestCsv } from "./helpers/api";
+import {
+  assertConfigReflection,
+  type ConfigFieldSpec,
+} from "./helpers/config-reflection";
+import { isMobileProject } from "./helpers/mobile";
+import { seedUiWorkspace } from "./helpers/workspace-ui";
+
+/**
+ * Phase A scaffold (gui-e2e-plan.md) — locks the four-step
+ * config-reflection invariant for ONE representative UI control:
+ * the CV Folds NumberInput, which writes `split.n_splits` on the
+ * stratified_kfold default that `seedUiWorkspace` lands on.
+ *
+ * Subsequent PRs (D-2 onwards) extend the fixture set in
+ * `fixtures/config-fields.ts` and loop this same assertion shape over
+ * every Config field. This file intentionally exercises ONE field so
+ * the helper contract (locator + action + path + values) is locked
+ * before the fixture-driven loop is built.
+ *
+ * Why we skip on mobile: `seedUiWorkspace` re-opens the Model panel
+ * after target selection, which on mobile collapses the Data accordion
+ * and hides the CV section. The CV controls live in the Data panel,
+ * so the mobile path needs a separate `openWorkspaceSectionIfMobile`
+ * step that's not yet wired into this helper.
+ */
+
+const CSV_PATH = "/tmp/e2e_config_reflection.csv";
+
+test.describe("Workspace config reflection (Phase A scaffold)", () => {
+  test.beforeAll(() => {
+    createTestCsv(100, CSV_PATH);
+  });
+
+  test.afterAll(() => {
+    if (fs.existsSync(CSV_PATH)) fs.unlinkSync(CSV_PATH);
+  });
+
+  test.beforeEach(async ({ request }) => {
+    await request.post(`${API}/workspace/reset`);
+  });
+
+  test("CV Folds NumberInput writes split.n_splits to PUT /config", async ({
+    page,
+    request,
+  }, testInfo) => {
+    if (isMobileProject(testInfo)) {
+      test.skip(true, "Mobile layout collapses Data accordion; covered by B-8");
+    }
+
+    await seedUiWorkspace(page, testInfo, {
+      csvPath: CSV_PATH,
+      target: "target",
+      expectedRows: 100,
+    });
+
+    // Sanity guard: the seed lands the workspace on stratified_kfold
+    // with n_splits=5 (binary classification default). If this base
+    // changes, the spec's defaultValue / testValue need to follow.
+    const seeded = await request.get(`${API}/workspace/config`);
+    expect(seeded.status()).toBe(200);
+    const seededBody = await seeded.json();
+    expect(seededBody.split.method).toBe("stratified_kfold");
+
+    const spec: ConfigFieldSpec<number> = {
+      name: "split.n_splits via Folds NumberInput",
+      configPath: "split.n_splits",
+      defaultValue: 5,
+      testValue: 7,
+      uiLocator: (p) =>
+        // The Folds NumberInput uses an unlabelled <Label> + <Input
+        // type="text" inputMode="decimal">, so we anchor on the wrapper
+        // div's "Folds" label text and grab the child input. Order is
+        // stable because CvSection renders Folds before Random State.
+        p
+          .locator("div", { has: p.getByText("Folds", { exact: true }) })
+          .filter({ has: p.locator("input[inputmode='decimal']") })
+          .locator("input")
+          .first(),
+      uiAction: async (locator, value) => {
+        await locator.fill(String(value));
+        await locator.blur();
+      },
+    };
+
+    await assertConfigReflection(page, request, spec);
+  });
+});

--- a/frontend/tests/e2e/workspace-config-reflection.spec.ts
+++ b/frontend/tests/e2e/workspace-config-reflection.spec.ts
@@ -70,15 +70,14 @@ test.describe("Workspace config reflection (Phase A scaffold)", () => {
       defaultValue: 5,
       testValue: 7,
       uiLocator: (p) =>
-        // The Folds NumberInput uses an unlabelled <Label> + <Input
-        // type="text" inputMode="decimal">, so we anchor on the wrapper
-        // div's "Folds" label text and grab the child input. Order is
-        // stable because CvSection renders Folds before Random State.
-        p
-          .locator("div", { has: p.getByText("Folds", { exact: true }) })
-          .filter({ has: p.locator("input[inputmode='decimal']") })
-          .locator("input")
-          .first(),
+        // CvSection renders the Folds NumberInput with `ariaLabel="Folds"`,
+        // surfacing the input as a role=textbox with that accessible name.
+        // Using getByRole avoids the deeply-nested locator chain that the
+        // first iteration of this spec relied on (which paid a several-
+        // minute auto-wait penalty under React's re-render churn after
+        // target selection — the helper would time out before the first
+        // `fill` call could even resolve).
+        p.getByRole("textbox", { name: "Folds", exact: true }),
       uiAction: async (locator, value) => {
         await locator.fill(String(value));
         await locator.blur();


### PR DESCRIPTION
## Summary

Phase A scaffold for the GUI E2E enhancement plan
(`/tmp/gui-e2e-plan.md`). Lays the helper contract that future PRs
extend with a fixture-driven loop covering every Config field.

- New `tests/e2e/helpers/config-reflection.ts` exposes
  `assertConfigReflection(page, request, spec)`. The four-step
  invariant it locks: baseline GET → UI action → PUT body → saved
  GET, all comparing against a single declared `configPath`.
- New `tests/e2e/workspace-config-reflection.spec.ts` exercises the
  helper with one representative field — the CV Folds NumberInput
  writing `split.n_splits` after `seedUiWorkspace` lands the
  workspace on the stratified_kfold default.

Scope is intentionally one field. Subsequent PRs (D-2…D-5 in the
plan) extend `fixtures/config-fields.ts` and loop the same shape
over data / features / split / model / training / tuning /
calibration sections.

## Test plan

- [ ] `pnpm exec tsc -b` green
- [ ] `pnpm exec biome check src/` green
- [ ] `pnpm exec playwright test --project=chromium tests/e2e/workspace-config-reflection.spec.ts` passes locally
- [ ] CI `e2e-chromium` job stays green (Mobile/Tablet projects skip via `isMobileProject`)
