### PR TITLE
docs(history): propose P-0094 (pytest-benchmark performance baseline) [proposal-only]

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2875,3 +2875,58 @@ terminal メッセージ（completed / error）が subscribe タイミングに�
 - 2026-05-01 **Approved** — Invariants 明示 + テスト先行。実装サイズ約 +60 行（progress.py）+ +10 行（metrics.py）+ +130 行（tests）で十分にコントロール可能。
 - 実装後の運用観察: `lizystudio_progress_terminal_replayed_total` の発生率を Prometheus で追跡し、定常レートが 0 でなければ subscribe-vs-send race が production でも発火していた裏付けになる。
 
+### P-0094: pytest-benchmark introduction for performance baseline（Issue #27 (a)）
+
+- **Date:** 2026-05-01 起票
+- **Related:** Issue #27 (a)、ROADMAP §5 / §7 Tier 3 #3、coupling refactor (B/C シリーズ) 後の baseline 確立
+
+#### Motivation
+
+直近の B/C coupling refactor（A-1〜A-10, B-1〜B-10, C-1〜C-12）で services/training/jobs のレイヤ分離が大きく動いた。各 PR で機能テストは緑だが、**性能 regression の検知装置がない**。LizyML adapter の fit 1 cycle が 5% 遅くなっても、緑の CI を通り抜けて develop に landing する状態。ROADMAP §5 で Issue #27 を 2 段階に分けたうち、(a) microbench 部分は「先行マージ可能 (tier-3)」と明記されている。本 Proposal は (a) のスコープに限定し、(b) stress harness は別 Proposal とする。
+
+#### Purpose
+
+- LizyML fit のベースライン性能（mean / stddev）を継続的に測定する基盤を導入
+- 将来の refactor / 依存ライブラリ更新で perf regression が起きた場合、測定した上で気づける状態にする
+
+#### Impact
+
+- 新規 dev dependency: `pytest-benchmark`（pytest 公式 plugin、活発にメンテ）
+- 新規ディレクトリ: `tests/bench/`（既存 `tests/regression/` などと同じ階層）
+- pytest 既定動作変更: `[tool.pytest.ini_options]` の addopts に `--benchmark-skip` を追記 → 通常の `uv run pytest` で bench は自動スキップ。CI 標準パスのコストは増えない
+- `.github/workflows/nightly.yml` に opt-in job を追加（`--benchmark-only`）
+
+#### Compatibility
+
+- 既存テスト挙動には影響なし（addopts skip により bench は除外）
+- runtime 依存ではないので production bundle / PyPI ホイール size 変化なし
+- Python バージョン要件は `pytest-benchmark>=4.0` で既存 CI matrix (3.10/3.11) と整合
+
+#### Alternatives considered
+
+- **(a) `asv` (airspeed velocity)** — Scientific Python 標準だが、独自 history DB と専用 worker を要する。LizyStudio の規模には重い
+- **(b) `pyperf` (CPython 公式)** — 単発計測には強いが pytest 統合のための自前 wrapper が必要。pytest-benchmark は同等を fixtures 経由で素直に使える
+- **(c) 自前で `time.perf_counter()` ラッパー** — outlier 除去 / mean / stddev 計算の再実装コストに見合わない
+
+→ pytest-benchmark を選択。理由: (1) pytest 既存テストと同居、(2) 学習コスト低、(3) outlier 除去機構あり、(4) 本タスクの想定規模に十分
+
+#### Acceptance criteria（実装 PR で達成）
+
+- [ ] `pyproject.toml` に `pytest-benchmark` を `[dependency-groups.dev]` に追加（uv.lock 更新含む）
+- [ ] `[tool.pytest.ini_options]` の addopts に `--benchmark-skip` を追記
+- [ ] `tests/bench/test_bench_lizyml_fit.py`（新規）— 100k 行の synthetic CSV を pytest tmpdir で生成、LizyMLAdapter で 1 fit cycle、`benchmark` fixture で測定
+- [ ] `tests/bench/conftest.py` で synthetic data generator を fixture 化
+- [ ] `.github/workflows/nightly.yml` に bench job 追加（`uv run pytest tests/bench/ --benchmark-only --benchmark-json=...`、artefact upload）
+- [ ] CI 標準 PR の `backend (3.10)` / `backend (3.11)` ジョブの実行時間が **増えない**（addopts skip が効いている確認）
+- [ ] nightly bench job が成功し、JSON artefact が upload される
+
+#### Out of scope（follow-up Proposal）
+
+- **regression 検知の自動化** — `--benchmark-compare` で previous run と比較する仕組みは別 Proposal で追加。最初は baseline JSON を蓄積するだけで OK
+- **stress harness** — 並行 fit の負荷テストは Issue #27 (b) で別 tier-4 タスク
+- **frontend 性能ベンチ** — 別 Proposal
+
+#### Decision
+
+- 2026-05-01 **Pending** — 本 Proposal-only PR で approach を review してもらい、accept された段階で本 Decision 行を **Approved** に書き換え、実装 PR の番号を追記
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -1208,8 +1208,33 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 
 ---
 
-## 採番ガイダンス（v3-16 以降）
+## Phase v3-16: pytest-benchmark performance baseline（P-0094 / Issue #27 (a)）🟡
 
-- 新規 Proposal は **P-0094** 以降を起票。
-- 仕様変更を伴う作業は HISTORY.md に Proposal → 本 PLAN.md にフェーズ追加（`v3-16`...）の順で進める。
+**期間:** 2026-05-01 起票 〜 実装 PR は P-0094 accept 後
+
+**対象 Proposal:** P-0094
+
+**動機:** B/C coupling refactor 後の services/training/jobs に perf regression 検知装置がない。LizyML adapter の fit 1 cycle のベースライン (mean / stddev) を継続測定する。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 |
+|---|---|---|
+| v3-16a | P-0094 Proposal 起票 | 🟡 進行中（本 PR） |
+| v3-16b | 実装：`pyproject.toml` + `tests/bench/` + nightly.yml job | 🔴 未着手（P-0094 Approved 後） |
+
+**DoD:**
+- [ ] HISTORY.md P-0094 が **Approved**
+- [ ] `pyproject.toml` に `pytest-benchmark` 追加 + `[tool.pytest.ini_options]` の addopts に `--benchmark-skip`
+- [ ] `tests/bench/test_bench_lizyml_fit.py` で 100k 行 synthetic CSV → fit 1 cycle の bench
+- [ ] `.github/workflows/nightly.yml` に bench job 追加、JSON artefact upload
+- [ ] CI 標準 PR の backend ジョブ実行時間が増えていない（addopts skip 効果確認）
+- [ ] nightly bench job が初回 baseline 取得に成功
+
+---
+
+## 採番ガイダンス（v3-17 以降）
+
+- 新規 Proposal は **P-0095** 以降を起票（P-0094 = 2026-05-01 pytest-benchmark）。
+- 仕様変更を伴う作業は HISTORY.md に Proposal → 本 PLAN.md にフェーズ追加（`v3-17`...）の順で進める。
 - 詳細な未着手バックログは `docs/ROADMAP.md` を参照。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 - このファイルは **横串インデックス** であり、詳細はリンク先で確認すること。
 - 着手する際は HISTORY に Proposal を起票（変更ゲート対象の場合）→ PLAN にフェーズ追加 → 実装、の順で進める。
 
-最終更新: 2026-05-01（P-0093 WS terminal-replay 完了 + #328 execution.log fix 完了 + §5/§7 ドリフト是正：closed 済み Issue 除去 + Tier 0/1/2 を完了済みアイテムから整理）
+最終更新: 2026-05-01（P-0094 pytest-benchmark Proposal 起票 + 直近 PR #329-#332 反映）
 
 ---
 
@@ -103,7 +103,10 @@
 
 | 完了日 | ID | タイトル | 主要 PR |
 |---|---|---|---|
-| 2026-05-01 | P-0093 (impl) | WebSocket terminal-replay（Issue #327） | branch `fix/issue-327-ws-terminal-replay` (PR 作成待ち) |
+| 2026-05-01 | Tier 3 docs sync | architecture / api / adapter-guide drift 是正 + drift gate | #332 |
+| 2026-05-01 | ROADMAP/PLAN cleanup | post-P-0093 drift 整理 (Issue #304 close ほか) | #331 |
+| 2026-05-01 | #328 | execution.log redirect | #330 |
+| 2026-05-01 | P-0093 | WebSocket terminal-replay（Issue #327） | #329 |
 | 2026-04-30 | **P-0092** | ConfigForm cross-hook write funnel（6 phase） | #290〜#295, #289（B-3 spec） |
 | 2026-04-30 | P-0092 follow-up | H-1〜H-4 / G-1〜G-8 / Issue #298 修正 | #300, #303, #306〜#310 |
 | 2026-04-22 | Coupling refactor A+B+C | 26 項目（API queries/Job lineage/format_version 等） | 多数。`docs/coupling-analysis.md:11` |
@@ -118,24 +121,28 @@
 
 ## 3. アクティブ：仕様変更を伴う Proposal
 
-### 3.0 P-0093：WebSocket terminal-message replay for late subscribers（Issue #327）
+### 3.0 P-0094：pytest-benchmark performance baseline（Issue #27 (a)）
 
-- **状態**: 🟢 実装完了（PR レビュー待ち）— branch `fix/issue-327-ws-terminal-replay`
-- **動機**: 高速 Fit (< 3 秒) で `ProgressBroadcaster.send()` が subscribe 前 message を破棄。UI の terminal-detection が 2〜4 秒遅延し、運用ログでユーザーが再 Fit する行動が観測された
-- **対象 Issue**: #327（同根の副症状 #328 は別 PR で対応）
-- **PLAN フェーズ**: v3-15（PLAN.md 参照）
-- **invariant test**: `tests/test_progress.py::TestTerminalReplay` 7 ケース
-- **次アクション**: PR 作成 → CI 全 green → develop マージ
+- **状態**: 🟡 Proposal-only PR 進行中（branch `docs/p-0094-pytest-benchmark`）。実装は accept 後に別ブランチで提出
+- **動機**: B/C coupling refactor 後の services/training/jobs に perf regression 検知装置がない。LizyML adapter の fit 1 cycle のベースライン (mean / stddev) を測定する基盤を導入
+- **対象 Issue**: #27 (a)（stress harness (b) は tier-4 で別 Proposal）
+- **PLAN フェーズ**: v3-16（PLAN.md 参照）
+- **change-gate**: 外部依存追加（`pytest-benchmark`）→ 対象、本 Proposal で起票
+- **次アクション**: 本 PR review → accept → 実装 PR
 
-### 3.1 P-0087 Phase 3：`cv_strategy_fields` を Pydantic から自動派生
+### 3.1 P-0093 (済)：WebSocket terminal-message replay for late subscribers（Issue #327）
+
+- **状態**: ✅ 完了（PR #329 merged 2026-05-01）— `tests/test_progress.py::TestTerminalReplay` 7 ケース緑、`lizystudio_progress_terminal_replayed_total` メトリクスで運用観察可能
+
+### 3.2 P-0087 Phase 3：`cv_strategy_fields` を Pydantic から自動派生
 
 - **状態**: 🟡 未着手（HISTORY.md:2418 で「Phase 3 PR で別途検討」と記載）
 - **動機**: 現在 `lizystudio/backends/lizyml_ui_schema.py` で hand-coded。lizyml 側の Pydantic model から生成すれば drift が原理的に消える
 - **ブロッカー**: lizyml 側に構造化フィールドメタデータの export を頼む必要あり（リポジトリ間調整）
 - **優先度**: 中（P-0087 Phase 1+2 で contract test が drift を検出可能なので、緊急ではないが残課題）
-- **着手手順**: HISTORY に P-0093 として Proposal 起票 → lizyml 側調整 → PLAN.md に `v3-13` として登録 → 実装
+- **着手手順**: HISTORY に P-0095 として Proposal 起票（P-0094 は本 PR で消化）→ lizyml 側調整 → PLAN.md に `v3-17` 以降として登録 → 実装
 
-### 3.2 ML Backend 抽象の 2nd 実装による検証
+### 3.3 ML Backend 抽象の 2nd 実装による検証
 
 - **状態**: 🟡 未着手（`docs/coupling-analysis.md:283` に flag、Issue 未起票）
 - **動機**: A-1〜A-6 で `BackendAdapter` Protocol を整備したが、実装が lizyml 1 件のみ。第 2 実装で抽象の妥当性を検証したい
@@ -250,9 +257,9 @@
 
 ### Tier 3：戦略課題
 
-1. **P-0094 として P-0087 Phase 3 を Proposal 化**（`cv_strategy_fields` の Pydantic 自動派生）— lizyml 側で構造化フィールドメタデータ export が前提のためリポジトリ間調整必要
-2. **#28** offline/resume resilience tests — `current_job_id` ライフサイクル契約決定が前提
-3. **#27 (a)** `pytest-benchmark` 100k-row microbench — 先行マージ可能、stress harness は tier-4
+1. **P-0094 implementation**: pytest-benchmark microbench — Proposal accept 後の実装 PR（`feat/pytest-benchmark-baseline-p0094` で着手予定）
+2. **P-0095 として P-0087 Phase 3 を Proposal 化**（`cv_strategy_fields` の Pydantic 自動派生）— lizyml 側で構造化フィールドメタデータ export が前提のためリポジトリ間調整必要
+3. **#28** offline/resume resilience tests — `current_job_id` ライフサイクル契約決定が前提
 
 ### Tier 4：要長期計画
 
@@ -264,7 +271,7 @@
 
 ## 8. 運用メモ
 
-- 新規 Proposal を起票するときは **P-0094 から採番**（P-0093 = WS terminal-replay は 2026-05-01 に消化）。`H-XXXX` 採番は終了。
+- 新規 Proposal を起票するときは **P-0095 から採番**（P-0094 = pytest-benchmark Proposal 起票は 2026-05-01 に消化）。`H-XXXX` 採番は終了。
 - E2E 単独追加（仕様変更なし）は HISTORY 起票不要、本 ROADMAP の §3 を更新するだけで OK。
 - 本 ROADMAP はステータス変更時に都度更新。タスク完了時は §1 へ移動、新規着手時は §2/§3/§4 へ追加する。
 - 古い ID（B-N coupling、A.M Phase A など）は履歴参照のためそのまま残す。検索性のため改名はしない。


### PR DESCRIPTION
## Summary

Proposal-only PR. Opens the change-gate flow for **#27 (a)** by introducing `pytest-benchmark` as a dev dependency that lets LizyStudio measure a LizyML fit baseline (mean / stddev) and notice perf regressions. **No implementation in this PR**; the dependency, bench file, and CI hook land separately in `feat/pytest-benchmark-baseline-p0094` once this Proposal is accepted (i.e. this PR is merged).

The Proposal text covers:

- Motivation — B/C coupling refactor (A-1..A-10, B-1..B-10, C-1..C-12) shipped without a perf regression detector
- Purpose — establish the baseline + the basis for a future regression detector
- Impact — 1 dev dep, 1 new dir, addopts `--benchmark-skip` so PR CI stays free, opt-in nightly job
- Compatibility — runtime dependency: none; existing CI matrix (3.10/3.11) unchanged
- Alternatives considered — `asv` (too heavy), `pyperf` (no pytest integration), home-grown timer (NIH)
- Acceptance criteria for the implementation PR
- Out-of-scope items reserved for follow-up Proposals (regression auto-detect, stress harness, frontend benches)

Decision is currently **Pending**; flipping it to **Approved** is part of the implementation PR's commit, where the implementation PR number is also recorded.

## Why a separate PR

Per CLAUDE.md §2 ("Addition or removal of external dependencies"), a dependency change is change-gate, so the Proposal must land before any code that uses the new dep. Splitting the Proposal from the implementation is also the recommended workflow in `.claude/skills/post-merge-next/SKILL.md` step 6 — it gives the reviewer a chance to push back on the *approach* before any concrete files exist that would be hard to revert.

## Change-gate (CLAUDE.md §2): the Proposal itself is docs-only

| Criterion | Match? | Notes |
|---|---|---|
| BackendAdapter Protocol change | NO | — |
| Common-type change | NO | — |
| API contract change | NO | — |
| State-machine / concurrency change | NO | — |
| **External dependency add / remove** | **YES** (motive of this Proposal) | This is precisely what the Proposal asks to add — the implementation PR will land it |
| Storage format / compatibility | NO | — |
| Build / distribution change | NO | dev-only dep, no runtime / wheel impact |

The Proposal *itself* is a docs-only change describing a future dependency change. The change-gate is satisfied by this PR existing and being reviewed; the implementation PR is what will actually mutate `pyproject.toml` / `uv.lock`.

## Test plan

- [x] `HISTORY.md` formatting follows the same template as P-0086..P-0093
- [x] `PLAN.md` v3-16 sub-phases align with the Proposal Acceptance criteria
- [x] `docs/ROADMAP.md` section 2 (recent merges) section 3.0 (active proposals) section 7 Tier 3 all consistently reference P-0094 + the numbering advance to P-0095 / v3-17
- [x] `git diff` shows zero non-docs changes (no `pyproject.toml`, `tests/bench/`, `nightly.yml`, no production code touched)
- [ ] CI on this PR (markdown / link-lint only — no test impact)

## Files

| File | Change |
|---|---|
| `HISTORY.md` | +55 lines: P-0094 Proposal section |
| `PLAN.md` | +31 lines: Phase v3-16 entry + numbering hint advance to P-0095 / v3-17 |
| `docs/ROADMAP.md` | section 2 / 3.0 / 3.2 / 7 Tier 3 / 8 / header timestamp updates |

## What happens after merge

1. Decision in HISTORY.md is flipped from **Pending** to **Approved** as part of the implementation PR's commit, with the implementation PR number recorded
2. New branch `feat/pytest-benchmark-baseline-p0094` adds:
   - `pyproject.toml`: `pytest-benchmark` to `[dependency-groups.dev]` + `--benchmark-skip` in `addopts`
   - `tests/bench/conftest.py`: synthetic 100k-row CSV generator fixture
   - `tests/bench/test_bench_lizyml_fit.py`: 1 fit-cycle benchmark
   - `.github/workflows/nightly.yml`: bench job with `--benchmark-only --benchmark-json=...` + artefact upload
3. The implementation PR's body uses the Acceptance criteria from this Proposal as its checklist