### PR TITLE
test(e2e): Phase C wave 8 — data column selectors + helper polling fix

### DIFF
--- a/frontend/tests/e2e/fixtures/config-fields.ts
+++ b/frontend/tests/e2e/fixtures/config-fields.ts
@@ -571,12 +571,70 @@ const calibrationNSplits: FixtureEntry = {
   precondition: enableCalibration,
 };
 
+const dataGroupCol: FixtureEntry = {
+  spec: {
+    name: "data.group_col (group_kfold) via Group column Select",
+    configPath: "data.group_col",
+    // After switching to group_kfold, applyCvDataFields injects
+    // data.group_col=null (because cv.groupCol is null until the
+    // user picks). Probed via tests/e2e:
+    // data = { path, target, time_col: null, group_col: null }.
+    defaultValue: null,
+    testValue: "gender",
+    // CvSection's Group column Select carries an explicit
+    // aria-label, so getByRole resolves it directly.
+    uiLocator: (p): Locator =>
+      p.getByRole("combobox", { name: "Group column", exact: true }),
+    uiAction: async (locator, value) => {
+      await locator.click();
+      await locator
+        .page()
+        .getByRole("option", { name: String(value), exact: true })
+        .click();
+    },
+  } as ConfigFieldSpec<unknown>,
+  precondition: async (page) => {
+    await page.getByRole("radio", { name: "GroupKFold", exact: true }).click();
+    // The Group column trigger materialises once the strategy
+    // reconciles into local state.
+    await page
+      .getByRole("combobox", { name: "Group column", exact: true })
+      .waitFor({ state: "visible", timeout: 5000 });
+  },
+};
+
+const dataTimeCol: FixtureEntry = {
+  spec: {
+    name: "data.time_col (time_series) via Time column Select",
+    configPath: "data.time_col",
+    defaultValue: null,
+    testValue: "age",
+    uiLocator: (p): Locator =>
+      p.getByRole("combobox", { name: "Time column", exact: true }),
+    uiAction: async (locator, value) => {
+      await locator.click();
+      await locator
+        .page()
+        .getByRole("option", { name: String(value), exact: true })
+        .click();
+    },
+  } as ConfigFieldSpec<unknown>,
+  precondition: async (page) => {
+    await page
+      .getByRole("radio", { name: "TimeSeriesSplit", exact: true })
+      .click();
+    await page
+      .getByRole("combobox", { name: "Time column", exact: true })
+      .waitFor({ state: "visible", timeout: 5000 });
+  },
+};
+
 /**
- * Phase C wave 7: 20 fields. Adds 4 nullable / conditional
- * fixtures: time-series train_size_max / test_size_max plus
- * calibration method / n_splits (both gated by the Calibration
- * Switch precondition). Introduces an `enableCalibration` helper
- * mirroring the `switchToCvStrategy` pattern.
+ * Phase C wave 8: 22 fields. Adds the two `data.*_col` Selects
+ * gated by their respective CV strategies (group_kfold for
+ * group_col, time_series for time_col). Both use defaultValue=null
+ * because applyCvDataFields injects null until the user picks a
+ * column from the dropdown.
  */
 export const CONFIG_FIELD_FIXTURES: FixtureEntry[] = [
   splitNSplits,
@@ -599,4 +657,6 @@ export const CONFIG_FIELD_FIXTURES: FixtureEntry[] = [
   splitTestSizeMax,
   calibrationMethod,
   calibrationNSplits,
+  dataGroupCol,
+  dataTimeCol,
 ];

--- a/frontend/tests/e2e/helpers/config-reflection.ts
+++ b/frontend/tests/e2e/helpers/config-reflection.ts
@@ -209,11 +209,14 @@ export async function assertConfigReflection<TValue>(
 
   // (4) confirm the saved config reflects the new value. useConfigSync
   //     calls setQueryData on success so a subsequent GET returns the
-  //     server view; we assert the server view directly to avoid any
-  //     client-cache illusion.
-  const after = await readSavedConfig(request);
-  expect(
-    deepGet(after, spec.configPath),
-    `saved config mismatch at ${spec.configPath}`,
-  ).toEqual(spec.testValue);
+  //     server view. Use waitForConfigSettle so a slow funnel commit
+  //     under CI load doesn't fail the spec — the PUT body filter
+  //     already proved the wire write is correct; this step only
+  //     verifies that the server view eventually agrees.
+  await waitForConfigSettle(
+    request,
+    (cfg) =>
+      JSON.stringify(deepGet(cfg, spec.configPath)) === expectedValueJson,
+    { timeoutMs: 5000 },
+  );
 }


### PR DESCRIPTION
## Summary
Extends `tests/e2e/fixtures/config-fields.ts` from 20 → **22 fields** (≈55% Phase A coverage).

| Field | Control | Default → Test | Precondition |
|---|---|---|---|
| `data.group_col` | Select | `null → "gender"` | switch to GroupKFold |
| `data.time_col` | Select | `null → "age"` | switch to TimeSeriesSplit |

Both Selects carry explicit aria-labels in CvSection.tsx:200/220 so `getByRole("combobox", { name })` resolves directly.

## Helper change
`config-reflection.ts` step (4) — saved-config check now uses `waitForConfigSettle` instead of a one-shot `readSavedConfig + expect.toEqual`. Under load the funnel commit can trail the PUT body observation by a few ms, causing intermittent "saved config mismatch" failures on chromium-tablet and chromium-mobile when running all 22 fixtures back-to-back. The PUT body filter (strict testValue match from develop@91569f1) still pins the wire contract — the polling check only relaxes the timing assumption on the GET side.

## Test plan
- [x] `pnpm exec playwright test workspace-config-fields-loop.spec.ts` — 44/44 pass on chromium + chromium-tablet (22 skipped on chromium-mobile per existing guard)

## Coverage progress
| Wave | PR | Added | Total |
|---|---|---|---|
| 1-7 | #317-#324 | 20 | 20 |
| 8 | this PR | 2 | **22** |

22/40+ Phase A fields ≈ 55% generator coverage.