### PR TITLE
test(e2e): add CV strategy switching invariant spec (B-3)

### DIFF
--- a/frontend/tests/e2e/helpers/config-reflection.ts
+++ b/frontend/tests/e2e/helpers/config-reflection.ts
@@ -57,6 +57,39 @@ export async function readSavedConfig(
 }
 
 /**
+ * Poll GET /config until `predicate(config)` returns true, or throw a
+ * clear timeout error. Used to wait for `useConfigSync`'s cascading
+ * PUTs to settle after a UI seed step or a strategy switch — the hook
+ * re-runs on multiple state dependencies (target, task, cv, blocked)
+ * so a single click can produce a short burst of PUTs over ~150–500ms
+ * before reaching steady state. Polling the saved config directly
+ * sidesteps the brittleness of `page.waitForRequest` race-matching the
+ * "right" PUT in a burst.
+ *
+ * Returns the final config so callers can immediately assert against
+ * it without an extra round-trip.
+ */
+export async function waitForConfigSettle(
+  request: APIRequestContext,
+  predicate: (config: Record<string, unknown>) => boolean,
+  {
+    timeoutMs = 5000,
+    intervalMs = 100,
+  }: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<Record<string, unknown>> {
+  const start = Date.now();
+  let last: Record<string, unknown> = {};
+  while (Date.now() - start < timeoutMs) {
+    last = await readSavedConfig(request);
+    if (predicate(last)) return last;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(
+    `waitForConfigSettle timed out after ${timeoutMs}ms; last=${JSON.stringify(last).slice(0, 400)}`,
+  );
+}
+
+/**
  * Walk a dotted path through a JSON object. Returns `undefined` if any
  * segment is missing — callers compare against the expected value
  * directly, so a missing field surfaces as a clear `undefined !==

--- a/frontend/tests/e2e/workspace-cv.spec.ts
+++ b/frontend/tests/e2e/workspace-cv.spec.ts
@@ -1,0 +1,164 @@
+import { expect, test } from "@playwright/test";
+import * as fs from "node:fs";
+import { API, createTestCsv } from "./helpers/api";
+import { readSavedConfig } from "./helpers/config-reflection";
+import { isMobileProject } from "./helpers/mobile";
+import { seedUiWorkspace } from "./helpers/workspace-ui";
+
+/**
+ * B-3 (gui-e2e-plan.md) — CV strategy switching invariants.
+ *
+ * The post-#271 smoke surfaced multiple state-sync regressions where
+ * clicking a CV Strategy radio failed to land the new method on the
+ * server (#272 / #278), or where switching strategies left the previous
+ * strategy's fields in the wire payload and tripped Pydantic
+ * validation (#258 / #259). PR #281 (P-0087) locked the schema-level
+ * drift via contract tests; this spec adds the matching UI-level lock:
+ *
+ *   - Clicking each Strategy radio drives `split.method` to that wire
+ *     value through PUT /api/workspace/config.
+ *   - The saved config exposes ONLY the fields declared by that
+ *     strategy's Pydantic model — fields belonging to a previously
+ *     selected strategy must not leak through.
+ *
+ * Group-dependent strategies (group_kfold / stratified_group_kfold /
+ * group_time_series / blocked_group_kfold) are exercised via the same
+ * radio click, but `group_col` defaults to null on the seeded dataset
+ * (no group column selected) — that's still the regression we want to
+ * prevent: clicking the radio MUST update method even when downstream
+ * fields aren't filled in. Filling in group_col / time_col is covered
+ * by the per-field reflection specs (D-3 onward).
+ *
+ * BlockedGroupKFold is excluded from the simple loop because it has a
+ * dedicated 2-axis editor that reshapes the entire panel; it warrants
+ * its own spec (B-3b, deferred).
+ */
+
+const CSV_PATH = "/tmp/e2e_cv_strategy.csv";
+
+// Allowed top-level keys per strategy. Must match the lizyml Pydantic
+// `*Config.model_fields` for each method. If a backend bump adds or
+// removes a field, this array is the canary that flips red.
+const ALLOWED_SPLIT_KEYS: Record<string, readonly string[]> = {
+  kfold: ["method", "n_splits", "random_state", "shuffle"],
+  stratified_kfold: ["method", "n_splits", "random_state"],
+  group_kfold: ["method", "n_splits"],
+  stratified_group_kfold: ["method", "n_splits", "random_state", "shuffle"],
+  time_series: [
+    "method",
+    "n_splits",
+    "gap",
+    "train_size_max",
+    "test_size_max",
+  ],
+  purged_time_series: [
+    "method",
+    "n_splits",
+    "purge_gap",
+    "embargo",
+    "train_size_max",
+    "test_size_max",
+  ],
+  group_time_series: [
+    "method",
+    "n_splits",
+    "gap",
+    "train_size_max",
+    "test_size_max",
+  ],
+};
+
+const STRATEGY_LABELS: Record<string, string> = {
+  kfold: "KFold",
+  stratified_kfold: "StratifiedKFold",
+  group_kfold: "GroupKFold",
+  stratified_group_kfold: "StratifiedGroup",
+  time_series: "TimeSeriesSplit",
+  purged_time_series: "PurgedTimeSeries",
+  group_time_series: "GroupTimeSeries",
+};
+
+test.describe("Workspace CV strategy switching (B-3)", () => {
+  test.beforeAll(() => {
+    createTestCsv(100, CSV_PATH);
+  });
+
+  test.afterAll(() => {
+    if (fs.existsSync(CSV_PATH)) fs.unlinkSync(CSV_PATH);
+  });
+
+  test.beforeEach(async ({ request }) => {
+    await request.post(`${API}/workspace/reset`);
+  });
+
+  // One test per strategy. We intentionally do NOT loop them inside one
+  // test — Playwright's report becomes much more useful when each
+  // strategy is its own independent failure (caller can rerun a single
+  // strategy without rebuilding the whole CV state).
+  for (const [strategy, label] of Object.entries(STRATEGY_LABELS)) {
+    test(`switching to ${strategy} sets split.method and prunes prior strategy fields`, async ({
+      page,
+      request,
+    }, testInfo) => {
+      if (isMobileProject(testInfo)) {
+        test.skip(
+          true,
+          "Mobile layout collapses Data accordion; covered by B-8",
+        );
+      }
+
+      await seedUiWorkspace(page, testInfo, {
+        csvPath: CSV_PATH,
+        target: "target",
+        expectedRows: 100,
+      });
+
+      // Sanity guard: seedUiWorkspace lands on stratified_kfold for a
+      // binary classification target. If the default ever changes we
+      // want this to fail loudly with a meaningful message rather than
+      // a confusing downstream mismatch.
+      const seeded = await readSavedConfig(request);
+      expect((seeded.split as Record<string, unknown>).method).toBe(
+        "stratified_kfold",
+      );
+
+      // The Strategy SegmentGroup renders each method as a role=radio
+      // with the visible label as accessible name. Click the desired
+      // strategy and wait for the resulting PUT /config to land.
+      const strategyRadio = page.getByRole("radio", {
+        name: label,
+        exact: true,
+      });
+      await expect(strategyRadio).toBeVisible();
+
+      const putPromise = page.waitForRequest(
+        (req) =>
+          req.method() === "PUT" &&
+          req.url().endsWith("/api/workspace/config"),
+      );
+      await strategyRadio.click();
+      const putReq = await putPromise;
+      const putBody = putReq.postDataJSON() as {
+        split?: { method?: string };
+      };
+      expect(putBody.split?.method).toBe(strategy);
+
+      // Verify the saved config: method matches AND every key on the
+      // saved split block is allowed for that strategy. The second
+      // assertion is the post-#271 invariant — it catches the case
+      // where previously-selected strategy fields leak into the wire
+      // payload and survive Pydantic discrimination.
+      const after = await readSavedConfig(request);
+      const splitAfter = after.split as Record<string, unknown>;
+      expect(splitAfter.method).toBe(strategy);
+
+      const allowed = ALLOWED_SPLIT_KEYS[strategy];
+      const actualKeys = Object.keys(splitAfter).sort();
+      const unexpected = actualKeys.filter((k) => !allowed.includes(k));
+      expect(
+        unexpected,
+        `unexpected split keys for ${strategy}: ${unexpected.join(", ")}`,
+      ).toEqual([]);
+    });
+  }
+});

--- a/frontend/tests/e2e/workspace-cv.spec.ts
+++ b/frontend/tests/e2e/workspace-cv.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import * as fs from "node:fs";
 import { API, createTestCsv } from "./helpers/api";
-import { readSavedConfig } from "./helpers/config-reflection";
+import { waitForConfigSettle } from "./helpers/config-reflection";
 import { isMobileProject } from "./helpers/mobile";
 import { seedUiWorkspace } from "./helpers/workspace-ui";
 
@@ -113,45 +113,53 @@ test.describe("Workspace CV strategy switching (B-3)", () => {
         expectedRows: 100,
       });
 
+      // useConfigSync issues several PUTs after target selection (one
+      // per state dependency) before settling on the seeded default.
+      // Wait for that burst to land before treating the saved config
+      // as the baseline — otherwise the GET races against an in-flight
+      // PUT and `seeded.split` can be observed as undefined.
+      const seeded = await waitForConfigSettle(
+        request,
+        (cfg) =>
+          (cfg.split as Record<string, unknown> | undefined)?.method ===
+          "stratified_kfold",
+      );
       // Sanity guard: seedUiWorkspace lands on stratified_kfold for a
       // binary classification target. If the default ever changes we
       // want this to fail loudly with a meaningful message rather than
       // a confusing downstream mismatch.
-      const seeded = await readSavedConfig(request);
       expect((seeded.split as Record<string, unknown>).method).toBe(
         "stratified_kfold",
       );
 
       // The Strategy SegmentGroup renders each method as a role=radio
-      // with the visible label as accessible name. Click the desired
-      // strategy and wait for the resulting PUT /config to land.
+      // with the visible label as accessible name. Click the radio and
+      // poll the saved config until the new method lands. We do not
+      // try to single out the "right" PUT in waitForRequest because
+      // useConfigSync emits a short burst of PUTs across multiple
+      // useEffect re-runs after a state change — racing against that
+      // burst is brittle. The saved config (post-burst) is the
+      // observable contract we actually want to lock.
       const strategyRadio = page.getByRole("radio", {
         name: label,
         exact: true,
       });
       await expect(strategyRadio).toBeVisible();
-
-      const putPromise = page.waitForRequest(
-        (req) =>
-          req.method() === "PUT" &&
-          req.url().endsWith("/api/workspace/config"),
-      );
       await strategyRadio.click();
-      const putReq = await putPromise;
-      const putBody = putReq.postDataJSON() as {
-        split?: { method?: string };
-      };
-      expect(putBody.split?.method).toBe(strategy);
 
-      // Verify the saved config: method matches AND every key on the
-      // saved split block is allowed for that strategy. The second
-      // assertion is the post-#271 invariant — it catches the case
-      // where previously-selected strategy fields leak into the wire
-      // payload and survive Pydantic discrimination.
-      const after = await readSavedConfig(request);
+      const after = await waitForConfigSettle(
+        request,
+        (cfg) =>
+          (cfg.split as Record<string, unknown> | undefined)?.method ===
+          strategy,
+      );
       const splitAfter = after.split as Record<string, unknown>;
       expect(splitAfter.method).toBe(strategy);
 
+      // post-#271 invariant: the saved split block exposes ONLY the
+      // fields declared by the new strategy's Pydantic model. Fields
+      // belonging to a previously selected strategy must not survive
+      // the discriminated union.
       const allowed = ALLOWED_SPLIT_KEYS[strategy];
       const actualKeys = Object.keys(splitAfter).sort();
       const unexpected = actualKeys.filter((k) => !allowed.includes(k));


### PR DESCRIPTION
## Summary

Phase B-3 of gui-e2e-plan.md — CV strategy switching invariants.

The post-#271 smoke surfaced multiple regressions where clicking a CV
Strategy radio failed to land the new method on the server (#272 /
#278), or where switching strategies leaked the previous strategy's
fields into the wire payload and tripped Pydantic discrimination
(#258 / #259). PR #281 (P-0087) locked the schema-level drift via
contract tests; this PR adds the matching UI-level lock so a future
regression in `useConfigSync` / `cv-state` flips red on the next CI
run instead of waiting for the next manual smoke.

## What it asserts (per strategy)

- Clicking the Strategy radio drives `split.method` through PUT
  `/api/workspace/config` to that wire value.
- The saved config exposes **only** the fields declared by that
  strategy's Pydantic `*Config` model — fields from any previously
  selected strategy must not leak through.

`ALLOWED_SPLIT_KEYS` is the per-strategy contract:

```ts
kfold:                  [method, n_splits, random_state, shuffle]
stratified_kfold:       [method, n_splits, random_state]
group_kfold:            [method, n_splits]
stratified_group_kfold: [method, n_splits, random_state, shuffle]
time_series:            [method, n_splits, gap, train_size_max, test_size_max]
purged_time_series:     [method, n_splits, purge_gap, embargo, train_size_max, test_size_max]
group_time_series:      [method, n_splits, gap, train_size_max, test_size_max]
```

A backend bump that adds or removes a `*Config` field will flip these
arrays red as soon as the spec runs — that's the intended canary.

## Out of scope

- **BlockedGroupKFold** uses a dedicated 2-axis editor that reshapes
  the entire panel; deferred to **B-3b**.
- **Per-field reflection** (`group_col` / `time_col` / `gap` / etc.
  values) is the responsibility of the field-level reflection specs
  (**D-3** onward, gui-e2e-plan.md §A.3).
- **Mobile / tablet** projects skip via `isMobileProject` because the
  Data accordion collapses on small viewports — the re-open helper is
  **B-8**.

## Test plan

- [ ] `pnpm exec tsc -b` green
- [ ] `pnpm exec playwright test --list tests/e2e/workspace-cv.spec.ts` lists 21 tests (7 strategies × 3 projects)
- [ ] CI `e2e-chromium` job stays green; only the chromium project runs
  the 7 effective tests (mobile / tablet skip)
