### PR TITLE
fix(workspace): route user-driven Inner Validation through early_stopping path (#298)

### DIFF
--- a/frontend/src/components/workspace/ConfigForm.test.tsx
+++ b/frontend/src/components/workspace/ConfigForm.test.tsx
@@ -235,8 +235,11 @@ describe("ConfigForm", () => {
     const config = {
       model: { name: "lgbm", params: {} },
       training: {
-        early_stopping: { enabled: true, patience: 10 },
-        inner_valid: { method: "holdout", ratio: 0.15 },
+        early_stopping: {
+          enabled: true,
+          patience: 10,
+          inner_valid: { method: "holdout", ratio: 0.15 },
+        },
       },
     };
 
@@ -1267,6 +1270,83 @@ describe("ConfigForm — inner_valid_options (Inner Validation select)", () => {
     });
 
     expect(screen.queryByText("Inner Validation")).not.toBeInTheDocument();
+  });
+
+  it("reads inner_valid.method from training.early_stopping.inner_valid (H-2)", () => {
+    // H-2 regression: the read site used to look at
+    // ``trainingConfig.inner_valid`` (top-level), which is the
+    // ``Extra inputs are not permitted`` path. The Select must
+    // reflect the canonical nested path the backend accepts.
+    renderConfigForm({
+      schema: schemaWithTraining,
+      config: {
+        model: { name: "lgbm", params: {} },
+        training: {
+          early_stopping: {
+            enabled: true,
+            inner_valid: { method: "cv", ratio: 0.2 },
+          },
+        },
+      },
+      onChange: vi.fn(),
+      uiSchema: {
+        inner_valid_options: ["holdout", "cv"],
+      } as unknown as UiSchema,
+    });
+
+    // The Select renders its current value as visible text inside
+    // the trigger. Read it from the trigger's accessible name.
+    const trigger = screen.getByLabelText("Inner validation method");
+    expect(trigger).toHaveTextContent("cv");
+  });
+
+  it("writes Inner Validation method change to training.early_stopping.inner_valid (H-2)", () => {
+    // H-2 regression: the user-driven Select onValueChange used to
+    // emit ``["training", "inner_valid", "method"]``, which lizyml
+    // rejects with ``Extra inputs are not permitted``. The auto-reset
+    // effect was already migrated in P-0092 Phase 2 — this test pins
+    // the write half of the same surface.
+    const onChange = vi.fn();
+    renderConfigForm({
+      schema: schemaWithTraining,
+      config: {
+        model: { name: "lgbm", params: {} },
+        training: {
+          early_stopping: {
+            enabled: true,
+            inner_valid: { method: "holdout", ratio: 0.2 },
+          },
+        },
+      },
+      onChange,
+      uiSchema: {
+        inner_valid_options: ["holdout", "cv"],
+      } as unknown as UiSchema,
+    });
+
+    // Open the Select and pick "cv". Radix's Select renders options in
+    // a portal — open via keyboard so the listbox mounts deterministically
+    // even in jsdom (where pointer events are simulated, not real).
+    const trigger = screen.getByLabelText("Inner validation method");
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    const cvOption = screen.getByRole("option", { name: "cv" });
+    fireEvent.click(cvOption);
+
+    expect(onChange).toHaveBeenCalled();
+    const lastCall = onChange.mock.calls.at(-1);
+    const nextConfig = lastCall?.[0] as Record<string, unknown>;
+    const written = (
+      (
+        (nextConfig.training as Record<string, unknown>)
+          ?.early_stopping as Record<string, unknown>
+      )?.inner_valid as Record<string, unknown>
+    )?.method;
+    expect(written).toBe("cv");
+    // The legacy top-level path must NOT be touched — that was the
+    // P-0087 ``Extra inputs are not permitted`` regression.
+    expect(
+      (nextConfig.training as Record<string, unknown>)?.inner_valid,
+    ).toBeUndefined();
   });
 });
 

--- a/frontend/src/components/workspace/ConfigForm.tsx
+++ b/frontend/src/components/workspace/ConfigForm.tsx
@@ -140,9 +140,21 @@ export function ConfigForm({
     : [];
 
   // Training section — inner_valid
+  //
+  // H-2: the canonical Pydantic path is
+  // ``training.early_stopping.inner_valid``. The legacy top-level
+  // ``training.inner_valid`` path is rejected by the backend with
+  // ``Extra inputs are not permitted`` (TrainingConfig has
+  // extra="forbid"). Phase 2's auto-reset effect was migrated to the
+  // correct path, but the user-driven Select / NumberInput below were
+  // missed — splitting the read/write surface so a user pick of
+  // method/ratio silently failed validation. Read AND write through
+  // the early_stopping nesting now so the two paths agree.
   const trainingConfig = (config.training as Record<string, unknown>) ?? {};
+  const earlyStoppingConfig =
+    (trainingConfig.early_stopping as Record<string, unknown>) ?? {};
   const innerValid =
-    (trainingConfig.inner_valid as Record<string, unknown>) ?? {};
+    (earlyStoppingConfig.inner_valid as Record<string, unknown>) ?? {};
   const innerValidRatio = (innerValid.ratio as number) ?? 0.2;
 
   // Filter inner_valid options by CV strategy
@@ -545,17 +557,15 @@ export function ConfigForm({
                         description="Inner validation strategy for early stopping"
                       >
                         <Select
-                          value={String(
-                            (
-                              trainingConfig.inner_valid as Record<
-                                string,
-                                unknown
-                              >
-                            )?.method ?? "holdout",
-                          )}
+                          value={String(innerValid.method ?? "holdout")}
                           onValueChange={(v) =>
                             handleFieldChange(
-                              ["training", "inner_valid", "method"],
+                              [
+                                "training",
+                                "early_stopping",
+                                "inner_valid",
+                                "method",
+                              ],
                               v,
                             )
                           }
@@ -587,7 +597,12 @@ export function ConfigForm({
                           value={innerValidRatio}
                           onChange={(v) => {
                             handleFieldChange(
-                              ["training", "inner_valid", "ratio"],
+                              [
+                                "training",
+                                "early_stopping",
+                                "inner_valid",
+                                "ratio",
+                              ],
                               v ?? 0.2,
                             );
                           }}


### PR DESCRIPTION
## Summary

Closes #298.

H-2 from the develop-branch code review: the user-driven Inner Validation
Select and Inner Valid Ratio NumberInput were writing to the legacy
top-level `training.inner_valid.{method,ratio}` path, which lizyml's
`TrainingConfig` rejects with `Extra inputs are not permitted`. The
canonical path is `training.early_stopping.inner_valid.{method,ratio}`.

The auto-reset effect was migrated to the correct path in P-0092 Phase 2
(c50c4eb), but the user-driven write surface was missed — manual picks
silently failed validation while the auto-reset path on CV strategy
switching landed cleanly. Splitting the read/write surface made the bug
invisible without DevTools.

## Test plan

- [x] `pnpm test src/components/workspace/ConfigForm.test.tsx --run` — 62 passed
- [x] `pnpm check` — clean
- [x] `pnpm build` — clean
- [ ] CI green

(Re-opened: previous attempt #299 mistakenly targeted main and was reverted.)