### PR TITLE
[docs-only] docs(blueprint): reflect P-0086..P-0094 Decisions in BLUEPRINT.md

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -205,6 +205,8 @@ class BackendCore(Protocol):
     def load_checkpoint(self, path: Any, *, allowed_root: Any | None = None) -> Any: ...
     def verify_checkpoint_compatibility(self, job_dir: Any) -> None: ...  # H-0068
         # pickle / sidecar 互換性を確認できないときは backends.exceptions.CheckpointIncompatibleError を raise
+    def preflight_checkpoint_dir(self, job_dir: Any) -> None: ...  # H-0062
+        # tune 開始前に書き込み権限と picklable 性を検証。問題があれば PICKLE_PREFLIGHT_FAILED を raise
 
     # --- Persistence ---
     def export_model(self, model: Any, path: str) -> str: ...
@@ -296,10 +298,12 @@ class BackendAdapter(
 | `workspace_config` | `dict \| None` | Config設定時に生成 |
 | `workspace_data` | `DataRef \| None` | データ指定時に生成 |
 | `workspace_result` | `Job \| None` | 現セッション中の直近fit結果のみ |
+| `active_job_id` | `str \| None` | 実行中ジョブのスロット。`JobStore.active_job_id` が単一所有者として保持（P-0089 / Issue #279） |
 
 - `workspace_result` は現セッション中にWorkspaceからfitした場合のみセットされる
 - ブラウザ再アクセス時は `workspace_result = None`（右パネル空）
 - 過去のJob結果は表示しない（混乱防止）
+- **Active job lock (P-0089)**: `active_job_id` がセットされている間、`PUT /api/workspace/config` および `PATCH /api/workspace/config` は 409 `WORKSPACE_LOCKED` を返す。これは UI 上の cross-hook race（CV strategy 切り替え / target 変更等）が走行中ジョブの config を後から書き換えるのを構造的に防ぐ。INV: `meta.json` に保存される config は `claim_active` 直前の workspace config と完全一致する
 
 #### 3.4.2 Job 状態（永続・ディスク）
 
@@ -2308,7 +2312,7 @@ Workspace の揮発状態を管理する。
 
 | メソッド | パス | 説明 |
 |---------|------|------|
-| GET | `/api/workspace/status` | Workspace の現在状態（data, config, result の有無） |
+| GET | `/api/workspace/status` | Workspace の現在状態（data, config, result の有無）+ `files_root: str` で `/api/files` がアクセス可能なルートディレクトリも返す（P-0088 / Issue #256） |
 | POST | `/api/workspace/reset` | Workspace 状態をリセット |
 
 #### Config
@@ -2376,6 +2380,10 @@ Workspace の揮発状態を管理する。
 
 レスポンス（共通）: `{ "job_id": "job_042" }`
 Workspace の `workspace_result` は完了時に自動更新される。
+
+**Optional `config` body (P-0086 / Issue #251):** `/fit` `/tune` のリクエストボディに `{"config": {...}}` を含めると、`/config` PUT を待たずに fit/tune と同じトランザクション内で workspace config を atomic に上書きしてから実行できる。これは Frontend 側の保留中 PUT と POST `/fit` 間の race window を閉じるためで、body が省略された場合は従来通り workspace の現行 config が使われる（後方互換）。
+
+**Active-job lock (P-0089 / Issue #279):** ジョブが running 中は `PUT /api/workspace/config` / `PATCH /api/workspace/config` が `WORKSPACE_LOCKED` (409) を返す。詳細は §3.4。
 
 ### 5.3 Jobs API
 
@@ -2524,6 +2532,8 @@ Workspace の `workspace_result` は完了時に自動更新される。
 `ping` は 30 秒間隔の keepalive メッセージ（H-0058）。クライアントは受信しても無視してよい（WebSocket 接続維持のため）。
 
 **Schema SSOT (H-0069):** 上記 4 variant は `src/lizystudio/ws/messages.py` の Pydantic discriminated union として単一定義される。サーバ側送信は `WsMessage.model_dump_json(exclude_none=True)` を通り、フロントは生成 `schema.d.ts` から `WsMessage` 型を import する。optional フィールド (`fold_results` / `trial_results`) は値が存在するときだけ wire に現れ、`null` フィールドはシリアライズしない（既存 wire format と bit-identical）。
+
+**Terminal replay (P-0093 / Issue #327):** `completed` / `error` メッセージは `ProgressBroadcaster._last_terminal` に per-jobId でキャッシュされ、subscribe より前に送信された場合でも late subscriber に replay される。TTL は default 5 分（環境変数 `LIZYSTUDIO_WS_TERMINAL_TTL_S` で上書き可）。これにより高速 fit (< 3 秒) の subscribe-vs-send race が解消される。INV-1: terminal メッセージは subscribe タイミングに関わらず subscriber に **少なくとも一度** 届く。INV-2: live broadcast 経路と replay 経路は subscriber の登録タイミングを境に disjoint なので、同一 subscriber への重複配信は発生しない。replay 発生は `lizystudio_progress_terminal_replayed_total` Counter で観測可能。
 
 進捗追跡の内部実装: 子プロセス → 親プロセスの JSONL 経路は `services/subprocess_runner.py` の独自 dict 形式を保持しており、親プロセスの `_forward_progress` が `WsMessage` への変換を担う。JSONL の wire は `job_id` を含まない（子プロセスは自 job を知らない前提）が、外部に露出しない内部通信のため SSOT 対象外。
 
@@ -2785,8 +2795,10 @@ lizystudio_active_jobs 0.0
 |--------|------|---------------|
 | `WORKSPACE_NO_CONFIG` | Workspace に Config 未設定 | 400 |
 | `WORKSPACE_NO_DATA` | Workspace にデータ未読込 | 400 |
+| `WORKSPACE_LOCKED` | Job が running 中の Config 書き込み試行を拒否（P-0089 / Issue #279） | 409 |
 | `JOB_NOT_FOUND` | 指定されたジョブが存在しない | 404 |
 | `JOB_NOT_COMPLETED` | ジョブが未完了（Inference/Export等の前提） | 400 |
+| `JOB_CONFLICT` | active-job スロットを別ジョブが占有中（CRITICAL-2 / `JobStore.create_and_claim_active`） | 409 |
 | `VALIDATION_ERROR` | Config バリデーション失敗 | 422 |
 | `FILE_INVALID` | ファイルの読み込み失敗 | 400 |
 | `PATH_NOT_FOUND` | 指定されたローカルパスが存在しない | 400 |
@@ -2852,6 +2864,7 @@ frontend/src/api/
 | Unit | Service 層の個別メソッド | pytest |
 | API | 各エンドポイントのリクエスト/レスポンス | pytest + httpx (TestClient) |
 | Integration | LizyML との統合動作 | pytest (実際の LizyML 呼び出し) |
+| Performance | LizyML fit baseline (mean / stddev) | pytest-benchmark, `tests/bench/` (P-0094 / Issue #27 (a)) — PR CI からは `--benchmark-skip` で除外、nightly workflow が `--benchmark-only` で実行し JSON artefact を upload |
 
 ### 8.2 フロントエンド
 
@@ -3135,3 +3148,7 @@ Phase B では `{jobs_dir}/{job_id}/model.pkl` に cloudpickle で Tune Job の�
 - **API 経路**: pickle ファイルは HTTP リクエスト経由でアップロード/参照されない。`POST /api/jobs/{id}/retune` と `POST /api/jobs/{id}/resume` は `job_id` をパスから受け取り、`validate_path_within` で `jobs_dir` 内に解決されることを保証してから、その配下の `model.pkl` を `cloudpickle.load()` する。
 - **DoS 観点**: lineage tree / cascade delete の幅は無制限だが、子作成は per-parent 排他ロックで直列化されるため self-DoS のみが現実的なリスク。BLUEPRINT §11.5 と同じく、ローカル前提に基づき rate limiting は導入しない。
 - **エラー情報**: `PARENT_LOCKED` / `PARENT_HAS_ACTIVE_CHILDREN` のレスポンスには他 child の `job_id` を含めるが、シングルユーザー前提のもと意図的な情報露出として扱う。
+
+---
+
+_Last reconciled: 2026-05-01 against develop @ ad4c581. P-0086 (config body) / P-0088 (`files_root`) / P-0089 (active-job lock + `WORKSPACE_LOCKED`) / P-0093 (WS terminal-replay) / P-0094 (perf baseline) / `JOB_CONFLICT` / `preflight_checkpoint_dir` を本サイクルで反映。Tier 3 派生 doc（`docs/architecture.md` / `api.md` / `adapter-guide.md`）は #332 で同期済み。_

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -243,6 +243,7 @@
 
 | 対象 | 最終更新 | リスク | 対応 |
 |---|---|---|---|
+| `BLUEPRINT.md` | ✅ 2026-05-01 reconciled | — | P-0086 / P-0088 / P-0089 / P-0093 / `JOB_CONFLICT` / `preflight_checkpoint_dir` / P-0094 perf bench の drift を反映済み |
 | `docs/architecture.md` / `api.md` / `adapter-guide.md` | ✅ 2026-05-01 reconciled | — | 棚卸し完了。`tests/contract/test_adapter_guide_method_names.py` で adapter-guide.md ↔ Protocol の drift を gating |
 | `PLAN.md` v3-13/14/15 | ✅ 反映済み（2026-04-30, 2026-05-01） | — | — |
 | `HISTORY.md` P-0092 follow-ups | ✅ 反映済み（2026-04-30、PR #303 周辺で追記） | — | — |


### PR DESCRIPTION
## Summary

BLUEPRINT.md is the top of the priority hierarchy declared in CLAUDE.md section 1. PR #332 reconciled the Tier 3 derivatives (`docs/architecture.md` / `api.md` / `adapter-guide.md`) to implementation; this PR closes the loop by reflecting the same Decisions in BLUEPRINT itself so that the source of truth and its derivatives stay in sync.

This is a verified-then-applied reconciliation, not a structural rewrite. Six drift items (one Protocol method, one state-management invariant, two API endpoint notes, one WebSocket behaviour, two error codes, one testing-strategy row) were identified by greping BLUEPRINT against keywords from each Approved Proposal, and patched in place.

## Verified drift, applied

| Drift | Source | Fix |
|---|---|---|
| `preflight_checkpoint_dir` Protocol method missing | `src/lizystudio/backends/base.py:132` (H-0062) | section 3.3 — added next to `save_checkpoint` / `load_checkpoint` / `verify_checkpoint_compatibility` |
| `active_job_id` state row + active-job lock invariant missing | P-0089 / Issue #279 (`JobStore.active_job_id`) | section 3.4 — added row + invariant callout linking to section 5.2's 409 |
| `/api/workspace/status` response did not declare `files_root` | P-0088 / Issue #256 | section 5.2 — column note on the status row |
| `/fit` `/tune` optional `config` body not mentioned | P-0086 / Issue #251 | section 5.2 Fit/Tune subsection — body callout |
| `PUT/PATCH /config` 409 during running job not mentioned | P-0089 | section 5.2 Fit/Tune subsection — cross-reference to section 3.4 |
| WS terminal-replay (5 min cache) not mentioned | P-0093 / Issue #327 | section 5.5 — terminal-replay block with INV-1 / INV-2 + metric pointer |
| `WORKSPACE_LOCKED` error code missing | P-0089 / Issue #279 | section 6.1 |
| `JOB_CONFLICT` error code missing | CRITICAL-2 (`JobStore.create_and_claim_active`) | section 6.1 |
| Performance testing row missing | P-0094 / Issue #27 (a) | section 8.1 — pytest-benchmark / tests/bench/ row |

A `_Last reconciled: 2026-05-01 against develop @ ad4c581_` footer was added so the next drift cycle has a clear baseline date. The hash `ad4c581` is the develop tip at the moment of this branch (i.e. the merge commit of #334).

## Verification (grep against BLUEPRINT.md)

Each token was counted with `grep -c <token> BLUEPRINT.md`. The two terminal-replay rows are intentional: section 5.5 uses prose form ("Terminal replay") while the footer uses the hyphenated technical name ("terminal-replay"). Both refer to the same P-0093 mechanism.

| Token | Count | Locations |
|---|---|---|
| `files_root` | 2 | section 5.2 + footer |
| `WORKSPACE_LOCKED` | 4 | section 3.4 + section 5.2 + section 6.1 + footer |
| `JOB_CONFLICT` | 2 | section 6.1 + footer |
| `Terminal replay` (prose) | 1 | section 5.5 |
| `terminal-replay` (hyphenated) | 1 | footer |
| `preflight_checkpoint_dir` | 2 | section 3.3 + footer |
| `pytest-benchmark` | 1 | section 8.1 |
| `P-0086` | 2 | section 5.2 + footer |
| `active_job_id` / `active-job` | 8 | section 3.4 + cross-references |

## Out of scope

- **P-0087 Phase 1+2** (UI schema ↔ Pydantic contract test) — implementation-level concern; the contract test in `tests/contract/test_ui_schema_matches_pydantic.py` is self-documenting and BLUEPRINT does not cite individual contract tests
- **P-0090..P-0092** (cross-hook write funnel) — frontend internals; BLUEPRINT section 7 stays at the high-level state-management policy
- **BLUEPRINT structural rewrites** or pre-existing drift outside the P-0086..P-0094 window
- **Updating other docs** (already done in #332)

## Change-gate (CLAUDE.md section 2): not applicable

This PR reflects only Decisions that are already **Approved** in HISTORY.md (P-0086 .. P-0094, plus the `JOB_CONFLICT` error code that ships in `api/jobs.py` + `workspace.py`). No new spec is introduced; introducing new behaviour would require a fresh Proposal.

| Criterion | Match? | Notes |
|---|---|---|
| BackendAdapter Protocol change | NO | Protocol surface unchanged; BLUEPRINT now lists a method that `base.py` already exports |
| Common-type change | NO | — |
| API contract change | NO | every endpoint, body, and response field already shipped |
| State-machine / concurrency change | NO | active-job lock invariant was already enforced in `JobStore`; BLUEPRINT now documents it |
| External dependency change | NO | — |
| Storage format / compatibility | NO | — |
| Build / distribution change | NO | — |

CLAUDE.md / git-workflow §"When a docs-only PR is acceptable" item "Structural documentation refactors" applies. Tagged `[docs-only]` so reviewers can fast-track.

## Test plan

- [x] No code change → no test impact
- [x] Each drift fix is reachable by a grep token (table above)
- [x] Token counts re-verified by direct `grep -c` (terminal-replay split into two rows because BLUEPRINT uses two surface forms — both intentional and pointing at the same P-0093 mechanism)
- [x] Footer commit hash `ad4c581` matches `git log --oneline ad4c581 -1` ("Merge pull request #334")
- [x] BLUEPRINT.md sectioning unchanged (no headings renamed, no new top-level sections)
- [x] ROADMAP.md section 6 docs-drift table now records BLUEPRINT.md as reconciled
- [ ] CI on this PR (markdown / link-lint only)

## Files

| File | Change |
|---|---|
| `BLUEPRINT.md` | +18 lines: 6 drift fixes across sections 3.3 / 3.4 / 5.2 / 5.5 / 6.1 / 8.1 + footer |
| `docs/ROADMAP.md` | +1 line: section 6 row marking BLUEPRINT.md reconciled |
