### PR TITLE
refactor(workspace): remove unused strict funnel hook + refresh stale comments

### DIFF
--- a/frontend/src/components/workspace/ConfigForm.tsx
+++ b/frontend/src/components/workspace/ConfigForm.tsx
@@ -76,20 +76,21 @@ export function ConfigForm({
     [onChange],
   );
 
-  // P-0092 Q-1 Phase 2: route the three auto-reset effects (inner_valid,
-  // calibration, objective/metric) through the write funnel so their
-  // PUTs land *behind* whichever cv / task / target change triggered
-  // them. The funnel guarantees per-reason serialisation, so a
-  // `cv-change` PUT cannot be silently overwritten by an `auto-reset`
-  // PUT that started from a stale snapshot.
+  // P-0092 Q-1: the three auto-reset effects (inner_valid, calibration,
+  // objective/metric) route through the write funnel so their PUTs land
+  // *behind* whichever cv / task / target change triggered them. The
+  // funnel guarantees per-reason serialisation, so a `cv-change` PUT
+  // cannot be silently overwritten by an `auto-reset` PUT that started
+  // from a stale snapshot.
   //
-  // User-driven field edits keep using `handleFieldChange` and the
-  // legacy onChange path — Phase 4 migrates that as well. Until then
-  // the auto-reset case (which is what fired the post-#271 smoke
-  // regression PR #289 caught) is the only user of `enqueueAutoReset`.
+  // User-driven field edits still use `handleFieldChange` and the
+  // legacy onChange path — production-side that path also rides the
+  // funnel via the per-hook reasons (config-form-edit, target-select,
+  // cv-change), so the only paths that go directly through onChange
+  // are isolated test/story renders without a Provider.
   //
   // We use the *optional* hook so isolated rendering paths (Storybook,
-  // ConfigForm.test.tsx without a provider) can keep falling back to
+  // ConfigForm.test.tsx without a provider) keep falling back to
   // `handleFieldChange`. Production WorkspacePage always mounts the
   // provider so this fallback never fires under real usage.
   const funnel = useConfigWriteFunnelOptional();

--- a/frontend/src/hooks/useConfigWriteFunnel.ts
+++ b/frontend/src/hooks/useConfigWriteFunnel.ts
@@ -137,10 +137,10 @@ interface UseConfigWriteFunnelOptions {
    */
   getCachedConfig: () => ConfigSnapshot | undefined;
   /**
-   * Called immediately after a successful PUT lands. Phase 5 will use
-   * this to update the React Query cache atomically; Phase 1 leaves
-   * it as an injectable hook so unit tests can observe terminal state
-   * without coupling to TanStack Query.
+   * Called immediately after a successful PUT lands. WorkspacePage
+   * uses this to update the React Query cache atomically with the
+   * server-side saved snapshot. Optional so unit tests can observe
+   * terminal state without coupling to TanStack Query.
    */
   onWriteCommitted?: (saved: ConfigSnapshot) => void;
   /**

--- a/frontend/src/hooks/useConfigWriteFunnelContext.tsx
+++ b/frontend/src/hooks/useConfigWriteFunnelContext.tsx
@@ -4,18 +4,19 @@ import type { ConfigWriteFunnel } from "./useConfigWriteFunnel";
 /**
  * Context wrapper for the P-0092 Q-1 write funnel.
  *
- * Phase 2 introduces this so ConfigForm — and, in later phases, every
- * other writer-bearing hook in the Workspace tree — can reach the
- * same `enqueueWrite` instance without prop-drilling. The provider
- * is mounted once by `WorkspacePage`, which owns the lifecycle of
- * the underlying funnel via `useConfigWriteFunnel(...)`.
+ * Mounted once by `WorkspacePage`, which owns the lifecycle of the
+ * underlying funnel via `useConfigWriteFunnel(...)`. Every writer-
+ * bearing hook in the Workspace tree (useConfigSync, useTargetSelection,
+ * useModelPanelData, useDataPanel, ConfigForm) reads the same
+ * `enqueueWrite` instance through `useConfigWriteFunnelOptional`
+ * without prop-drilling.
  *
- * Calling `useConfigWriteFunnelOptional()` returns `null` when no
- * provider is present (e.g. Storybook stories or unit tests that
- * render ConfigForm in isolation). This is intentional: such call
- * sites either provide their own writer through props or rely on
- * the legacy `onChange` path that Phase 2 leaves untouched. Returning
- * `null` lets the consumer fall back instead of crashing.
+ * `useConfigWriteFunnelOptional` returns `null` when no provider is
+ * present (Storybook stories, unit tests that render a single hook
+ * in isolation). This is intentional: such call sites either inject
+ * their own writer through props or rely on the legacy `updateConfig`
+ * fallback. Returning `null` lets the consumer fall back instead of
+ * crashing.
  */
 
 const FunnelContext = createContext<ConfigWriteFunnel | null>(null);
@@ -32,23 +33,10 @@ export function ConfigWriteFunnelProvider({ funnel, children }: ProviderProps) {
 }
 
 /**
- * Strict hook — throws when no provider is mounted. Use this from
- * places that *must* go through the funnel (Phases 4..6 entry points).
- */
-export function useConfigWriteFunnelContext(): ConfigWriteFunnel {
-  const ctx = useContext(FunnelContext);
-  if (ctx === null) {
-    throw new Error(
-      "useConfigWriteFunnelContext must be used within a ConfigWriteFunnelProvider",
-    );
-  }
-  return ctx;
-}
-
-/**
- * Optional hook — returns `null` if no provider is mounted. Phase 2's
- * ConfigForm uses this so isolated rendering paths (Storybook, unit
- * tests) keep working without a provider.
+ * Optional hook — returns `null` if no provider is mounted. The only
+ * production reader is `WorkspacePage`'s subtree, which always mounts
+ * the provider. Isolated test/story renders fall back to the legacy
+ * writer or the injected stub.
  */
 export function useConfigWriteFunnelOptional(): ConfigWriteFunnel | null {
   return useContext(FunnelContext);


### PR DESCRIPTION
## Summary

P-0092 Q-1 post-merge cleanup audit findings:

1. **Drop `useConfigWriteFunnelContext` (strict, throw-on-missing variant).**
   No external caller — production reads through
   `useConfigWriteFunnelOptional` exclusively.
2. **Refresh stale phase-milestone comments.** Multiple comments still
   read as "Phase N will / Phase N leaves..." even though the referenced
   phases have already shipped.

No behaviour change; no test changes.

## Test plan

- [x] `pnpm test src/hooks/useConfigWriteFunnel.test.ts ... --run` — 120 passed
- [x] `pnpm check` — clean
- [x] `pnpm build` — clean
- [ ] CI green

(Re-opened: previous attempt #302 mistakenly targeted main and was reverted.)