### PR TITLE
fix(workspace): funnel error classification + undo/redo cache override (H-3/H-4/G-6/G-8)

### DIFF
--- a/frontend/src/hooks/useConfigWriteFunnel.test.ts
+++ b/frontend/src/hooks/useConfigWriteFunnel.test.ts
@@ -446,4 +446,189 @@ describe("useConfigWriteFunnel", () => {
       });
     }
   });
+
+  // ----------------------------------------------------------------------
+  // G-6 — putConfig error classification.
+  //
+  // Before this PR the funnel flattened every thrown error into
+  // `error: "network"`, leaving every caller (useConfigSync,
+  // useModelPanelData) to re-detect ApiError + WORKSPACE_LOCKED themselves.
+  // The classifier in flushOne now distinguishes locked / rejected / network
+  // so callers can branch on `error` directly.
+  // ----------------------------------------------------------------------
+  describe("error classification (G-6)", () => {
+    it("classifies 409 WORKSPACE_LOCKED as error=locked", async () => {
+      const { ApiError } = await import("@/api/client");
+      const err = new ApiError(409, {
+        error: {
+          code: "WORKSPACE_LOCKED",
+          message: "Config is locked while job xyz is running",
+          details: { job_id: "xyz" },
+        },
+      });
+      const putConfig = vi.fn().mockRejectedValue(err);
+      const { result } = renderHook(() =>
+        useConfigWriteFunnel({
+          getCachedConfig: () => undefined,
+          putConfig,
+        }),
+      );
+
+      const res = await result.current.enqueueWrite({
+        kind: "replace",
+        config: { task: "binary" },
+        reason: "config-form-edit",
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.error).toBe("locked");
+        // Original error stays in details so callers that want the
+        // structured body (job_id etc.) can reach it.
+        expect(res.details).toBe(err);
+      }
+    });
+
+    it("classifies 4xx ApiErrors that are NOT lock as error=rejected", async () => {
+      const { ApiError } = await import("@/api/client");
+      const err = new ApiError(422, {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Body validation failed",
+          details: {},
+        },
+      });
+      const putConfig = vi.fn().mockRejectedValue(err);
+      const { result } = renderHook(() =>
+        useConfigWriteFunnel({
+          getCachedConfig: () => undefined,
+          putConfig,
+        }),
+      );
+
+      const res = await result.current.enqueueWrite({
+        kind: "replace",
+        config: { task: "binary" },
+        reason: "config-form-edit",
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error).toBe("rejected");
+    });
+
+    it("classifies generic thrown errors as error=network", async () => {
+      const putConfig = vi.fn().mockRejectedValue(new Error("dns gone"));
+      const { result } = renderHook(() =>
+        useConfigWriteFunnel({
+          getCachedConfig: () => undefined,
+          putConfig,
+        }),
+      );
+
+      const res = await result.current.enqueueWrite({
+        kind: "replace",
+        config: { task: "binary" },
+        reason: "config-form-edit",
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error).toBe("network");
+    });
+
+    it("classifies 5xx ApiErrors as error=network (not rejected)", async () => {
+      const { ApiError } = await import("@/api/client");
+      const err = new ApiError(500, {
+        error: { code: "INTERNAL", message: "boom", details: {} },
+      });
+      const putConfig = vi.fn().mockRejectedValue(err);
+      const { result } = renderHook(() =>
+        useConfigWriteFunnel({
+          getCachedConfig: () => undefined,
+          putConfig,
+        }),
+      );
+
+      const res = await result.current.enqueueWrite({
+        kind: "replace",
+        config: { task: "binary" },
+        reason: "config-form-edit",
+      });
+      expect(res.ok).toBe(false);
+      // Server-side faults are not "rejected by validation" and not
+      // "locked". They fall through to the network bucket so callers
+      // surface the generic retry path.
+      if (!res.ok) expect(res.error).toBe("network");
+    });
+  });
+
+  // ----------------------------------------------------------------------
+  // G-8 — ConfigUpdateResponse wrapper passes through onWriteCommitted.
+  //
+  // Production putConfig is `updateConfig` from @/api/workspace, which
+  // returns `{config, errors, saved}` (not just the flat config). The
+  // funnel must NOT unwrap that itself — the wrapper stays the truth that
+  // WorkspacePage's onWriteCommitted reads from to set the cache and
+  // observe `saved=false`. Earlier wrapper-leak bugs (Phase 4 follow-up)
+  // came from a writer assuming the funnel flattened the body.
+  // ----------------------------------------------------------------------
+  describe("response shape pass-through (G-8)", () => {
+    it("forwards the full ConfigUpdateResponse wrapper to onWriteCommitted", async () => {
+      const wrapper = {
+        config: { task: "binary", split: { method: "kfold" } },
+        errors: [],
+        saved: true,
+      };
+      const putConfig = vi.fn().mockResolvedValue(wrapper);
+      const onWriteCommitted = vi.fn();
+
+      const { result } = renderHook(() =>
+        useConfigWriteFunnel({
+          getCachedConfig: () => undefined,
+          putConfig,
+          onWriteCommitted,
+        }),
+      );
+
+      const res = await result.current.enqueueWrite({
+        kind: "replace",
+        config: { task: "binary" },
+        reason: "target-select",
+      });
+
+      // The funnel must NOT flatten or peek inside `saved` — the
+      // wrapper goes through verbatim so the Page-level callback owns
+      // the saved=false branching.
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.saved).toBe(wrapper);
+      expect(onWriteCommitted).toHaveBeenCalledTimes(1);
+      expect(onWriteCommitted).toHaveBeenCalledWith(wrapper);
+    });
+
+    it("forwards a saved=false wrapper without throwing", async () => {
+      // Even a backend-rejected wrapper is still "ok" at the funnel
+      // layer (the HTTP call succeeded). The hook caller observes
+      // `saved=false` and surfaces the toast itself.
+      const wrapper = {
+        config: { task: "binary" },
+        errors: [{ path: "data", message: "Field required" }],
+        saved: false,
+      };
+      const putConfig = vi.fn().mockResolvedValue(wrapper);
+      const onWriteCommitted = vi.fn();
+
+      const { result } = renderHook(() =>
+        useConfigWriteFunnel({
+          getCachedConfig: () => undefined,
+          putConfig,
+          onWriteCommitted,
+        }),
+      );
+
+      const res = await result.current.enqueueWrite({
+        kind: "replace",
+        config: { task: "binary" },
+        reason: "config-form-edit",
+      });
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.saved).toBe(wrapper);
+      expect(onWriteCommitted).toHaveBeenCalledWith(wrapper);
+    });
+  });
 });

--- a/frontend/src/hooks/useConfigWriteFunnel.ts
+++ b/frontend/src/hooks/useConfigWriteFunnel.ts
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
+import { ApiError } from "@/api/client";
+import { isStudioError } from "@/api/errors";
 import { updateConfig } from "@/api/workspace";
 
 /**
@@ -111,10 +113,41 @@ export function materializeOp(
  * Coalesce two queued ops that share a `reason`. The latest wins
  * outright — partial merging across patch + replace would re-introduce
  * the cross-snapshot race the funnel exists to eliminate.
+ *
+ * H-4: callers ALWAYS gate on `tail.reason === op.reason` before
+ * invoking this helper, so the function can simply return `next`.
+ * The argument list is preserved for documentation symmetry with
+ * other reducer-shaped helpers and to keep an obvious extension
+ * point should a future reason want partial-merge semantics.
  */
-export function coalesceByReason(queued: WriteOp, next: WriteOp): WriteOp {
-  if (queued.reason !== next.reason) return next;
+export function coalesceByReason(_queued: WriteOp, next: WriteOp): WriteOp {
   return next;
+}
+
+/**
+ * Classify a thrown error from the network layer into a discrete
+ * `WriteResult.error` tag so consumers can branch on the failure
+ * mode without rummaging through `details`. G-6: the funnel used
+ * to flatten everything into `"network"` and rely on every caller
+ * to re-detect 409 WORKSPACE_LOCKED itself.
+ */
+function classifyPutError(err: unknown): {
+  error: "locked" | "rejected" | "network";
+  details: unknown;
+} {
+  if (err instanceof ApiError) {
+    if (
+      err.status === 409 &&
+      isStudioError(err.body) &&
+      err.body.error.code === "WORKSPACE_LOCKED"
+    ) {
+      return { error: "locked", details: err };
+    }
+    if (err.status >= 400 && err.status < 500) {
+      return { error: "rejected", details: err };
+    }
+  }
+  return { error: "network", details: err };
 }
 
 interface FunnelState {
@@ -196,7 +229,8 @@ export function useConfigWriteFunnel(
       onWriteCommitted?.(saved);
       result = { ok: true, saved };
     } catch (err) {
-      result = { ok: false, error: "network", details: err };
+      const classified = classifyPutError(err);
+      result = { ok: false, ...classified };
     }
 
     // Resolve all op promises that point at this flush. After

--- a/frontend/src/hooks/useModelPanelData.test.ts
+++ b/frontend/src/hooks/useModelPanelData.test.ts
@@ -803,7 +803,7 @@ describe("useModelPanelData", () => {
         saved: { config: {}, errors: [], saved: true },
       }));
 
-      const { wrapper, queryClient } = makeWrapper();
+      const { wrapper } = makeWrapper();
       const { result } = renderHook(
         () =>
           useModelPanelData({
@@ -829,11 +829,14 @@ describe("useModelPanelData", () => {
         await result.current.handleUndo();
       });
 
-      const reasons = calls.map((c) => c.reason);
-      expect(reasons).toContain("undo");
-      expect(queryClient.getQueryData(queryKeys.config())).toEqual({
-        model: { name: "A" },
-      });
+      // H-3: the funnel path no longer writes to the cache locally —
+      // production wires `onWriteCommitted` to apply the backend's
+      // canonical (post-normalisation) snapshot, which the stub funnel
+      // here does not simulate. Assert that the undo enqueued with
+      // the right reason AND the right body (the prior history entry).
+      const undoCall = calls.find((c) => c.reason === "undo");
+      expect(undoCall).toBeDefined();
+      expect(undoCall?.config).toEqual({ model: { name: "A" } });
     });
 
     it("handleRedo routes through funnel with reason=redo", async () => {
@@ -842,7 +845,7 @@ describe("useModelPanelData", () => {
         saved: { config: {}, errors: [], saved: true },
       }));
 
-      const { wrapper, queryClient } = makeWrapper();
+      const { wrapper } = makeWrapper();
       const { result } = renderHook(
         () =>
           useModelPanelData({
@@ -868,11 +871,11 @@ describe("useModelPanelData", () => {
         await result.current.handleRedo();
       });
 
-      const reasons = calls.map((c) => c.reason);
-      expect(reasons).toContain("redo");
-      expect(queryClient.getQueryData(queryKeys.config())).toEqual({
-        model: { name: "B" },
-      });
+      // H-3: same rationale as the undo test above. Assert the redo
+      // enqueued with the right reason and the right history body.
+      const redoCall = calls.find((c) => c.reason === "redo");
+      expect(redoCall).toBeDefined();
+      expect(redoCall?.config).toEqual({ model: { name: "B" } });
     });
 
     it("handleUndo surfaces 'Undo failed' toast when funnel returns ok=false", async () => {

--- a/frontend/src/hooks/useModelPanelData.ts
+++ b/frontend/src/hooks/useModelPanelData.ts
@@ -243,24 +243,32 @@ export function useModelPanelData({
   // because undo is unlikely to race with a running job (the controls
   // are disabled while running) and a redo of a legitimate prior state
   // either re-saves or no-ops.
+  //
+  // H-3: the funnel path returns `viaFunnel=true` so the caller can
+  // skip its explicit `setQueryData` — the funnel's `onWriteCommitted`
+  // already wrote the backend's *canonical* (post-normalisation)
+  // snapshot to the cache. Following up with the local history entry
+  // would silently undo whatever the backend normalised (e.g. inserted
+  // random_state defaults). The legacy path still needs the explicit
+  // setQueryData because no `onWriteCommitted` is wired there.
   const sendThroughFunnelOrLegacy = useCallback(
     async (
       body: Record<string, unknown>,
       reason: WriteReason,
-    ): Promise<boolean> => {
+    ): Promise<{ ok: boolean; viaFunnel: boolean }> => {
       if (writeFunnel) {
         const result = await writeFunnel.enqueueWrite({
           kind: "replace",
           config: body,
           reason,
         });
-        return result.ok;
+        return { ok: result.ok, viaFunnel: true };
       }
       try {
         await updateConfig(body);
-        return true;
+        return { ok: true, viaFunnel: false };
       } catch {
-        return false;
+        return { ok: false, viaFunnel: false };
       }
     },
     [writeFunnel],
@@ -269,9 +277,11 @@ export function useModelPanelData({
   const handleUndo = useCallback(async () => {
     const prev = history.undo();
     if (!prev) return;
-    const ok = await sendThroughFunnelOrLegacy(prev, "undo");
+    const { ok, viaFunnel } = await sendThroughFunnelOrLegacy(prev, "undo");
     if (ok) {
-      queryClient.setQueryData(queryKeys.config(), prev);
+      if (!viaFunnel) {
+        queryClient.setQueryData(queryKeys.config(), prev);
+      }
       toast.info("Config undone");
     } else {
       toast.error("Undo failed");
@@ -281,9 +291,11 @@ export function useModelPanelData({
   const handleRedo = useCallback(async () => {
     const next = history.redo();
     if (!next) return;
-    const ok = await sendThroughFunnelOrLegacy(next, "redo");
+    const { ok, viaFunnel } = await sendThroughFunnelOrLegacy(next, "redo");
     if (ok) {
-      queryClient.setQueryData(queryKeys.config(), next);
+      if (!viaFunnel) {
+        queryClient.setQueryData(queryKeys.config(), next);
+      }
       toast.info("Config redone");
     } else {
       toast.error("Redo failed");


### PR DESCRIPTION
## Summary

Code-review follow-ups for the P-0092 funnel.

### H-3 — `handleUndo` / `handleRedo` no longer overwrite the cache
The funnel's `onWriteCommitted` has already written the backend's
canonical (post-normalisation) snapshot. The local
`setQueryData(prev/next)` that followed silently undid backend
defaulting (e.g. inserted `random_state`). `sendThroughFunnelOrLegacy`
now returns `viaFunnel` so the cache write only happens on the legacy
path that has no `onWriteCommitted` wired.

### H-4 — Drop the dead-but-deceiving branch in `coalesceByReason`
The caller already gates by `tail.reason === op.reason`, so the helper
just returns `next`. Comment expanded so a future partial-merge
extension does not accidentally reintroduce the same shape.

### G-6 — Classify funnel errors
`classifyPutError` in `flushOne` distinguishes `locked` / `rejected` /
`network` so callers can branch on `result.error` directly instead of
rummaging through `details` for `ApiError + WORKSPACE_LOCKED`. Existing
consumer paths still work because both layers do the detection — the
funnel layer is the fast path, the consumer layer is defense-in-depth
for the legacy code path.

### G-8 — `ConfigUpdateResponse` wrapper pass-through
Pin that the `{config, errors, saved}` shape returned by `updateConfig`
passes through `onWriteCommitted` verbatim. WorkspacePage's
`onWriteCommitted` is the only legitimate unwrapper; locking this
contract prevents the wrapper-leak class of bug that bit Phase 4
follow-up.

## Test additions

- 4 new G-6 tests pin lock / rejected / network / 5xx classification
- 2 new G-8 tests pin wrapper pass-through (saved=true and saved=false)
- 2 existing undo/redo tests updated to assert on enqueued reason +
  body instead of cache contents (cache write is now the funnel's
  responsibility, tested at the funnel layer)

## Test plan

- [x] `pnpm test src/hooks/useConfigWriteFunnel.test.ts src/hooks/useModelPanelData.test.ts src/hooks/useConfigSync.test.ts --run` — 66 passed
- [x] `pnpm check` — clean
- [x] `pnpm build` — clean
- [ ] CI green