### PR TITLE
test(e2e): Phase C wave 3 — 5 more config-reflection fixtures

### DIFF
--- a/frontend/tests/e2e/fixtures/config-fields.ts
+++ b/frontend/tests/e2e/fixtures/config-fields.ts
@@ -123,15 +123,113 @@ const earlyStoppingRounds: FixtureEntry = {
   } as ConfigFieldSpec<unknown>,
 };
 
+const earlyStoppingEnabled: FixtureEntry = {
+  spec: {
+    name: "training.early_stopping.enabled via Enabled Switch",
+    configPath: "training.early_stopping.enabled",
+    // lizyml defaults endpoint sets training.early_stopping.enabled=true
+    // for binary tasks. Toggling it OFF locks the regression where the
+    // form's Switch flips but the wire body retains the prior value.
+    defaultValue: true,
+    testValue: false,
+    // "Enabled" is unique to training.early_stopping in the post-seed
+    // Fit form — calibration uses a different switch label.
+    uiLocator: (p): Locator => p.getByRole("switch", { name: "Enabled" }),
+    uiAction: async (locator) => {
+      await locator.click();
+    },
+  } as ConfigFieldSpec<unknown>,
+};
+
+const modelAutoNumLeaves: FixtureEntry = {
+  spec: {
+    name: "model.auto_num_leaves via Auto Num Leaves Switch",
+    configPath: "model.auto_num_leaves",
+    // lizyml defaults endpoint sets model.auto_num_leaves=true for
+    // binary tasks. Toggling OFF disables num_leaves_ratio in the
+    // UI but the Switch itself drives a clean wire write.
+    defaultValue: true,
+    testValue: false,
+    uiLocator: (p): Locator =>
+      p.getByRole("switch", { name: "Auto Num Leaves" }),
+    uiAction: async (locator) => {
+      await locator.click();
+    },
+  } as ConfigFieldSpec<unknown>,
+};
+
+const modelNumLeavesRatio: FixtureEntry = {
+  spec: {
+    name: "model.num_leaves_ratio via Num Leaves Ratio NumberInput",
+    configPath: "model.num_leaves_ratio",
+    // Default = 1 (per the rendered Smart Params section). NOTE:
+    // this control is enabled only while auto_num_leaves=true (the
+    // seed default). The auto_num_leaves fixture above runs in its
+    // own isolated workspace (beforeEach reset) so this fixture
+    // sees the seeded auto=true state.
+    //
+    // testValue stays inside the UI default_range of [0.5, 1.0]
+    // (lizyml_ui_schema.py default_range hint) — values outside
+    // that hint occasionally round-trip back to the default at the
+    // server boundary.
+    defaultValue: 1,
+    testValue: 0.7,
+    uiLocator: (p): Locator =>
+      p.getByRole("textbox", { name: "Num Leaves Ratio", exact: true }),
+    uiAction: async (locator, value) => {
+      await locator.fill(String(value));
+      await locator.blur();
+    },
+  } as ConfigFieldSpec<unknown>,
+};
+
+const modelMinDataInLeafRatio: FixtureEntry = {
+  spec: {
+    name: "model.min_data_in_leaf_ratio via Min Data In Leaf Ratio NumberInput",
+    configPath: "model.min_data_in_leaf_ratio",
+    // Default = 0.01 per the Smart Params block. The schema marks
+    // this nullable, but lizyml's defaults endpoint always emits
+    // a numeric value.
+    defaultValue: 0.01,
+    testValue: 0.05,
+    uiLocator: (p): Locator =>
+      p.getByRole("textbox", { name: "Min Data In Leaf Ratio", exact: true }),
+    uiAction: async (locator, value) => {
+      await locator.fill(String(value));
+      await locator.blur();
+    },
+  } as ConfigFieldSpec<unknown>,
+};
+
+const modelMinDataInBinRatio: FixtureEntry = {
+  spec: {
+    name: "model.min_data_in_bin_ratio via Min Data In Bin Ratio NumberInput",
+    configPath: "model.min_data_in_bin_ratio",
+    defaultValue: 0.01,
+    testValue: 0.05,
+    uiLocator: (p): Locator =>
+      p.getByRole("textbox", { name: "Min Data In Bin Ratio", exact: true }),
+    uiAction: async (locator, value) => {
+      await locator.fill(String(value));
+      await locator.blur();
+    },
+  } as ConfigFieldSpec<unknown>,
+};
+
 /**
- * Phase C wave 2: 4 fields covering NumberInput + Switch shapes
+ * Phase C wave 3: 9 fields covering NumberInput + Switch shapes
  * across 3 sections (split / model / training). Adding a fixture
  * row in the next PR is the unit of work for extending coverage
- * to all 32+ Config fields enumerated in gui-e2e-plan §A.
+ * to the remaining ~26 Config fields enumerated in gui-e2e-plan §A.
  */
 export const CONFIG_FIELD_FIXTURES: FixtureEntry[] = [
   splitNSplits,
   modelBalanced,
   trainingSeed,
   earlyStoppingRounds,
+  earlyStoppingEnabled,
+  modelAutoNumLeaves,
+  modelNumLeavesRatio,
+  modelMinDataInLeafRatio,
+  modelMinDataInBinRatio,
 ];

--- a/frontend/tests/e2e/helpers/config-reflection.ts
+++ b/frontend/tests/e2e/helpers/config-reflection.ts
@@ -175,16 +175,30 @@ export async function assertConfigReflection<TValue>(
   // (2)+(3) drive the UI and observe the immediate PUT body. The
   // promise is created BEFORE the UI action so we don't drop the
   // request — Playwright's waitForRequest is a one-shot subscription.
-  // We filter the body so partial PUTs that don't carry `configPath`
-  // (e.g. P-0092 Phase 2 `auto-reset` patches that only flush the
-  // evaluation/objective fields) are skipped — the spec asserts a
-  // specific field, so the relevant PUT is the one whose body
-  // contains a value at that path.
+  //
+  // Body filter strategy:
+  //   - Skip PUTs that don't carry `configPath` (P-0092 Phase 2
+  //     auto-reset patches that flush only evaluation/objective).
+  //   - For fields whose default is included in every PUT body
+  //     (e.g. model.min_data_in_bin_ratio always lands at 0.01 even
+  //     when the user is editing some other field), `!== undefined`
+  //     is too permissive: a quiescence-tail PUT from the seed step
+  //     can match before the user's UI action lands. Tighten the
+  //     filter to require the body's value at configPath EQUAL the
+  //     spec.testValue. The matcher uses JSON-equality so nested
+  //     structures (e.g. model.feature_weights) round-trip cleanly.
+  //
+  // CI flake repro (PR #320 e2e-chromium 2026-04-30): with the loose
+  // `!== undefined` filter, 8/9 fixtures were flaky and
+  // model.min_data_in_bin_ratio failed both attempts because the
+  // helper grabbed a stale 0.01 PUT instead of the post-fill 0.05.
   const locator = spec.uiLocator(page);
   await expect(locator).toBeVisible();
+  const expectedValueJson = JSON.stringify(spec.testValue);
   const putPromise = nextPutConfigBody(
     page,
-    (body) => deepGet(body, spec.configPath) !== undefined,
+    (body) =>
+      JSON.stringify(deepGet(body, spec.configPath)) === expectedValueJson,
   );
   await spec.uiAction(locator, spec.testValue);
   const putBody = await putPromise;


### PR DESCRIPTION
## Summary
Extends `tests/e2e/fixtures/config-fields.ts` from 4 → 9 fields covered. 5 new fixtures across model + training:

- `training.early_stopping.enabled` (Switch, true → false)
- `model.auto_num_leaves`            (Switch, true → false)
- `model.num_leaves_ratio`           (NumberInput, 1 → 0.7)
- `model.min_data_in_leaf_ratio`     (NumberInput, 0.01 → 0.05)
- `model.min_data_in_bin_ratio`      (NumberInput, 0.01 → 0.05)

## Why
ROADMAP §4.2 wants ~32 field coverage; waves 1+2 shipped 4. Wave 3 brings the total to 9 (≈22% of Phase A matrix). Each fixture is a 4-line declarative block driving the same `assertConfigReflection` helper — no new spec files.

## Test plan
- [x] `pnpm exec playwright test workspace-config-fields-loop.spec.ts` — 18 passed / 9 skipped
  - 9/9 fixtures × chromium + chromium-tablet = 18 passes
  - 9 skipped on chromium-mobile per helper's mobile guard (covered by B-8)

## Caveat documented in fixture
`num_leaves_ratio` testValue stays inside the UI `default_range` hint of [0.5, 1.0]. Values outside that hint round-trip to the default at the server boundary; the helper surfaces that as a saved-config mismatch. Fixture comment locks the constraint so future edits don't regress.

## Coverage progress
- Wave 1 (#317): 2 fields (split.n_splits, model.balanced)
- Wave 2 (#319): +2 (training.seed, training.early_stopping.rounds)
- Wave 3 (this PR): +5 → 9 fields total