### PR TITLE
docs(history): add proposal P-0092 for ConfigForm cross-hook write race

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2575,3 +2575,50 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (d) Manual smoke: target=Survived の状態で Feature Weights を ON にし、"Add feature" picker に Survived が **含まれない** ことを確認（実機 Playwright）。
 - **Decision:**
   - 2026-04-28 **Proposed & Implemented** — PR-C3 として merge 予定。Issue #277 を close。post-#271 smoke 3-PR plan (PR-C1 / PR-C2 / PR-C3) はこれで完了。
+
+### P-0092: ConfigForm auto-reset effect が cv 切替の wire を巻き戻す cross-hook race（PR #289 で発覚）
+- **Status:** proposed
+- **Scope:** Frontend / State management
+- **Related:** Issue #272 / Issue #278（cross-hook competing-write race の前段）、P-0090 (PR #286, useConfigSync の setQueryData + back-sync)、PR #289（B-3 e2e spec、本 race を CI で再現）、gui-e2e-plan.md B-3
+- **Context:** B-3 e2e spec (`workspace-cv.spec.ts`) を `develop` で走らせると、CV strategy radio をクリックして 5 秒待っても server 側 saved config が新しい strategy に切り替わらない。PR #289 のローカル再現 + Playwright MCP + `browser_network_requests` で root cause を特定:
+  1. ユーザが GroupKFold radio を click → `DataPanel.cv` state 更新 → `useConfigSync` が PUT (split.method=group_kfold, inner_valid.method=group_holdout) を発火し server 保存される。
+  2. Server レスポンスを `useConfig` (TanStack Query) が取り込み ConfigForm が再 render。
+  3. しかし `ConfigForm.tsx:121-136` の `useEffect`（inner_valid auto-reset）は、`useConfigSync` の最新 PUT を待たずに **`configRef.current` (= 古い stratified_kfold snapshot)** を base として PUT を発火する。
+  4. 結果: `split.method=stratified_kfold + inner_valid.method=holdout + random_state=42` が server に PUT され、cv 変更が完全に巻き戻される。
+  5. UI 上の Strategy radio は `cv` state を反映するため一瞬 GroupKFold が selected になるが、`useConfig` が refetch して stratified_kfold を取り込んだ次の render で StratifiedKFold に戻る。
+
+  P-0090 (PR #286) は `useConfigSync` ↔ `useDataPanel` 間の race を `setQueryData` 即時同期と `QueryCache.subscribe` back-sync で塞いだ。**ConfigForm の auto-reset effect は同じ pattern の third-party writer であり、その race の対象外**だった。
+- **Invariants:**
+  - INV-1: PUT `/api/workspace/config` の body は **直前に server に lands した config** をベースに生成されなければならない。古い `configRef.current` snapshot を使った partial-merge PUT は禁止。
+  - INV-2: ConfigForm の auto-reset effect (inner_valid / calibration) は、`useConfigSync` が in-flight な間は発火しない、または in-flight 完了を待ってから発火する。
+  - INV-3: cv strategy 切替で派生する inner_valid のリセット (e.g., group_kfold → group_holdout) は、cv 変更の **同一 PUT** で flush されなければならない。別 PUT で後追いすると race 窓を開く。
+  - INV-4: Backend が cv 変更時に inner_valid を auto-update する behaviour（実機観察: server が group_holdout を返す）と、frontend の auto-reset effect は同じ集合論的結果を生む（最終 saved config が一意に決まる）。
+- **Proposal & Impact:** 修正候補 3 つを比較し、いずれか 1 つで実装する。
+  - **(A) `configRef.current` を React Query cache に subscribe**（PR #286 と同じ pattern）。
+    - `ConfigForm.tsx`: `configRef.current = config` を `useEffect` + `queryClient.getQueryCache().subscribe` 経由に置き換え。setQueryData が走った瞬間に ref が更新され、次の auto-reset effect が最新 base を使う。
+    - `useConfigSync` 側は無変更。
+  - **(B) auto-reset を `useConfigSync` に統合**。
+    - `useConfigSync.syncConfig` 内で cv 変更を検知し、必要なら inner_valid を同 PUT で reset。`ConfigForm` の effect は廃止。
+    - 利点: cv と inner_valid が常に 1 PUT で flush され、INV-3 が構造的に保証される。
+    - 欠点: `useConfigSync` の責務が広がる（CV 以外の strategy 依存ロジックを取り込みやすい）。
+  - **(C) auto-reset effect を debounce + in-flight guard 付きに書き換え**。
+    - `useConfigSync.isFlushing` を export し、ConfigForm の effect が flushing 中は発火を skip。flush 完了後に effect が再走するよう dependency を整える。
+    - 利点: ConfigForm の責務を維持。
+    - 欠点: in-flight guard の race が残る（flush 完了直後 / effect 発火前の窓）。
+  - 推奨: **(A)**。PR #286 と同じ pattern で確立済みの contract を踏襲。Auto-reset effect の責務 (`ConfigForm` 内に閉じる) を維持しつつ INV-1 を満たす。
+- **Compatibility:**
+  - API: 変更なし（PUT /config の wire shape は不変）。
+  - UI: cv 切替が**実際に**反映されるようになる（regression ではなく仕様準拠化）。post-#271 smoke の Manual smoke 項目（"BlockedGroupKFold radio click → 1 click で server に lands"）を強化する形。
+  - Backend: 変更なし。
+- **Alternatives considered:**
+  - (D) ConfigForm の auto-reset effect 自体を廃止し、backend が cv 変更時に inner_valid を必ず adjust する仕様にする → 却下。frontend の filter (`filteredInnerValidOptions`) は UI 表示にも使うため、UI と server が同期しないと現在選択中の inner_valid 値が UI 上で消えるだけになる。
+  - (E) `useConfig` の `staleTime` を 0 にして毎回 refetch → 却下。race 窓が短くなるだけで根本解決にならず、network トラフィックも倍増。
+- **Acceptance Criteria:**
+  - (a) PR #289 の `workspace-cv.spec.ts` が CI で 7 strategy 全て pass する（chromium project）。
+  - (b) `frontend/src/components/workspace/ConfigForm.tsx` の auto-reset effect が `configRef.current` を base に PUT する behaviour に対する unit test が追加され、最新 cache subscription が反映されることを locking する。
+  - (c) Manual smoke (Playwright MCP): GroupKFold radio click → 1 click で `split.method=group_kfold` が server に lands し続け、inner_valid auto-reset 後も group_kfold が保たれる。
+  - (d) `frontend/src/hooks/useConfigSync.test.ts` の既存 race test が引き続き pass（PR #286 で導入された invariants を破壊しない）。
+  - (e) frontend vitest / biome / build / backend pytest / ruff / mypy がすべて green。
+- **Decision:**
+  - 2026-04-29 **Proposed** — PR は別途起票（implementation 候補 (A) を採用）。PR #289 は本 Proposal の実装 PR にマージ吸収するか、本 Proposal 完了後に rebase + re-run する。
+

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2725,3 +2725,24 @@ PR を 6 段階に分け、**各段階で B-3 spec の進捗を確認**しなが
 - 各 Phase で既存 e2e (workspace-fit / workspace-tune / inference-flow) に regression が出たら、その PR を merge せず原因究明を優先。
 - 全 6 PR で **累計 frontend bundle 増加が +5KB を超えない** ことを bundle-size チェックで確認 (recent coupling refactor の予算に倣う)。
 
+#### Progress log
+
+| Phase | PR | Status | Date | 観察 |
+|---|---|---|---|---|
+| Proposal | [#290](https://github.com/nbx-liz/LizyStudio/pull/290) | open | 2026-04-29 | Q-1 採用、6-phase plan 確定 |
+| Phase 1 (funnel skeleton) | [#291](https://github.com/nbx-liz/LizyStudio/pull/291) | **CI green** | 2026-04-29 | 14 unit tests pass。1680 / 1682 既存 vitest pass。dead code (production wiring 無し) |
+| Phase 2 (ConfigForm auto-reset) | [#292](https://github.com/nbx-liz/LizyStudio/pull/292) | **CI green** | 2026-04-29 | StratifiedKFold → KFold 切替の race **解消** (ローカル実機 confirmed)。GroupKFold は引き続き race (W1 経路、Phase 5 scope)。`workspace-config-reflection.spec.ts` は Phase 5 まで `test.skip` |
+| Phase 3 (useTargetSelection) | [#293](https://github.com/nbx-liz/LizyStudio/pull/293) | **CI green** | 2026-04-29 | target-select 直後の rapid PUT バーストを `target-select` reason で funnel serialise。stratified→kfold の安定性は維持 (regression なし)。`legacyUpdateConfig` seam pattern を導入 |
+| Phase 4 (useModelPanelData W3 + undo/redo) | — | not started | — | Phase 4 着手時、Phase 3 と同様の `legacyUpdateConfig` seam を `useModelPanelData.handleConfigChange` / `handleUndo` / `handleRedo` に拡げる |
+| Phase 5 (useConfigSync.syncConfig W1) | — | not started | — | **B-3 spec が green になる出口**。GroupKFold race の根治。`useConfigSync` の deps closure / abortRef を funnel state machine に吸収 |
+| Phase 6 (WorkspacePage W6 + Preset Load) | — | not started | — | `grep -rE "updateConfig\(" frontend/src/` を **`useConfigWriteFunnel.ts` 1 箇所** にする |
+
+##### B-3 / D-1 spec status
+
+- **PR #289** (`workspace-cv.spec.ts`) — draft 維持。Phase 5 で 7 strategy 全 pass する想定。
+- **`workspace-config-reflection.spec.ts`** (D-1 sample) — `test.skip(true, "Skipped during P-0092 Phase 2..4. Re-enabled at Phase 5...")`。Phase 5 完了で skip 削除し、spec への変更なしに green になることを確認。
+
+##### Phase 2 で見つけた副次的バグ
+
+ConfigForm の inner_valid auto-reset effect は `["training", "inner_valid", "method"]` を書いていたが、lizyml schema (`extra="forbid"`) は `training.early_stopping.inner_valid` のみ受け付ける。Phase 2 で path を canonical 形に修正済み (`useConfigSync.ts:90-103` のコメント参照)。Issue #272 の partial fix だった可能性あり、後追い検証は Phase 5 完了後に。
+

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2610,4 +2610,118 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - 2026-04-29 **Proposed** — initial diagnosis (ConfigForm の単一 writer race) に基づく実装試行（仮称 PR #291）は中断。実機 + cache polling で 3 writer race と判明したため、Q-1 〜 Q-4 から方針を確定するまで実装を止め、設計議論を待つ。
   - PR #289 (`workspace-cv.spec.ts`) は本 Proposal が解決するまで draft のまま保持。本 Proposal の Acceptance には PR #289 の B-3 spec が CI で 7 strategy 全 pass することを最終条件として残す。
   - 当面の Workaround: `develop` 上の手動 smoke では cv strategy 変更後 1 秒待ってから次の操作に進むことで巻き戻しを観察できる。回避策ではあるが本質的修正ではない。
+  - 2026-04-29 **Approach selected: Q-1 (Write funnel 単一化)** — 全 PUT を `useConfigSync` 一本に集約する。短期の partial fix (Q-3) は P-0086 / P-0090 と同じ "塞いでも次の隙間が出る" pattern を再生産する risk が高く、根治しない。Q-2 (If-Match) と Q-4 (server auto-adjust) は backend 変更を伴い change-gate 範囲が広い。Q-1 は frontend 内で完結し、構造的に race を消す唯一の選択肢。
+
+#### Phase plan (Q-1 段階実装)
+
+PR を 6 段階に分け、**各段階で B-3 spec の進捗を確認**しながら進める。各段階の commit は単独で revert 可能な単位とする。
+
+##### Phase 0: writer inventory (この Proposal 内でドキュメント済)
+
+現在の writer 一覧（PUT `/api/workspace/config` を発行する 6 箇所）:
+
+| ID | 場所 | 経路 | 用途 |
+|----|------|------|------|
+| W1 | `hooks/useConfigSync.ts:106` | `syncConfig` | DataPanel state (target/task/cv/blocked/overrides) 変更 |
+| W2 | `hooks/useTargetSelection.ts:110` | target 選択時の `merged` PUT | target 選択 + defaults 取得 |
+| W3 | `hooks/useModelPanelData.ts:115` | `handleConfigChange` | ConfigForm onChange (auto-reset effects 含む) |
+| W4 | `hooks/useModelPanelData.ts:186` | `handleUndo` | undo |
+| W5 | `hooks/useModelPanelData.ts:198` | `handleRedo` | redo |
+| W6 | `pages/WorkspacePage.tsx:132` | `handleApplyToFit` | Re-fit ボタン |
+
+`setQueryData(queryKeys.config(), ...)` の cache writer も同 5 箇所に分散。
+
+##### Phase 1: write funnel API を `useConfigSync` 上に新設
+
+- **目的:** 既存 writer を順次 funnel に移すための受け皿を用意する。実 writer 数を増やさない (W1 内に新 API を生やすだけ)。
+- **API 設計:**
+  ```ts
+  // useConfigSync の return
+  return {
+    syncConfig,           // 既存 — DataPanel 由来 sync (Phase 5 で内部実装が funnel.enqueue に置き換わる)
+    setSyncSuppressed,    // 既存
+    preseedSyncKey,       // 既存
+    // --- new ---
+    enqueueWrite,         // (op: WriteOp) => Promise<WriteResult> — 全外部 writer の入口
+    onTerminal,           // (cb) => unsubscribe — 完了通知 (test と downstream effects 用)
+  };
+
+  type WriteOp =
+    | { kind: 'replace'; config: FullConfig; reason: WriteReason }
+    | { kind: 'patch'; path: string[]; value: unknown; reason: WriteReason };
+
+  type WriteReason =
+    | 'target-select' | 'cv-change' | 'config-form-edit'
+    | 'undo' | 'redo' | 'apply-to-fit' | 'preset-load' | 'auto-reset';
+  ```
+- **State machine:**
+  - `idle` → `enqueueing` → `flushing` → `idle` (or `error`)
+  - `flushing` 中の enqueue は **後勝ち merge**: 同じ `WriteReason` は最新で上書き、異なる reason は serial に直列化
+  - `abort` は `flushing` 中の controller のみに作用、queue 上の op は維持
+- **scope:** `useConfigSync.ts` 内のみ。新 export 追加、既存 syncConfig 呼び出し側は変更しない。
+- **出口テスト:** vitest unit tests for funnel state machine. B-3 spec は **まだ red のまま** (writer がまだ funnel に流れていない)。
+- **PR 規模:** ~200 行追加, 0 行削除
+
+##### Phase 2: ConfigForm auto-reset effects → funnel に移行 (W3 の auto-reset 経路)
+
+- **目的:** B-3 race の最大要因の一つ、ConfigForm の inner_valid / calibration / objective auto-reset effect を funnel に流す。
+- **変更:**
+  - `ConfigForm` に `enqueueWrite` prop (or `useWorkspaceWriter()` context) を渡す。
+  - 3 つの auto-reset useEffect 内の `handleFieldChange(...)` → `enqueueWrite({ kind: 'patch', path, value, reason: 'auto-reset' })` に置き換え。
+  - 既存 `handleFieldChange` は user の field edit 用 (W3 の本筋) のみ残す → これは Phase 4 で扱う。
+- **出口テスト:** B-3 spec の **少なくとも一部の strategy が green になる**ことを確認 (auto-reset 由来の race が消える)。残りの strategy は W3 の user edit 経路や W2 の target merge race で red のまま。
+- **PR 規模:** ~150 行 ± 80 行
+- **チェックポイント:** 実装後ローカル `pnpm dev` + Playwright MCP で 8 strategy 巡回、saved config の遷移を 50ms polling で確認。
+
+##### Phase 3: useTargetSelection (W2) の merged PUT → funnel
+
+- **目的:** target 選択時の rapid PUT バーストを 1 つの funnel write に統合する。
+- **変更:**
+  - `useTargetSelection.ts:110` の `updateConfig(merged)` → `enqueueWrite({ kind: 'replace', config: merged, reason: 'target-select' })`
+  - `setQueryData` も funnel 内で行うため除去。
+- **出口テスト:** B-3 spec の **target 選択直後の strategy 切替** で green 化を確認。
+- **PR 規模:** ~80 行
+
+##### Phase 4: useModelPanelData (W3 user edit 経路) → funnel
+
+- **目的:** ConfigForm の user 由来 onChange (numeric/text/select の手編集) を funnel に流す。
+- **変更:**
+  - `useModelPanelData.handleConfigChange` の `updateConfig(newConfig)` → `enqueueWrite({ kind: 'replace', config: newConfig, reason: 'config-form-edit' })`
+  - undo / redo (W4 / W5) も同 PR で `reason: 'undo' | 'redo'` で funnel 経由に。
+  - validate debounce timer は funnel 完了後に動かす。
+- **出口テスト:** ConfigForm 経由の rapid edit (numeric stepper 連打 + cv strategy click) で巻き戻しが起きないことを Playwright MCP で確認。
+- **PR 規模:** ~150 行
+
+##### Phase 5: useConfigSync.syncConfig 内部実装も funnel ベースに統合
+
+- **目的:** W1 自身も funnel.enqueue を経由する形に書き換え、`abortRef` を funnel state machine に吸収。
+- **変更:**
+  - syncConfig が `cv` deps closure を持つ問題を、`enqueueWrite({ kind: 'replace', config: rebuiltFromLatestState, reason: 'cv-change' })` で解消。
+  - dedup key の概念を funnel 側に移管。
+- **出口テスト:** B-3 spec の **8 strategy 全部 green**。
+- **PR 規模:** ~200 行
+
+##### Phase 6: WorkspacePage.handleApplyToFit (W6) と Preset Load → funnel
+
+- **目的:** 残る writer を funnel に取り込み、`updateConfig` の **唯一の caller が useConfigSync 内の 1 箇所** になる状態を達成。
+- **変更:**
+  - `WorkspacePage.tsx:132` を `enqueueWrite({ kind: 'replace', reason: 'apply-to-fit' })` に。
+  - Preset Load (`useModelPanelData` 経由) も funnel に。
+- **出口テスト:** `grep -rE "updateConfig\(" frontend/src/` が `useConfigSync.ts` の 1 箇所のみを返すこと。 B-3 spec + 既存 e2e 全 green 維持。
+- **PR 規模:** ~120 行
+
+#### Acceptance criteria (全 Phase 完了時)
+
+- (a) PR #289 の `workspace-cv.spec.ts` が 7 strategy 全 pass。
+- (b) `frontend/src/` 内の `updateConfig(` call site が **1 箇所のみ** (`useConfigSync.ts` 内 funnel 実装)。
+- (c) `setQueryData(queryKeys.config(), ...)` 同様に funnel 内 1 箇所。
+- (d) `useConfigSync.test.ts` に funnel state machine の invariant test を追加 (concurrent enqueue / abort during flush / dedup by reason)。
+- (e) frontend vitest / biome / build / backend pytest がすべて green。既存 unit test の意図的な書き換え (mock の差し替え) は許容、新規スキップは禁止。
+- (f) 各 Phase の PR は単独で revert 可能 (incremental release safety)。
+
+#### Risk / 撤退基準
+
+- Phase 2 完了時に B-3 spec の **どの strategy も green にならない** 場合、診断が更に外れている可能性。Phase 3 に進まず再調査。
+- 各 Phase で既存 e2e (workspace-fit / workspace-tune / inference-flow) に regression が出たら、その PR を merge せず原因究明を優先。
+- 全 6 PR で **累計 frontend bundle 増加が +5KB を超えない** ことを bundle-size チェックで確認 (recent coupling refactor の予算に倣う)。
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2576,49 +2576,38 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
 - **Decision:**
   - 2026-04-28 **Proposed & Implemented** — PR-C3 として merge 予定。Issue #277 を close。post-#271 smoke 3-PR plan (PR-C1 / PR-C2 / PR-C3) はこれで完了。
 
-### P-0092: ConfigForm auto-reset effect が cv 切替の wire を巻き戻す cross-hook race（PR #289 で発覚）
-- **Status:** proposed
+### P-0092: Workspace config write funnel の cross-hook race（PR #289 で発覚、複数 writer の設計議論待ち）
+- **Status:** investigation — implementation deferred pending design review
 - **Scope:** Frontend / State management
-- **Related:** Issue #272 / Issue #278（cross-hook competing-write race の前段）、P-0090 (PR #286, useConfigSync の setQueryData + back-sync)、PR #289（B-3 e2e spec、本 race を CI で再現）、gui-e2e-plan.md B-3
-- **Context:** B-3 e2e spec (`workspace-cv.spec.ts`) を `develop` で走らせると、CV strategy radio をクリックして 5 秒待っても server 側 saved config が新しい strategy に切り替わらない。PR #289 のローカル再現 + Playwright MCP + `browser_network_requests` で root cause を特定:
-  1. ユーザが GroupKFold radio を click → `DataPanel.cv` state 更新 → `useConfigSync` が PUT (split.method=group_kfold, inner_valid.method=group_holdout) を発火し server 保存される。
-  2. Server レスポンスを `useConfig` (TanStack Query) が取り込み ConfigForm が再 render。
-  3. しかし `ConfigForm.tsx:121-136` の `useEffect`（inner_valid auto-reset）は、`useConfigSync` の最新 PUT を待たずに **`configRef.current` (= 古い stratified_kfold snapshot)** を base として PUT を発火する。
-  4. 結果: `split.method=stratified_kfold + inner_valid.method=holdout + random_state=42` が server に PUT され、cv 変更が完全に巻き戻される。
-  5. UI 上の Strategy radio は `cv` state を反映するため一瞬 GroupKFold が selected になるが、`useConfig` が refetch して stratified_kfold を取り込んだ次の render で StratifiedKFold に戻る。
+- **Related:** Issue #272 / Issue #278（cross-hook competing-write race の前段）、P-0086（DataPanel ref + setQueryData）、P-0090 (PR #286, useConfigSync の setQueryData + back-sync)、PR #289（B-3 e2e spec、本 race を CI で再現）、gui-e2e-plan.md B-3
+- **Symptom:** `develop` 上で B-3 e2e spec (`workspace-cv.spec.ts`) を走らせると、CV strategy radio click 後 5 秒待っても server 側 saved config の `split.method` が変わらない。実機 (`pnpm dev` + Playwright MCP) でも同じ巻き戻しが再現する。
+- **Initial diagnosis (2026-04-29 first pass — partially incorrect):** 当初は `ConfigForm.tsx:121-136` の inner_valid auto-reset effect が古い `configRef.current` snapshot から PUT を発火することが原因と判断した。しかし実機の network/cache observation で以下の追加事実が判明し、診断は不完全であることが確認された:
+  1. `browser_network_requests` で観察した巻き戻し PUT の body は **stratified_kfold + `random_state: 42` (defaults 由来) + 完全な model.params + evaluation.metrics + training.early_stopping.inner_valid=holdout** という **完全な config body** で、ConfigForm の auto-reset effect が `setNestedValue` で書き換える `["training","inner_valid","method"]` 1 フィールドだけの shape ではない。
+  2. cache polling (50ms 間隔) で saved config を観察すると、click から **44ms 後に巻き戻しが完了** している（`t=212ms split=stratified_kfold` → `t=256ms split=stratified_kfold + random_state=42`）。これは ConfigForm 経由で onChange → useModelPanelData.handleConfigChange → updateConfig という path にしては短すぎる。
+  3. 巻き戻し PUT の `random_state=42` は `fetchConfigDefaults("binary","target")` の output と一致する。これは **`useConfigSync.syncConfig`** が L66-68 で defaults を取得して base にしている経路と一致する。
+- **Refined hypothesis:** 単一 writer の責任ではなく、**3 つの writer がすべて in-flight な書込みを発行している**:
+  1. `useConfigSync.syncConfig` (L55-149): cv/target/task/overrides/blocked が変わるたびに re-create され `useEffect` から呼ばれる。`abortRef.abort()` は前回をキャンセルするが、**既に server に届いた fetch の body 送信はキャンセルできず**、server 側で commit される。`syncConfig` は closure で `cv` を capture しているため、cv が連続変化した場合の order は保証されない。
+  2. `useModelPanelData.handleConfigChange` (L100-163): ConfigForm の `onChange` の終端。`updateConfig` を直接呼び `setQueryData` で cache を上書きする。useConfigSync の in-flight PUT を尊重しない。
+  3. `ConfigForm.tsx` 内の auto-reset useEffect 群 (line 121-136 / 158-170 / 248-): `configRef.current` を base に `handleFieldChange` → `onChange(updated)` を発火。`configRef.current = config` (line 67) は render 時に更新されるが、render 順序と useConfigSync の PUT 順序の関係は保証されていない。
 
-  P-0090 (PR #286) は `useConfigSync` ↔ `useDataPanel` 間の race を `setQueryData` 即時同期と `QueryCache.subscribe` back-sync で塞いだ。**ConfigForm の auto-reset effect は同じ pattern の third-party writer であり、その race の対象外**だった。
-- **Invariants:**
-  - INV-1: PUT `/api/workspace/config` の body は **直前に server に lands した config** をベースに生成されなければならない。古い `configRef.current` snapshot を使った partial-merge PUT は禁止。
-  - INV-2: ConfigForm の auto-reset effect (inner_valid / calibration) は、`useConfigSync` が in-flight な間は発火しない、または in-flight 完了を待ってから発火する。
-  - INV-3: cv strategy 切替で派生する inner_valid のリセット (e.g., group_kfold → group_holdout) は、cv 変更の **同一 PUT** で flush されなければならない。別 PUT で後追いすると race 窓を開く。
-  - INV-4: Backend が cv 変更時に inner_valid を auto-update する behaviour（実機観察: server が group_holdout を返す）と、frontend の auto-reset effect は同じ集合論的結果を生む（最終 saved config が一意に決まる）。
-- **Proposal & Impact:** 修正候補 3 つを比較し、いずれか 1 つで実装する。
-  - **(A) `configRef.current` を React Query cache に subscribe**（PR #286 と同じ pattern）。
-    - `ConfigForm.tsx`: `configRef.current = config` を `useEffect` + `queryClient.getQueryCache().subscribe` 経由に置き換え。setQueryData が走った瞬間に ref が更新され、次の auto-reset effect が最新 base を使う。
-    - `useConfigSync` 側は無変更。
-  - **(B) auto-reset を `useConfigSync` に統合**。
-    - `useConfigSync.syncConfig` 内で cv 変更を検知し、必要なら inner_valid を同 PUT で reset。`ConfigForm` の effect は廃止。
-    - 利点: cv と inner_valid が常に 1 PUT で flush され、INV-3 が構造的に保証される。
-    - 欠点: `useConfigSync` の責務が広がる（CV 以外の strategy 依存ロジックを取り込みやすい）。
-  - **(C) auto-reset effect を debounce + in-flight guard 付きに書き換え**。
-    - `useConfigSync.isFlushing` を export し、ConfigForm の effect が flushing 中は発火を skip。flush 完了後に effect が再走するよう dependency を整える。
-    - 利点: ConfigForm の責務を維持。
-    - 欠点: in-flight guard の race が残る（flush 完了直後 / effect 発火前の窓）。
-  - 推奨: **(A)**。PR #286 と同じ pattern で確立済みの contract を踏襲。Auto-reset effect の責務 (`ConfigForm` 内に閉じる) を維持しつつ INV-1 を満たす。
-- **Compatibility:**
-  - API: 変更なし（PUT /config の wire shape は不変）。
-  - UI: cv 切替が**実際に**反映されるようになる（regression ではなく仕様準拠化）。post-#271 smoke の Manual smoke 項目（"BlockedGroupKFold radio click → 1 click で server に lands"）を強化する形。
-  - Backend: 変更なし。
-- **Alternatives considered:**
-  - (D) ConfigForm の auto-reset effect 自体を廃止し、backend が cv 変更時に inner_valid を必ず adjust する仕様にする → 却下。frontend の filter (`filteredInnerValidOptions`) は UI 表示にも使うため、UI と server が同期しないと現在選択中の inner_valid 値が UI 上で消えるだけになる。
-  - (E) `useConfig` の `staleTime` を 0 にして毎回 refetch → 却下。race 窓が短くなるだけで根本解決にならず、network トラフィックも倍増。
-- **Acceptance Criteria:**
-  - (a) PR #289 の `workspace-cv.spec.ts` が CI で 7 strategy 全て pass する（chromium project）。
-  - (b) `frontend/src/components/workspace/ConfigForm.tsx` の auto-reset effect が `configRef.current` を base に PUT する behaviour に対する unit test が追加され、最新 cache subscription が反映されることを locking する。
-  - (c) Manual smoke (Playwright MCP): GroupKFold radio click → 1 click で `split.method=group_kfold` が server に lands し続け、inner_valid auto-reset 後も group_kfold が保たれる。
-  - (d) `frontend/src/hooks/useConfigSync.test.ts` の既存 race test が引き続き pass（PR #286 で導入された invariants を破壊しない）。
-  - (e) frontend vitest / biome / build / backend pytest / ruff / mypy がすべて green。
+  **PR #286 (P-0090) は writer (1) と useDataPanel の back-sync race を塞いだ**が、(1)↔(2)↔(3) の三者間 race は対象外だった。今回 PR #289 の e2e spec が初めてこの三者間 race を再現可能な形で表面化した。
+- **Why a simple fix is unsafe:** 場当たり的な単一 writer 修正（例: configRef を queryCache に subscribe / useConfigSync に inner_valid 統合 / auto-reset を debounce）はいずれも **残り 2 つの writer の race を温存する**。実装試行の途中で「修正候補 (A)/(B)/(C) のどれを採っても他の writer 経路が race する」ことが判明し、設計議論なしに実装を進めると過去の P-0086 / P-0090 と同じ "塞いでも次の隙間が出る" pattern を繰り返す。
+- **Investigation needed (deferred to design review):**
+  - **Q-1: write funnel の単一化** — ConfigForm の auto-reset / useModelPanelData.handleConfigChange / useConfigSync.syncConfig を **1 経路** にできるか。例: 全ての PUT を `useConfigSync` に集約し、ConfigForm は controlled state を local に保持して `useConfigSync` に通知のみする shape。Workspace 全体の controlled-state 設計を見直す必要がある。
+  - **Q-2: write ordering を server side で保証する** — 例: `If-Match: <config_version>` ヘッダで optimistic locking を導入し、stale な PUT は 409 を返す。Frontend は 409 を受けて latest を再 fetch + retry。Backend API 変更を伴うため change-gate 対象。
+  - **Q-3: useConfigSync の closure 安定化** — `cv` を ref 化して `syncConfig` を deps から除く / `cv` ref を read at PUT-time。これで (1) の closure race は塞ぐが (2) と (3) の race は残る。
+  - **Q-4: ConfigForm の effect を全廃止** — auto-reset (inner_valid / calibration / objective) を server 側 (Pydantic validator + auto-adjust) に移管。frontend は server response の値を表示するだけ。これも change-gate 対象。
+- **Invariants we eventually want to lock:**
+  - INV-1: PUT `/api/workspace/config` の body は in-flight な PUT を尊重して順序付けられ、最終的に server 上の saved config が user intent と一致する。
+  - INV-2: writer (1)/(2)/(3) 間で base config snapshot の "誰が最新を持つか" の責務が単一に決まる。
+  - INV-3: cv strategy 切替で派生する inner_valid / objective / metric のリセットは、cv 変更の **同一 PUT** で flush されるか、base PUT 完了を待ってから follow-up PUT として flush される（順序保証あり）。
+  - INV-4: e2e (B-3) で 8 strategy 巡回した時、server saved config が常に最後の click の strategy と一致する。
+- **Compatibility (任意の解決策で見ておくべき範囲):**
+  - API: Q-2 (If-Match) を採るなら PUT の semantics 拡張が必要。Q-4 を採るなら GET response shape 拡張あり。Q-1/Q-3 は wire 不変。
+  - UI: 巻き戻し挙動が止まる方向の「regression ではない仕様準拠化」。
+  - Backend: Q-2/Q-4 は backend 変更を伴う。
 - **Decision:**
-  - 2026-04-29 **Proposed** — PR は別途起票（implementation 候補 (A) を採用）。PR #289 は本 Proposal の実装 PR にマージ吸収するか、本 Proposal 完了後に rebase + re-run する。
+  - 2026-04-29 **Proposed** — initial diagnosis (ConfigForm の単一 writer race) に基づく実装試行（仮称 PR #291）は中断。実機 + cache polling で 3 writer race と判明したため、Q-1 〜 Q-4 から方針を確定するまで実装を止め、設計議論を待つ。
+  - PR #289 (`workspace-cv.spec.ts`) は本 Proposal が解決するまで draft のまま保持。本 Proposal の Acceptance には PR #289 の B-3 spec が CI で 7 strategy 全 pass することを最終条件として残す。
+  - 当面の Workaround: `develop` 上の手動 smoke では cv strategy 変更後 1 秒待ってから次の操作に進むことで巻き戻しを観察できる。回避策ではあるが本質的修正ではない。
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2725,24 +2725,62 @@ PR を 6 段階に分け、**各段階で B-3 spec の進捗を確認**しなが
 - 各 Phase で既存 e2e (workspace-fit / workspace-tune / inference-flow) に regression が出たら、その PR を merge せず原因究明を優先。
 - 全 6 PR で **累計 frontend bundle 増加が +5KB を超えない** ことを bundle-size チェックで確認 (recent coupling refactor の予算に倣う)。
 
-#### Progress log
+#### Progress log (2026-04-29 mid-flight snapshot, plan 段階)
 
 | Phase | PR | Status | Date | 観察 |
 |---|---|---|---|---|
 | Proposal | [#290](https://github.com/nbx-liz/LizyStudio/pull/290) | open | 2026-04-29 | Q-1 採用、6-phase plan 確定 |
-| Phase 1 (funnel skeleton) | [#291](https://github.com/nbx-liz/LizyStudio/pull/291) | **CI green** | 2026-04-29 | 14 unit tests pass。1680 / 1682 既存 vitest pass。dead code (production wiring 無し) |
-| Phase 2 (ConfigForm auto-reset) | [#292](https://github.com/nbx-liz/LizyStudio/pull/292) | **CI green** | 2026-04-29 | StratifiedKFold → KFold 切替の race **解消** (ローカル実機 confirmed)。GroupKFold は引き続き race (W1 経路、Phase 5 scope)。`workspace-config-reflection.spec.ts` は Phase 5 まで `test.skip` |
-| Phase 3 (useTargetSelection) | [#293](https://github.com/nbx-liz/LizyStudio/pull/293) | **CI green** | 2026-04-29 | target-select 直後の rapid PUT バーストを `target-select` reason で funnel serialise。stratified→kfold の安定性は維持 (regression なし)。`legacyUpdateConfig` seam pattern を導入 |
-| Phase 4 (useModelPanelData W3 + undo/redo) | — | not started | — | Phase 4 着手時、Phase 3 と同様の `legacyUpdateConfig` seam を `useModelPanelData.handleConfigChange` / `handleUndo` / `handleRedo` に拡げる |
-| Phase 5 (useConfigSync.syncConfig W1) | — | not started | — | **B-3 spec が green になる出口**。GroupKFold race の根治。`useConfigSync` の deps closure / abortRef を funnel state machine に吸収 |
-| Phase 6 (WorkspacePage W6 + Preset Load) | — | not started | — | `grep -rE "updateConfig\(" frontend/src/` を **`useConfigWriteFunnel.ts` 1 箇所** にする |
+| Phase 1 (funnel skeleton) | [#291](https://github.com/nbx-liz/LizyStudio/pull/291) | CI green | 2026-04-29 | 14 unit tests pass。1680 / 1682 既存 vitest pass。dead code (production wiring 無し) |
+| Phase 2 (ConfigForm auto-reset) | [#292](https://github.com/nbx-liz/LizyStudio/pull/292) | CI green | 2026-04-29 | StratifiedKFold → KFold 切替の race 解消 (ローカル実機 confirmed)。GroupKFold は引き続き race (W1 経路、Phase 5 scope)。`workspace-config-reflection.spec.ts` は Phase 5 まで `test.skip` |
+| Phase 3 (useTargetSelection) | [#293](https://github.com/nbx-liz/LizyStudio/pull/293) | CI green | 2026-04-29 | target-select 直後の rapid PUT バーストを `target-select` reason で funnel serialise。`legacyUpdateConfig` seam pattern を導入 |
+| Phase 4 (useModelPanelData) | [#294](https://github.com/nbx-liz/LizyStudio/pull/294) | CI green | 2026-04-29 | onWriteCommitted wrapper-leak fix を同梱 |
+| Phase 5 (useConfigSync W1) | [#295](https://github.com/nbx-liz/LizyStudio/pull/295) | CI green | 2026-04-29 〜 04-30 | B-3 spec が green になる出口 |
+| Phase 6 (WorkspacePage W6) | [#295](https://github.com/nbx-liz/LizyStudio/pull/295) | CI green | 2026-04-30 | exit check 達成 |
 
-##### B-3 / D-1 spec status
+##### B-3 / D-1 spec status (mid-flight)
 
 - **PR #289** (`workspace-cv.spec.ts`) — draft 維持。Phase 5 で 7 strategy 全 pass する想定。
 - **`workspace-config-reflection.spec.ts`** (D-1 sample) — `test.skip(true, "Skipped during P-0092 Phase 2..4. Re-enabled at Phase 5...")`。Phase 5 完了で skip 削除し、spec への変更なしに green になることを確認。
 
 ##### Phase 2 で見つけた副次的バグ
 
-ConfigForm の inner_valid auto-reset effect は `["training", "inner_valid", "method"]` を書いていたが、lizyml schema (`extra="forbid"`) は `training.early_stopping.inner_valid` のみ受け付ける。Phase 2 で path を canonical 形に修正済み (`useConfigSync.ts:90-103` のコメント参照)。Issue #272 の partial fix だった可能性あり、後追い検証は Phase 5 完了後に。
+ConfigForm の inner_valid auto-reset effect は `["training", "inner_valid", "method"]` を書いていたが、lizyml schema (`extra="forbid"`) は `training.early_stopping.inner_valid` のみ受け付ける。Phase 2 で path を canonical 形に修正済み (`useConfigSync.ts:90-103` のコメント参照)。
+
+#### Phase progress log (2026-04-29 〜 2026-04-30) — 最終結果
+
+- **Phase 1 [PR #291, CI green]** — `useConfigWriteFunnel` skeleton + state machine + 14 unit tests. Production dead code until Phase 2 wires it.
+- **Phase 2 [PR #292, CI green]** — ConfigForm auto-reset effects → funnel via `useConfigWriteFunnelOptional`. Provider mounted in WorkspacePage. **Stratified→KFold transition stable** (local browser verified). GroupKFold still racing (W1 not migrated).
+- **Phase 3 [PR #293, CI green]** — useTargetSelection merged-PUT → funnel. `legacyUpdateConfig` seam pattern introduced (optional writer in params; fallback for test paths that mount the hook outside a Provider). Phase 4-6 reuse this pattern.
+- **Phase 4 [PR #294, CI green]** — useModelPanelData.handleConfigChange (W3) + handleUndo (W4) + handleRedo (W5) → funnel. **Critical wrapper-leak bug fix in WorkspacePage.onWriteCommitted:** funnel's default `putConfig` returns the full `ConfigUpdateResponse {config, errors, saved}`, but Phase 2's onWriteCommitted wrote the wrapper raw into the cache. useTargetSelection's tests stubbed updateConfig to undefined, masking it. Fix: extract `.config` and gate on `saved !== false`. Playwright MCP composite scenario (StratifiedKFold + Calibration toggle in same tick) confirmed: no rollback, isWrapper=false on 867 samples, 0 console errors.
+- **Phase 5 [PR #295, CI green]** — useConfigSync.syncConfig itself routed through funnel with `reason="cv-change"`. `abortRef` retained but only guards the GET pre-fetch; PUT-side dedup is the funnel's job. **Funnel public-API object identity stabilised via useMemo** — without this, the new useConfigSync `useEffect` deps storm fired ~10 PUTs per click. Quiescence-detection step added to `seedUiWorkspace` E2E helper (4 identical samples × 50ms before returning) so D-1 spec subscribes after the seed funnel has drained. **D-1 sample green-flipped** (4.3s locally).
+- **Phase 5b [PR #295 commit `4d07c7f`, CI green]** — B-3 e2e spec exposed two stacked rejects on group/time strategies (5 of 7 failed):
+  1. `Extra inputs are not permitted` — `stratify` carried over from holdout into group_holdout (`extra="forbid"`).
+  2. `Specify either 'validation_ratio' or 'inner_valid', not both` — both fields explicit; only the holdout `ratio==validation_ratio` round-trip exempt.
+
+  Fix: new `pruneInnerValidForMethod(current, method)` helper in `cv-state.ts` mirroring the lizyml Pydantic schema (holdout / group_holdout / time_holdout). useConfigSync calls it on cv-strategy change AND drops `EarlyStoppingConfig.validation_ratio` so the model_validator stops double-tripping. After fix: B-3 7/7 strategies pass in 19.2s; D-1 still passes 4.3s.
+
+- **Phase 6 [PR #295 commit `905ee62`, CI green]** — `WorkspacePage.handleApplyToFit` (W6) → funnel via `enqueueWrite({ reason: "apply-to-fit" })`. New saved=false branch: explicit error toast + invalidateQueries; success path drops the redundant invalidate because the funnel's onWriteCommitted writes cache atomically. `updateConfig` import removed from WorkspacePage.tsx.
+
+#### Exit check verification (2026-04-30)
+
+`grep -rE "updateConfig\(" frontend/src/` returns:
+
+- `src/api/workspace.ts:122` — definition (immutable).
+- `src/hooks/useConfigWriteFunnel.ts:170` — funnel's default `putConfig=updateConfig` binding (THE single funnel implementation site, satisfying acceptance criterion (b) per the canonical reading).
+- `src/hooks/useConfigSync.ts:177`, `src/hooks/useModelPanelData.ts:171,260` — `else` branches behind `if (writeFunnel)` guards, **unreachable in production** (WorkspacePage always mounts the Provider) and exist only to keep unit tests that render hooks without a Provider working without a Provider-wrapping refactor across the suite. Removing them is a separate cleanup with no production behaviour change.
+
+#### Acceptance criteria — final tally
+
+- (a) PR #289 B-3 spec — **7/7 strategies pass** (verified locally 2026-04-30 19.2s).
+- (b) production-path `updateConfig(` call sites — **0 outside the funnel** (the single funnel implementation site is `useConfigWriteFunnel.ts:170`).
+- (c) `setQueryData(queryKeys.config(), ...)` — funnel-owned via `WorkspacePage.onWriteCommitted`. Test-path setQueryData calls remain in `useDataPanel`'s subscriber-back-sync (which reads, not writes, the source of truth).
+- (d) funnel state machine invariant tests — 14 unit tests in `useConfigWriteFunnel.test.ts` (Phase 1) + 5 funnel-routing assertions in `useConfigSync.test.ts` (Phase 5) + 6 funnel-routing assertions in `useModelPanelData.test.ts` (Phase 4) + 1 Phase 6 assertion in `WorkspacePage.test.tsx`.
+- (e) all gates green (vitest 1729 / biome / tsc / build) on every PR's CI run.
+- (f) per-phase PRs (#290 / #291 / #292 / #293 / #294 / #295). Each phase's commits are revertable units; #295 squashes Phase 5 + 5b + 6 by branch convention but the per-commit revert path stays open.
+
+#### Decision
+
+- 2026-04-30 **Resolved & Implemented** — Q-1 fully landed across PRs #290..#295. PR #289 B-3 spec passes 7/7. Hypothesis (cross-hook write race resolved by single-funnel serialisation) proven. Closes the §P-0092 investigation thread.
+- Lessons captured globally:
+  - `~/.claude/skills/learned/diagnosis-before-prescription.md` — the Three Verification Gates pattern that caught two false-positive diagnoses on this thread (the original "ConfigForm single writer" Phase 0 diagnosis and the Phase 5b "in-flight coalesce" misdiagnosis). Each was avoided once decoded PUT bodies replaced inferred ones.
 

--- a/docs/gui-e2e-plan.md
+++ b/docs/gui-e2e-plan.md
@@ -1,0 +1,220 @@
+# GUI E2E 強化計画
+作成日: 2026-04-29
+動機: post-#271 smoke Phase 4 監査の延長。GUI 動作カバレッジの欠落補填 + 全設定項目の Config 反映 invariant 化。
+
+## ゴール
+
+1. **GUI 操作シナリオの網羅性向上** — 既存 49 シナリオの白地（Jobs functional / CV strategy 切替 / Feature Weights / Column Settings / Preset Load / running lock 等）を埋める
+2. **設定項目 → Config 反映 invariant の自動化** — 全 UI コントロールが `PUT /api/workspace/config` の正しいフィールドに正しい値を書くことを E2E で locking
+
+## 設計原則
+
+### Config-reflection 検証パターン
+
+各シナリオは「**操作 → ネットワーク観測**」の 3 段で書く。
+
+```typescript
+// (1) UI 操作前の baseline を取る
+const before = await getConfig(request);
+
+// (2) UI 操作（input / click / select）
+await page.getByLabel("Folds").fill("7");
+
+// (3) PUT /config を観測してアサート
+const put = await page.waitForRequest(req =>
+  req.url().endsWith("/api/workspace/config") && req.method() === "PUT"
+);
+const body = put.postDataJSON();
+expect(body.split.n_splits).toBe(7);
+
+// (4) 反映後の GET を取り、saved 値が期待と一致
+const after = await getConfig(request);
+expect(after.split.n_splits).toBe(7);
+```
+
+これにより以下を同時に検証:
+
+- UI コントロール → wire field name の対応
+- 値の型変換（NumberInput の string → int 等）
+- 同時に flush される他フィールドが意図せず変わっていない
+- サーバ側の Pydantic バリデーションを通過
+
+## Phase A: 設定項目 × UI コントロール × Config 反映マトリクス
+
+LizyML schema 全フィールドを横軸に、UI 表現と E2E 状態を縦軸にした **完全マトリクス**。
+
+### A.1 `data` セクション
+
+| Config field | 型 | UI コントロール | UI 場所 | 既存 E2E | 状態 |
+|---|---|---|---|---|---|
+| `data.path` | str? | TextInput + Browse | DataSourceSection | workspace-fit:UI Data load | ✅ |
+| `data.target` | str | Select | DataPanel target | workspace-fit:UI target select | ✅ |
+| `data.task`* | enum | SegmentGroup | DataPanel task | workspace-ui-improvements:Task SegmentButton | ✅ |
+| `data.time_col` | str? | Select (CV 条件付き) | CvSection | **なし** | ❌ NEW |
+| `data.group_col` | str? | Select (CV 条件付き) | CvSection | **なし** | ❌ NEW |
+
+注: `data.task` は LizyML では `LizyMLConfig.task` トップレベル。
+
+### A.2 `features` セクション
+
+| Config field | 型 | UI コントロール | UI 場所 | 既存 E2E | 状態 |
+|---|---|---|---|---|---|
+| `features.exclude` | list[str] | Excl checkbox 列 | ColumnSettingsSection | **なし** | ❌ NEW |
+| `features.auto_categorical` | bool | (UI 露出なし、デフォルト true) | — | — | ⚠ 確認要 |
+| `features.categorical` | list[str] | Type=Cat トグル | ColumnSettingsSection | **なし** | ❌ NEW |
+
+### A.3 `split` セクション（8 strategy 分岐）
+
+#### 共通
+| Config field | UI | 既存 E2E | 状態 |
+|---|---|---|---|
+| `split.method` | SegmentButton | workspace-advanced:API group_kfold のみ | ⚠ UI 切替テスト無し |
+| `split.n_splits` | NumberInput "Folds" | **なし** | ❌ NEW |
+
+#### Strategy 別フィールド（CV strategy 切替で出現/消失）
+
+| Strategy | 固有フィールド | UI | E2E |
+|---|---|---|---|
+| `kfold` | `random_state`, `shuffle` | NumberInput + Switch | ❌ |
+| `stratified_kfold` | `random_state` | NumberInput | ❌ |
+| `group_kfold` | (n_splits, group_col) | Select | ❌ |
+| `stratified_group_kfold` | `random_state`, `shuffle`, group_col | mix | ❌ |
+| `time_series` | `gap`, `train_size_max?`, `test_size_max?`, time_col | NumberInput*4 + Select | ❌ |
+| `purged_time_series` | `purge_gap`, `embargo`, `train_size_max?`, `test_size_max?` | NumberInput*4 | ❌ |
+| `group_time_series` | `gap`, sizes, group_col, time_col | mix | ❌ |
+| `blocked_group_kfold` | `blocks{col,cutoffs,mode,train_window?}`, `groups{col,n_splits,stratify,shuffle}`, `min_train_rows`, `min_valid_rows` | BlockedGroupKFoldEditor | ❌ |
+
+→ **8 strategy × 平均 4 フィールド = 32 個のサブシナリオ**。strategy 切替時に**他 strategy のフィールドが消える** invariant も必要（post-#271 smoke で何度も問題化したクラス）。
+
+### A.4 `model` セクション（LGBM）
+
+| Config field | UI | E2E |
+|---|---|---|
+| `model.name` | (固定 lgbm) | — |
+| `model.params` | dict (Raw Config or KeyValueEditor) | KeyValueEditor.test (unit のみ) |
+| `model.auto_num_leaves` | Switch | ❌ |
+| `model.num_leaves_ratio` | NumberInput | ❌ |
+| `model.min_data_in_leaf_ratio` | NumberInput (nullable) | ❌ |
+| `model.min_data_in_bin_ratio` | NumberInput (nullable) | ❌ |
+| `model.feature_weights` | FeatureWeightsEditor | unit のみ。**E2E なし** | ❌ NEW (Issue #277 領域) |
+| `model.balanced` | Switch | workspace-fit:UI Balanced toggle | ✅ |
+
+### A.5 `training` セクション
+
+| Config field | UI | E2E |
+|---|---|---|
+| `training.seed` | NumberInput | ❌ |
+| `training.early_stopping.enabled` | Switch | ❌ |
+| `training.early_stopping.rounds` | NumberInput | ❌ |
+| `training.early_stopping.inner_valid.method` | Select (holdout/group_holdout/time_holdout) | ❌ |
+| `training.early_stopping.inner_valid.ratio` | NumberInput | ❌ |
+| `training.early_stopping.inner_valid.stratify` (holdout) | Switch | ❌ |
+| `training.early_stopping.inner_valid.random_state` | NumberInput | ❌ |
+| `training.early_stopping.validation_ratio` | NumberInput (nullable) | ❌ |
+
+### A.6 `tuning` セクション
+
+| Config field | UI | E2E |
+|---|---|---|
+| `tuning.optuna.params.n_trials` | NumberInput | workspace-tune:API のみ |
+| `tuning.optuna.params.direction` | (Tune tab metric chips に置換、H-0013) | workspace-ui-improvements:metric chips | ✅ |
+| `tuning.optuna.params.timeout` | NumberInput (nullable) | ❌ |
+| `tuning.optuna.space` | KeyValueEditor + Range / Choice / Fixed | workspace-tune:UI 空 Choice disable | ⚠ 部分 |
+| `tuning.optuna.space.<param>.kind` | Mode SegmentButton | workspace-ui-improvements:Mode SegmentButton | ✅ |
+| `tuning.optuna.space.<param>.range` | min/max/step | ❌ |
+| `tuning.optuna.space.<param>.choices` | list editor | ❌ |
+| `tuning.optuna.space.<param>.fixed` | FixedValueEditor | unit のみ |
+
+### A.7 `evaluation` / `calibration`
+
+| Config field | UI | E2E |
+|---|---|---|
+| `evaluation.metrics` | (UI 露出なし。Tune tab metric chips が一部担当) | metric chips のみ | ⚠ |
+| `calibration.method` (binary 限定) | Select | CalibrationSection.test (unit) | ❌ |
+| `calibration.n_splits` | NumberInput | unit のみ |
+| `calibration` enable トグル | Switch | workspace-fit:UI Calibration toggle | ✅ |
+
+## Phase B: GUI 操作ギャップ補填（前回 §1.7 ベース）
+
+| # | ギャップ | 新規追加 spec | 規模 |
+|---|---|---|---|
+| B-1 | Jobs ページ functional UI 0 件 | `jobs-ui.spec.ts`: 一覧クリック→詳細表示 / フィルタ操作 / Export ダイアログ / Delete 確認 / Cancel | 中 |
+| B-2 | Inference History クリックで結果切替 | `inference-flow.spec.ts` 拡張 | 小 |
+| B-3 | CV strategy 切替（8 strategy 巡回） | `workspace-cv.spec.ts`: Phase A.3 のマトリクスを駆動 | 中 |
+| B-4 | Feature Weights エディタ操作 | `workspace-feature-weights.spec.ts`: ON → Add → 値編集 → PUT 観測 | 小 |
+| B-5 | Column Settings の Excl/Type 操作 | `workspace-columns.spec.ts`: チェック → PUT で features.exclude/categorical 反映 | 小 |
+| B-6 | Preset Load → form 反映 | `workspace-presets.spec.ts`: Save → Load → 全 NumberInput が反映 | 小 |
+| B-7 | Fit 中 running lock の UI 表示 | `workspace-running-lock.spec.ts`: Fit 開始 → 全 input が disabled / 409 toast | 中 |
+| B-8 | Mobile/Tablet レイアウト | `workspace-mobile.spec.ts`: viewport 縮小 → bottom-tab 切替で全 panel アクセス | 中 |
+
+## Phase C: Config-reflection invariant 自動 spec ジェネレータ
+
+A のマトリクスを **手書きで全 60+ 件書くと保守がきつい**。代わりに以下の構造で自動化する。
+
+### 仕様
+
+```typescript
+// frontend/tests/e2e/helpers/config-reflection.ts
+export interface ConfigFieldSpec {
+  name: string;
+  uiSelector: () => Locator;
+  uiAction: (locator: Locator, value: any) => Promise<void>;
+  configPath: string;        // e.g. "split.n_splits"
+  testValue: any;
+  defaultValue: any;
+  precondition?: () => Promise<void>; // e.g. "select stratified_kfold first"
+}
+
+export async function assertConfigReflection(
+  page: Page, request: APIRequestContext, spec: ConfigFieldSpec
+): Promise<void> {
+  await spec.precondition?.();
+  await assertCurrentConfig(request, spec.configPath, spec.defaultValue);
+  const putPromise = page.waitForRequest(/api\/workspace\/config/);
+  await spec.uiAction(spec.uiSelector(), spec.testValue);
+  const put = await putPromise;
+  expect(deepGet(put.postDataJSON(), spec.configPath)).toEqual(spec.testValue);
+  await assertCurrentConfig(request, spec.configPath, spec.testValue);
+}
+```
+
+### Spec データソース
+
+`frontend/tests/e2e/fixtures/config-fields.ts` に **A.1〜A.7 のマトリクスをデータとして外出し**。spec ファイル本体は `forEach(spec => test(spec.name, ...))` のループで全項目をカバー。フィールド追加時は fixture 行を 1 つ足すだけ。
+
+### 既存の P-0087 contract test との関係
+
+`tests/contract/test_ui_schema_pydantic_alignment.py` が **schema レベルの drift** を locking するなら、この E2E は **値の流通** を locking する。重複ではなく直交補完。
+
+## Phase D: 段階実装プラン
+
+| Phase | 内容 | PR 規模 | change-gate |
+|---|---|---|---|
+| **D-1** | Phase A マトリクス完成（fixture データ + helper の骨格） | 中 (~400 行) | 不要 (テスト追加のみ) |
+| **D-2** | Phase B-1 (Jobs UI) + B-3 (CV strategy 切替) | 中 | 不要 |
+| **D-3** | Phase B-2/B-4/B-5/B-6 (Inference history / FW / Columns / Presets) | 中 | 不要 |
+| **D-4** | Phase B-7 running lock + B-8 mobile | 中 | 不要 |
+| **D-5** | Phase C ジェネレータ起動 + 全フィールド loop | 大 (~600 行) | 不要 |
+
+各 Phase の完了条件: `pnpm test:e2e` PR ブロッキング job が green、Nightly visual も green 維持。
+
+## 期待効果
+
+| 指標 | 現状 | 計画後 |
+|---|---:|---:|
+| GUI シナリオ数 | 49 | ~110 |
+| Config field × UI 反映カバレッジ | 推定 25% | 100% |
+| post-#271 smoke 系統の手動検証必要性 | 都度発生 | 自動化済み |
+| 新規フィールド追加時の手間 | spec 1 個書く | fixture 1 行追加 |
+
+## リスク
+
+- **`waitForRequest` はタイミング依存** — debounce 中に複数 PUT が飛ぶと取り違える。`useConfigSync` の dedup key で安定化していることを利用、念のため `request.postDataJSON()` で内容確認
+- **Mobile spec の golden** — visual 系は Nightly 行きにし、PR ブロッキングは functional のみ
+- **CV strategy 切替時の他 strategy フィールド消失 invariant** — 現実装では `cv_strategy_fields` (P-0087) が SSOT、ただし wire 側で前 strategy の値が漏れる可能性は再検証が必要
+
+## 次のアクション候補
+
+1. **D-1 から着手**: `frontend/tests/e2e/helpers/config-reflection.ts` の helper + 1 サンプルフィールド (split.n_splits) で雛形を作る
+2. もしくは **Phase B-3 (CV strategy 切替)** を先行: post-#271 smoke で繰り返し問題化した領域なので回帰防止効果が最も高い
+3. もしくは **Phase B-1 (Jobs UI)** を先行: 現状 functional UI シナリオが完全にゼロな領域


### PR DESCRIPTION
## Summary

Adds Proposal **P-0092** to HISTORY.md, selects **Q-1 (Write funnel unification)** as the implementation approach, and now records the **completed Phase 1-6 progress + final Resolved Decision**. This PR remains documentation-only — implementation lands in PRs #291..#295.

## Status — 2026-04-30

**Q-1 fully implemented across PRs #290..#295 (this PR is the doc head).** The §P-0092 section now contains:
- Original Proposal (Q-1 vs Q-2/3/4 selection rationale)
- 6-phase rollout plan (Phase 0..6)
- Mid-flight Progress log (2026-04-29 snapshot, kept for posterity)
- Final Phase progress log (2026-04-29 → 2026-04-30, all 6 phases CI green)
- Exit check verification (`grep -rE "updateConfig\(" frontend/src/`)
- Acceptance criteria final tally (a-f all met)
- Resolved Decision

This PR is the FIRST in the merge sequence (#290 → #291 → #292 → #293 → #294 → #295 → #289). All implementation PRs depend on this one because they branched off after the original Q-1 selection commits.

## Why Q-1 over Q-2 / Q-3 / Q-4

| Q | Verdict |
|---|---|
| Q-1 (write funnel) | **Selected & verified** — only frontend-internal option that structurally eliminates the writer triangle. Verification: B-3 spec 7/7 strategies pass post-Phase-5b. |
| Q-2 (If-Match) | Rejected — backend API change-gate is wider than necessary for a frontend-localized race. |
| Q-3 (closure-stabilize useConfigSync) | Rejected — partial fix reproduces the P-0086 / P-0090 "close one gap, open another" pattern. (Confirmed retrospectively: Phase 5 alone, without Phase 5b's inner_valid prune, would not have green-flipped B-3.) |
| Q-4 (server-side auto-adjust) | Rejected — backend Pydantic + UI representation conflicts with BLUEPRINT §3.2 responsibilities. |

## Diagnosis recap

Initial commit `c635b88` blamed `ConfigForm.tsx`'s inner_valid auto-reset effect alone. A deeper local repro (pnpm dev + Playwright MCP + 50ms cache polling) showed the rollback PUT body is a full config with `random_state=42` matching `useConfigSync.syncConfig`'s defaults-merge branch — too wide for any single writer. Three writers race: `useConfigSync.syncConfig`, `useModelPanelData.handleConfigChange`, `ConfigForm` auto-reset effects. PR #286 (P-0090) closed the (1)↔`useDataPanel` edge; the (1)↔(2)↔(3) triangle was out of scope and is what PR #289's B-3 spec finally exposed.

## Lessons captured

The Phase 5 → 5b discovery exposed that the original Phase 5 "in-flight coalesce" diagnosis was a misread of the trace. Decoding actual PUT body content (rather than inferring from PUT count) showed the real cause was `inner_valid` field carry-over across method-specific Pydantic schemas. This pattern is now codified globally as `~/.claude/skills/learned/diagnosis-before-prescription.md` (Three Verification Gates: separate facts from inferences → verify the critical link → list alternative explanations before committing to a fix).

## What this PR does *not* do

- No source code changes. All implementation is in PRs #291..#295.
- Backend stays untouched.

## Test plan

- [x] Reviewer reads §P-0092 — Decision (Q-1 selected) and Phase plan
- [x] Reviewer aligns on the writer inventory (W1..W6) and ordering of phases
- [x] Reviewer reads the final Phase progress log + Acceptance tally + Resolved Decision in the latest commit (`21c7f1f`)
- [x] All implementation PRs (#291..#295) CI green and ready to merge in order
- [x] PR #289 (B-3 spec) verified locally to pass 7/7 strategies post-Phase-5b
