### PR TITLE
chore(testing): link skipped tests to tracking issue #304

### DIFF
--- a/frontend/src/components/workspace/DataPanel.test.tsx
+++ b/frontend/src/components/workspace/DataPanel.test.tsx
@@ -432,6 +432,8 @@ describe("DataPanel", () => {
   // Column grid rendering requires a complex async chain (load → fetchColumns
   // → fetchConfigDefaults → updateConfig) that is unreliable in headless DOM.
   // These paths are covered by E2E visual regression tests instead.
+  // Tracked under Issue #304 — restore as a passing component test or delete
+  // and lean on the E2E coverage explicitly.
   it.skip("renders column settings grid when data is loaded with target", async () => {
     mockLoadDataFromPath.mockResolvedValue({
       data_ref: { shape: [100, 5], path: "/data.csv" },
@@ -519,6 +521,9 @@ describe("DataPanel", () => {
     expect(catButtons.length).toBeGreaterThan(0);
   });
 
+  // Tracked under Issue #304 — same async-chain reliability problem
+  // as the column-grid test above; covered by E2E visual regression
+  // until restored or removed.
   it.skip("shows summary stats after data is loaded", async () => {
     mockLoadDataFromPath.mockResolvedValue({
       data_ref: { shape: [100, 4], path: "/data.csv" },

--- a/frontend/tests/e2e/workspace-fit.spec.ts
+++ b/frontend/tests/e2e/workspace-fit.spec.ts
@@ -295,7 +295,7 @@ test.describe("Workspace Fit Flow", () => {
     if (isMobileProject(testInfo)) {
       // The mobile layout hides the Fit button behind the tab nav;
       // covered separately by ui-improvements specs.
-      test.skip(true, "Mobile layout path is covered elsewhere");
+      test.skip(true, "Mobile layout path is covered elsewhere — see Issue #304");
     }
 
     const csvPath = createTestCsv();
@@ -356,7 +356,7 @@ test.describe("Workspace Fit Flow", () => {
     // the 120s default in playwright.config.ts.
     test.setTimeout(180_000);
     if (isMobileProject(testInfo)) {
-      test.skip(true, "Mobile layout path is covered elsewhere");
+      test.skip(true, "Mobile layout path is covered elsewhere — see Issue #304");
     }
 
     const csvPath = createTestCsv();
@@ -451,7 +451,7 @@ test.describe("Workspace Fit Flow", () => {
   }, testInfo) => {
     test.setTimeout(60_000);
     if (isMobileProject(testInfo)) {
-      test.skip(true, "Mobile layout path is covered elsewhere");
+      test.skip(true, "Mobile layout path is covered elsewhere — see Issue #304");
     }
 
     const csvPath = createTestCsv();

--- a/frontend/tests/e2e/workspace-tune.spec.ts
+++ b/frontend/tests/e2e/workspace-tune.spec.ts
@@ -282,7 +282,7 @@ test.describe("Workspace tune flow", () => {
     if (isMobileProject(testInfo)) {
       // Mobile layout collapses the Tune tab behind the tab nav;
       // covered separately by ui-improvements specs.
-      test.skip(true, "Mobile layout path is covered elsewhere");
+      test.skip(true, "Mobile layout path is covered elsewhere — see Issue #304");
     }
 
     const csvPath = createTestCsv();
@@ -360,7 +360,7 @@ test.describe("Workspace tune flow", () => {
     // case. 300s leaves ~2× headroom for CI IO jitter.
     test.setTimeout(300_000);
     if (isMobileProject(testInfo)) {
-      test.skip(true, "Mobile layout path is covered elsewhere");
+      test.skip(true, "Mobile layout path is covered elsewhere — see Issue #304");
     }
 
     const csvPath = createTestCsv();
@@ -450,7 +450,7 @@ test.describe("Workspace tune flow", () => {
   }, testInfo) => {
     test.setTimeout(60_000);
     if (isMobileProject(testInfo)) {
-      test.skip(true, "Mobile layout path is covered elsewhere");
+      test.skip(true, "Mobile layout path is covered elsewhere — see Issue #304");
     }
 
     const csvPath = createTestCsv();


### PR DESCRIPTION
## Summary

CLAUDE.md §7 requires every `flaky` / `quarantine` / `skip` marker to
have a tracking issue. The develop-branch audit on 2026-04-30 flagged
8 skip tests with no link. Filed [Issue #304](https://github.com/nbx-liz/LizyStudio/issues/304) as the umbrella tracker
and updated the comments to reference it.

## Changes

- `frontend/src/components/workspace/DataPanel.test.tsx:435,524` —
  add Issue #304 reference next to the existing "Radix Select
  unreliable in jsdom" note.
- 6 mobile-only `test.skip(true, "Mobile layout path is covered
  elsewhere")` calls in `workspace-fit.spec.ts` (298, 359, 454) and
  `workspace-tune.spec.ts` (285, 363, 453) now include
  `— see Issue #304`.

No behavioural changes; tests still skip, but the bookkeeping satisfies
the project rule and makes future cleanup easier to scope.

## Test plan

- [x] `pnpm test src/components/workspace/DataPanel.test.tsx --run` — 52 passed | 2 skipped
- [x] `pnpm build` — clean
- [ ] CI green