### PR TITLE
fix(ws): replay cached terminal to late WS subscribers (P-0093, #327)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2804,3 +2804,74 @@ A code-review + test-coverage audit run immediately after the §P-0092 Resolved 
 
 PRs were initially opened against `main` (the repo's default base for `gh pr create`) and merged 5 of 8 before the deviation was caught. main was rolled back to `cd1c51e` and all 8 PRs re-created against develop. Branch-guard hook (`.claude/hooks/branch-guard.sh`) extended to require explicit `--base develop` on `gh pr create` to prevent recurrence.
 
+### P-0093: WebSocket terminal-message replay for late subscribers（Issue #327）
+
+- **Date:** 2026-05-01 起票
+- **Related:** Issue #327、`src/lizystudio/ws/progress.py`、H-0035（WS exponential backoff）、H-0058 / H-0069（ping/keepalive）、Issue #151（queue overflow policy）
+
+#### Symptom（観察事実）
+
+直近の Workspace 運用ログに、同一 config・8 秒間隔の **連続 Fit（同一データセット、再 Fit）** が観測された。両ジョブとも `meta.json` で `status="completed"`, `error=null`、`fit_result.json` (3889 byte) も同一内容で正しく書かれており、**バックエンドは健全**。フロントエンドの terminal-detection が遅延／欠落して、ユーザーが「結果が見えない」と再 Fit したと推定される。
+
+| 時刻 (UTC) | Job ID | duration | 観察 |
+|---|---|---|---|
+| 04:50:44 | job_7c3c1f5b | 3.5s | strategy 切替 (group_kfold) |
+| 04:50:52 | job_b44d9de7 | 2.2s | **同一 config の再 Fit（8 秒後）** |
+
+#### Root cause
+
+`ProgressBroadcaster.send()` は subscribe 前に送信されたメッセージを **subscriber 不在として丸ごと破棄** する設計だった（旧実装）。高速 Fit (< 3 秒) では：
+
+1. `POST /fit` がスレッドを起動して即時 return（`start_fit_async`、`training.py:236-273`）
+2. クライアント: `setCurrentJobId` → React render → `connectJobProgress` → WS handshake
+3. **同時に** subprocess が短時間で完走 → `broadcaster.send_completed()`
+4. WS handshake → `broadcaster.subscribe()` の **前に** completed が送られると `_queues[job_id]` が空 → メッセージ drop
+5. WS handler は subscribe 後に空キューを 30 秒待ち、ping のみ流れる
+6. 復旧パスは `useJob` の HTTP polling fallback (2s 間隔)。最終的に completed を検出するが **2〜4 秒の遅延** が発生し、ユーザーが再試行する余地がある
+
+#### Purpose
+
+terminal メッセージ（completed / error）が subscribe タイミングに依存せず、各 jobId に対して subscriber に **少なくとも一度** 届くことを保証する。
+
+#### Impact
+
+- `lizystudio.ws.progress.ProgressBroadcaster` のみ変更。**wire format 変更なし**、クライアント側の `connectJobProgress` ハンドラそのまま流用可能。
+- `MetricsRegistry` に `lizystudio_progress_terminal_replayed_total` Counter を追加（observability）。
+- 環境変数 `LIZYSTUDIO_WS_TERMINAL_TTL_S` で TTL 上書き可能（default 300 秒 = 5 分）。
+
+#### Compatibility
+
+- 既存テスト 30 件（progress.py 23 + 新規 7）すべて green。
+- 無症状ジョブ（subscribe が間に合った通常フロー）は live broadcast 経路のままで挙動変化なし。
+- メトリクス購読側の Prometheus scrape ターゲットに新カウンター名が増えるが、ラベル無しなので破壊的変更ではない。
+
+#### Alternatives considered
+
+- (a) WS handler 側で subscribe 直後に明示的に `broadcaster.replay_terminal(job_id, queue)` を呼ぶ実装。Broadcaster 内蔵と機能的に等価だが、INV-1 を「Broadcaster の責務」としてセマンティックに局所化したい目的で却下。
+- (b) クライアント側 polling 強化のみ（`useJob.refetchInterval` を拡張）。2〜4 秒の遅延が残るためユーザー体験を直接改善しない。Issue #327 の補強策として将来検討可能。
+- (c) `POST /fit` ハンドラ側で synchronous に最初の `running` ステータスを書き込んでから return → `useJob` の最初の fetch を必ず非完了状態にする。バックエンドの thread spawn 順序を改変するため副作用が大きく、根本対策にならない（subscribe 時点で既に completed のケースが残る）。
+
+#### Invariants
+
+- **INV-1**: 各 jobId について、terminal メッセージ（completed / error）は subscribe タイミングに関わらず subscriber に **少なくとも一度** 届く。
+- **INV-2**: 同一 jobId の同一 terminal は同一 subscriber に **高々一度** 配信される。live broadcast 経路と replay 経路は subscribe が `_queues` に登録されるタイミングを境に **disjoint**。
+- **INV-3**: `_last_terminal` cache は `_terminal_ttl_s` 秒で expire し、subscribe 時の lazy GC で除去される。
+
+実装上の保証：
+- INV-2 は `send()` の lock 内で `qs = list(self._queues.get(job_id, []))` のスナップショットを取った瞬間に決定する。subscribe より前にスナップショットが取られた subscriber → live のみ。subscribe より後の新しい subscriber → cache から replay のみ。両者が同時に発生する race は lock で排他されている。
+
+#### Acceptance criteria
+
+- [x] `ProgressBroadcaster._last_terminal` cache を導入、TTL で GC される
+- [x] `subscribe` がキャッシュされた terminal を first message として queue に注入
+- [x] `tests/test_progress.py::TestTerminalReplay` 7 ケース（INV-1 / INV-2 / INV-3 / metric / TTL env）追加
+- [x] 既存 `tests/test_progress.py` 23 ケース全 green
+- [x] `MetricsRegistry.progress_terminal_replayed_total` 追加
+- [x] mypy / ruff / ruff format 全 green
+- [x] HISTORY.md に Proposal 起票（concurrency / ownership change-gate 対応）
+
+#### Decision
+
+- 2026-05-01 **Approved** — Invariants 明示 + テスト先行。実装サイズ約 +60 行（progress.py）+ +10 行（metrics.py）+ +130 行（tests）で十分にコントロール可能。
+- 実装後の運用観察: `lizystudio_progress_terminal_replayed_total` の発生率を Prometheus で追跡し、定常レートが 0 でなければ subscribe-vs-send race が production でも発火していた裏付けになる。
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -1181,8 +1181,35 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 
 ---
 
-## 採番ガイダンス（v3-15 以降）
+## Phase v3-15: WebSocket terminal-replay（P-0093 / Issue #327）✅
 
-- 新規 Proposal は **P-0093** 以降を起票。
-- 仕様変更を伴う作業は HISTORY.md に Proposal → 本 PLAN.md にフェーズ追加（`v3-15`...）の順で進める。
+**期間:** 2026-05-01
+
+**対象 Proposal:** P-0093
+
+**動機:** 高速 Fit (< 3 秒) で `ProgressBroadcaster.send()` が subscribe 前 message を破棄し、UI の terminal-detection が 2〜4 秒遅延（`useJob` polling fallback 経由）。直近 Workspace 運用ログで「同一 config・8 秒間隔の連続 Fit」が観測され、ユーザーの再試行行動を裏付けた。
+
+**成果物:**
+- `ProgressBroadcaster._last_terminal` per-jobId cache + TTL ベース lazy GC
+- `subscribe()` が cache 内 terminal を queue の first message として注入
+- `MetricsRegistry.progress_terminal_replayed_total` Counter 追加
+- 環境変数 `LIZYSTUDIO_WS_TERMINAL_TTL_S` で TTL 上書き（default 300 秒）
+- `tests/test_progress.py::TestTerminalReplay` 7 ケース（INV-1 / INV-2 / INV-3 / metric / TTL env）
+
+**主要 PR:** TBD（fix/issue-327-ws-terminal-replay）
+
+**DoD:**
+- [x] `tests/test_progress.py` 全 30 件 green（既存 23 + 新規 7）
+- [x] `tests/test_metrics_registry.py` / `tests/test_metrics_api.py` 全 green
+- [x] mypy / ruff / ruff format 全 green
+- [x] HISTORY.md P-0093 Proposal が Approved
+- [x] BLUEPRINT 変更不要（wire format 変更なし、内部実装のみ）
+- [ ] CI（develop ブランチ）で e2e 含む全 gate green（PR 作成後に確認）
+
+---
+
+## 採番ガイダンス（v3-16 以降）
+
+- 新規 Proposal は **P-0094** 以降を起票。
+- 仕様変更を伴う作業は HISTORY.md に Proposal → 本 PLAN.md にフェーズ追加（`v3-16`...）の順で進める。
 - 詳細な未着手バックログは `docs/ROADMAP.md` を参照。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 - このファイルは **横串インデックス** であり、詳細はリンク先で確認すること。
 - 着手する際は HISTORY に Proposal を起票（変更ゲート対象の場合）→ PLAN にフェーズ追加 → 実装、の順で進める。
 
-最終更新: 2026-05-01（Phase C wave 1〜8 完了：22/40+ field カバー）
+最終更新: 2026-05-01（P-0093 WS terminal-replay 起票 + Phase C wave 1〜8 完了：22/40+ field カバー）
 
 ---
 
@@ -103,6 +103,7 @@
 
 | 完了日 | ID | タイトル | 主要 PR |
 |---|---|---|---|
+| 2026-05-01 | P-0093 (impl) | WebSocket terminal-replay（Issue #327） | branch `fix/issue-327-ws-terminal-replay` (PR 作成待ち) |
 | 2026-04-30 | **P-0092** | ConfigForm cross-hook write funnel（6 phase） | #290〜#295, #289（B-3 spec） |
 | 2026-04-30 | P-0092 follow-up | H-1〜H-4 / G-1〜G-8 / Issue #298 修正 | #300, #303, #306〜#310 |
 | 2026-04-22 | Coupling refactor A+B+C | 26 項目（API queries/Job lineage/format_version 等） | 多数。`docs/coupling-analysis.md:11` |
@@ -116,6 +117,15 @@
 ---
 
 ## 3. アクティブ：仕様変更を伴う Proposal
+
+### 3.0 P-0093：WebSocket terminal-message replay for late subscribers（Issue #327）
+
+- **状態**: 🟢 実装完了（PR レビュー待ち）— branch `fix/issue-327-ws-terminal-replay`
+- **動機**: 高速 Fit (< 3 秒) で `ProgressBroadcaster.send()` が subscribe 前 message を破棄。UI の terminal-detection が 2〜4 秒遅延し、運用ログでユーザーが再 Fit する行動が観測された
+- **対象 Issue**: #327（同根の副症状 #328 は別 PR で対応）
+- **PLAN フェーズ**: v3-15（PLAN.md 参照）
+- **invariant test**: `tests/test_progress.py::TestTerminalReplay` 7 ケース
+- **次アクション**: PR 作成 → CI 全 green → develop マージ
 
 ### 3.1 P-0087 Phase 3：`cv_strategy_fields` を Pydantic から自動派生
 
@@ -214,6 +224,8 @@
 
 | Issue | タイトル | priority | 推奨アクション |
 |---|---|---|---|
+| **#327** | WebSocket "completed" race — results not visible after fast Fit | **high** | 🟢 実装完了。PR 作成 → CI green 待ち（branch `fix/issue-327-ws-terminal-replay`、P-0093 / v3-15） |
+| **#328** | execution.log empty — subprocess stdout discarded | medium | subprocess_runner.py で stdout を log file にリダイレクト + size bound + regression test |
 | **#27** | [Testing] Add load and concurrency tests | medium / tier-4 | (a) `pytest-benchmark` 100k-row microbench を tier-3 で先行マージ可 / (b) 並行 fit stress harness は tier-4 |
 | **#28** | [Testing] Add offline/resume resilience tests | medium / tier-4 | `current_job_id` ライフサイクル契約決定が前提。post-completion deep-link は #143 でカバー済み、during-run reload が gap |
 | **#125** | chore(frontend): migrate Tailwind CSS v3 → v4 | medium / tier-4 | Owner status: `Button` で spike → 専用 sprint。即着手は推奨しない |

--- a/src/lizystudio/metrics.py
+++ b/src/lizystudio/metrics.py
@@ -62,6 +62,7 @@ class MetricsRegistry:
     active_jobs: Gauge = field(init=False)
     jobs_duration: Histogram = field(init=False)
     progress_dropped_total: Counter = field(init=False)
+    progress_terminal_replayed_total: Counter = field(init=False)
 
     def __post_init__(self) -> None:
         # HTTP request counter. Labels:
@@ -116,6 +117,18 @@ class MetricsRegistry:
         self.progress_dropped_total = Counter(
             "lizystudio_progress_dropped_total",
             "Progress messages dropped due to a full subscriber queue",
+            registry=self.registry,
+        )
+
+        # Issue #327 / P-0093: counts terminal messages (completed / error)
+        # that were delivered via the per-jobId terminal cache to a
+        # subscriber that joined AFTER the message was sent. A non-zero
+        # rate signals the subscribe-before-send race actually fires in
+        # production; sustained growth suggests either very fast jobs or
+        # a slow client connect path.
+        self.progress_terminal_replayed_total = Counter(
+            "lizystudio_progress_terminal_replayed_total",
+            "Terminal messages replayed to late WebSocket subscribers",
             registry=self.registry,
         )
 

--- a/src/lizystudio/ws/progress.py
+++ b/src/lizystudio/ws/progress.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import threading
+import time
 from typing import TYPE_CHECKING, Any
 
 from fastapi import WebSocket, WebSocketDisconnect
@@ -49,6 +50,12 @@ MAX_QUEUE_SIZE: int = 1024
 # make room instead of dropping the terminal itself.
 _TERMINAL_TYPES: frozenset[str] = frozenset({"completed", "error"})
 
+# Issue #327 / P-0093: per-jobId retention window for terminal-replay.
+# Five minutes is long enough to cover slow client connect paths (e.g.
+# WSL2 Vite HMR cold-start, mobile network reconnect) without growing
+# the cache unbounded. Override via ``LIZYSTUDIO_WS_TERMINAL_TTL_S``.
+_DEFAULT_TERMINAL_TTL_S: float = 300.0
+
 
 class ProgressBroadcaster:
     """In-memory progress broadcaster.
@@ -63,9 +70,34 @@ class ProgressBroadcaster:
       ``PROGRESS_DROPPED_TOTAL`` is incremented.
     - Terminal messages (``completed`` / ``error``) never drop; on a
       full queue the oldest non-terminal item is evicted to make room.
+
+    Terminal replay (Issue #327 / P-0093):
+
+    - Every ``completed`` / ``error`` message is cached per jobId with
+      a monotonic timestamp.
+    - A subscriber that joins later (race: send wins handshake; or WS
+      reconnect after disconnect) reads the cached terminal as the
+      first message in its queue, so ``onCompleted`` / ``onError`` fires
+      even if the live broadcast missed it.
+    - Cached entries expire after ``_terminal_ttl_s`` (default 5 min,
+      override via ``LIZYSTUDIO_WS_TERMINAL_TTL_S``).
+    - Subscribers that were present at send time are NOT replayed to —
+      they already received the live message via :meth:`send`.
+
+    Invariants:
+
+    - INV-1: every terminal message reaches each subscriber at least once
+      per jobId, regardless of subscribe vs. send timing.
+    - INV-2: cached terminal is delivered at most once per subscriber via
+      replay (live and replay paths are disjoint by construction).
+    - INV-3: cache retention is bounded by ``_terminal_ttl_s``.
     """
 
-    def __init__(self, metrics: MetricsRegistry | None = None) -> None:
+    def __init__(
+        self,
+        metrics: MetricsRegistry | None = None,
+        terminal_ttl_s: float | None = None,
+    ) -> None:
         self._queues: dict[str, list[asyncio.Queue[dict[str, Any]]]] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
         self._lock = threading.Lock()
@@ -76,15 +108,59 @@ class ProgressBroadcaster:
         # case instead of bumping a disconnected global.
         self._metrics = metrics
 
+        # Issue #327: per-jobId terminal cache for late subscribers.
+        # Stores (sent_at_monotonic, message) so :meth:`subscribe` can
+        # replay a cached terminal without consulting the wall clock.
+        self._last_terminal: dict[str, tuple[float, dict[str, Any]]] = {}
+        if terminal_ttl_s is None:
+            env_value = os.environ.get("LIZYSTUDIO_WS_TERMINAL_TTL_S")
+            try:
+                terminal_ttl_s = (
+                    float(env_value) if env_value else _DEFAULT_TERMINAL_TTL_S
+                )
+            except ValueError:
+                _logger.warning(
+                    "Invalid LIZYSTUDIO_WS_TERMINAL_TTL_S=%r; using default %ss",
+                    env_value,
+                    _DEFAULT_TERMINAL_TTL_S,
+                )
+                terminal_ttl_s = _DEFAULT_TERMINAL_TTL_S
+        self._terminal_ttl_s = terminal_ttl_s
+
     def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
         """Store the event loop reference for thread-safe enqueuing."""
         self._loop = loop
 
     def subscribe(self, job_id: str) -> asyncio.Queue[dict[str, Any]]:
-        """Create a new subscription queue for a job. Called from async."""
+        """Create a new subscription queue for a job. Called from async.
+
+        Issue #327: if a terminal message was cached for ``job_id`` within
+        the TTL window, replay it as the first item in the new queue so
+        the late subscriber observes the terminal even when the live
+        broadcast lost the subscribe-vs-send race.
+        """
         q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=MAX_QUEUE_SIZE)
+        replay_message: dict[str, Any] | None = None
         with self._lock:
             self._queues.setdefault(job_id, []).append(q)
+            cached = self._last_terminal.get(job_id)
+            if cached is not None:
+                sent_at, message = cached
+                if time.monotonic() - sent_at <= self._terminal_ttl_s:
+                    replay_message = message
+                else:
+                    # Lazy GC of expired entries — keeps the dict bounded
+                    # by the rate of new subscriptions for stale jobs.
+                    self._last_terminal.pop(job_id, None)
+        if replay_message is not None:
+            try:
+                q.put_nowait(replay_message)
+            except asyncio.QueueFull:
+                # Fresh queue with maxsize=1024; should be impossible.
+                _logger.error("terminal replay failed: fresh queue full for %s", job_id)
+            else:
+                if self._metrics is not None:
+                    self._metrics.progress_terminal_replayed_total.inc()
         return q
 
     def unsubscribe(self, job_id: str, q: asyncio.Queue[dict[str, Any]]) -> None:
@@ -102,12 +178,22 @@ class ProgressBroadcaster:
         Honours the terminal-preservation policy: a ``completed`` or
         ``error`` message evicts an older non-terminal on a full queue
         rather than being dropped itself.
+
+        Issue #327: terminal messages are also cached in ``_last_terminal``
+        before broadcast so :meth:`subscribe` can replay them to late
+        subscribers. The cache write happens under ``_lock`` together
+        with the subscriber-list snapshot so a subscribe call sequenced
+        AFTER this send observes the cached terminal, while subscribers
+        already present at send time receive the live broadcast (no
+        double-delivery).
         """
+        is_terminal = message.get("type") in _TERMINAL_TYPES
         with self._lock:
+            if is_terminal:
+                self._last_terminal[job_id] = (time.monotonic(), message)
             qs = list(self._queues.get(job_id, []))
         if not qs or self._loop is None:
             return
-        is_terminal = message.get("type") in _TERMINAL_TYPES
         for q in qs:
             self._loop.call_soon_threadsafe(self._enqueue, q, message, is_terminal)
 

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -544,3 +544,162 @@ class TestWebsocketProgressThreadSafety:
 
         assert len(broadcaster._queues.get("job-ts", [])) == 10
         loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Issue #327 — terminal-replay invariants (P-0093)
+#
+# INV-1: terminal messages (completed / error) reach a subscriber that joins
+#        AFTER the message was sent, as long as the per-jobId cache is still
+#        within its TTL.
+# INV-2: each cached terminal is delivered at most once per subscriber via
+#        replay (already enforced UI-side via terminalFiredRef; here we only
+#        guarantee the server side does not duplicate the message into a
+#        subscriber that was present at send time).
+# INV-3: cache retention is bounded by ``LIZYSTUDIO_WS_TERMINAL_TTL_S``
+#        (default 5 minutes); expired entries are dropped on the next
+#        subscribe and never replayed.
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalReplay:
+    """INV-1..INV-3: subscribe-before-send race fix (Issue #327)."""
+
+    def test_completed_replayed_to_late_subscriber(
+        self, broadcaster: ProgressBroadcaster
+    ) -> None:
+        """INV-1: a fast Fit's send_completed BEFORE subscribe still reaches
+        the eventual subscriber via the per-jobId terminal cache."""
+        loop = broadcaster._loop
+        assert loop is not None
+
+        # send terminal BEFORE any subscriber exists for this job
+        broadcaster.send_completed("job_late", "Done!")
+        loop.run_until_complete(asyncio.sleep(0.01))
+
+        # late subscribe — terminal must be replayed as the queue's first item
+        q = broadcaster.subscribe("job_late")
+        assert not q.empty()
+        msg = q.get_nowait()
+        assert msg["type"] == "completed"
+        assert msg["job_id"] == "job_late"
+        assert msg["message"] == "Done!"
+
+    def test_error_replayed_to_late_subscriber(
+        self, broadcaster: ProgressBroadcaster
+    ) -> None:
+        """INV-1 (error variant): error terminals are also replayed."""
+        loop = broadcaster._loop
+        assert loop is not None
+
+        broadcaster.send_error("job_err", "boom", code="X_TEST")
+        loop.run_until_complete(asyncio.sleep(0.01))
+
+        q = broadcaster.subscribe("job_err")
+        assert not q.empty()
+        msg = q.get_nowait()
+        assert msg["type"] == "error"
+        assert msg["code"] == "X_TEST"
+        assert msg["message"] == "boom"
+
+    def test_progress_not_cached_for_replay(
+        self, broadcaster: ProgressBroadcaster
+    ) -> None:
+        """INV-1 negative: non-terminal progress is not stored, so a late
+        subscriber starts with an empty queue (status quo for progress)."""
+        loop = broadcaster._loop
+        assert loop is not None
+
+        broadcaster.send_progress("job_p", current=1, total=2, message="hi")
+        loop.run_until_complete(asyncio.sleep(0.01))
+
+        q = broadcaster.subscribe("job_p")
+        assert q.empty()
+
+    def test_ttl_expired_entry_is_dropped(
+        self, broadcaster: ProgressBroadcaster
+    ) -> None:
+        """INV-3: cache retention is bounded; an expired entry is dropped on
+        the next subscribe and the queue starts empty as if no terminal was
+        ever sent."""
+        # Shrink TTL inside the test so we don't have to wait minutes.
+        broadcaster._terminal_ttl_s = 0.001  # 1ms
+
+        loop = broadcaster._loop
+        assert loop is not None
+
+        broadcaster.send_completed("job_ttl")
+        loop.run_until_complete(asyncio.sleep(0.05))  # >> TTL
+
+        q = broadcaster.subscribe("job_ttl")
+        # Expired: nothing to replay.
+        assert q.empty()
+        # And the cache entry itself is gone after the lazy GC.
+        assert "job_ttl" not in broadcaster._last_terminal
+
+    def test_replay_does_not_duplicate_to_present_subscriber(
+        self, broadcaster: ProgressBroadcaster
+    ) -> None:
+        """INV-2: a subscriber that was present at send time receives the
+        terminal exactly once (via the live broadcast path), NOT twice
+        (no double delivery via replay)."""
+        loop = broadcaster._loop
+        assert loop is not None
+
+        q_present = broadcaster.subscribe("job_present")
+        broadcaster.send_completed("job_present", "Done!")
+        loop.run_until_complete(asyncio.sleep(0.01))
+
+        # Drain — exactly one message expected.
+        msgs: list[dict[str, Any]] = []
+        while not q_present.empty():
+            msgs.append(q_present.get_nowait())
+        assert len(msgs) == 1
+        assert msgs[0]["type"] == "completed"
+
+    def test_reconnect_subscriber_gets_replayed_terminal(
+        self, broadcaster: ProgressBroadcaster
+    ) -> None:
+        """INV-1 (reconnect variant): the original subscriber drops, then a
+        fresh subscriber for the same job_id (e.g. WS reconnect) receives
+        the cached terminal so the UI never hangs in 'running' forever."""
+        loop = broadcaster._loop
+        assert loop is not None
+
+        q1 = broadcaster.subscribe("job_reconn")
+        broadcaster.send_completed("job_reconn", "Done!")
+        loop.run_until_complete(asyncio.sleep(0.01))
+
+        # Drain + drop original subscriber (simulates client disconnect).
+        assert q1.get_nowait()["type"] == "completed"
+        broadcaster.unsubscribe("job_reconn", q1)
+
+        # Reconnect — fresh subscriber must still see the terminal.
+        q2 = broadcaster.subscribe("job_reconn")
+        assert not q2.empty()
+        replayed = q2.get_nowait()
+        assert replayed["type"] == "completed"
+        assert replayed["job_id"] == "job_reconn"
+
+    def test_replay_increments_metric(self, broadcaster: ProgressBroadcaster) -> None:
+        """The replay path bumps the metrics counter so we can observe how
+        often the race actually fires in production."""
+        loop = broadcaster._loop
+        assert loop is not None
+
+        metrics = MagicMock()
+        broadcaster._metrics = metrics
+
+        broadcaster.send_completed("job_metric")
+        loop.run_until_complete(asyncio.sleep(0.01))
+
+        broadcaster.subscribe("job_metric")
+        metrics.progress_terminal_replayed_total.inc.assert_called_once()
+
+    def test_ttl_default_from_env_var(self) -> None:
+        """``LIZYSTUDIO_WS_TERMINAL_TTL_S`` overrides the default TTL."""
+        with patch.dict(
+            "os.environ", {"LIZYSTUDIO_WS_TERMINAL_TTL_S": "12.5"}, clear=False
+        ):
+            b = ProgressBroadcaster()
+        assert b._terminal_ttl_s == pytest.approx(12.5)


### PR DESCRIPTION
## Summary

- Fixes #327: terminal (`completed` / `error`) messages are now cached per jobId in `ProgressBroadcaster` and replayed to subscribers that join after the message was sent — closing the subscribe-before-send race that left fast Fit jobs (< 3 s) stuck on "Running…" until the 2 s HTTP polling fallback caught up.
- Adds `MetricsRegistry.progress_terminal_replayed_total` so the replay rate is observable in production.
- Records the change as Proposal **P-0093** in `HISTORY.md` and as Phase **v3-15** in `PLAN.md`. ROADMAP.md updated to point at this PR.

## Why this design

`send()` previously did `if not qs: return` and dropped any message whose subscriber list was empty. For a 2 s Fit, the typical sequence is

1. `POST /fit` returns and spawns the training thread (`start_fit_async`)
2. Client `setCurrentJobId` → render → `connectJobProgress` → WS handshake
3. **In parallel**, the subprocess finishes and calls `broadcaster.send_completed()`
4. If the WS handshake (and `subscribe()`) lands after step 3, the queue is empty and the `completed` message is silently dropped
5. The WS handler then waits 30 s for a message that never comes; the UI eventually recovers via `useJob` polling but with a 2–4 s lag

We considered three alternatives (logged in `HISTORY.md` P-0093 §Alternatives):

- (a) replay from inside the WS handler — same effect, but locates the invariant outside the broadcaster
- (b) only harden client polling — leaves the latency window in place
- (c) synchronously persist `running` before `POST /fit` returns — invasive thread-spawn change that does not cover the case where the subprocess finishes before any client request lands

Caching one terminal per jobId in the broadcaster is the smallest change that satisfies INV-1 (every terminal reaches every subscriber at least once) without altering the wire format.

## Invariants

- **INV-1**: every terminal message reaches each subscriber at least once per jobId, regardless of subscribe vs. send timing.
- **INV-2**: each terminal is delivered at most once per subscriber. The live broadcast snapshot in `send()` and the cache lookup in `subscribe()` share `_lock`, so a subscriber present at send time receives the live message only, and a subscriber added afterwards receives the replay only — no double delivery.
- **INV-3**: cache retention is bounded by `_terminal_ttl_s` (default 300 s, override `LIZYSTUDIO_WS_TERMINAL_TTL_S`); expired entries are dropped on the next subscribe.

## Failure paths covered

- [x] Normal completion (subscribe wins handshake) — live broadcast unchanged
- [x] **Fast completion (send wins handshake)** — replay restores the terminal to the late subscriber
- [x] Reconnect (subscriber drops, new subscriber joins for same jobId) — replay covers the new subscriber
- [x] Error terminals — same cache mechanism, same TTL
- [x] TTL expiry — entry GC'd lazily on next subscribe
- [x] Subscriber present at send time — exactly one delivery, no replay duplicate
- [ ] Server restart — terminal cache is in-memory only (acceptable; on-disk job status remains the source of truth and `useJob` polling closes the loop)

## Test plan

- [x] `tests/test_progress.py::TestTerminalReplay` — 7 new cases (INV-1 / INV-2 / INV-3 / metric / TTL env)
- [x] `uv run pytest tests/test_progress.py tests/test_progress_reader.py tests/test_metrics_registry.py tests/test_metrics_api.py` — 58 / 58 green locally
- [x] `uv run ruff check . && uv run ruff format --check . && uv run mypy src/lizystudio/` — green
- [ ] CI full matrix on this PR
- [ ] Manual smoke: run two consecutive fast Fits via the dev server, confirm Results panel switches to the completed view immediately for both runs

## Files

| Area | File | Change |
|---|---|---|
| backend | `src/lizystudio/ws/progress.py` | `_last_terminal` cache, TTL handling, replay in `subscribe()` |
| backend | `src/lizystudio/metrics.py` | `progress_terminal_replayed_total` Counter |
| tests | `tests/test_progress.py` | `TestTerminalReplay` class (7 cases) |
| docs | `HISTORY.md` | P-0093 Proposal |
| docs | `PLAN.md` | Phase v3-15 entry |
| docs | `docs/ROADMAP.md` | §2 / §3 / §5 updates |

Closes #327