### PR TITLE
fix(workspace): bail useConfigSync funnel path on aborted result (H-1)

### DIFF
--- a/frontend/src/hooks/useConfigSync.test.ts
+++ b/frontend/src/hooks/useConfigSync.test.ts
@@ -441,5 +441,35 @@ describe("useConfigSync", () => {
         "Config sync failed — changes may not be saved",
       );
     });
+
+    it("does not call onDataChanged when funnel returns ok=false with error=aborted", async () => {
+      // H-1 regression: when the funnel returns { ok:false, error:"aborted" }
+      // (e.g. unmount mid-flush), `result.details` is undefined. Earlier
+      // code coerced that to a falsy `putError` and fell through to the
+      // success path, firing onDataChanged + spurious cache invalidations
+      // even though the PUT was never sent.
+      const onDataChanged = vi.fn();
+      const { funnel } = createStubFunnel(() => ({
+        ok: false,
+        error: "aborted",
+      }));
+      const { wrapper } = testWrapper;
+      renderHook(
+        () =>
+          useConfigSync(
+            defaultParams({
+              onDataChanged,
+              // biome-ignore lint/suspicious/noExplicitAny: stub funnel
+              writeFunnel: funnel as any,
+            }),
+          ),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(funnel.enqueueWrite).toHaveBeenCalledTimes(1));
+      await new Promise((r) => setTimeout(r, 30));
+      expect(onDataChanged).not.toHaveBeenCalled();
+      expect(mocks.toastError).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/hooks/useConfigSync.ts
+++ b/frontend/src/hooks/useConfigSync.ts
@@ -170,7 +170,12 @@ export function useConfigSync({
           reason: "cv-change",
         });
         if (!result.ok) {
-          putError = result.details;
+          // Aborted writes (funnel unmount, or upstream cancel) are not
+          // user-visible failures — the caller has already torn down,
+          // so falling through to onDataChanged would fire spurious
+          // cache invalidations. Bail silently.
+          if (result.error === "aborted") return;
+          putError = result.details ?? result.error;
         }
       } else {
         try {


### PR DESCRIPTION
## Summary

H-1 from the develop-branch code review: when the funnel returned
`{ ok: false, error: "aborted" }` (e.g. funnel unmount mid-flush),
`result.details` was undefined which made the `if (putError)` guard
falsy. The hook then fell through to `onDataChanged()` and fired
spurious cache invalidations even though the PUT had never been sent.

The fix returns early on `error === "aborted"` so the funnel path
matches the legacy DOMException AbortError branch a few lines below.

## Files changed

- `frontend/src/hooks/useConfigSync.ts` — early return on aborted
- `frontend/src/hooks/useConfigSync.test.ts` — regression test

## Test plan

- [x] `pnpm test` — 1737 passed
- [x] `pnpm check` — clean
- [ ] CI green

(Re-opened: previous attempt #296 mistakenly targeted main and was reverted.)