### PR TITLE
docs: reconcile Tier 3 architecture/api/adapter-guide drift (post-P-0093)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -236,7 +236,7 @@
 
 | 対象 | 最終更新 | リスク | 対応 |
 |---|---|---|---|
-| `docs/architecture.md` / `api.md` / `adapter-guide.md` | 2026-04-10 | services/training/jobs が 2026-04-22 以降も continually refactor（B/C シリーズ + P-0086〜P-0093）。Adapter 契約の記載が古い可能性 | 🟡 未着手（§7 Tier 3 #1） |
+| `docs/architecture.md` / `api.md` / `adapter-guide.md` | ✅ 2026-05-01 reconciled | — | 棚卸し完了。`tests/contract/test_adapter_guide_method_names.py` で adapter-guide.md ↔ Protocol の drift を gating |
 | `PLAN.md` v3-13/14/15 | ✅ 反映済み（2026-04-30, 2026-05-01） | — | — |
 | `HISTORY.md` P-0092 follow-ups | ✅ 反映済み（2026-04-30、PR #303 周辺で追記） | — | — |
 | `MEMORY.md` 古いノート | ✅ 直近セッションで更新（`project_coupling_refactor_progress` 等は post-#271 / P-0092 完了以降に上書き済み） | — | — |
@@ -250,10 +250,9 @@
 
 ### Tier 3：戦略課題
 
-1. **`docs/architecture.md` / `api.md` / `adapter-guide.md` ドリフト是正棚卸し** — 2026-04-10 から未更新、その間 services/training/jobs が refactor 多数（B/C シリーズ + P-0086〜P-0093）。BLUEPRINT を真として Tier 3 を追従
-2. **P-0094 として P-0087 Phase 3 を Proposal 化**（`cv_strategy_fields` の Pydantic 自動派生）— lizyml 側で構造化フィールドメタデータ export が前提のためリポジトリ間調整必要
-3. **#28** offline/resume resilience tests — `current_job_id` ライフサイクル契約決定が前提
-4. **#27 (a)** `pytest-benchmark` 100k-row microbench — 先行マージ可能、stress harness は tier-4
+1. **P-0094 として P-0087 Phase 3 を Proposal 化**（`cv_strategy_fields` の Pydantic 自動派生）— lizyml 側で構造化フィールドメタデータ export が前提のためリポジトリ間調整必要
+2. **#28** offline/resume resilience tests — `current_job_id` ライフサイクル契約決定が前提
+3. **#27 (a)** `pytest-benchmark` 100k-row microbench — 先行マージ可能、stress harness は tier-4
 
 ### Tier 4：要長期計画
 

--- a/docs/adapter-guide.md
+++ b/docs/adapter-guide.md
@@ -94,6 +94,9 @@ def importance(self, model: Any, kind: str = "split") -> dict[str, float]:
 def importance_kinds(self, model: Any) -> list[str]:
     """Return available importance types (e.g. ['split', 'gain', 'shap'])."""
 
+def learning_curve_metrics(self, model: Any) -> list[str]:
+    """Return eval metric names available for the learning-curve plot."""
+
 def confusion_matrix(self, model: Any, threshold: float = 0.5) -> dict[str, Any]:
     """Return confusion matrix (classification only)."""
 
@@ -118,6 +121,39 @@ def load_model(self, path: str) -> Any:
 
 def model_info(self, model: Any) -> dict[str, Any]:
     """Return model metadata (feature count, training date, etc.)."""
+```
+
+### Re-tune checkpoints (H-0062)
+
+These methods enable the Re-tune / Resume flow that lets users add more
+trials to a completed tune, or continue a failed tune from where it
+stopped. A backend that does not support multi-round tuning may raise
+``NotImplementedError`` here; the routes return a clear 4xx in that case.
+
+```python
+def save_checkpoint(self, model: Any, path: Any) -> None:
+    """Persist the live tuner state (Optuna study, RNG, etc.) under path."""
+
+def load_checkpoint(self, path: Any, *, allowed_root: Any | None = None) -> Any:
+    """Restore the tuner state previously saved via save_checkpoint.
+
+    ``allowed_root`` constrains where unpickling may read from
+    (defense-in-depth against arbitrary-path pickle attacks).
+    """
+
+def verify_checkpoint_compatibility(self, job_dir: Any) -> None:
+    """Raise on pickle schema mismatch or library-major-version skew.
+
+    Issued before resume / re-tune so the user sees a clear
+    PICKLE_INCOMPATIBLE error instead of a deserialisation crash.
+    """
+
+def preflight_checkpoint_dir(self, job_dir: Any) -> None:
+    """Verify writability + picklable model state before tune starts.
+
+    Catches config issues that would otherwise only surface after the
+    first trial finishes and the checkpoint write fails.
+    """
 ```
 
 ## Common types
@@ -230,10 +266,16 @@ for the change gate requirements.
 
 ## Reference implementation
 
-The LizyML adapter (`src/lizystudio/backends/lizyml.py`) is the reference
-implementation. Study it for patterns on:
+The LizyML adapter (`src/lizystudio/backends/lizyml/` — split across
+several modules per H-0070) is the reference implementation. Study it
+for patterns on:
 
 - Converting between native and common types
 - Implementing progress callbacks
 - Handling edge cases (empty data, missing features, etc.)
 - Splitting complex logic into helper modules
+
+---
+
+_Last reconciled: 2026-05-01 against develop (post-PR #331). The Protocol surface lives in `src/lizystudio/backends/base.py` (split into BackendCore / BackendEvaluation / etc. via H-0068; `BackendAdapter` is the union alias). Drift between this guide and the Protocol is policed by `tests/contract/test_adapter_guide_method_names.py`._
+

--- a/docs/api.md
+++ b/docs/api.md
@@ -66,8 +66,8 @@ When the server is running, visit:
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/api/workspace/fit` | Start a fit job → `{ "job_id": "..." }` |
-| POST | `/api/workspace/tune` | Start a tune job → `{ "job_id": "..." }` |
+| POST | `/api/workspace/fit` | Start a fit job → `{ "job_id": "..." }`. Optional body `{ "config": {...} }` overrides workspace config atomically (P-0086) |
+| POST | `/api/workspace/tune` | Start a tune job → `{ "job_id": "..." }`. Same optional body semantics as `/fit` |
 
 ### Jobs
 
@@ -80,13 +80,17 @@ When the server is running, visit:
 | GET | `/api/jobs/{job_id}/split-summary` | Per-fold CV summary |
 | GET | `/api/jobs/{job_id}/importance` | Feature importance (query: `kind`) |
 | GET | `/api/jobs/{job_id}/importance-kinds` | Available importance types |
+| GET | `/api/jobs/{job_id}/learning-curve/metrics` | Eval metrics available for the learning-curve plot |
 | GET | `/api/jobs/{job_id}/plot/{plot_type}` | Plotly JSON visualization |
 | GET | `/api/jobs/{job_id}/plots` | Available plot types |
 | POST | `/api/jobs/{job_id}/export` | Export model artifacts |
 | GET | `/api/jobs/{job_id}/export-code` | Download standalone code (ZIP) |
 | GET | `/api/jobs/{job_id}/log` | Execution log |
 | POST | `/api/jobs/{job_id}/cancel` | Cancel running job |
-| DELETE | `/api/jobs/{job_id}` | Delete job |
+| POST | `/api/jobs/{job_id}/retune` | Re-tune from a completed tune job (H-0062) |
+| POST | `/api/jobs/{job_id}/resume` | Resume a failed tune job, continue remaining trials (H-0062) |
+| GET | `/api/jobs/{job_id}/lineage` | Parent / child tree for re-tune chains (H-0062) |
+| DELETE | `/api/jobs/{job_id}` | Delete job (query: `cascade=true` to remove descendants) |
 
 ### Inference
 
@@ -108,13 +112,21 @@ When the server is running, visit:
 |--------|------|-------------|
 | GET | `/api/files` | Directory listing (query: `path`) — CSV/Parquet/TSV only |
 
+### Operations (health / metrics)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/health` | Liveness probe (always 200 while the server runs) |
+| GET | `/api/health/ready` | Readiness probe — returns ok only when the backend is loaded and the jobs directory is reachable (P-0084) |
+| GET | `/api/metrics` | Prometheus exposition for the per-app `MetricsRegistry` (A-9): request counters, ML job durations, progress drops, terminal-replay rate (P-0093), … |
+
 ### WebSocket
 
 | Path | Direction | Description |
 |------|-----------|-------------|
 | `/ws/jobs/{job_id}/progress` | Server → Client | Real-time training progress |
 
-**Message types:** `progress`, `completed`, `error`, `ping` (30s keepalive)
+**Message types:** `progress`, `completed`, `error`, `ping` (30s keepalive). Terminal messages (`completed` / `error`) are cached per jobId for ~5 minutes (P-0093) so a late subscriber still receives them.
 
 ## Error codes
 
@@ -122,8 +134,13 @@ When the server is running, visit:
 |------|---------|-------------|
 | `WORKSPACE_NO_CONFIG` | Config not set | 400 |
 | `WORKSPACE_NO_DATA` | Data not loaded | 400 |
+| `WORKSPACE_LOCKED` | Config write attempted while a job is running (P-0089 / #279) | 409 |
 | `JOB_NOT_FOUND` | Job does not exist | 404 |
 | `JOB_NOT_COMPLETED` | Job still running or failed | 400 |
+| `JOB_CONFLICT` | Another job already holds the active slot | 409 |
+| `JOB_CANCELLED` | Job was cancelled (terminal status; reported via WS error envelope) | — |
+| `PARENT_LOCKED` | A re-tune / resume child is already running for this parent (H-0062) | 409 |
+| `PICKLE_INCOMPATIBLE` | Re-tune / resume rejected because pickle schema or library major version differs (H-0062) | 400 |
 | `VALIDATION_ERROR` | Config validation failed | 422 |
 | `FILE_INVALID` | File read error | 400 |
 | `PATH_NOT_FOUND` | Path does not exist | 400 |
@@ -140,3 +157,8 @@ pnpm generate:api    # generates types from http://localhost:8501/openapi.json
 ```
 
 Never hand-write API types — always regenerate from the backend.
+
+---
+
+_Last reconciled: 2026-05-01 against develop (post-PR #331). Changes since the previous sync: H-0062 re-tune / resume / lineage endpoints, P-0084 health endpoints, A-9 metrics endpoint, P-0086 fit/tune optional `config` body, P-0089 `WORKSPACE_LOCKED`, P-0093 WS terminal-replay note._
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,13 +71,15 @@ The **Workspace** holds the current session state:
 ```
 User configures form  →  PUT /api/workspace/config
 User uploads data     →  POST /api/workspace/data/upload
-User clicks Fit       →  POST /api/workspace/fit
+User clicks Fit       →  POST /api/workspace/fit  (optional body { config } overrides ws.config atomically — P-0086)
                           │
-                          ├── Service creates Job (pending)
+                          ├── Service claims the active-job slot (P-0089)
+                          │     └── Subsequent PUT/PATCH /config return 409 WORKSPACE_LOCKED until release
+                          ├── Service creates Job (pending) and writes meta.json
                           ├── Adapter.create_model()
                           ├── Adapter.fit() with progress callback
-                          │     └── WebSocket: progress updates
-                          ├── Job status → completed
+                          │     └── WebSocket: progress updates + terminal completed/error (cached for ~5 min so late subscribers still see it — P-0093)
+                          ├── Job status → completed / failed / cancelled, slot released
                           └── Response: { job_id }
 ```
 
@@ -121,3 +123,8 @@ code changes** — the form updates automatically.
 - [BLUEPRINT.md](../BLUEPRINT.md) — full specification
 - [Adapter Guide](adapter-guide.md) — how to implement a new ML backend
 - [API Reference](api.md) — REST API endpoints
+
+---
+
+_Last reconciled: 2026-05-01 against develop (post-PR #331). High-level layout unchanged since the previous sync; only the Fit/Tune workflow box was updated to reflect P-0086 (config body) / P-0089 (active-job lock) / P-0093 (terminal-message replay)._
+

--- a/tests/contract/test_adapter_guide_method_names.py
+++ b/tests/contract/test_adapter_guide_method_names.py
@@ -1,0 +1,106 @@
+"""Contract: every method name cited in ``docs/adapter-guide.md`` must exist
+on ``BackendAdapter`` (the Protocol that documents itself).
+
+The Tier 3 reference docs (`docs/architecture.md`, `docs/api.md`,
+`docs/adapter-guide.md`) are derived from BLUEPRINT and the implementation;
+they drift when refactors rename a method, add a new one, or split the
+Protocol (H-0068 split into BackendCore / BackendEvaluation / etc.).
+
+This test parses every code block in `adapter-guide.md`, extracts the
+``def <name>(`` signatures, and asserts each name is reachable on the
+runtime-checkable ``BackendAdapter`` Protocol. It does NOT compare full
+signatures — that would be too brittle against minor parameter renames.
+The contract is "names cited in the doc must exist", not "signatures
+match byte-for-byte".
+
+Adding a new method to BackendAdapter? Document it in adapter-guide.md
+in the next PR. Renaming an existing one? This test fails first and
+forces the doc update.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from lizystudio.backends.base import BackendAdapter
+
+pytestmark = pytest.mark.unit
+
+
+_ADAPTER_GUIDE = (
+    Path(__file__).resolve().parent.parent.parent / "docs" / "adapter-guide.md"
+)
+
+
+# Exclude method names that the doc cites for the *user's* adapter class
+# (e.g. step-by-step examples), generic Python dunders, or well-known
+# stdlib names that are not part of the BackendAdapter Protocol.
+_EXCLUDED_NAMES = frozenset(
+    {
+        # generic Python / unrelated context
+        "__call__",  # ProgressCallback signature
+        "on_progress",  # ProgressCallback name in user-side examples
+    }
+)
+
+
+def _extract_def_names(markdown: str) -> set[str]:
+    """Return the set of ``def <name>`` identifiers in fenced code blocks."""
+    in_block = False
+    names: set[str] = set()
+    pattern = re.compile(r"^\s*def\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+    for line in markdown.splitlines():
+        if line.lstrip().startswith("```"):
+            in_block = not in_block
+            continue
+        if not in_block:
+            continue
+        m = pattern.match(line)
+        if m:
+            names.add(m.group(1))
+    return names
+
+
+def test_adapter_guide_exists() -> None:
+    assert _ADAPTER_GUIDE.is_file(), (
+        f"docs/adapter-guide.md missing at {_ADAPTER_GUIDE}"
+    )
+
+
+def test_every_method_name_in_doc_exists_on_protocol() -> None:
+    """All ``def <name>`` from adapter-guide code blocks must be present on
+    BackendAdapter (or be in the excluded list of unrelated/example names)."""
+    text = _ADAPTER_GUIDE.read_text(encoding="utf-8")
+    names = _extract_def_names(text)
+    assert names, "adapter-guide.md should contain at least one def example"
+
+    protocol_attrs = set(dir(BackendAdapter))
+    missing: list[str] = []
+    for name in sorted(names - _EXCLUDED_NAMES):
+        if name not in protocol_attrs:
+            missing.append(name)
+
+    assert not missing, (
+        "adapter-guide.md cites method name(s) that do not exist on the "
+        "BackendAdapter Protocol — either the doc has drifted (rename / "
+        "removed method) or this test's _EXCLUDED_NAMES needs an entry "
+        f"for an unrelated example: {missing}"
+    )
+
+
+def test_core_lifecycle_methods_are_documented() -> None:
+    """The doc must mention the four canonical lifecycle method names so a
+    contributor can find them quickly. This is the load-bearing minimum;
+    the broader exhaustive coverage is enforced by the symmetric direction
+    above."""
+    text = _ADAPTER_GUIDE.read_text(encoding="utf-8")
+    names = _extract_def_names(text)
+    required = {"fit", "tune", "predict", "create_model"}
+    missing_in_doc = required - names
+    assert not missing_in_doc, (
+        f"adapter-guide.md should keep `def` examples for the core "
+        f"lifecycle methods; missing from doc: {sorted(missing_in_doc)}"
+    )


### PR DESCRIPTION
## Summary

Reconciles the three Tier 3 reference docs (`docs/architecture.md`, `docs/api.md`, `docs/adapter-guide.md`) with the implementation as of develop @ `56ae361`. The docs were last touched 2026-04-10; intervening work (B/C coupling-refactor series + Proposals P-0086..P-0093, all merged) had drifted them out of sync. Adds a contract test that gates future drift between `adapter-guide.md` and the `BackendAdapter` Protocol.

This is a verified-then-applied reconciliation. The drift list and edits were derived from `gh pr view` against the relevant PRs and direct grep of the implementation, not from memory.

## Verified drift, applied

### `docs/api.md`

| Drift | Source | Fix |
|---|---|---|
| `/api/jobs/{id}/learning-curve/metrics` not listed | `src/lizystudio/api/jobs.py:295` | added under Jobs |
| `/api/jobs/{id}/retune`, `/resume`, `/lineage` not listed | `src/lizystudio/api/retune.py:149,215,304` (H-0062, 2026-04-14) | added under Jobs |
| `/api/health` and `/api/health/ready` not listed | `src/lizystudio/api/health.py` (P-0084 / Issue #30, 2026-04-17) | new "Operations (health / metrics)" section |
| `/api/metrics` not listed | `src/lizystudio/api/metrics_api.py` (A-9 per-app `MetricsRegistry`, 2026-04-17) | same section |
| `POST /workspace/fit` and `/tune` optional `config` body | P-0086 (2026-04-25) | description footnote |
| `DELETE /api/jobs/{id}` cascade query | `src/lizystudio/api/jobs.py:167` | description footnote |
| Error codes missing: `WORKSPACE_LOCKED`, `JOB_CONFLICT`, `PARENT_LOCKED`, `PICKLE_INCOMPATIBLE`, `JOB_CANCELLED` | P-0089, CRITICAL-2, H-0062 | added to Error codes table |
| WebSocket section silent on terminal-replay cache | P-0093 (2026-05-01) | description footnote |

### `docs/adapter-guide.md`

| Drift | Source | Fix |
|---|---|---|
| `learning_curve_metrics` Protocol method missing | `src/lizystudio/backends/base.py:173` | added to Evaluation block |
| `save_checkpoint` / `load_checkpoint` / `verify_checkpoint_compatibility` / `preflight_checkpoint_dir` Protocol methods missing | `base.py:108-145` (H-0062) | new "Re-tune checkpoints" section |
| Reference implementation pointer was `lizyml.py` (legacy single-file path) | `src/lizystudio/backends/lizyml/` is a directory after H-0070 | pointer updated |

### `docs/architecture.md`

| Drift | Source | Fix |
|---|---|---|
| Fit/Tune workflow box did not mention the active-job lock | P-0089 (#279) | flow box updated |
| Fit/Tune workflow box did not mention optional `config` body | P-0086 (#251) | flow box updated |
| Fit/Tune workflow box did not mention terminal-replay cache | P-0093 (#327) | flow box updated |

Each updated doc gained a `_Last reconciled: 2026-05-01_` footer so the next drift cycle can date itself easily.

## Drift gate

`tests/contract/test_adapter_guide_method_names.py` parses every fenced `def <name>(` from `adapter-guide.md` and asserts each name exists on the runtime-checkable `BackendAdapter` Protocol. The contract is "names cited in the doc must exist on the Protocol", not "signatures match byte-for-byte" — that would be too brittle.

3 cases:

- `test_adapter_guide_exists` — sanity check
- `test_every_method_name_in_doc_exists_on_protocol` — the load-bearing assertion (with an `_EXCLUDED_NAMES` allowlist for ProgressCallback / user-class examples)
- `test_core_lifecycle_methods_are_documented` — symmetric direction: the doc must keep `def` examples for `fit` / `tune` / `predict` / `create_model`

This catches future drift in either direction: a Protocol method renamed without the doc update, OR an example added to the doc that points at a method that does not exist.

## Change-gate (CLAUDE.md §2): not applicable

| Criterion | Match? |
|---|---|
| BackendAdapter Protocol change | NO (Protocol surface unchanged; doc catches up to it) |
| Common-type change | NO |
| API contract change | NO (every endpoint listed is already shipped) |
| State-machine / concurrency change | NO |
| External dependency change | NO |
| Storage format / compatibility | NO |
| Build / distribution change | NO |

The contract test is a drift monitor that asserts doc/code agreement; it does not change runtime behaviour. CLAUDE.md / git-workflow §"When a docs-only PR is acceptable" item "Structural documentation refactors" applies. Not tagged `[docs-only]` because the contract test counts as code; runs on the standard CI path.

## Test plan

- [x] `uv run pytest tests/contract/` — 12 / 12 green (3 new + 9 existing)
- [x] `uv run ruff check tests/contract/test_adapter_guide_method_names.py docs/` — green
- [x] `uv run mypy tests/contract/test_adapter_guide_method_names.py` — green
- [x] Endpoint list cross-checked against `grep -rn "@router\\." src/lizystudio/api/`
- [x] Protocol method list cross-checked against `grep "    def " src/lizystudio/backends/base.py`
- [x] PR / Issue / proposal IDs cited in doc footers all map to merged work (verified via `gh pr view` / `gh issue view`)
- [ ] CI on this PR

## Files

| File | Change |
|---|---|
| `docs/api.md` | +20 lines: 8 endpoints, 5 error codes, body / cascade / WS footnotes, Last reconciled |
| `docs/adapter-guide.md` | +43 lines: Evaluation `learning_curve_metrics`, new "Re-tune checkpoints" section, lizyml pointer fix, Last reconciled |
| `docs/architecture.md` | +9 lines: Fit/Tune workflow box updates, Last reconciled |
| `tests/contract/test_adapter_guide_method_names.py` (new) | +110 lines: drift gate |
| `docs/ROADMAP.md` | §6 docs-drift row marked resolved; §7 Tier 3 reduced 4 → 3 items |