### PR TITLE
feat(workspace): add write funnel hook + state machine (P-0092 Q-1 Phase 1)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2575,3 +2575,50 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - (d) Manual smoke: target=Survived の状態で Feature Weights を ON にし、"Add feature" picker に Survived が **含まれない** ことを確認（実機 Playwright）。
 - **Decision:**
   - 2026-04-28 **Proposed & Implemented** — PR-C3 として merge 予定。Issue #277 を close。post-#271 smoke 3-PR plan (PR-C1 / PR-C2 / PR-C3) はこれで完了。
+
+### P-0092: ConfigForm auto-reset effect が cv 切替の wire を巻き戻す cross-hook race（PR #289 で発覚）
+- **Status:** proposed
+- **Scope:** Frontend / State management
+- **Related:** Issue #272 / Issue #278（cross-hook competing-write race の前段）、P-0090 (PR #286, useConfigSync の setQueryData + back-sync)、PR #289（B-3 e2e spec、本 race を CI で再現）、gui-e2e-plan.md B-3
+- **Context:** B-3 e2e spec (`workspace-cv.spec.ts`) を `develop` で走らせると、CV strategy radio をクリックして 5 秒待っても server 側 saved config が新しい strategy に切り替わらない。PR #289 のローカル再現 + Playwright MCP + `browser_network_requests` で root cause を特定:
+  1. ユーザが GroupKFold radio を click → `DataPanel.cv` state 更新 → `useConfigSync` が PUT (split.method=group_kfold, inner_valid.method=group_holdout) を発火し server 保存される。
+  2. Server レスポンスを `useConfig` (TanStack Query) が取り込み ConfigForm が再 render。
+  3. しかし `ConfigForm.tsx:121-136` の `useEffect`（inner_valid auto-reset）は、`useConfigSync` の最新 PUT を待たずに **`configRef.current` (= 古い stratified_kfold snapshot)** を base として PUT を発火する。
+  4. 結果: `split.method=stratified_kfold + inner_valid.method=holdout + random_state=42` が server に PUT され、cv 変更が完全に巻き戻される。
+  5. UI 上の Strategy radio は `cv` state を反映するため一瞬 GroupKFold が selected になるが、`useConfig` が refetch して stratified_kfold を取り込んだ次の render で StratifiedKFold に戻る。
+
+  P-0090 (PR #286) は `useConfigSync` ↔ `useDataPanel` 間の race を `setQueryData` 即時同期と `QueryCache.subscribe` back-sync で塞いだ。**ConfigForm の auto-reset effect は同じ pattern の third-party writer であり、その race の対象外**だった。
+- **Invariants:**
+  - INV-1: PUT `/api/workspace/config` の body は **直前に server に lands した config** をベースに生成されなければならない。古い `configRef.current` snapshot を使った partial-merge PUT は禁止。
+  - INV-2: ConfigForm の auto-reset effect (inner_valid / calibration) は、`useConfigSync` が in-flight な間は発火しない、または in-flight 完了を待ってから発火する。
+  - INV-3: cv strategy 切替で派生する inner_valid のリセット (e.g., group_kfold → group_holdout) は、cv 変更の **同一 PUT** で flush されなければならない。別 PUT で後追いすると race 窓を開く。
+  - INV-4: Backend が cv 変更時に inner_valid を auto-update する behaviour（実機観察: server が group_holdout を返す）と、frontend の auto-reset effect は同じ集合論的結果を生む（最終 saved config が一意に決まる）。
+- **Proposal & Impact:** 修正候補 3 つを比較し、いずれか 1 つで実装する。
+  - **(A) `configRef.current` を React Query cache に subscribe**（PR #286 と同じ pattern）。
+    - `ConfigForm.tsx`: `configRef.current = config` を `useEffect` + `queryClient.getQueryCache().subscribe` 経由に置き換え。setQueryData が走った瞬間に ref が更新され、次の auto-reset effect が最新 base を使う。
+    - `useConfigSync` 側は無変更。
+  - **(B) auto-reset を `useConfigSync` に統合**。
+    - `useConfigSync.syncConfig` 内で cv 変更を検知し、必要なら inner_valid を同 PUT で reset。`ConfigForm` の effect は廃止。
+    - 利点: cv と inner_valid が常に 1 PUT で flush され、INV-3 が構造的に保証される。
+    - 欠点: `useConfigSync` の責務が広がる（CV 以外の strategy 依存ロジックを取り込みやすい）。
+  - **(C) auto-reset effect を debounce + in-flight guard 付きに書き換え**。
+    - `useConfigSync.isFlushing` を export し、ConfigForm の effect が flushing 中は発火を skip。flush 完了後に effect が再走するよう dependency を整える。
+    - 利点: ConfigForm の責務を維持。
+    - 欠点: in-flight guard の race が残る（flush 完了直後 / effect 発火前の窓）。
+  - 推奨: **(A)**。PR #286 と同じ pattern で確立済みの contract を踏襲。Auto-reset effect の責務 (`ConfigForm` 内に閉じる) を維持しつつ INV-1 を満たす。
+- **Compatibility:**
+  - API: 変更なし（PUT /config の wire shape は不変）。
+  - UI: cv 切替が**実際に**反映されるようになる（regression ではなく仕様準拠化）。post-#271 smoke の Manual smoke 項目（"BlockedGroupKFold radio click → 1 click で server に lands"）を強化する形。
+  - Backend: 変更なし。
+- **Alternatives considered:**
+  - (D) ConfigForm の auto-reset effect 自体を廃止し、backend が cv 変更時に inner_valid を必ず adjust する仕様にする → 却下。frontend の filter (`filteredInnerValidOptions`) は UI 表示にも使うため、UI と server が同期しないと現在選択中の inner_valid 値が UI 上で消えるだけになる。
+  - (E) `useConfig` の `staleTime` を 0 にして毎回 refetch → 却下。race 窓が短くなるだけで根本解決にならず、network トラフィックも倍増。
+- **Acceptance Criteria:**
+  - (a) PR #289 の `workspace-cv.spec.ts` が CI で 7 strategy 全て pass する（chromium project）。
+  - (b) `frontend/src/components/workspace/ConfigForm.tsx` の auto-reset effect が `configRef.current` を base に PUT する behaviour に対する unit test が追加され、最新 cache subscription が反映されることを locking する。
+  - (c) Manual smoke (Playwright MCP): GroupKFold radio click → 1 click で `split.method=group_kfold` が server に lands し続け、inner_valid auto-reset 後も group_kfold が保たれる。
+  - (d) `frontend/src/hooks/useConfigSync.test.ts` の既存 race test が引き続き pass（PR #286 で導入された invariants を破壊しない）。
+  - (e) frontend vitest / biome / build / backend pytest / ruff / mypy がすべて green。
+- **Decision:**
+  - 2026-04-29 **Proposed** — PR は別途起票（implementation 候補 (A) を採用）。PR #289 は本 Proposal の実装 PR にマージ吸収するか、本 Proposal 完了後に rebase + re-run する。
+

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2610,4 +2610,118 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
   - 2026-04-29 **Proposed** — initial diagnosis (ConfigForm の単一 writer race) に基づく実装試行（仮称 PR #291）は中断。実機 + cache polling で 3 writer race と判明したため、Q-1 〜 Q-4 から方針を確定するまで実装を止め、設計議論を待つ。
   - PR #289 (`workspace-cv.spec.ts`) は本 Proposal が解決するまで draft のまま保持。本 Proposal の Acceptance には PR #289 の B-3 spec が CI で 7 strategy 全 pass することを最終条件として残す。
   - 当面の Workaround: `develop` 上の手動 smoke では cv strategy 変更後 1 秒待ってから次の操作に進むことで巻き戻しを観察できる。回避策ではあるが本質的修正ではない。
+  - 2026-04-29 **Approach selected: Q-1 (Write funnel 単一化)** — 全 PUT を `useConfigSync` 一本に集約する。短期の partial fix (Q-3) は P-0086 / P-0090 と同じ "塞いでも次の隙間が出る" pattern を再生産する risk が高く、根治しない。Q-2 (If-Match) と Q-4 (server auto-adjust) は backend 変更を伴い change-gate 範囲が広い。Q-1 は frontend 内で完結し、構造的に race を消す唯一の選択肢。
+
+#### Phase plan (Q-1 段階実装)
+
+PR を 6 段階に分け、**各段階で B-3 spec の進捗を確認**しながら進める。各段階の commit は単独で revert 可能な単位とする。
+
+##### Phase 0: writer inventory (この Proposal 内でドキュメント済)
+
+現在の writer 一覧（PUT `/api/workspace/config` を発行する 6 箇所）:
+
+| ID | 場所 | 経路 | 用途 |
+|----|------|------|------|
+| W1 | `hooks/useConfigSync.ts:106` | `syncConfig` | DataPanel state (target/task/cv/blocked/overrides) 変更 |
+| W2 | `hooks/useTargetSelection.ts:110` | target 選択時の `merged` PUT | target 選択 + defaults 取得 |
+| W3 | `hooks/useModelPanelData.ts:115` | `handleConfigChange` | ConfigForm onChange (auto-reset effects 含む) |
+| W4 | `hooks/useModelPanelData.ts:186` | `handleUndo` | undo |
+| W5 | `hooks/useModelPanelData.ts:198` | `handleRedo` | redo |
+| W6 | `pages/WorkspacePage.tsx:132` | `handleApplyToFit` | Re-fit ボタン |
+
+`setQueryData(queryKeys.config(), ...)` の cache writer も同 5 箇所に分散。
+
+##### Phase 1: write funnel API を `useConfigSync` 上に新設
+
+- **目的:** 既存 writer を順次 funnel に移すための受け皿を用意する。実 writer 数を増やさない (W1 内に新 API を生やすだけ)。
+- **API 設計:**
+  ```ts
+  // useConfigSync の return
+  return {
+    syncConfig,           // 既存 — DataPanel 由来 sync (Phase 5 で内部実装が funnel.enqueue に置き換わる)
+    setSyncSuppressed,    // 既存
+    preseedSyncKey,       // 既存
+    // --- new ---
+    enqueueWrite,         // (op: WriteOp) => Promise<WriteResult> — 全外部 writer の入口
+    onTerminal,           // (cb) => unsubscribe — 完了通知 (test と downstream effects 用)
+  };
+
+  type WriteOp =
+    | { kind: 'replace'; config: FullConfig; reason: WriteReason }
+    | { kind: 'patch'; path: string[]; value: unknown; reason: WriteReason };
+
+  type WriteReason =
+    | 'target-select' | 'cv-change' | 'config-form-edit'
+    | 'undo' | 'redo' | 'apply-to-fit' | 'preset-load' | 'auto-reset';
+  ```
+- **State machine:**
+  - `idle` → `enqueueing` → `flushing` → `idle` (or `error`)
+  - `flushing` 中の enqueue は **後勝ち merge**: 同じ `WriteReason` は最新で上書き、異なる reason は serial に直列化
+  - `abort` は `flushing` 中の controller のみに作用、queue 上の op は維持
+- **scope:** `useConfigSync.ts` 内のみ。新 export 追加、既存 syncConfig 呼び出し側は変更しない。
+- **出口テスト:** vitest unit tests for funnel state machine. B-3 spec は **まだ red のまま** (writer がまだ funnel に流れていない)。
+- **PR 規模:** ~200 行追加, 0 行削除
+
+##### Phase 2: ConfigForm auto-reset effects → funnel に移行 (W3 の auto-reset 経路)
+
+- **目的:** B-3 race の最大要因の一つ、ConfigForm の inner_valid / calibration / objective auto-reset effect を funnel に流す。
+- **変更:**
+  - `ConfigForm` に `enqueueWrite` prop (or `useWorkspaceWriter()` context) を渡す。
+  - 3 つの auto-reset useEffect 内の `handleFieldChange(...)` → `enqueueWrite({ kind: 'patch', path, value, reason: 'auto-reset' })` に置き換え。
+  - 既存 `handleFieldChange` は user の field edit 用 (W3 の本筋) のみ残す → これは Phase 4 で扱う。
+- **出口テスト:** B-3 spec の **少なくとも一部の strategy が green になる**ことを確認 (auto-reset 由来の race が消える)。残りの strategy は W3 の user edit 経路や W2 の target merge race で red のまま。
+- **PR 規模:** ~150 行 ± 80 行
+- **チェックポイント:** 実装後ローカル `pnpm dev` + Playwright MCP で 8 strategy 巡回、saved config の遷移を 50ms polling で確認。
+
+##### Phase 3: useTargetSelection (W2) の merged PUT → funnel
+
+- **目的:** target 選択時の rapid PUT バーストを 1 つの funnel write に統合する。
+- **変更:**
+  - `useTargetSelection.ts:110` の `updateConfig(merged)` → `enqueueWrite({ kind: 'replace', config: merged, reason: 'target-select' })`
+  - `setQueryData` も funnel 内で行うため除去。
+- **出口テスト:** B-3 spec の **target 選択直後の strategy 切替** で green 化を確認。
+- **PR 規模:** ~80 行
+
+##### Phase 4: useModelPanelData (W3 user edit 経路) → funnel
+
+- **目的:** ConfigForm の user 由来 onChange (numeric/text/select の手編集) を funnel に流す。
+- **変更:**
+  - `useModelPanelData.handleConfigChange` の `updateConfig(newConfig)` → `enqueueWrite({ kind: 'replace', config: newConfig, reason: 'config-form-edit' })`
+  - undo / redo (W4 / W5) も同 PR で `reason: 'undo' | 'redo'` で funnel 経由に。
+  - validate debounce timer は funnel 完了後に動かす。
+- **出口テスト:** ConfigForm 経由の rapid edit (numeric stepper 連打 + cv strategy click) で巻き戻しが起きないことを Playwright MCP で確認。
+- **PR 規模:** ~150 行
+
+##### Phase 5: useConfigSync.syncConfig 内部実装も funnel ベースに統合
+
+- **目的:** W1 自身も funnel.enqueue を経由する形に書き換え、`abortRef` を funnel state machine に吸収。
+- **変更:**
+  - syncConfig が `cv` deps closure を持つ問題を、`enqueueWrite({ kind: 'replace', config: rebuiltFromLatestState, reason: 'cv-change' })` で解消。
+  - dedup key の概念を funnel 側に移管。
+- **出口テスト:** B-3 spec の **8 strategy 全部 green**。
+- **PR 規模:** ~200 行
+
+##### Phase 6: WorkspacePage.handleApplyToFit (W6) と Preset Load → funnel
+
+- **目的:** 残る writer を funnel に取り込み、`updateConfig` の **唯一の caller が useConfigSync 内の 1 箇所** になる状態を達成。
+- **変更:**
+  - `WorkspacePage.tsx:132` を `enqueueWrite({ kind: 'replace', reason: 'apply-to-fit' })` に。
+  - Preset Load (`useModelPanelData` 経由) も funnel に。
+- **出口テスト:** `grep -rE "updateConfig\(" frontend/src/` が `useConfigSync.ts` の 1 箇所のみを返すこと。 B-3 spec + 既存 e2e 全 green 維持。
+- **PR 規模:** ~120 行
+
+#### Acceptance criteria (全 Phase 完了時)
+
+- (a) PR #289 の `workspace-cv.spec.ts` が 7 strategy 全 pass。
+- (b) `frontend/src/` 内の `updateConfig(` call site が **1 箇所のみ** (`useConfigSync.ts` 内 funnel 実装)。
+- (c) `setQueryData(queryKeys.config(), ...)` 同様に funnel 内 1 箇所。
+- (d) `useConfigSync.test.ts` に funnel state machine の invariant test を追加 (concurrent enqueue / abort during flush / dedup by reason)。
+- (e) frontend vitest / biome / build / backend pytest がすべて green。既存 unit test の意図的な書き換え (mock の差し替え) は許容、新規スキップは禁止。
+- (f) 各 Phase の PR は単独で revert 可能 (incremental release safety)。
+
+#### Risk / 撤退基準
+
+- Phase 2 完了時に B-3 spec の **どの strategy も green にならない** 場合、診断が更に外れている可能性。Phase 3 に進まず再調査。
+- 各 Phase で既存 e2e (workspace-fit / workspace-tune / inference-flow) に regression が出たら、その PR を merge せず原因究明を優先。
+- 全 6 PR で **累計 frontend bundle 増加が +5KB を超えない** ことを bundle-size チェックで確認 (recent coupling refactor の予算に倣う)。
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2576,49 +2576,38 @@ v2 再開発ブランチ（`feat/v2`）にて、フロントエンドのテッ�
 - **Decision:**
   - 2026-04-28 **Proposed & Implemented** — PR-C3 として merge 予定。Issue #277 を close。post-#271 smoke 3-PR plan (PR-C1 / PR-C2 / PR-C3) はこれで完了。
 
-### P-0092: ConfigForm auto-reset effect が cv 切替の wire を巻き戻す cross-hook race（PR #289 で発覚）
-- **Status:** proposed
+### P-0092: Workspace config write funnel の cross-hook race（PR #289 で発覚、複数 writer の設計議論待ち）
+- **Status:** investigation — implementation deferred pending design review
 - **Scope:** Frontend / State management
-- **Related:** Issue #272 / Issue #278（cross-hook competing-write race の前段）、P-0090 (PR #286, useConfigSync の setQueryData + back-sync)、PR #289（B-3 e2e spec、本 race を CI で再現）、gui-e2e-plan.md B-3
-- **Context:** B-3 e2e spec (`workspace-cv.spec.ts`) を `develop` で走らせると、CV strategy radio をクリックして 5 秒待っても server 側 saved config が新しい strategy に切り替わらない。PR #289 のローカル再現 + Playwright MCP + `browser_network_requests` で root cause を特定:
-  1. ユーザが GroupKFold radio を click → `DataPanel.cv` state 更新 → `useConfigSync` が PUT (split.method=group_kfold, inner_valid.method=group_holdout) を発火し server 保存される。
-  2. Server レスポンスを `useConfig` (TanStack Query) が取り込み ConfigForm が再 render。
-  3. しかし `ConfigForm.tsx:121-136` の `useEffect`（inner_valid auto-reset）は、`useConfigSync` の最新 PUT を待たずに **`configRef.current` (= 古い stratified_kfold snapshot)** を base として PUT を発火する。
-  4. 結果: `split.method=stratified_kfold + inner_valid.method=holdout + random_state=42` が server に PUT され、cv 変更が完全に巻き戻される。
-  5. UI 上の Strategy radio は `cv` state を反映するため一瞬 GroupKFold が selected になるが、`useConfig` が refetch して stratified_kfold を取り込んだ次の render で StratifiedKFold に戻る。
+- **Related:** Issue #272 / Issue #278（cross-hook competing-write race の前段）、P-0086（DataPanel ref + setQueryData）、P-0090 (PR #286, useConfigSync の setQueryData + back-sync)、PR #289（B-3 e2e spec、本 race を CI で再現）、gui-e2e-plan.md B-3
+- **Symptom:** `develop` 上で B-3 e2e spec (`workspace-cv.spec.ts`) を走らせると、CV strategy radio click 後 5 秒待っても server 側 saved config の `split.method` が変わらない。実機 (`pnpm dev` + Playwright MCP) でも同じ巻き戻しが再現する。
+- **Initial diagnosis (2026-04-29 first pass — partially incorrect):** 当初は `ConfigForm.tsx:121-136` の inner_valid auto-reset effect が古い `configRef.current` snapshot から PUT を発火することが原因と判断した。しかし実機の network/cache observation で以下の追加事実が判明し、診断は不完全であることが確認された:
+  1. `browser_network_requests` で観察した巻き戻し PUT の body は **stratified_kfold + `random_state: 42` (defaults 由来) + 完全な model.params + evaluation.metrics + training.early_stopping.inner_valid=holdout** という **完全な config body** で、ConfigForm の auto-reset effect が `setNestedValue` で書き換える `["training","inner_valid","method"]` 1 フィールドだけの shape ではない。
+  2. cache polling (50ms 間隔) で saved config を観察すると、click から **44ms 後に巻き戻しが完了** している（`t=212ms split=stratified_kfold` → `t=256ms split=stratified_kfold + random_state=42`）。これは ConfigForm 経由で onChange → useModelPanelData.handleConfigChange → updateConfig という path にしては短すぎる。
+  3. 巻き戻し PUT の `random_state=42` は `fetchConfigDefaults("binary","target")` の output と一致する。これは **`useConfigSync.syncConfig`** が L66-68 で defaults を取得して base にしている経路と一致する。
+- **Refined hypothesis:** 単一 writer の責任ではなく、**3 つの writer がすべて in-flight な書込みを発行している**:
+  1. `useConfigSync.syncConfig` (L55-149): cv/target/task/overrides/blocked が変わるたびに re-create され `useEffect` から呼ばれる。`abortRef.abort()` は前回をキャンセルするが、**既に server に届いた fetch の body 送信はキャンセルできず**、server 側で commit される。`syncConfig` は closure で `cv` を capture しているため、cv が連続変化した場合の order は保証されない。
+  2. `useModelPanelData.handleConfigChange` (L100-163): ConfigForm の `onChange` の終端。`updateConfig` を直接呼び `setQueryData` で cache を上書きする。useConfigSync の in-flight PUT を尊重しない。
+  3. `ConfigForm.tsx` 内の auto-reset useEffect 群 (line 121-136 / 158-170 / 248-): `configRef.current` を base に `handleFieldChange` → `onChange(updated)` を発火。`configRef.current = config` (line 67) は render 時に更新されるが、render 順序と useConfigSync の PUT 順序の関係は保証されていない。
 
-  P-0090 (PR #286) は `useConfigSync` ↔ `useDataPanel` 間の race を `setQueryData` 即時同期と `QueryCache.subscribe` back-sync で塞いだ。**ConfigForm の auto-reset effect は同じ pattern の third-party writer であり、その race の対象外**だった。
-- **Invariants:**
-  - INV-1: PUT `/api/workspace/config` の body は **直前に server に lands した config** をベースに生成されなければならない。古い `configRef.current` snapshot を使った partial-merge PUT は禁止。
-  - INV-2: ConfigForm の auto-reset effect (inner_valid / calibration) は、`useConfigSync` が in-flight な間は発火しない、または in-flight 完了を待ってから発火する。
-  - INV-3: cv strategy 切替で派生する inner_valid のリセット (e.g., group_kfold → group_holdout) は、cv 変更の **同一 PUT** で flush されなければならない。別 PUT で後追いすると race 窓を開く。
-  - INV-4: Backend が cv 変更時に inner_valid を auto-update する behaviour（実機観察: server が group_holdout を返す）と、frontend の auto-reset effect は同じ集合論的結果を生む（最終 saved config が一意に決まる）。
-- **Proposal & Impact:** 修正候補 3 つを比較し、いずれか 1 つで実装する。
-  - **(A) `configRef.current` を React Query cache に subscribe**（PR #286 と同じ pattern）。
-    - `ConfigForm.tsx`: `configRef.current = config` を `useEffect` + `queryClient.getQueryCache().subscribe` 経由に置き換え。setQueryData が走った瞬間に ref が更新され、次の auto-reset effect が最新 base を使う。
-    - `useConfigSync` 側は無変更。
-  - **(B) auto-reset を `useConfigSync` に統合**。
-    - `useConfigSync.syncConfig` 内で cv 変更を検知し、必要なら inner_valid を同 PUT で reset。`ConfigForm` の effect は廃止。
-    - 利点: cv と inner_valid が常に 1 PUT で flush され、INV-3 が構造的に保証される。
-    - 欠点: `useConfigSync` の責務が広がる（CV 以外の strategy 依存ロジックを取り込みやすい）。
-  - **(C) auto-reset effect を debounce + in-flight guard 付きに書き換え**。
-    - `useConfigSync.isFlushing` を export し、ConfigForm の effect が flushing 中は発火を skip。flush 完了後に effect が再走するよう dependency を整える。
-    - 利点: ConfigForm の責務を維持。
-    - 欠点: in-flight guard の race が残る（flush 完了直後 / effect 発火前の窓）。
-  - 推奨: **(A)**。PR #286 と同じ pattern で確立済みの contract を踏襲。Auto-reset effect の責務 (`ConfigForm` 内に閉じる) を維持しつつ INV-1 を満たす。
-- **Compatibility:**
-  - API: 変更なし（PUT /config の wire shape は不変）。
-  - UI: cv 切替が**実際に**反映されるようになる（regression ではなく仕様準拠化）。post-#271 smoke の Manual smoke 項目（"BlockedGroupKFold radio click → 1 click で server に lands"）を強化する形。
-  - Backend: 変更なし。
-- **Alternatives considered:**
-  - (D) ConfigForm の auto-reset effect 自体を廃止し、backend が cv 変更時に inner_valid を必ず adjust する仕様にする → 却下。frontend の filter (`filteredInnerValidOptions`) は UI 表示にも使うため、UI と server が同期しないと現在選択中の inner_valid 値が UI 上で消えるだけになる。
-  - (E) `useConfig` の `staleTime` を 0 にして毎回 refetch → 却下。race 窓が短くなるだけで根本解決にならず、network トラフィックも倍増。
-- **Acceptance Criteria:**
-  - (a) PR #289 の `workspace-cv.spec.ts` が CI で 7 strategy 全て pass する（chromium project）。
-  - (b) `frontend/src/components/workspace/ConfigForm.tsx` の auto-reset effect が `configRef.current` を base に PUT する behaviour に対する unit test が追加され、最新 cache subscription が反映されることを locking する。
-  - (c) Manual smoke (Playwright MCP): GroupKFold radio click → 1 click で `split.method=group_kfold` が server に lands し続け、inner_valid auto-reset 後も group_kfold が保たれる。
-  - (d) `frontend/src/hooks/useConfigSync.test.ts` の既存 race test が引き続き pass（PR #286 で導入された invariants を破壊しない）。
-  - (e) frontend vitest / biome / build / backend pytest / ruff / mypy がすべて green。
+  **PR #286 (P-0090) は writer (1) と useDataPanel の back-sync race を塞いだ**が、(1)↔(2)↔(3) の三者間 race は対象外だった。今回 PR #289 の e2e spec が初めてこの三者間 race を再現可能な形で表面化した。
+- **Why a simple fix is unsafe:** 場当たり的な単一 writer 修正（例: configRef を queryCache に subscribe / useConfigSync に inner_valid 統合 / auto-reset を debounce）はいずれも **残り 2 つの writer の race を温存する**。実装試行の途中で「修正候補 (A)/(B)/(C) のどれを採っても他の writer 経路が race する」ことが判明し、設計議論なしに実装を進めると過去の P-0086 / P-0090 と同じ "塞いでも次の隙間が出る" pattern を繰り返す。
+- **Investigation needed (deferred to design review):**
+  - **Q-1: write funnel の単一化** — ConfigForm の auto-reset / useModelPanelData.handleConfigChange / useConfigSync.syncConfig を **1 経路** にできるか。例: 全ての PUT を `useConfigSync` に集約し、ConfigForm は controlled state を local に保持して `useConfigSync` に通知のみする shape。Workspace 全体の controlled-state 設計を見直す必要がある。
+  - **Q-2: write ordering を server side で保証する** — 例: `If-Match: <config_version>` ヘッダで optimistic locking を導入し、stale な PUT は 409 を返す。Frontend は 409 を受けて latest を再 fetch + retry。Backend API 変更を伴うため change-gate 対象。
+  - **Q-3: useConfigSync の closure 安定化** — `cv` を ref 化して `syncConfig` を deps から除く / `cv` ref を read at PUT-time。これで (1) の closure race は塞ぐが (2) と (3) の race は残る。
+  - **Q-4: ConfigForm の effect を全廃止** — auto-reset (inner_valid / calibration / objective) を server 側 (Pydantic validator + auto-adjust) に移管。frontend は server response の値を表示するだけ。これも change-gate 対象。
+- **Invariants we eventually want to lock:**
+  - INV-1: PUT `/api/workspace/config` の body は in-flight な PUT を尊重して順序付けられ、最終的に server 上の saved config が user intent と一致する。
+  - INV-2: writer (1)/(2)/(3) 間で base config snapshot の "誰が最新を持つか" の責務が単一に決まる。
+  - INV-3: cv strategy 切替で派生する inner_valid / objective / metric のリセットは、cv 変更の **同一 PUT** で flush されるか、base PUT 完了を待ってから follow-up PUT として flush される（順序保証あり）。
+  - INV-4: e2e (B-3) で 8 strategy 巡回した時、server saved config が常に最後の click の strategy と一致する。
+- **Compatibility (任意の解決策で見ておくべき範囲):**
+  - API: Q-2 (If-Match) を採るなら PUT の semantics 拡張が必要。Q-4 を採るなら GET response shape 拡張あり。Q-1/Q-3 は wire 不変。
+  - UI: 巻き戻し挙動が止まる方向の「regression ではない仕様準拠化」。
+  - Backend: Q-2/Q-4 は backend 変更を伴う。
 - **Decision:**
-  - 2026-04-29 **Proposed** — PR は別途起票（implementation 候補 (A) を採用）。PR #289 は本 Proposal の実装 PR にマージ吸収するか、本 Proposal 完了後に rebase + re-run する。
+  - 2026-04-29 **Proposed** — initial diagnosis (ConfigForm の単一 writer race) に基づく実装試行（仮称 PR #291）は中断。実機 + cache polling で 3 writer race と判明したため、Q-1 〜 Q-4 から方針を確定するまで実装を止め、設計議論を待つ。
+  - PR #289 (`workspace-cv.spec.ts`) は本 Proposal が解決するまで draft のまま保持。本 Proposal の Acceptance には PR #289 の B-3 spec が CI で 7 strategy 全 pass することを最終条件として残す。
+  - 当面の Workaround: `develop` 上の手動 smoke では cv strategy 変更後 1 秒待ってから次の操作に進むことで巻き戻しを観察できる。回避策ではあるが本質的修正ではない。
 

--- a/frontend/src/hooks/useConfigWriteFunnel.test.ts
+++ b/frontend/src/hooks/useConfigWriteFunnel.test.ts
@@ -1,0 +1,449 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ConfigSnapshot,
+  coalesceByReason,
+  materializeOp,
+  useConfigWriteFunnel,
+  type WriteOp,
+} from "./useConfigWriteFunnel";
+
+/**
+ * Phase 1 invariants for the write funnel (P-0092).
+ *
+ * The funnel is the substrate the rest of P-0092 builds on, so these
+ * tests deliberately stay at the level of "the queue does what it
+ * promises" — concrete writer migrations come in Phases 2..6 and
+ * grow their own integration tests then. Each `describe` block
+ * locks one invariant from the HISTORY.md plan.
+ */
+
+function flushMicrotasks() {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+describe("materializeOp", () => {
+  it("replace ops pass through verbatim", () => {
+    const op: WriteOp = {
+      kind: "replace",
+      config: { task: "binary", split: { method: "kfold" } },
+      reason: "cv-change",
+    };
+    const out = materializeOp(op, { task: "regression" });
+    expect(out).toEqual({ task: "binary", split: { method: "kfold" } });
+  });
+
+  it("patch ops merge onto the current cache snapshot", () => {
+    const current: ConfigSnapshot = {
+      task: "binary",
+      training: { early_stopping: { rounds: 100 } },
+    };
+    const op: WriteOp = {
+      kind: "patch",
+      path: ["training", "early_stopping", "rounds"],
+      value: 50,
+      reason: "config-form-edit",
+    };
+    const out = materializeOp(op, current);
+    expect(out).toEqual({
+      task: "binary",
+      training: { early_stopping: { rounds: 50 } },
+    });
+    // Original snapshot must not mutate — ConfigForm relies on
+    // referential equality to skip useEffect runs that have not
+    // observed real changes.
+    expect(current.training).toEqual({ early_stopping: { rounds: 100 } });
+  });
+
+  it("patch ops handle a cold cache by starting from an empty object", () => {
+    const op: WriteOp = {
+      kind: "patch",
+      path: ["split", "method"],
+      value: "kfold",
+      reason: "cv-change",
+    };
+    expect(materializeOp(op, undefined)).toEqual({
+      split: { method: "kfold" },
+    });
+  });
+});
+
+describe("coalesceByReason", () => {
+  it("collapses two same-reason ops to the latter (last write wins)", () => {
+    const a: WriteOp = {
+      kind: "replace",
+      config: { split: { method: "kfold" } },
+      reason: "cv-change",
+    };
+    const b: WriteOp = {
+      kind: "replace",
+      config: { split: { method: "stratified_kfold" } },
+      reason: "cv-change",
+    };
+    expect(coalesceByReason(a, b)).toBe(b);
+  });
+
+  it("keeps the new op when the reasons differ", () => {
+    const a: WriteOp = {
+      kind: "replace",
+      config: { split: { method: "kfold" } },
+      reason: "cv-change",
+    };
+    const b: WriteOp = {
+      kind: "replace",
+      config: { task: "binary" },
+      reason: "target-select",
+    };
+    expect(coalesceByReason(a, b)).toBe(b);
+  });
+});
+
+describe("useConfigWriteFunnel", () => {
+  it("flushes a single replace op via putConfig and resolves with the saved snapshot", async () => {
+    const putConfig = vi.fn().mockResolvedValue({
+      task: "binary",
+      split: { method: "kfold" },
+    });
+    const { result } = renderHook(() =>
+      useConfigWriteFunnel({
+        getCachedConfig: () => undefined,
+        putConfig,
+      }),
+    );
+
+    const promise = result.current.enqueueWrite({
+      kind: "replace",
+      config: { task: "binary", split: { method: "kfold" } },
+      reason: "cv-change",
+    });
+
+    const res = await promise;
+    expect(res).toEqual({
+      ok: true,
+      saved: { task: "binary", split: { method: "kfold" } },
+    });
+    expect(putConfig).toHaveBeenCalledTimes(1);
+    expect(putConfig).toHaveBeenCalledWith({
+      task: "binary",
+      split: { method: "kfold" },
+    });
+  });
+
+  it("invokes onWriteCommitted with the saved snapshot", async () => {
+    const onWriteCommitted = vi.fn();
+    const putConfig = vi
+      .fn()
+      .mockResolvedValue({ task: "binary", split: { method: "kfold" } });
+    const { result } = renderHook(() =>
+      useConfigWriteFunnel({
+        getCachedConfig: () => undefined,
+        putConfig,
+        onWriteCommitted,
+      }),
+    );
+
+    await result.current.enqueueWrite({
+      kind: "replace",
+      config: { task: "binary", split: { method: "kfold" } },
+      reason: "cv-change",
+    });
+
+    expect(onWriteCommitted).toHaveBeenCalledWith({
+      task: "binary",
+      split: { method: "kfold" },
+    });
+  });
+
+  it("coalesces a synchronous burst of same-reason replace ops into a single PUT", async () => {
+    // The exact race we are killing in Phase 5: a synchronous burst
+    // of cv-strategy clicks must not generate four PUTs whose
+    // ordering is racy. Because `drain` yields one microtask before
+    // the first flush, all enqueues posted before that microtask
+    // boundary collapse into one PUT carrying only the final
+    // selection. (A cross-microtask burst — e.g. user clicking again
+    // *after* the first PUT has started — produces a second flush;
+    // that case is covered by the next test.)
+    const putConfig = vi
+      .fn()
+      .mockImplementation((body: ConfigSnapshot) => Promise.resolve(body));
+
+    const { result } = renderHook(() =>
+      useConfigWriteFunnel({
+        getCachedConfig: () => undefined,
+        putConfig,
+      }),
+    );
+
+    const p1 = result.current.enqueueWrite({
+      kind: "replace",
+      config: { split: { method: "kfold" } },
+      reason: "cv-change",
+    });
+    const p2 = result.current.enqueueWrite({
+      kind: "replace",
+      config: { split: { method: "stratified_kfold" } },
+      reason: "cv-change",
+    });
+    const p3 = result.current.enqueueWrite({
+      kind: "replace",
+      config: { split: { method: "group_kfold" } },
+      reason: "cv-change",
+    });
+    const p4 = result.current.enqueueWrite({
+      kind: "replace",
+      config: { split: { method: "time_series" } },
+      reason: "cv-change",
+    });
+
+    const results = await Promise.all([p1, p2, p3, p4]);
+
+    // All four enqueues observe the same final body — coalesced.
+    for (const r of results) {
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.saved).toEqual({ split: { method: "time_series" } });
+    }
+    // Single PUT — the entire burst collapsed before flush started.
+    expect(putConfig).toHaveBeenCalledTimes(1);
+    expect(putConfig.mock.calls[0][0]).toEqual({
+      split: { method: "time_series" },
+    });
+  });
+
+  it("a second burst arriving after the first PUT starts produces a second coalesced flush", async () => {
+    // Cross-microtask burst: the first enqueue starts a flush, then
+    // a follow-up burst lands while that flush is in flight. The
+    // second burst must not overwrite the in-flight body, but must
+    // itself coalesce, and must run only after the first PUT clears.
+    let resolveFirst: (v: ConfigSnapshot) => void = () => {};
+    const putConfig = vi.fn().mockImplementation((body: ConfigSnapshot) => {
+      if (putConfig.mock.calls.length === 1) {
+        return new Promise<ConfigSnapshot>((res) => {
+          resolveFirst = res;
+        });
+      }
+      return Promise.resolve(body);
+    });
+
+    const { result } = renderHook(() =>
+      useConfigWriteFunnel({
+        getCachedConfig: () => undefined,
+        putConfig,
+      }),
+    );
+
+    const p1 = result.current.enqueueWrite({
+      kind: "replace",
+      config: { split: { method: "kfold" } },
+      reason: "cv-change",
+    });
+    // Let the drain microtask fire so the first PUT is actually in
+    // flight before the next burst arrives.
+    await flushMicrotasks();
+    expect(putConfig).toHaveBeenCalledTimes(1);
+
+    const p2 = result.current.enqueueWrite({
+      kind: "replace",
+      config: { split: { method: "stratified_kfold" } },
+      reason: "cv-change",
+    });
+    const p3 = result.current.enqueueWrite({
+      kind: "replace",
+      config: { split: { method: "time_series" } },
+      reason: "cv-change",
+    });
+
+    resolveFirst({ split: { method: "kfold" } });
+    await Promise.all([p1, p2, p3]);
+
+    expect(putConfig).toHaveBeenCalledTimes(2);
+    expect(putConfig.mock.calls[0][0]).toEqual({ split: { method: "kfold" } });
+    expect(putConfig.mock.calls[1][0]).toEqual({
+      split: { method: "time_series" },
+    });
+  });
+
+  it("serialises ops with different reasons (no two PUTs in flight)", async () => {
+    const inFlight: ConfigSnapshot[] = [];
+    let resolveFirst: (v: ConfigSnapshot) => void = () => {};
+    const putConfig = vi.fn().mockImplementation((body: ConfigSnapshot) => {
+      inFlight.push(body);
+      if (putConfig.mock.calls.length === 1) {
+        return new Promise<ConfigSnapshot>((res) => {
+          resolveFirst = res;
+        });
+      }
+      return Promise.resolve(body);
+    });
+
+    const { result } = renderHook(() =>
+      useConfigWriteFunnel({
+        getCachedConfig: () => undefined,
+        putConfig,
+      }),
+    );
+
+    const p1 = result.current.enqueueWrite({
+      kind: "replace",
+      config: { task: "binary" },
+      reason: "target-select",
+    });
+    const p2 = result.current.enqueueWrite({
+      kind: "replace",
+      config: { split: { method: "kfold" } },
+      reason: "cv-change",
+    });
+
+    await flushMicrotasks();
+    // Only the first op should be in flight while we hold its
+    // resolver — the funnel is serial, not parallel.
+    expect(inFlight).toHaveLength(1);
+    expect(inFlight[0]).toEqual({ task: "binary" });
+
+    resolveFirst({ task: "binary" });
+    await Promise.all([p1, p2]);
+
+    expect(putConfig).toHaveBeenCalledTimes(2);
+    expect(putConfig.mock.calls[1][0]).toEqual({ split: { method: "kfold" } });
+  });
+
+  it("isFlushing reflects in-flight state and clears after drain", async () => {
+    let resolve: (v: ConfigSnapshot) => void = () => {};
+    const putConfig = vi.fn().mockImplementation(
+      () =>
+        new Promise<ConfigSnapshot>((res) => {
+          resolve = res;
+        }),
+    );
+
+    const { result } = renderHook(() =>
+      useConfigWriteFunnel({
+        getCachedConfig: () => undefined,
+        putConfig,
+      }),
+    );
+
+    expect(result.current.isFlushing()).toBe(false);
+
+    const p = result.current.enqueueWrite({
+      kind: "replace",
+      config: { task: "binary" },
+      reason: "target-select",
+    });
+    await flushMicrotasks();
+    expect(result.current.isFlushing()).toBe(true);
+
+    resolve({ task: "binary" });
+    await p;
+    // Allow the drain loop to wind down before reading the flag.
+    await flushMicrotasks();
+    expect(result.current.isFlushing()).toBe(false);
+  });
+
+  it("converts a putConfig rejection into a network WriteResult without throwing", async () => {
+    const putConfig = vi.fn().mockRejectedValue(new Error("backend down"));
+    const { result } = renderHook(() =>
+      useConfigWriteFunnel({
+        getCachedConfig: () => undefined,
+        putConfig,
+      }),
+    );
+
+    const res = await result.current.enqueueWrite({
+      kind: "replace",
+      config: { task: "binary" },
+      reason: "target-select",
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error).toBe("network");
+      expect(res.details).toBeInstanceOf(Error);
+    }
+  });
+
+  it("aborts pending ops on unmount", async () => {
+    let resolve: (v: ConfigSnapshot) => void = () => {};
+    const putConfig = vi.fn().mockImplementation(
+      () =>
+        new Promise<ConfigSnapshot>((res) => {
+          resolve = res;
+        }),
+    );
+
+    const { result, unmount } = renderHook(() =>
+      useConfigWriteFunnel({
+        getCachedConfig: () => undefined,
+        putConfig,
+      }),
+    );
+
+    const p1 = result.current.enqueueWrite({
+      kind: "replace",
+      config: { task: "binary" },
+      reason: "target-select",
+    });
+    // Queue a second op behind the first in-flight one so unmount
+    // observes a pending resolver.
+    const p2 = result.current.enqueueWrite({
+      kind: "replace",
+      config: { split: { method: "kfold" } },
+      reason: "cv-change",
+    });
+
+    await flushMicrotasks();
+    unmount();
+
+    // The second op had not flushed yet, so its resolver was held by
+    // resolversRef. Unmount should drain it with `aborted` so callers
+    // do not leak a pending Promise.
+    const r2 = await p2;
+    expect(r2.ok).toBe(false);
+    if (!r2.ok) expect(r2.error).toBe("aborted");
+
+    // Resolve the in-flight call so the leftover putConfig promise
+    // does not leak past the test.
+    resolve({ task: "binary" });
+    await p1.catch(() => {});
+  });
+
+  it("materialises a patch op against the freshest cached config at flush time, not enqueue time", async () => {
+    // This is the closure-race fix from §P-0092 in miniature: the
+    // body sent to the server must be derived from the cache as it
+    // looks when the funnel is about to flush, not from a snapshot
+    // captured when the caller invoked enqueueWrite.
+    let cached: ConfigSnapshot = {
+      split: { method: "stratified_kfold", n_splits: 5 },
+    };
+    const putConfig = vi
+      .fn()
+      .mockImplementation((body: ConfigSnapshot) => Promise.resolve(body));
+
+    const { result } = renderHook(() =>
+      useConfigWriteFunnel({
+        getCachedConfig: () => cached,
+        putConfig,
+      }),
+    );
+
+    // Simulate an external writer landing a fresher cv-state into
+    // the cache between enqueue and flush.
+    const promise = result.current.enqueueWrite({
+      kind: "patch",
+      path: ["split", "n_splits"],
+      value: 7,
+      reason: "config-form-edit",
+    });
+    cached = {
+      split: { method: "group_kfold", n_splits: 5 },
+      data: { target: "y" },
+    };
+
+    const res = await promise;
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.saved).toEqual({
+        split: { method: "group_kfold", n_splits: 7 },
+        data: { target: "y" },
+      });
+    }
+  });
+});

--- a/frontend/src/hooks/useConfigWriteFunnel.ts
+++ b/frontend/src/hooks/useConfigWriteFunnel.ts
@@ -1,0 +1,287 @@
+import { useCallback, useEffect, useRef } from "react";
+import { updateConfig } from "@/api/workspace";
+
+/**
+ * Write funnel for `PUT /api/workspace/config` (P-0092 Phase 1).
+ *
+ * Background — see HISTORY.md §P-0092 for the full diagnosis. The
+ * Workspace currently has 6 writers spread across `useConfigSync`,
+ * `useTargetSelection`, `useModelPanelData`, and `WorkspacePage`,
+ * plus 5 cache writers. Every writer can step on every other one's
+ * snapshot, and the resulting cross-hook race is what makes
+ * `workspace-cv.spec.ts` (B-3) fail. Q-1's plan is to drain all
+ * writers into a single funnel; this file is the funnel.
+ *
+ * Phase 1 scope (this file): own the queue, the state machine, and
+ * the network call. **No existing writers are migrated yet** — that's
+ * Phases 2..6 in the HISTORY.md plan. Until callers are migrated the
+ * funnel is dead code in production; only the unit tests exercise it.
+ *
+ * Design notes:
+ *
+ * - `WriteOp` is the only thing callers send. It carries enough
+ *   metadata (`reason`) for the funnel to decide which queued ops can
+ *   be coalesced — same reason wins last (e.g., a rapid burst of
+ *   `cv-change` writes from a stuck user collapses to one PUT) — and
+ *   which must run in order (different reasons are serialised).
+ *
+ * - The state machine is intentionally tiny: `idle | flushing`. A
+ *   third "draining the queue between flushes" state is implicit in
+ *   the post-flush check inside `flushOne`. Avoiding an explicit
+ *   "enqueueing" state keeps the reasoning simple — every public
+ *   method either schedules work onto `pending` or awaits the
+ *   in-flight `currentFlush` promise.
+ *
+ * - Aborting the in-flight network call (when Phase 5 wires
+ *   useConfigSync's existing `AbortController`-based dedup into the
+ *   funnel) is a Phase-5 concern. For Phase 1 we only need to make
+ *   sure that a queued op is not lost while another is flushing —
+ *   the simpler "wait, then send" semantics suffice.
+ */
+
+export type WriteReason =
+  | "target-select"
+  | "cv-change"
+  | "config-form-edit"
+  | "undo"
+  | "redo"
+  | "apply-to-fit"
+  | "preset-load"
+  | "auto-reset";
+
+export type ConfigSnapshot = Record<string, unknown>;
+
+export type WriteOp =
+  | { kind: "replace"; config: ConfigSnapshot; reason: WriteReason }
+  | {
+      kind: "patch";
+      path: readonly string[];
+      value: unknown;
+      reason: WriteReason;
+    };
+
+export type WriteResult =
+  | { ok: true; saved: ConfigSnapshot }
+  | {
+      ok: false;
+      error: "aborted" | "rejected" | "locked" | "network";
+      details?: unknown;
+    };
+
+/**
+ * Resolve a dotted path into the snapshot shape for `kind: "patch"`
+ * ops. Mirrors `setNestedValue` in `config-utils.ts` but stays in
+ * this module so the funnel has no implementation dependency on the
+ * ConfigForm helpers (which are slated for restructuring in Phases
+ * 2 and 4).
+ */
+function setNestedImmutable(
+  base: ConfigSnapshot,
+  path: readonly string[],
+  value: unknown,
+): ConfigSnapshot {
+  if (path.length === 0) return base;
+  const [head, ...rest] = path;
+  const child = (base[head] ?? {}) as ConfigSnapshot;
+  return {
+    ...base,
+    [head]: rest.length === 0 ? value : setNestedImmutable(child, rest, value),
+  };
+}
+
+/**
+ * Materialise a `WriteOp` against the current cache snapshot. Replace
+ * ops pass through unchanged; patch ops are applied to `current` (or
+ * an empty object if the cache is still cold) and the resulting
+ * full-config body is returned.
+ *
+ * Returning an undefined snapshot from this function is forbidden:
+ * funnel callers must always end up sending a full body, since the
+ * server-side PUT handler treats the body as authoritative.
+ */
+export function materializeOp(
+  op: WriteOp,
+  current: ConfigSnapshot | undefined,
+): ConfigSnapshot {
+  if (op.kind === "replace") return op.config;
+  return setNestedImmutable(current ?? {}, op.path, op.value);
+}
+
+/**
+ * Coalesce two queued ops that share a `reason`. The latest wins
+ * outright — partial merging across patch + replace would re-introduce
+ * the cross-snapshot race the funnel exists to eliminate.
+ */
+export function coalesceByReason(queued: WriteOp, next: WriteOp): WriteOp {
+  if (queued.reason !== next.reason) return next;
+  return next;
+}
+
+interface FunnelState {
+  /**
+   * FIFO queue of pending ops. Same-reason coalescing collapses
+   * consecutive entries into the latest one (see `enqueueWrite`).
+   * Different-reason ops are preserved in arrival order so the
+   * funnel honours the per-reason serialisation guarantee.
+   */
+  pending: WriteOp[];
+  /** In-flight flush promise, or null when idle. */
+  currentFlush: Promise<void> | null;
+}
+
+interface UseConfigWriteFunnelOptions {
+  /**
+   * Snapshot getter — typically `() => queryClient.getQueryData(...)`.
+   * Called at flush time so the body sent to the server is built from
+   * the freshest cached config rather than a stale closure capture.
+   */
+  getCachedConfig: () => ConfigSnapshot | undefined;
+  /**
+   * Called immediately after a successful PUT lands. Phase 5 will use
+   * this to update the React Query cache atomically; Phase 1 leaves
+   * it as an injectable hook so unit tests can observe terminal state
+   * without coupling to TanStack Query.
+   */
+  onWriteCommitted?: (saved: ConfigSnapshot) => void;
+  /**
+   * Network call. Defaulted to `updateConfig` from `@/api/workspace`,
+   * but injectable so unit tests can stub it without `vi.mock`.
+   */
+  putConfig?: (body: ConfigSnapshot) => Promise<unknown>;
+}
+
+/**
+ * Public funnel API — the hook returns the writer-facing surface.
+ * Existing call sites continue to import `updateConfig` directly until
+ * the per-phase migrations replace them with `enqueueWrite`.
+ */
+export interface ConfigWriteFunnel {
+  enqueueWrite: (op: WriteOp) => Promise<WriteResult>;
+  /** True while a PUT is in flight. Useful for upstream guards. */
+  isFlushing: () => boolean;
+}
+
+export function useConfigWriteFunnel(
+  options: UseConfigWriteFunnelOptions,
+): ConfigWriteFunnel {
+  const {
+    getCachedConfig,
+    onWriteCommitted,
+    putConfig = updateConfig,
+  } = options;
+
+  // The state lives in a ref so updates from inside the async flush
+  // loop do not trigger re-renders. The hook does not own any visible
+  // state — it is a side-effect coordinator.
+  const stateRef = useRef<FunnelState>({
+    pending: [],
+    currentFlush: null,
+  });
+
+  // Resolver registry keyed on op identity so an enqueue can wait for
+  // the specific PUT result that materialises its op (or its merged
+  // successor, if it was coalesced into a later enqueue).
+  const resolversRef = useRef<Map<WriteOp, (result: WriteResult) => void>>(
+    new Map(),
+  );
+
+  const flushOne = useCallback(async (): Promise<void> => {
+    const op = stateRef.current.pending.shift();
+    if (op === undefined) return;
+
+    const body = materializeOp(op, getCachedConfig());
+    let result: WriteResult;
+    try {
+      const saved = (await putConfig(body)) as ConfigSnapshot;
+      onWriteCommitted?.(saved);
+      result = { ok: true, saved };
+    } catch (err) {
+      result = { ok: false, error: "network", details: err };
+    }
+
+    // Resolve all op promises that point at this flush. After
+    // same-reason coalescing only the latest op of that reason
+    // survives in `pending`, but earlier same-reason callers still
+    // hold their handle in `resolversRef` and observe the same
+    // saved snapshot.
+    for (const [pendingOp, resolve] of resolversRef.current) {
+      if (pendingOp.reason === op.reason) {
+        resolve(result);
+        resolversRef.current.delete(pendingOp);
+      }
+    }
+  }, [getCachedConfig, onWriteCommitted, putConfig]);
+
+  const drain = useCallback(async (): Promise<void> => {
+    // Yield once before the first flush so any synchronous state
+    // updates that follow `enqueueWrite` (cache writes, ref bumps)
+    // settle before we read the snapshot. This mirrors how
+    // useConfigSync's PUTs land in a microtask after the React
+    // commit cycle, and is what closes the closure-time-vs-flush-time
+    // gap that §P-0092 §Investigation Q-3 alone could not.
+    await Promise.resolve();
+    while (stateRef.current.pending.length > 0) {
+      await flushOne();
+    }
+    stateRef.current = { ...stateRef.current, currentFlush: null };
+  }, [flushOne]);
+
+  const enqueueWrite = useCallback(
+    (op: WriteOp): Promise<WriteResult> => {
+      // Same-reason coalescing collapses into the queue's tail entry
+      // when its reason matches `op.reason`. Cross-reason ops are
+      // appended so target-select / cv-change / config-form-edit
+      // bursts land in arrival order without one stomping the next.
+      const queue = stateRef.current.pending;
+      const tail = queue[queue.length - 1];
+      if (tail && tail.reason === op.reason) {
+        queue[queue.length - 1] = coalesceByReason(tail, op);
+      } else {
+        queue.push(op);
+      }
+
+      return new Promise<WriteResult>((resolve) => {
+        resolversRef.current.set(op, resolve);
+        if (stateRef.current.currentFlush === null) {
+          const flushPromise = drain();
+          stateRef.current = {
+            ...stateRef.current,
+            currentFlush: flushPromise,
+          };
+          // Failsafe: if drain rejects (it should not — flushOne
+          // catches and converts to WriteResult), surface it as a
+          // rejected promise to any pending resolver.
+          flushPromise.catch((err) => {
+            for (const [pending, r] of resolversRef.current) {
+              r({ ok: false, error: "network", details: err });
+              resolversRef.current.delete(pending);
+            }
+          });
+        }
+      });
+    },
+    [drain],
+  );
+
+  const isFlushing = useCallback(
+    () => stateRef.current.currentFlush !== null,
+    [],
+  );
+
+  // Cleanup on unmount: reject any unresolved promises so callers
+  // do not hang. Phase 5 may relax this once the funnel is owned by
+  // a Provider that outlives individual page mounts.
+  useEffect(() => {
+    return () => {
+      for (const [op, resolve] of resolversRef.current) {
+        resolve({ ok: false, error: "aborted" });
+        resolversRef.current.delete(op);
+      }
+    };
+  }, []);
+
+  return {
+    enqueueWrite,
+    isFlushing,
+  };
+}


### PR DESCRIPTION
## Summary

P-0092 Q-1 Phase 1: introduce a side-effect-only **write funnel** that
all six existing writers (W1..W6 in the §P-0092 inventory) will be
migrated onto in Phases 2..6.

This PR adds the funnel hook + 14 unit tests. **No existing writer is
wired through it yet** — the funnel is dead code in production until
Phase 2 lands the first migration. The PR therefore cannot regress
any current behaviour.

> Context PR: **#290** (HISTORY.md P-0092 Proposal). #290 documents
> the diagnosis, the four-way comparison, the Q-1 selection, and the
> 6-phase plan this PR is the first instalment of.

## API surface

```ts
const { enqueueWrite, isFlushing } = useConfigWriteFunnel({
  getCachedConfig: () => queryClient.getQueryData(queryKeys.config()),
  putConfig?: ...,         // injectable for tests
  onWriteCommitted?: ...,  // hook for cache update — used by Phase 5
});

type WriteOp =
  | { kind: 'replace'; config: ConfigSnapshot; reason: WriteReason }
  | { kind: 'patch'; path: readonly string[]; value: unknown; reason: WriteReason };

type WriteReason =
  | 'target-select' | 'cv-change' | 'config-form-edit'
  | 'undo' | 'redo' | 'apply-to-fit' | 'preset-load' | 'auto-reset';
```

## State machine guarantees (locked by tests)

| Invariant | Test |
|---|---|
| Single-microtask burst of same-reason ops collapses to one PUT carrying the latest body | `coalesces a synchronous burst of same-reason replace ops...` |
| Cross-microtask burst during an in-flight flush starts a second coalesced flush after the first clears | `a second burst arriving after the first PUT starts produces a second coalesced flush` |
| Different-reason ops serialise in arrival order; no two PUTs in flight | `serialises ops with different reasons (no two PUTs in flight)` |
| Patch ops materialise against the freshest cache snapshot at flush time, not enqueue time | `materialises a patch op against the freshest cached config at flush time, not enqueue time` |
| `putConfig` rejection → `WriteResult` error instead of unhandled throw | `converts a putConfig rejection into a network WriteResult without throwing` |
| Unmount drains pending resolvers with `aborted` so callers don't hang | `aborts pending ops on unmount` |
| `isFlushing()` reflects in-flight state and clears after drain | `isFlushing reflects in-flight state and clears after drain` |

The microtask-yield in `drain()` is the key step that closes the
closure-time-vs-flush-time gap Q-3 alone could not — synchronous
React state updates and cache writes settle before the funnel reads
the snapshot. See §P-0092 §Investigation in HISTORY.md.

## Test plan

- [x] `pnpm exec tsc -b` green
- [x] `pnpm exec biome check` green
- [x] `pnpm exec vitest run src/hooks/useConfigWriteFunnel.test.ts` — 14 / 14 pass
- [x] `pnpm exec vitest run` (full suite) — 1680 / 1682 pass (2 skipped, no new failures)
- [x] `pnpm build` green
- [ ] CI on this PR turns green
- [ ] Reviewer aligns on the API surface before Phase 2 (ConfigForm
  auto-reset migration) opens

## Out of scope

- No production wiring (Phase 2..6).
- No backend change.
- No bundle-size budget check yet — re-measured at Phase 6 once all
  call sites have been migrated.
