### PR TITLE
fix(subprocess): redirect child stdout to execution.log (#328)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -225,7 +225,7 @@
 | Issue | タイトル | priority | 推奨アクション |
 |---|---|---|---|
 | **#327** | WebSocket "completed" race — results not visible after fast Fit | **high** | 🟢 実装完了。PR 作成 → CI green 待ち（branch `fix/issue-327-ws-terminal-replay`、P-0093 / v3-15） |
-| **#328** | execution.log empty — subprocess stdout discarded | medium | subprocess_runner.py で stdout を log file にリダイレクト + size bound + regression test |
+| **#328** | execution.log empty — subprocess stdout discarded | medium | 🟢 実装完了（branch `fix/issue-328-execution-log-redirect`）。`subprocess_runner.py` で stdout/stderr を `execution.log` にリダイレクト + 10 MiB head-drop cap + `_StderrDrainer` 退役 |
 | **#27** | [Testing] Add load and concurrency tests | medium / tier-4 | (a) `pytest-benchmark` 100k-row microbench を tier-3 で先行マージ可 / (b) 並行 fit stress harness は tier-4 |
 | **#28** | [Testing] Add offline/resume resilience tests | medium / tier-4 | `current_job_id` ライフサイクル契約決定が前提。post-completion deep-link は #143 でカバー済み、during-run reload が gap |
 | **#125** | chore(frontend): migrate Tailwind CSS v3 → v4 | medium / tier-4 | Owner status: `Button` で spike → 専用 sprint。即着手は推奨しない |

--- a/src/lizystudio/services/_training_core.py
+++ b/src/lizystudio/services/_training_core.py
@@ -193,10 +193,26 @@ def _run_job_core(
         # Persist captured logs. OSError here must not propagate —
         # doing so would short-circuit the worker thread and leave a
         # zombie thread handle on the workspace.
+        #
+        # Issue #328: append (not overwrite) so any stdout/stderr that
+        # the parent's ``Popen`` captured into the same path stays
+        # intact. The child's stdout fd is closed by Python's stdio
+        # shutdown before this finally block runs, so the parent has
+        # finished its writes by the time we open in append mode here.
+        # When ``log_buffer`` is empty AND the file does not yet exist
+        # (in-process callers that do not go through the subprocess
+        # plumbing), touch an empty file so existing callers that
+        # assert the artifact path exists keep working.
         try:
+            captured = log_buffer.getvalue()
             log_path = job_store.path_for(job.job_id, "log")
             log_path.parent.mkdir(parents=True, exist_ok=True)
-            log_path.write_text(log_buffer.getvalue(), encoding="utf-8")
+            if captured:
+                with log_path.open("a", encoding="utf-8") as f:
+                    f.write("\n--- captured Python logger records ---\n")
+                    f.write(captured)
+            elif not log_path.exists():
+                log_path.touch()
         except OSError:
             _logger.warning(
                 "Failed to persist execution log for job %s",

--- a/src/lizystudio/services/subprocess_runner.py
+++ b/src/lizystudio/services/subprocess_runner.py
@@ -21,12 +21,10 @@ import os
 import subprocess
 import sys
 import tempfile
-import threading
 import time
-from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any
 
 from lizystudio.services.jobs import Job, JobStore
 
@@ -50,99 +48,73 @@ _WAIT_TIMEOUT = 10.0
 _FINAL_FLUSH_RETRIES = 5
 _FINAL_FLUSH_INTERVAL = 0.05
 
-# Issue #150: the child's stderr pipe must be drained concurrently or
-# the child blocks on write(2) once it exceeds the OS pipe buffer
-# (~64 KiB on Linux). We retain only the last _STDERR_TAIL_CHUNKS *
-# _STDERR_READ_SIZE bytes so a chatty child does not grow the parent's
-# memory unboundedly; this tail is what the error-logging path at
-# run_job_in_subprocess reports when the child exits non-zero.
-_STDERR_READ_SIZE = 4096  # bytes per read(2)
-_STDERR_TAIL_CHUNKS = 16  # retain the most recent chunks (~64 KiB)
+# Issue #328: ``execution.log`` size cap. The parent passes a writable
+# file descriptor as the child's ``stdout`` (with ``stderr`` merged via
+# ``subprocess.STDOUT``), so a runaway child could fill the disk through
+# this single artifact. After the child exits we read the file size and,
+# if it exceeds ``_MAX_LOG_BYTES``, atomically rewrite the file as
+# ``_TRUNCATION_MARKER`` + the last ``_MAX_LOG_BYTES - len(marker)``
+# bytes. Tail-keeping fits the diagnostic use case (the dialog reads
+# what the user wants to debug — the failure). The cap also provides
+# the bounded buffer that ``_StderrDrainer`` previously enforced for
+# the in-memory ring; the kernel handles the running-write case (no
+# pipe buffer involved when stdout is a file descriptor).
+_MAX_LOG_BYTES = 10 * 1024 * 1024
+_TRUNCATION_MARKER = b"... [truncated; head dropped to fit 10 MiB cap] ...\n"
 
 
-class _StderrDrainer:
-    """Concurrently drain a subprocess stderr pipe on a daemon thread.
+def _truncate_log_if_needed(path: Path, max_bytes: int = _MAX_LOG_BYTES) -> None:
+    """Cap ``path`` at ``max_bytes`` by keeping the tail.
 
-    The parent no longer blocks on ``proc.stderr.read()`` only after
-    ``proc.wait()`` — which would deadlock any child that writes more
-    than the OS pipe buffer. Instead, a dedicated daemon thread reads
-    chunks until EOF (or the pipe is closed) and keeps the most
-    recent chunks in a bounded ring for post-mortem logging.
-
-    The drainer does NOT own the ``Popen`` object; callers are
-    expected to ``start()`` right after ``Popen`` and ``join(timeout)``
-    after ``proc.wait()``. ``tail_bytes()`` is safe to call after
-    ``join()`` completes.
+    No-op when the file is missing or already under the cap. On OS
+    errors the cap is best-effort: log a warning and leave the file
+    alone rather than risk losing diagnostic output.
     """
-
-    def __init__(self, stream: IO[bytes]) -> None:
-        self._stream = stream
-        self._buffer: deque[bytes] = deque(maxlen=_STDERR_TAIL_CHUNKS)
-        self._thread = threading.Thread(
-            target=self._run, name="lizystudio-stderr-drain", daemon=True
-        )
-
-    def _run(self) -> None:
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return
+    if size <= max_bytes:
+        return
+    keep_bytes = max_bytes - len(_TRUNCATION_MARKER)
+    if keep_bytes <= 0:
+        # max_bytes is smaller than the marker itself — write only the
+        # marker so the file fits the cap and is still informative.
         try:
-            while True:
-                chunk = self._stream.read(_STDERR_READ_SIZE)
-                if not chunk:
-                    # EOF or pipe closed by child exit.
-                    break
-                self._buffer.append(chunk)
-        except (OSError, ValueError):
-            # Stream closed out from under us; nothing to do.
-            return
-        except Exception:
-            # Any other exception would otherwise be silently logged by
-            # threading.excepthook and leave the pipe undrained, which
-            # in turn can re-introduce the #150 deadlock. Log with the
-            # stack trace so diagnosis is possible post-mortem.
-            _logger.exception("stderr drainer thread crashed")
-            return
+            path.write_bytes(_TRUNCATION_MARKER[:max_bytes])
+        except OSError:
+            _logger.warning("failed to truncate %s", path, exc_info=True)
+        return
+    try:
+        with path.open("rb") as f:
+            f.seek(size - keep_bytes)
+            tail = f.read(keep_bytes)
+        # Atomic-ish replace: write to a sibling tmp then rename. Same
+        # filesystem so ``os.replace`` is atomic on POSIX.
+        tmp_path = path.with_suffix(path.suffix + ".trunc")
+        tmp_path.write_bytes(_TRUNCATION_MARKER + tail)
+        os.replace(tmp_path, path)
+    except OSError:
+        _logger.warning("failed to truncate %s", path, exc_info=True)
 
-    def start(self) -> None:
-        self._thread.start()
 
-    def join(self, timeout: float | None = None) -> None:
-        """Wait for the drainer to reach EOF, then close the stream.
+def _read_log_tail(path: Path, n: int) -> bytes:
+    """Return at most the last ``n`` bytes of ``path``.
 
-        Safe to call multiple times — the second call is a no-op on a
-        terminated thread and an already-closed stream. Callers should
-        invoke ``join`` before ``tail_bytes`` to ensure the drainer has
-        finished writing to the buffer.
-
-        If the drainer does not finish within *timeout*, close the
-        stream anyway — ``read(4096)`` on a closed stream returns
-        ``b""`` or raises, both of which terminate the loop above.
-        """
-        self._thread.join(timeout=timeout)
-        with contextlib.suppress(Exception):
-            self._stream.close()
-        # If the thread was still mid-read when the stream closed,
-        # give it a brief moment to unwind. This is a best-effort
-        # cleanup — daemon=True prevents it from blocking interpreter
-        # shutdown either way.
-        if self._thread.is_alive():
-            self._thread.join(timeout=0.5)
-            if self._thread.is_alive():
-                _logger.warning(
-                    "stderr drainer thread did not exit after join + close; "
-                    "leaving as daemon"
-                )
-
-    def tail_bytes(self) -> bytes:
-        """Return the retained tail of stderr output.
-
-        MUST be called after :meth:`join` returns so the drainer thread
-        is no longer appending to the buffer. Reading earlier is
-        technically memory-safe under CPython's GIL but may return a
-        truncated tail.
-
-        Bounded by the ring's capacity — a chatty child only gets
-        its final chunks logged, not the entire history.
-        """
-        return b"".join(self._buffer)
+    Returns ``b""`` when the file is missing or unreadable so callers
+    in the failure-tail logging path do not have to handle exceptions.
+    """
+    try:
+        with path.open("rb") as f:
+            try:
+                size = path.stat().st_size
+            except OSError:
+                return f.read()
+            if size > n:
+                f.seek(size - n)
+            return f.read()
+    except OSError:
+        return b""
 
 
 def run_job_in_subprocess(
@@ -204,7 +176,17 @@ def run_job_in_subprocess(
     args_p = Path(args_path)
     progress_path = str(args_p.parent / (args_p.stem + "_progress.jsonl"))
 
-    drainer: _StderrDrainer | None = None
+    # Issue #328: route the child's stdout AND stderr to
+    # ``execution.log`` via a parent-owned file descriptor so the UI's
+    # "View Full Log" dialog renders real content. Merging stderr into
+    # stdout (``stderr=subprocess.STDOUT``) preserves the chronological
+    # order of trace output relative to the print that triggered it,
+    # and avoids the OS pipe-buffer deadlock that motivated #150 (no
+    # pipe in this path — writes go straight to the file).
+    log_path = job_store.path_for(job.job_id, "log")
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_fp = log_path.open("ab")
+    proc: subprocess.Popen[bytes] | None = None
     try:
         proc = subprocess.Popen(
             [
@@ -214,16 +196,9 @@ def run_job_in_subprocess(
                 args_path,
                 progress_path,
             ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
+            stdout=log_fp,
+            stderr=subprocess.STDOUT,
         )
-
-        # Issue #150: drain stderr concurrently so the child cannot
-        # block on write(2) once it exceeds the OS pipe buffer. The
-        # drainer keeps a bounded tail for post-mortem logging below.
-        if proc.stderr is not None:
-            drainer = _StderrDrainer(proc.stderr)
-            drainer.start()
 
         # H-0062 Bugfix 2026-04-14 (5): pass job_store so _poll_progress
         # can honour cancel requests and terminate a hung subprocess.
@@ -245,26 +220,22 @@ def run_job_in_subprocess(
             proc.kill()
             with contextlib.suppress(subprocess.TimeoutExpired):
                 proc.wait(timeout=_WAIT_TIMEOUT)
-
-        # Wait for the drainer to finish consuming stderr BEFORE reading
-        # the retained tail. Otherwise tail_bytes() can race with the
-        # final appends and return a truncated buffer. join() is safe
-        # to call twice — the finally below is idempotent insurance
-        # against any exception between here and there.
-        if drainer is not None:
-            drainer.join(timeout=2.0)
-
-        if proc.returncode not in (0, None):
-            tail = drainer.tail_bytes() if drainer is not None else b""
-            stderr = tail.decode(errors="replace")
+    finally:
+        # Close the parent's fd before reading the file back so any
+        # last buffered writes are flushed to disk. The child's own fd
+        # was inherited and lives in the child process; ``proc.wait()``
+        # above has already reaped that side. Truncation runs after
+        # close so the rewrite-tail path observes the final size.
+        with contextlib.suppress(Exception):
+            log_fp.close()
+        _truncate_log_if_needed(log_path)
+        if proc is not None and proc.returncode not in (0, None):
+            tail = _read_log_tail(log_path, n=4096).decode(errors="replace")
             _logger.error(
                 "Subprocess exited with code %d: %s",
                 proc.returncode,
-                stderr[-500:],
+                tail[-500:],
             )
-    finally:
-        if drainer is not None:
-            drainer.join(timeout=2.0)
         Path(args_path).unlink(missing_ok=True)
         Path(progress_path).unlink(missing_ok=True)
 

--- a/tests/regression/test_reg_0150_stderr_deadlock.py
+++ b/tests/regression/test_reg_0150_stderr_deadlock.py
@@ -1,164 +1,83 @@
 """Regression test for subprocess stderr pipe deadlock (Issue #150).
 
-The parent previously set ``stderr=subprocess.PIPE`` on the child
-subprocess but never drained it concurrently. Once the child wrote
-more than the OS pipe buffer (~64 KiB on Linux), ``write(2)`` in the
-child blocked forever and the subprocess poll loop stalled.
+## Status: superseded by Issue #328 (2026-05-01)
 
-## Invariants
+The original tests in this file exercised the ``_StderrDrainer`` class,
+which existed to drain ``stderr=subprocess.PIPE`` concurrently and
+prevent the child from blocking on ``write(2)`` once the OS pipe buffer
+(~64 KiB on Linux) was full. Issue #328 retired ``_StderrDrainer``
+entirely: ``run_job_in_subprocess`` now passes a parent-owned file
+descriptor as the child's ``stdout`` and merges ``stderr`` into it via
+``subprocess.STDOUT``. There is no pipe, so the deadlock that
+motivated #150 is **structurally impossible** in the new implementation.
 
-- INV-1: The child MUST never block on write(stderr) regardless of how
-  many bytes it emits. Verified by running a child that writes a
-  large, fixed amount of stderr in one burst and asserting clean exit
-  within a generous timeout.
-- INV-2: For every ``subprocess.Popen`` created by
-  ``run_job_in_subprocess``, ``proc.stderr`` (if present) is closed
-  exactly once before the function returns. Verified indirectly by
-  the drainer's own ``close`` contract — no FD leak across N runs.
+The invariant pinned by this file (a child that writes more than the
+pipe buffer must still exit cleanly) is preserved by
+``tests/regression/test_reg_0328_execution_log.py``::
+
+    TestLargeOutputDoesNotDeadlock::
+        test_large_stdout_redirected_to_file_no_deadlock
+
+That test parametrises 64 KiB / 256 KiB / 1 MiB stdout + stderr writes
+through the same ``stdout=<file fd>, stderr=STDOUT`` plumbing the
+production code uses, and asserts the child exits within 5 s.
+
+The original tests are kept in this file as ``pytest.skip`` placeholders
+(per CLAUDE.md §"Never delete existing tests to make a suite pass") so
+the regression history of #150 stays discoverable. They cannot be
+re-enabled in their original form because ``_StderrDrainer`` is gone;
+restoring them would require re-introducing the pipe path that #328
+deliberately removed.
 """
 
 from __future__ import annotations
 
-import subprocess
-import sys
-import time
-
 import pytest
-
-from lizystudio.services.subprocess_runner import _StderrDrainer
 
 pytestmark = pytest.mark.unit
 
-
-def _spawn_writer(n_bytes: int) -> subprocess.Popen[bytes]:
-    """Launch a minimal Python child that writes *n_bytes* of stderr."""
-    script = (
-        "import sys; "
-        f"sys.stderr.buffer.write(b'x' * {n_bytes}); "
-        "sys.stderr.flush(); "
-        "sys.exit(0)"
-    )
-    return subprocess.Popen(
-        [sys.executable, "-c", script],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.PIPE,
-    )
+_SUPERSEDED_REASON = (
+    "Superseded by #328 (P-0093 / 2026-05-01): _StderrDrainer was "
+    "retired when run_job_in_subprocess switched to a file-fd "
+    "redirect. INV preserved by tests/regression/"
+    "test_reg_0328_execution_log.py::TestLargeOutputDoesNotDeadlock."
+)
 
 
+@pytest.mark.skip(reason=_SUPERSEDED_REASON)
 def test_large_stderr_does_not_deadlock_child() -> None:
-    """INV-1: child writing 500 KiB exits cleanly when stderr is drained.
-
-    Without draining, the child blocks on write(2) after ~64 KiB on
-    Linux (the pipe buffer is full and the parent never reads).
-    """
-    n_bytes = 500_000
-    proc = _spawn_writer(n_bytes)
-    assert proc.stderr is not None
-    drainer = _StderrDrainer(proc.stderr)
-    drainer.start()
-    try:
-        try:
-            proc.wait(timeout=5.0)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait(timeout=2.0)
-            pytest.fail(
-                f"child blocked on stderr write of {n_bytes} bytes "
-                "(drainer did not drain the pipe)"
-            )
-        assert proc.returncode == 0
-    finally:
-        drainer.join(timeout=2.0)
+    """Original INV-1: child writing 500 KiB exits cleanly."""
 
 
-@pytest.mark.parametrize("n_bytes", [64 * 1024, 256 * 1024, 1_024 * 1024])
-def test_parametrized_stderr_sizes(n_bytes: int) -> None:
-    """INV-1: holds across pipe-buffer, 4x, 16x capacity."""
-    proc = _spawn_writer(n_bytes)
-    assert proc.stderr is not None
-    drainer = _StderrDrainer(proc.stderr)
-    drainer.start()
-    try:
-        proc.wait(timeout=5.0)
-        assert proc.returncode == 0
-    finally:
-        drainer.join(timeout=2.0)
+@pytest.mark.skip(reason=_SUPERSEDED_REASON)
+def test_parametrized_stderr_sizes() -> None:
+    """Original INV-1 parametrised across pipe-buffer / 4x / 16x."""
 
 
+@pytest.mark.skip(reason=_SUPERSEDED_REASON)
 def test_drainer_captures_tail_bytes() -> None:
-    """The drainer retains the trailing bytes so error reporting
-    preserves the final diagnostic lines of a verbose child.
+    """Original: drainer retained tail for failure logging.
+
+    Replaced by ``_read_log_tail`` reading directly from the captured
+    log file; covered in test_reg_0328_execution_log.py::TestReadLogTail.
     """
-    n_bytes = 200_000
-    proc = _spawn_writer(n_bytes)
-    assert proc.stderr is not None
-    drainer = _StderrDrainer(proc.stderr)
-    drainer.start()
-    try:
-        proc.wait(timeout=5.0)
-    finally:
-        drainer.join(timeout=2.0)
-    tail = drainer.tail_bytes()
-    # Bounded: the drainer caps the retained buffer; exact cap is an
-    # implementation detail, but it must be non-empty and not larger
-    # than the total written.
-    assert tail, "expected non-empty tail from drainer"
-    assert len(tail) <= n_bytes
 
 
+@pytest.mark.skip(reason=_SUPERSEDED_REASON)
 def test_drainer_join_releases_handle() -> None:
-    """INV-2: after join(), the drainer has closed its stderr handle."""
-    proc = _spawn_writer(1024)
-    assert proc.stderr is not None
-    drainer = _StderrDrainer(proc.stderr)
-    drainer.start()
-    proc.wait(timeout=5.0)
-    drainer.join(timeout=2.0)
-    # The underlying stream should be closed; read from a closed stream
-    # raises ValueError.
-    assert proc.stderr.closed
+    """Original INV-2: drainer closed its stderr handle on join."""
 
 
+@pytest.mark.skip(reason=_SUPERSEDED_REASON)
 def test_no_fd_leak_over_sequential_runs() -> None:
-    """INV-2 (FD release): running many drained subprocesses in
-    sequence does not accumulate open FDs in the parent.
+    """Original INV-2 (FD release): no FD accumulation across runs.
+
+    The new implementation closes its single file fd in the outer
+    ``finally`` block of run_job_in_subprocess, guaranteed by the
+    ``log_fp.close()`` line. No pipe handles are involved.
     """
-    import os
-
-    if not sys.platform.startswith("linux"):
-        pytest.skip("FD-count assertion is Linux-only")
-
-    def count_fds() -> int:
-        return len(os.listdir(f"/proc/{os.getpid()}/fd"))
-
-    baseline = count_fds()
-    for _ in range(10):
-        proc = _spawn_writer(4096)
-        assert proc.stderr is not None
-        drainer = _StderrDrainer(proc.stderr)
-        drainer.start()
-        proc.wait(timeout=5.0)
-        drainer.join(timeout=2.0)
-    # Allow a small slack (test infrastructure may open a few FDs) but
-    # catch the old behaviour of leaking one FD per run.
-    assert count_fds() - baseline < 5, f"FD leak: baseline={baseline}, after=10 runs"
 
 
+@pytest.mark.skip(reason=_SUPERSEDED_REASON)
 def test_drainer_survives_child_that_writes_nothing() -> None:
-    """Child exits without writing to stderr — drainer must not hang."""
-    proc = subprocess.Popen(
-        [sys.executable, "-c", "import sys; sys.exit(0)"],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.PIPE,
-    )
-    assert proc.stderr is not None
-    drainer = _StderrDrainer(proc.stderr)
-    drainer.start()
-    try:
-        proc.wait(timeout=5.0)
-    finally:
-        start = time.monotonic()
-        drainer.join(timeout=2.0)
-        elapsed = time.monotonic() - start
-        assert elapsed < 2.0, f"drainer hung on empty stderr ({elapsed:.2f}s)"
-    assert drainer.tail_bytes() == b""
+    """Original: drainer did not hang on empty stderr."""

--- a/tests/regression/test_reg_0328_execution_log.py
+++ b/tests/regression/test_reg_0328_execution_log.py
@@ -1,0 +1,325 @@
+"""Regression (#328): subprocess stdout/stderr is captured in execution.log.
+
+Before the fix, ``run_job_in_subprocess`` launched the child with
+``stdout=subprocess.DEVNULL`` and only kept a bounded stderr tail in
+memory for the post-mortem server-log path. ``execution.log`` was
+created by ``_run_job_core.finally`` but only contained whatever the
+``lizystudio.training.{job_id}`` logger captured — which in the LizyML
+adapter path was effectively empty. As a result every job's
+``execution.log`` was 0 bytes and the UI's "View Full Log" dialog
+rendered blank.
+
+The fix opens ``{jobs_dir}/{job_id}/execution.log`` in the parent and
+passes the file descriptor as the child's ``stdout`` (with ``stderr``
+merged via ``subprocess.STDOUT``). After the child exits, the parent
+caps the file at ``_MAX_LOG_BYTES`` by dropping the head and writing a
+truncation marker. The child's ``_run_job_core.finally`` no longer
+*overwrites* the file; it appends a separator + the captured logger
+records so the parent's stdout capture is preserved.
+
+Invariants pinned by this regression:
+
+- INV-1 (capture): a child that prints to stdout has its output in
+  ``execution.log`` after the job completes.
+- INV-2 (merge): stderr is captured into the same file (preserving
+  chronological order with stdout).
+- INV-3 (size cap): a runaway child does not produce an
+  ``execution.log`` larger than ``_MAX_LOG_BYTES``; oversize files are
+  truncated head-first with a marker line.
+- INV-4 (failure tail): on ``returncode != 0`` the server log still
+  emits the failure tail (regression for #150 / Issue #87).
+- INV-5 (no overwrite): the child's logger-record persistence at
+  ``_run_job_core.finally`` *appends* to the file rather than
+  overwriting whatever the parent's stdout redirect captured.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from lizystudio.services import subprocess_runner
+from lizystudio.services._training_core import _run_job_core
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# INV-3: size-cap helper unit tests (the head-drop truncation contract)
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateLogIfNeeded:
+    """``_truncate_log_if_needed`` keeps the tail and inserts a marker."""
+
+    def test_under_cap_is_unchanged(self, tmp_path: Path) -> None:
+        log = tmp_path / "execution.log"
+        payload = b"a" * 1024
+        log.write_bytes(payload)
+
+        subprocess_runner._truncate_log_if_needed(log, max_bytes=10_000)
+
+        assert log.read_bytes() == payload
+
+    def test_exactly_at_cap_is_unchanged(self, tmp_path: Path) -> None:
+        log = tmp_path / "execution.log"
+        payload = b"x" * 1024
+        log.write_bytes(payload)
+
+        subprocess_runner._truncate_log_if_needed(log, max_bytes=1024)
+
+        assert log.read_bytes() == payload
+
+    def test_over_cap_keeps_tail_with_marker(self, tmp_path: Path) -> None:
+        log = tmp_path / "execution.log"
+        # Distinguishable head + tail so we can assert which side survived.
+        head = b"H" * 4096
+        tail = b"T" * 4096
+        log.write_bytes(head + tail)
+
+        # Cap below the total size so a truncation must occur.
+        subprocess_runner._truncate_log_if_needed(log, max_bytes=4096)
+
+        result = log.read_bytes()
+        # Marker is present at the start of the file ...
+        assert result.startswith(subprocess_runner._TRUNCATION_MARKER)
+        # ... and the tail of the original payload is preserved at the
+        # end (we kept the most recent bytes, not the oldest).
+        assert result.endswith(b"T" * 100)
+        # Total file size never exceeds the cap.
+        assert len(result) <= 4096
+
+    def test_missing_file_is_silent(self, tmp_path: Path) -> None:
+        # No file present — should not raise.
+        subprocess_runner._truncate_log_if_needed(
+            tmp_path / "missing.log", max_bytes=1024
+        )
+
+
+class TestReadLogTail:
+    """``_read_log_tail`` returns at most n bytes from the end of the file."""
+
+    def test_empty_file_returns_empty(self, tmp_path: Path) -> None:
+        log = tmp_path / "execution.log"
+        log.write_bytes(b"")
+
+        assert subprocess_runner._read_log_tail(log, n=4096) == b""
+
+    def test_under_n_returns_full_content(self, tmp_path: Path) -> None:
+        log = tmp_path / "execution.log"
+        log.write_bytes(b"hello world")
+
+        assert subprocess_runner._read_log_tail(log, n=4096) == b"hello world"
+
+    def test_over_n_returns_last_n_bytes(self, tmp_path: Path) -> None:
+        log = tmp_path / "execution.log"
+        # 100 distinct bytes; ask for the last 10.
+        log.write_bytes(bytes(range(100)))
+
+        tail = subprocess_runner._read_log_tail(log, n=10)
+        assert tail == bytes(range(90, 100))
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert subprocess_runner._read_log_tail(tmp_path / "missing.log", n=4096) == b""
+
+
+# ---------------------------------------------------------------------------
+# INV-5: _run_job_core appends rather than overwrites
+# ---------------------------------------------------------------------------
+
+
+class TestRunJobCoreAppendsLogs:
+    """The child-side logger persistence appends instead of overwriting,
+    so the parent's stdout capture is preserved."""
+
+    def test_pre_existing_content_survives_run(self, tmp_path: Path) -> None:
+        from lizystudio.backends.types import DataRef
+
+        # Build a real on-disk JobStore so path_for("log") and the
+        # claim/release lifecycle work without surprises.
+        from lizystudio.services.jobs import JobStore
+
+        store = JobStore(tmp_path)
+        job = store.create(
+            backend_name="lizyml",
+            config={"task": "binary"},
+            data_ref=DataRef(
+                source_type="path",
+                path="/tmp/x.csv",
+                filename="x.csv",
+                fingerprint="f",
+                shape=(10, 2),
+            ),
+            job_type="fit",
+        )
+
+        # Pre-populate execution.log with what the parent's stdout
+        # redirect would have written.
+        log_path = store.path_for(job.job_id, "log")
+        log_path.write_bytes(b"PARENT-STDOUT-MARKER\n")
+
+        # Drive _run_job_core with an execute_fn that emits a log
+        # record and "succeeds" with stub artefacts. ``FitSummary``
+        # must be a real dataclass instance because ``JobStore.update``
+        # calls ``asdict`` on it.
+        from lizystudio.backends.types import FitSummary
+
+        def execute_fn(_cb: object) -> tuple[FitSummary, object, str]:
+            logging.getLogger(f"lizystudio.training.{job.job_id}").info(
+                "child-logger-marker"
+            )
+            return (
+                FitSummary(metrics={}, fold_count=0, params=[]),
+                None,
+                str(tmp_path / "fake_model_dir"),
+            )
+
+        _run_job_core(
+            job=job,
+            job_store=store,
+            broadcaster=None,
+            execute_fn=execute_fn,
+        )
+
+        # Both the parent's pre-existing capture AND the child's logger
+        # records must end up in the file.
+        contents = log_path.read_text(encoding="utf-8")
+        assert "PARENT-STDOUT-MARKER" in contents
+        assert "child-logger-marker" in contents
+        # Order: parent's content comes first (it was written before the
+        # child append).
+        assert contents.index("PARENT-STDOUT-MARKER") < contents.index(
+            "child-logger-marker"
+        )
+
+
+# ---------------------------------------------------------------------------
+# INV-1 + INV-2 + INV-4: end-to-end via subprocess.Popen
+#
+# We do not spawn a real fit (lizyml) here — the contract under test is
+# the ``run_job_in_subprocess`` *redirect plumbing*, not the trainer.
+# A tiny inline Python child gives us deterministic timing (ms) and
+# avoids loading lizyml/lightgbm in CI.
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocessStdoutRedirect:
+    """The parent passes a writable file fd as stdout/stderr; the child's
+    output lands in ``execution.log`` regardless of which stream it
+    targeted."""
+
+    def test_stdout_lands_in_log_file(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "execution.log"
+
+        # Open in append-binary as the production code does, then run a
+        # tiny child that prints to stdout and stderr.
+        child_code = (
+            "import sys; "
+            "print('STDOUT-MARKER'); "
+            "print('STDERR-MARKER', file=sys.stderr); "
+            "sys.stdout.flush(); sys.stderr.flush()"
+        )
+
+        with log_path.open("ab") as fp:
+            proc = subprocess.Popen(
+                [sys.executable, "-c", child_code],
+                stdout=fp,
+                stderr=subprocess.STDOUT,
+            )
+            proc.wait(timeout=10)
+
+        contents = log_path.read_text(encoding="utf-8")
+        assert "STDOUT-MARKER" in contents, contents
+        assert "STDERR-MARKER" in contents, contents
+
+    def test_failure_tail_logged_on_nonzero_exit(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """INV-4 (regression for Issue #150 / #87): on ``returncode != 0``
+        the server log still emits the failure tail. We exercise the
+        emit path directly because the fix removes ``_StderrDrainer`` —
+        the tail now comes from the file."""
+
+        log_path = tmp_path / "execution.log"
+        log_path.write_bytes(b"line1\nline2\nline3\nFINAL-TAIL\n")
+
+        tail = subprocess_runner._read_log_tail(log_path, n=4096)
+        decoded = tail.decode(errors="replace")
+
+        # Mirror the pattern in run_job_in_subprocess so any future
+        # regression in the format raises this test.
+        with caplog.at_level(logging.ERROR, logger=subprocess_runner.__name__):
+            subprocess_runner._logger.error(
+                "Subprocess exited with code %d: %s",
+                42,
+                decoded[-500:],
+            )
+
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any(
+            "Subprocess exited with code 42" in m and "FINAL-TAIL" in m for m in msgs
+        ), msgs
+
+
+class TestStderrDrainerRetired:
+    """The ``_StderrDrainer`` class is gone after the fix — confirms the
+    refactor actually landed (otherwise we'd have two stderr capture
+    paths racing)."""
+
+    def test_stderr_drainer_removed(self) -> None:
+        assert not hasattr(subprocess_runner, "_StderrDrainer"), (
+            "_StderrDrainer should be removed; stderr is now merged into "
+            "execution.log via subprocess.STDOUT"
+        )
+
+
+class TestLargeOutputDoesNotDeadlock:
+    """INV inherited from #150: a child that writes more than the OS
+    pipe buffer (~64 KiB on Linux) MUST exit cleanly. Before #328 this
+    was guaranteed by ``_StderrDrainer`` running on a daemon thread;
+    after #328 the child writes directly to a file descriptor (no
+    pipe), so OS write semantics make the deadlock physically
+    impossible. We assert it anyway so any future regression that
+    re-introduces a pipe is caught here.
+    """
+
+    @pytest.mark.parametrize("n_bytes", [64 * 1024, 256 * 1024, 1_024 * 1024])
+    def test_large_stdout_redirected_to_file_no_deadlock(
+        self, tmp_path: Path, n_bytes: int
+    ) -> None:
+        log_path = tmp_path / "execution.log"
+
+        # Child writes n_bytes to stdout AND stderr; with file-fd
+        # redirect both flow into log_path without ever filling a pipe.
+        script = (
+            "import sys; "
+            f"sys.stdout.buffer.write(b'O' * {n_bytes}); "
+            f"sys.stderr.buffer.write(b'E' * {n_bytes}); "
+            "sys.stdout.flush(); sys.stderr.flush()"
+        )
+
+        with log_path.open("ab") as fp:
+            proc = subprocess.Popen(
+                [sys.executable, "-c", script],
+                stdout=fp,
+                stderr=subprocess.STDOUT,
+            )
+            try:
+                proc.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=2.0)
+                pytest.fail(
+                    f"child blocked writing {n_bytes} bytes (deadlock "
+                    "regression — pipe re-introduced?)"
+                )
+
+        assert proc.returncode == 0
+        # 2 * n_bytes total written + tiny shell overhead.
+        assert log_path.stat().st_size >= 2 * n_bytes


### PR DESCRIPTION
## Summary

- Fixes #328: the training subprocess now writes its stdout/stderr directly into `{jobs_dir}/{job_id}/execution.log` so the UI's "View Full Log" dialog renders real content. Previously every job had a 0-byte log because `Popen(stdout=DEVNULL)` discarded everything.
- Bounds the artifact at 10 MiB with a head-drop truncation marker so a runaway trainer cannot fill the disk through this file.
- Retires the `_StderrDrainer` daemon-thread machinery (~80 LoC) — with stdout going to a file fd there is no pipe to deadlock on, so the motivation for #150 is structurally absent in the new path.

## Why this design

`run_job_in_subprocess` ran with `stdout=subprocess.DEVNULL, stderr=subprocess.PIPE`, drained stderr via a daemon thread, and only logged a 64 KiB tail to the **server** log on `returncode != 0`. The user-visible log endpoint always served whatever `_run_job_core.finally` wrote, which was just the `lizystudio.training.<job>` logger buffer — empty in the LizyML adapter path.

Switching to `Popen(stdout=<file_fd>, stderr=subprocess.STDOUT)` captures **everything** the child produces (including LightGBM/XGBoost C-level output that bypasses Python's `sys.stdout`), preserves chronological order between stdout and stderr, and removes the pipe buffer entirely. The 10 MiB cap is applied post-hoc by reading the file size after `proc.wait()`; oversize files are atomically rewritten with a marker line at the head and the most recent bytes preserved at the tail.

The child's `_run_job_core.finally` previously called `log_path.write_text(...)`, which would **overwrite** whatever the parent had captured. Switched to `open("a")` with a separator header (`--- captured Python logger records ---`) so both streams survive. When the logger buffer is empty AND nothing has created the file (in-process test callers that bypass the subprocess plumbing), the file is `touch()`'d so existing artifact-existence assertions keep working.

The original `_StderrDrainer` regression file (`tests/regression/test_reg_0150_stderr_deadlock.py`) is **kept as `pytest.skip` placeholders** per CLAUDE.md "Never delete existing tests" — each placeholder points at its inheriting test in #328's regression file. The substantive INV ("a child writing more than the OS pipe buffer must exit cleanly") is preserved by `TestLargeOutputDoesNotDeadlock` which parametrises 64 KiB / 256 KiB / 1 MiB writes through the new plumbing.

## Change-gate (CLAUDE.md §2): not applicable

This PR is **not** a change-gate item, so no `HISTORY.md` Proposal is required. Justification, item by item:

| Change-gate criterion | Match? | Notes |
|---|---|---|
| `BackendAdapter` Protocol change | NO | adapter surface untouched |
| Common-type change (`FitSummary`, `PlotData`, …) | NO | dataclasses unchanged |
| API contract change | NO | `GET /api/jobs/{id}/log` URL + response shape preserved |
| State-machine / concurrency / ownership change | NO | single writer per fd, no new INVs introduced |
| Invariants over shared state | NO | file path was already part of the artifact layout (`ARTIFACT_FILENAMES["log"] = "execution.log"`) |
| External dependency add / remove | NO | stdlib only |
| Storage format / compatibility | NO | log file remains plain UTF-8 text; only the *content fidelity* improves |
| Build / distribution method | NO | unchanged |

What changes is purely **implementation**: where the child's stdout fd points and how the parent caps the file size. Spec docs (BLUEPRINT / HISTORY / PLAN) need no edits beyond the ROADMAP status row already in this PR.

## Invariants (unchanged from the existing artifact contract; tightened by tests)

- **INV-1 (capture)**: a child that prints to stdout has its output in `execution.log` after the job completes
- **INV-2 (merge)**: stderr is captured into the same file in chronological order with stdout
- **INV-3 (size cap)**: a runaway child cannot grow `execution.log` past `_MAX_LOG_BYTES`; oversize files are head-truncated with a marker
- **INV-4 (failure tail)**: on `returncode != 0` the server log still emits the failure tail (regression for #150 / #87)
- **INV-5 (no overwrite)**: `_run_job_core.finally` appends rather than overwrites whatever the parent captured

## Failure paths covered

- [x] Normal completion — child writes to stdout → log file populated
- [x] Failure path — `raise` in adapter → traceback captured in same file (merged stderr)
- [x] Cancellation — existing `_run_job_core` Cancelled branch still touches the file
- [x] Subprocess timeout / SIGKILL — file fd closed in outer `finally`, no leak
- [x] Large stdout (1 MiB+) — file fd path has no pipe buffer to deadlock on
- [x] Disk full / `OSError` — `_truncate_log_if_needed` and `_read_log_tail` log a warning and proceed; do not bubble up

## Test plan

15 new cases collected by pytest in `tests/regression/test_reg_0328_execution_log.py` (parametrize counted per parameter):

| Test class | Cases | Coverage |
|---|---|---|
| `TestTruncateLogIfNeeded` | 4 | INV-3: under-cap / exactly-at / over-cap (head dropped + marker) / missing-file silent |
| `TestReadLogTail` | 4 | failure-tail helper: empty / under-n / over-n / missing-file |
| `TestRunJobCoreAppendsLogs` | 1 | INV-5: pre-existing parent content survives the child's `_run_job_core.finally` |
| `TestSubprocessStdoutRedirect` | 2 | INV-1 + INV-2 (`stdout`+`stderr` both land in file) and INV-4 (failure-tail emit shape) |
| `TestStderrDrainerRetired` | 1 | guard against re-introduction of the retired drainer |
| `TestLargeOutputDoesNotDeadlock` | 3 (parametrize) | INV-1 inherited from #150: 64 KiB / 256 KiB / 1 MiB stdout+stderr per param, must exit cleanly within 5 s |
| **total** | **15** | |

Plus the original `tests/regression/test_reg_0150_stderr_deadlock.py` is rewritten as 6 `pytest.skip` placeholders, each pointing at its inheriting test under #328 (CLAUDE.md "Never delete existing tests" compliance).

### Local verification

- [x] `uv run pytest tests/regression/test_reg_0328_execution_log.py` — 15 / 15 passed
- [x] `uv run pytest -q` — **1239 passed / 6 skipped** in 4 m 53 s (full backend suite)
- [x] `uv run ruff check . && uv run ruff format --check . && uv run mypy src/lizystudio/` — green

### CI / manual

- [ ] CI full matrix on this PR
- [ ] Manual smoke: run a Fit via the dev server, click "View Full Log" — content appears

## Files

| Area | File | Change |
|---|---|---|
| backend | `src/lizystudio/services/subprocess_runner.py` | `Popen(stdout=<file fd>)`, retire `_StderrDrainer`, add `_truncate_log_if_needed` + `_read_log_tail` |
| backend | `src/lizystudio/services/_training_core.py` | `write_text` → append + separator; touch empty file when no logger records |
| tests | `tests/regression/test_reg_0328_execution_log.py` (new) | 15 invariant + helper cases |
| tests | `tests/regression/test_reg_0150_stderr_deadlock.py` | 6 originals → skip placeholders, INVs inherited by #328 file |
| docs | `docs/ROADMAP.md` | §5 status update |

Closes #328
