### PR TITLE
test(e2e): Phase C wave 2 + Issue #304 DataPanel cleanup

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 - このファイルは **横串インデックス** であり、詳細はリンク先で確認すること。
 - 着手する際は HISTORY に Proposal を起票（変更ゲート対象の場合）→ PLAN にフェーズ追加 → 実装、の順で進める。
 
-最終更新: 2026-04-30
+最終更新: 2026-04-30（Phase D 全 spec 完了 / Phase C generator 起動）
 
 ---
 
@@ -142,15 +142,15 @@
 
 | ID | spec | 状態 | 規模 | ROI |
 |---|---|---|---|---|
-| **B-1** | `jobs-ui.spec.ts` — Jobs ページの click/フィルタ/Export ダイアログ/Delete 確認/Cancel | ❌ 未着手（既存 `jobs-flow.spec.ts` は API のみ） | 中 | 高 |
-| **B-2** | `inference-flow.spec.ts` 拡張 — History クリックで結果切替 | ❌ 既存 spec に未追加 | 小 | 中 |
+| **B-1** | `jobs-ui.spec.ts` — Jobs ページの click/フィルタ/Export ダイアログ/Delete 確認/Cancel | ✅ 完了（PR #316） | 中 | — |
+| **B-2** | `inference-flow.spec.ts` 拡張 — History クリックで結果切替 | ✅ 完了（PR #315） | 小 | — |
 | **B-3** | `workspace-cv.spec.ts` — 7 strategy 巡回 | ✅ 完了（PR #289） | — | — |
-| **B-3b** | BlockedGroupKFold エディタ専用 spec | ❌ 未着手（B-3 が deferred） | 中 | 中 |
-| **B-4** | `workspace-feature-weights.spec.ts` — FW エディタ操作 | ✅ 完了（test/e2e-feature-weights-b4） | 小 | — |
-| **B-5** | `workspace-columns.spec.ts` — Excl/Type 操作 | ❌ 未着手（`features.exclude` / `features.categorical` 無 E2E） | 小 | 高 |
-| **B-6** | `workspace-presets.spec.ts` — Preset Load → form 反映 | ⚠️ Save のみ既存（`workspace-model-panel.spec.ts:101`）、Load 反映未 assertion | 小 | 中 |
+| **B-3b** | BlockedGroupKFold エディタ専用 spec | 🔴 deferred — UI 経由で blocked_group_kfold へ切替えると discriminated union が partial wire body を 422 で拒否し、cache reconcile が cv.strategy を revert する funnel ループを踏む。Component test で代替（`BlockedGroupKFoldEditor.component.test.tsx`） | 中 | 中 |
+| **B-4** | `workspace-feature-weights.spec.ts` — FW エディタ操作 | ✅ 完了（PR #312） | 小 | — |
+| **B-5** | `workspace-columns.spec.ts` — Excl/Type 操作 | ✅ 完了（PR #313） | 小 | — |
+| **B-6** | `workspace-presets.spec.ts` — Preset Load → form 反映 | ✅ 完了（PR #314） | 小 | — |
 | **B-7** | `workspace-running-lock.spec.ts` — running lock UI mapping | ✅ 完了（PR #300） | — | — |
-| **B-8** | `workspace-mobile.spec.ts` — bottom-tab traversal | ❌ 未着手（Issue #304 と連動） | 中 | 低〜中 |
+| **B-8** | `workspace-mobile.spec.ts` — bottom-tab traversal | ✅ 完了（PR #318） | 中 | — |
 
 ### 4.2 Phase C: Config-reflection invariant generator
 
@@ -158,20 +158,19 @@
 |---|---|
 | Helper（`tests/e2e/helpers/config-reflection.ts`） | ✅ 既存（206 行、PR #288） |
 | Sample spec（`split.n_splits` のみ） | ✅ 既存 |
-| Fixture data（`tests/e2e/fixtures/config-fields.ts`） | ❌ 未作成 |
-| 32+ フィールドの自動 loop | ❌ 未着手 |
-
-着手すれば B-4/B-5/B-6 の一部を fixture 行追加だけで済ませられるため、**B-N より先に Phase C 起動を狙う方が ROI が高い可能性あり**。
+| Fixture data（`tests/e2e/fixtures/config-fields.ts`） | ✅ 完了（PR #317） |
+| Generator spec（`workspace-config-fields-loop.spec.ts`） | ✅ 完了（PR #317） |
+| 32+ フィールドの自動 loop | 🟡 wave 1（2 fields）完了。残り fixture 追加で増設 |
 
 ### 4.3 Phase D 段階プラン進捗
 
 | Phase | 内容 | 状態 |
 |---|---|---|
 | D-1 | Phase A helper + sample 1 件 | ✅ 完了（#288） |
-| D-2 | B-1（Jobs UI） + B-3（CV strategy） | 🟡 B-3 のみ完了。**B-1 未着手** |
-| D-3 | B-2 / B-4 / B-5 / B-6 | ❌ 全て未着手 |
-| D-4 | B-7 + B-8 | 🟡 B-7 完了。**B-8 未着手** |
-| D-5 | Phase C generator 起動 + 全フィールド loop | ❌ 未着手 |
+| D-2 | B-1（Jobs UI） + B-3（CV strategy） | ✅ 完了（B-3 #289 / B-1 #316） |
+| D-3 | B-2 / B-4 / B-5 / B-6 | ✅ 完了（#315 / #312 / #313 / #314） |
+| D-4 | B-7 + B-8 | ✅ 完了（#300 / #318） |
+| D-5 | Phase C generator 起動 + 全フィールド loop | 🟡 generator 起動済み（#317）、fixture 拡張継続中 |
 
 ---
 
@@ -183,7 +182,7 @@
 | **#28** | [Testing] Add offline/resume resilience tests | medium / tier-4 | `current_job_id` ライフサイクル契約決定が前提。post-completion deep-link は #143 でカバー済み、during-run reload が gap |
 | **#125** | chore(frontend): migrate Tailwind CSS v3 → v4 | medium / tier-4 | Owner status: `Button` で spike → 専用 sprint。即着手は推奨しない |
 | **#298** | Inner Validation user-driven path（H-2） | — | ✅ 完了（PR #308 でクローズ済み） |
-| **#304** | track skipped tests（DataPanel jsdom + mobile E2E） | low | DataPanel の 2 件と mobile 6 件を分割対応。Mobile 側は B-8 と一体で処理可 |
+| **#304** | track skipped tests（DataPanel jsdom + mobile E2E） | low | Mobile 6 件は B-8（PR #318）でクローズ済。DataPanel 2 件は jsdom + Radix Select の制約のため別 PR で対応 |
 
 ---
 

--- a/frontend/src/components/workspace/DataPanel.test.tsx
+++ b/frontend/src/components/workspace/DataPanel.test.tsx
@@ -426,158 +426,30 @@ describe("DataPanel", () => {
     });
   });
 
-  // Note: Radix Select interactions don't work reliably in headless DOM
-  // environments, so we skip tests that require Select option clicking.
-
-  // Column grid rendering requires a complex async chain (load → fetchColumns
-  // → fetchConfigDefaults → updateConfig) that is unreliable in headless DOM.
-  // These paths are covered by E2E visual regression tests instead.
-  // Tracked under Issue #304 — restore as a passing component test or delete
-  // and lean on the E2E coverage explicitly.
-  it.skip("renders column settings grid when data is loaded with target", async () => {
-    mockLoadDataFromPath.mockResolvedValue({
-      data_ref: { shape: [100, 5], path: "/data.csv" },
-    });
-    mockFetchColumns.mockResolvedValue({
-      columns: [
-        {
-          name: "age",
-          dtype: "int64",
-          unique_count: 50,
-          suggested_type: "numeric",
-          suggested_excluded: false,
-          exclude_reason: null,
-        },
-        {
-          name: "gender",
-          dtype: "object",
-          unique_count: 2,
-          suggested_type: "categorical",
-          suggested_excluded: false,
-          exclude_reason: null,
-        },
-        {
-          name: "id_col",
-          dtype: "int64",
-          unique_count: 100,
-          suggested_type: "numeric",
-          suggested_excluded: true,
-          exclude_reason: "id",
-        },
-        {
-          name: "target",
-          dtype: "int64",
-          unique_count: 2,
-          suggested_type: "numeric",
-          suggested_excluded: false,
-          exclude_reason: null,
-        },
-      ],
-      suggested_task: "binary",
-      target: "target",
-    });
-    mockFetchPreview.mockResolvedValue({
-      columns: ["age", "gender", "id_col", "target"],
-      data: [],
-    });
-    mockFetchConfigDefaults.mockResolvedValue({
-      task: "binary",
-      data: { target: "target" },
-    });
-    mockUpdateConfig.mockResolvedValue({});
-
-    const user = userEvent.setup();
-    render(<DataPanel onDataChanged={vi.fn()} onTaskChanged={vi.fn()} />);
-
-    // Switch to Path mode and load data
-    await user.click(screen.getByText("Path"));
-    const input = screen.getByPlaceholderText("/path/to/data.csv");
-    await user.type(input, "/data.csv");
-    await user.click(screen.getByRole("button", { name: "Load" }));
-
-    // Wait for columns to render
-    await waitFor(() => {
-      expect(screen.getByText("age")).toBeInTheDocument();
-    });
-
-    // Column grid headers should be visible
-    expect(screen.getByText("Name")).toBeInTheDocument();
-    expect(screen.getByText("Unique")).toBeInTheDocument();
-    expect(screen.getByText("Exclude")).toBeInTheDocument();
-    expect(screen.getByText("Type")).toBeInTheDocument();
-
-    // Columns should be displayed (excluding target)
-    expect(screen.getByText("age")).toBeInTheDocument();
-    expect(screen.getByText("gender")).toBeInTheDocument();
-    expect(screen.getByText("id_col")).toBeInTheDocument();
-
-    // ID badge should appear
-    expect(screen.getByText("ID")).toBeInTheDocument();
-
-    // Type toggle buttons (Num/Cat) should be present
-    const numButtons = screen.getAllByRole("button", { name: "Num" });
-    const catButtons = screen.getAllByRole("button", { name: "Cat" });
-    expect(numButtons.length).toBeGreaterThan(0);
-    expect(catButtons.length).toBeGreaterThan(0);
-  });
-
-  // Tracked under Issue #304 — same async-chain reliability problem
-  // as the column-grid test above; covered by E2E visual regression
-  // until restored or removed.
-  it.skip("shows summary stats after data is loaded", async () => {
-    mockLoadDataFromPath.mockResolvedValue({
-      data_ref: { shape: [100, 4], path: "/data.csv" },
-    });
-    mockFetchColumns.mockResolvedValue({
-      columns: [
-        {
-          name: "age",
-          dtype: "int64",
-          unique_count: 50,
-          suggested_type: "numeric",
-          suggested_excluded: false,
-          exclude_reason: null,
-        },
-        {
-          name: "gender",
-          dtype: "object",
-          unique_count: 2,
-          suggested_type: "categorical",
-          suggested_excluded: false,
-          exclude_reason: null,
-        },
-        {
-          name: "target",
-          dtype: "int64",
-          unique_count: 2,
-          suggested_type: "numeric",
-          suggested_excluded: false,
-          exclude_reason: null,
-        },
-      ],
-      suggested_task: "binary",
-      target: "target",
-    });
-    mockFetchPreview.mockResolvedValue({ columns: [], data: [] });
-    mockFetchConfigDefaults.mockResolvedValue({
-      task: "binary",
-      data: { target: "target" },
-    });
-    mockUpdateConfig.mockResolvedValue({});
-
-    const user = userEvent.setup();
-    render(<DataPanel onDataChanged={vi.fn()} onTaskChanged={vi.fn()} />);
-
-    await user.click(screen.getByText("Path"));
-    const input = screen.getByPlaceholderText("/path/to/data.csv");
-    await user.type(input, "/data.csv");
-    await user.click(screen.getByRole("button", { name: "Load" }));
-
-    // Summary should show numeric/categorical counts
-    await waitFor(() => {
-      expect(screen.getByText(/numeric/i)).toBeInTheDocument();
-    });
-  });
+  // Issue #304 follow-up: the previously skipped tests
+  // ``renders column settings grid when data is loaded with target``
+  // and ``shows summary stats after data is loaded`` were removed
+  // here. They drove the full Path → Load → fetchColumns →
+  // fetchConfigDefaults → updateConfig chain in jsdom and asserted
+  // on column-grid rendering, but the chain never completes
+  // reliably in headless DOM (verified 2026-04-30: unskipping
+  // produces a deterministic timeout on ``getByText("age")`` /
+  // ``getByText(/numeric/i)``).
+  //
+  // Coverage of the same surface lives in:
+  //   - The same file's ``Feature Summary`` extended suite
+  //     (3 passing tests covering numeric/categorical/excluded
+  //     counts via the seedDataPanel helper, which bypasses the
+  //     fragile UI-driven Path load).
+  //   - The same file's ``column type and exclude toggles`` suite
+  //     (4 passing tests covering Num / Cat / Excl / column filter).
+  //   - workspace-columns.spec.ts (E2E B-5, PR #313) which clicks
+  //     real Cat / Excl controls against a live backend and locks
+  //     the wire payload.
+  //
+  // Removing the skipped tests closes the Issue #304 acceptance
+  // criterion ``DataPanel.test.tsx:435/522 — restored as a passing
+  // component test or deleted with reasoning (E2E coverage cited)``.
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/tests/e2e/fixtures/config-fields.ts
+++ b/frontend/tests/e2e/fixtures/config-fields.ts
@@ -84,13 +84,54 @@ const modelBalanced: FixtureEntry = {
   } as ConfigFieldSpec<unknown>,
 };
 
+const trainingSeed: FixtureEntry = {
+  spec: {
+    name: "training.seed via Seed NumberInput",
+    configPath: "training.seed",
+    // lizyml defaults endpoint sets training.seed=42 for binary tasks.
+    defaultValue: 42,
+    testValue: 7,
+    // FormField wires <Label htmlFor> to the NumberInput's underlying
+    // <input>. The schema-rendered Training section produces a
+    // unique "Seed" label (no other "Seed" textbox is visible after
+    // seedUiWorkspace). Using getByRole+name avoids the deeply
+    // nested locator chain that would otherwise be required.
+    uiLocator: (p): Locator =>
+      p.getByRole("textbox", { name: "Seed", exact: true }),
+    uiAction: async (locator, value) => {
+      await locator.fill(String(value));
+      await locator.blur();
+    },
+  } as ConfigFieldSpec<unknown>,
+};
+
+const earlyStoppingRounds: FixtureEntry = {
+  spec: {
+    name: "training.early_stopping.rounds via Rounds NumberInput",
+    configPath: "training.early_stopping.rounds",
+    // lizyml defaults endpoint sets training.early_stopping.rounds=150
+    // for binary tasks.
+    defaultValue: 150,
+    testValue: 75,
+    // "Rounds" is unique to early_stopping in the post-seed Fit form.
+    uiLocator: (p): Locator =>
+      p.getByRole("textbox", { name: "Rounds", exact: true }),
+    uiAction: async (locator, value) => {
+      await locator.fill(String(value));
+      await locator.blur();
+    },
+  } as ConfigFieldSpec<unknown>,
+};
+
 /**
- * Initial Phase C wave: 2 fields covering NumberInput + Switch
- * shapes. Adding a fixture row in the next PR is the unit of work
- * for extending coverage to all 32+ Config fields enumerated in
- * gui-e2e-plan §A.
+ * Phase C wave 2: 4 fields covering NumberInput + Switch shapes
+ * across 3 sections (split / model / training). Adding a fixture
+ * row in the next PR is the unit of work for extending coverage
+ * to all 32+ Config fields enumerated in gui-e2e-plan §A.
  */
 export const CONFIG_FIELD_FIXTURES: FixtureEntry[] = [
   splitNSplits,
   modelBalanced,
+  trainingSeed,
+  earlyStoppingRounds,
 ];


### PR DESCRIPTION
## Summary
Three follow-ups bundled per the no-docs-only-PR rule:

1. **ROADMAP refresh** — mark all B-1/B-2/B-4/B-5/B-6/B-8 ✅ shipped (PRs #312-318), Phase C generator started, B-3b deferred with explicit rationale.
2. **Issue #304 DataPanel jsdom cleanup** — remove the 2 long-skipped tests at `DataPanel.test.tsx:437` and `:527` and replace with a docblock citing equivalent coverage in:
   - the same file's "Feature Summary" suite (3 passing tests)
   - the same file's "column type and exclude toggles" suite (4 passing tests)
   - `workspace-columns.spec.ts` E2E (B-5 / PR #313)
   Net: 52 passing tests / 0 skipped (was 52 / 2). Closes Issue #304.
3. **Phase C wave 2 fixtures** — extend `tests/e2e/fixtures/config-fields.ts` with two more fields:
   - `training.seed` (NumberInput "Seed", 42 → 7)
   - `training.early_stopping.rounds` (NumberInput "Rounds", 150 → 75)
   Wave 1 (split.n_splits, model.balanced) unchanged. 4/4 pass on chromium + tablet, 4 skip on mobile per existing guard.

## Why
- ROADMAP needs to track reality so future sessions don't duplicate work.
- Issue #304 mobile cluster was closed by B-8 (PR #318); the DataPanel jsdom skips were the last open item — verified by unskipping that they fail deterministically in jsdom (the load → fetchColumns chain doesn't complete) and the same logic is exercised by the extended-coverage suites already in the file plus E2E B-5.
- Phase C wave 2 doubles the fixture coverage (2 → 4 fields) and proves the generator pattern scales: each new field is a 4-line fixture diff, not a new spec.

## B-3b status
B-3b (BlockedGroupKFold editor E2E) is **explicitly deferred** in ROADMAP. The funnel/cache reconcile loop discovered while attempting it: clicking the BlockedGroup strategy radio fires a partial wire body (no `blocks` / `groups` yet), Pydantic 422s, and the `useDataPanel` cache reconcile parses `split.method=stratified_kfold` from the still-saved config and reverts `cv.strategy`, unmounting the editor mid-test. API-seeding past it works for editor mount but `target` stays null in local state without UI-driven seeding, blocking subsequent useConfigSync writes. The editor's wire-shaping contract is already locked at the unit level via `BlockedGroupKFoldEditor.component.test.tsx`.

## Test plan
- [x] `pnpm exec vitest run src/components/workspace/DataPanel.test.tsx` — 52 passed / 0 skipped
- [x] `pnpm exec playwright test workspace-config-fields-loop.spec.ts` — 8 passed / 4 skipped (mobile)