### PR TITLE
test(e2e): start Phase C config-reflection generator

### DIFF
--- a/frontend/tests/e2e/fixtures/config-fields.ts
+++ b/frontend/tests/e2e/fixtures/config-fields.ts
@@ -1,0 +1,96 @@
+import type { Locator, Page } from "@playwright/test";
+import type { ConfigFieldSpec } from "../helpers/config-reflection";
+
+/**
+ * Phase C (gui-e2e-plan §4.2) — fixture data driving the
+ * config-reflection invariant generator.
+ *
+ * Each entry declares the smallest unit needed to lock the
+ * "UI control → PUT /config" wire path for one Config field.
+ * The accompanying spec file (workspace-config-fields-loop.spec.ts)
+ * loops `assertConfigReflection` over this list, so adding coverage
+ * for a new field is one fixture row instead of one new spec.
+ *
+ * Conventions:
+ *
+ * - All entries assume the seed step has put the workspace on the
+ *   Fit tab with the Model section already mounted (the default
+ *   state after `seedUiWorkspace`). Fields that need a different
+ *   precondition (Tune tab, mobile section open, CV strategy
+ *   switch) belong in a separate fixture file or a dedicated spec.
+ * - `defaultValue` is the value the saved config holds AFTER
+ *   `seedUiWorkspace` returns and the funnel has quiesced. If the
+ *   value depends on the seed (e.g. binary classification picks
+ *   stratified_kfold and n_splits=5), encode that assumption here
+ *   and add a sanity guard in the spec body so a seed-default
+ *   change fails loudly instead of silently mismatching.
+ * - Locators must resolve uniquely on the post-seed page. Use
+ *   accessible-name selectors (`getByRole(..., { name })`,
+ *   `getByLabel`) over CSS class chains so the fixture survives
+ *   shadcn/ui style refactors.
+ */
+
+/**
+ * Fixture wrapper that ties the spec to the precondition it needs.
+ * Today every entry assumes "post-seedUiWorkspace, Fit tab, Model
+ * section mounted". Future fixtures (Tune tab, mobile, strategy
+ * switch) attach their precondition via this same field.
+ */
+export interface FixtureEntry {
+  spec: ConfigFieldSpec<unknown>;
+  /**
+   * Optional precondition driver run AFTER `seedUiWorkspace` and
+   * BEFORE the spec's locator resolves. Used for fields that need
+   * a tab switch, accordion open, or strategy change before the
+   * control is mountable. Today's fixtures don't need any.
+   */
+  precondition?: (page: Page) => Promise<void>;
+}
+
+const splitNSplits: FixtureEntry = {
+  spec: {
+    name: "split.n_splits via Folds NumberInput",
+    configPath: "split.n_splits",
+    defaultValue: 5,
+    testValue: 7,
+    // CvSection's Folds NumberInput sets ariaLabel="Folds" so the
+    // <input> surfaces as role=textbox with that accessible name.
+    uiLocator: (p): Locator =>
+      p.getByRole("textbox", { name: "Folds", exact: true }),
+    uiAction: async (locator, value) => {
+      await locator.fill(String(value));
+      await locator.blur();
+    },
+  } as ConfigFieldSpec<unknown>,
+};
+
+const modelBalanced: FixtureEntry = {
+  spec: {
+    name: "model.balanced via Smart Params Balanced switch",
+    configPath: "model.balanced",
+    // For binary classification (the seed task) lizyml's defaults
+    // endpoint leaves model.balanced as null (the Pydantic optional
+    // default). The Switch UI treats null/undefined/false as "off"
+    // — see renderBooleanField at field-renderers.tsx:104.
+    defaultValue: null,
+    testValue: true,
+    // FormField wires <Label htmlFor> to the Switch's underlying
+    // role=switch button. Issue #265 already locks "exactly one
+    // Balanced switch" so this getByRole match is unambiguous.
+    uiLocator: (p): Locator => p.getByRole("switch", { name: "Balanced" }),
+    uiAction: async (locator) => {
+      await locator.click();
+    },
+  } as ConfigFieldSpec<unknown>,
+};
+
+/**
+ * Initial Phase C wave: 2 fields covering NumberInput + Switch
+ * shapes. Adding a fixture row in the next PR is the unit of work
+ * for extending coverage to all 32+ Config fields enumerated in
+ * gui-e2e-plan §A.
+ */
+export const CONFIG_FIELD_FIXTURES: FixtureEntry[] = [
+  splitNSplits,
+  modelBalanced,
+];

--- a/frontend/tests/e2e/workspace-config-fields-loop.spec.ts
+++ b/frontend/tests/e2e/workspace-config-fields-loop.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+import * as fs from "node:fs";
+import { API, createTestCsv } from "./helpers/api";
+import {
+  assertConfigReflection,
+  type ConfigFieldSpec,
+} from "./helpers/config-reflection";
+import { CONFIG_FIELD_FIXTURES } from "./fixtures/config-fields";
+import { isMobileProject } from "./helpers/mobile";
+import { seedUiWorkspace } from "./helpers/workspace-ui";
+
+/**
+ * Phase C (gui-e2e-plan §4.2) — config-reflection invariant
+ * generator.
+ *
+ * Each fixture row in `fixtures/config-fields.ts` declares the four
+ * data points needed to lock the "UI control → PUT /config" path
+ * for one Config field. This spec loops `assertConfigReflection`
+ * over those rows, so adding coverage for a new field is a fixture
+ * row diff instead of a new spec file.
+ *
+ * The first wave covers `split.n_splits` (NumberInput) and
+ * `model.balanced` (Switch) — chosen to exercise both core control
+ * shapes and verify the loop pattern works before extending the
+ * fixture set.
+ *
+ * Mobile is skipped: every field in the initial wave lives in the
+ * Data / Model panels which collapse on mobile bottom-tab mount.
+ * B-8 is the dedicated mobile coverage track.
+ */
+
+const CSV_PATH = "/tmp/e2e_config_fields_loop.csv";
+
+test.describe("Workspace config-fields loop (Phase C)", () => {
+  test.beforeAll(() => {
+    createTestCsv(100, CSV_PATH);
+  });
+
+  test.afterAll(() => {
+    if (fs.existsSync(CSV_PATH)) fs.unlinkSync(CSV_PATH);
+  });
+
+  test.beforeEach(async ({ request }) => {
+    await request.post(`${API}/workspace/reset`);
+  });
+
+  for (const fixture of CONFIG_FIELD_FIXTURES) {
+    test(fixture.spec.name, async ({ page, request }, testInfo) => {
+      if (isMobileProject(testInfo)) {
+        test.skip(
+          true,
+          "Phase C wave 1 fixtures live in Data/Model panels; mobile " +
+            "needs a separate path covered by B-8.",
+        );
+      }
+
+      await seedUiWorkspace(page, testInfo, {
+        csvPath: CSV_PATH,
+        target: "target",
+        expectedRows: 100,
+      });
+
+      // Sanity guard: the seed lands on stratified_kfold (binary
+      // classification default). If the seed ever changes, every
+      // fixture's defaultValue would silently mismatch — the
+      // single-line check below makes that failure loud and
+      // pointable.
+      const seeded = await request.get(`${API}/workspace/config`);
+      expect(seeded.status()).toBe(200);
+      const seededBody = await seeded.json();
+      expect(seededBody.split.method).toBe("stratified_kfold");
+      expect(seededBody.task).toBe("binary");
+
+      if (fixture.precondition) {
+        await fixture.precondition(page);
+      }
+
+      await assertConfigReflection(
+        page,
+        request,
+        fixture.spec as ConfigFieldSpec<unknown>,
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Adds the **fixture-driven config-reflection generator** (gui-e2e-plan §4.2, Phase C).
- `frontend/tests/e2e/fixtures/config-fields.ts` — declarative rows pairing `{configPath, defaultValue, testValue, uiLocator, uiAction}`.
- `frontend/tests/e2e/workspace-config-fields-loop.spec.ts` — Playwright loop that runs each fixture row as its own test via `assertConfigReflection`.
- Initial wave: 2 fields covering NumberInput + Switch shapes.
  - `split.n_splits` (Folds NumberInput)
  - `model.balanced` (Smart Params Switch)

## Why
Pre-Phase C, locking each Config field's wire path required a new spec file. The helper at `helpers/config-reflection.ts` (PR #288) already proved the four-step invariant pattern; Phase C promotes the **fixture row** to the unit of work. Adding coverage for a new field is now a 4-line diff.

## Test plan
- [x] `pnpm exec playwright test workspace-config-fields-loop.spec.ts` — 4 passed / 2 skipped (chromium + tablet × 2 fixtures; mobile skipped, covered by B-8)

## Pattern
```ts
// fixtures/config-fields.ts
const splitNSplits: FixtureEntry = {
  spec: {
    name: "split.n_splits via Folds NumberInput",
    configPath: "split.n_splits",
    defaultValue: 5,
    testValue: 7,
    uiLocator: (p) => p.getByRole("textbox", { name: "Folds", exact: true }),
    uiAction: async (l, v) => { await l.fill(String(v)); await l.blur(); },
  },
};
```

## Next waves
This PR establishes the generator. Follow-up PRs add fixture rows for:
- `data.task` (SegmentGroup)
- `training.seed` / `training.early_stopping.*` (NumberInput / Switch)
- `tuning.optuna.params.n_trials` (Tune-tab precondition)
- 7 CV strategy fixtures (precondition: strategy switch)
- 32+ total fields per gui-e2e-plan §A