### PR TITLE
fix(jobs): stop polling-storm after Tune terminal (#339)

### DIFF
--- a/frontend/src/hooks/useBackgroundNotification.ts
+++ b/frontend/src/hooks/useBackgroundNotification.ts
@@ -1,9 +1,20 @@
+import { useCallback } from "react";
+
 /**
  * Send a browser notification when the tab is not focused.
  * Requests permission on first call if not yet granted.
+ *
+ * Issue #339: returned function is wrapped in ``useCallback`` so
+ * downstream ``useCallback`` consumers (handleJobDone → onTerminal →
+ * fireTerminal in useJobProgress) keep stable references across
+ * parent re-renders. Without this, every WorkspacePage re-render
+ * propagated a new reference all the way down and re-ran the WS
+ * subscription effect, which then re-subscribed and received the
+ * server's PR #329 cached terminal replay — fanning out into a
+ * polling storm of ``invalidateQueries`` calls.
  */
 export function useBackgroundNotification() {
-  return (title: string, body?: string) => {
+  return useCallback((title: string, body?: string) => {
     if (typeof Notification === "undefined") return;
     if (document.hasFocus()) return;
 
@@ -16,5 +27,5 @@ export function useBackgroundNotification() {
         }
       });
     }
-  };
+  }, []);
 }

--- a/frontend/src/hooks/useJobProgress.test.ts
+++ b/frontend/src/hooks/useJobProgress.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { JobDetail } from "@/api/types";
+import { connectJobProgress } from "@/api/websocket";
 import { useJobProgress } from "./useJobProgress";
 
 // Capture the callbacks passed to connectJobProgress so tests can
@@ -318,5 +319,85 @@ describe("useJobProgress — polling fallback", () => {
       job: runningJob({ job_id: "j2", status: "completed" }),
     });
     expect(onTerminal).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("useJobProgress — Issue #339 polling-storm guards", () => {
+  it("does NOT re-subscribe WS when onTerminal reference changes after terminal observed", () => {
+    // Repro of Issue #339: an unstable parent callback (e.g.
+    // ``useBackgroundNotification`` returning a fresh function each
+    // render before its useCallback fix) re-runs the WS effect AFTER
+    // ``onCompleted`` has fired but BEFORE ``job?.status`` has been
+    // refetched to "completed". Without the fix, the new subscribe
+    // receives the server's PR #329 cached terminal replay and fires
+    // onCompleted a second (or third, fourth...) time per cascade,
+    // each firing two ``invalidateQueries`` calls — the polling storm.
+    const { rerender } = renderHook(
+      ({ onTerminal }: { onTerminal: () => void }) =>
+        useJobProgress({ jobId: "j1", job: runningJob(), onTerminal }),
+      { wrapper, initialProps: { onTerminal: () => {} } },
+    );
+    expect(connectJobProgress).toHaveBeenCalledTimes(1);
+
+    // WS receives terminal — invalidate + fireTerminal both run.
+    act(() => {
+      lastCallbacks?.onCompleted?.(completedMsg);
+    });
+
+    // Parent re-renders with a NEW onTerminal reference WHILE
+    // ``job?.status`` is still "running" (refetch in flight). Before
+    // the fix this re-ran the effect and called connectJobProgress
+    // again.
+    rerender({ onTerminal: () => {} });
+
+    expect(connectJobProgress).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidateQueries fires at most twice per terminal observation (job + jobs)", () => {
+    // Even if the WS subscribe loop somehow opens a second connection
+    // (e.g. cleanup between renders allowed a brief window), the
+    // ``terminalInvalidatedRef`` guard ensures the cache is refreshed
+    // exactly once per jobId mount lifecycle.
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const customWrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: qc }, children);
+
+    renderHook(() => useJobProgress({ jobId: "j1", job: runningJob() }), {
+      wrapper: customWrapper,
+    });
+
+    // Simulate two onCompleted firings (live + replay race).
+    act(() => {
+      lastCallbacks?.onCompleted?.(completedMsg);
+    });
+    act(() => {
+      lastCallbacks?.onCompleted?.(completedMsg);
+    });
+
+    // Only the FIRST onCompleted's invalidate calls should land:
+    // 1 for queryKeys.job(jobId), 1 for queryKeys.jobs() = 2 total.
+    expect(invalidateSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-subscribes for a fresh jobId after terminal was observed for a different jobId", () => {
+    // The terminalFiredRef guard is per-jobId. Switching to a NEW
+    // jobId must allow a fresh subscribe even if the previous jobId
+    // had already terminal-fired.
+    const { rerender } = renderHook(
+      ({ id }: { id: string }) =>
+        useJobProgress({ jobId: id, job: runningJob({ job_id: id }) }),
+      { wrapper, initialProps: { id: "j1" } },
+    );
+    expect(connectJobProgress).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      lastCallbacks?.onCompleted?.(completedMsg);
+    });
+
+    rerender({ id: "j2" });
+    expect(connectJobProgress).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/hooks/useJobProgress.ts
+++ b/frontend/src/hooks/useJobProgress.ts
@@ -77,6 +77,18 @@ export function useJobProgress({
   // ------------------------------------------------------------------
   // WebSocket subscription
   // ------------------------------------------------------------------
+  // Issue #339: once a terminal message has been observed for ``jobId``
+  // we MUST NOT re-subscribe — the server's PR #329 replay would deliver
+  // the cached terminal again and invalidateQueries below would fire a
+  // second time per re-render cascade caused by unstable parent
+  // callbacks (notify / handleJobDone / onTerminal). The
+  // ``terminalFiredRef`` is shared with the polling-fallback effect so
+  // either path can flip it. ``terminalInvalidatedRef`` separately guards
+  // ``invalidateQueries`` so a duplicate WS terminal (live + replay race
+  // for a still-running ``job?.status`` window) never fires the cache
+  // refresh twice.
+  const terminalInvalidatedRef = useRef<string | null>(null);
+
   useEffect(() => {
     if (!jobId) return;
     // Optimistically subscribe even while the job is still undefined
@@ -84,6 +96,17 @@ export function useJobProgress({
     // without this a fast-completing re-tune child could drop its
     // events. If we already know the job is terminal, skip.
     if (job?.status && _isTerminal(job.status)) return;
+    // Issue #339: skip if we have already observed terminal for this
+    // jobId in this hook instance, even when the parent re-render
+    // cascade flips ``fireTerminal`` / ``onWsError`` references.
+    if (terminalFiredRef.current === jobId) return;
+
+    const invalidateOnce = () => {
+      if (terminalInvalidatedRef.current === jobId) return;
+      terminalInvalidatedRef.current = jobId;
+      queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
+    };
 
     const disconnect = connectJobProgress(jobId, {
       onProgress: (msg) => {
@@ -99,16 +122,14 @@ export function useJobProgress({
       onCompleted: () => {
         setProgress(null);
         if (trackFoldLog) setFoldLog([]);
-        queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
-        queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
+        invalidateOnce();
         fireTerminal();
       },
       onError: (msg) => {
         setProgress(null);
         if (trackFoldLog) setFoldLog([]);
         onWsError?.(msg.message);
-        queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
-        queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
+        invalidateOnce();
         fireTerminal();
       },
     });
@@ -131,6 +152,7 @@ export function useJobProgress({
       prevJobIdRef.current = jobId;
       prevStatusRef.current = undefined;
       terminalFiredRef.current = null;
+      terminalInvalidatedRef.current = null;
     }
     const prev = prevStatusRef.current;
     prevStatusRef.current = job?.status;


### PR DESCRIPTION
## Summary

Fixes #339 — after a Tune job reached terminal, the frontend kept firing `GET /api/jobs/{job_id}` against the completed job (~30+ post-terminal requests, plus 14 GETs to `/api/jobs/`).

**Manual smoke verify (post-fix)**: post-terminal GETs to `/api/jobs/{id}` drop from ~30 → **1** (matches the issue's acceptance criteria of ≤ 2-3).

## Root cause

`useBackgroundNotification()` returned a fresh function on every WorkspacePage render. That unstable reference propagated through `handleJobDone` → `onTerminal` → `fireTerminal` and ended up in `useJobProgress`'s WS effect dep array.

Sequence after WS receives the first `completed`:
1. `onCompleted` fires `invalidateQueries` + `setRunning(false)` (via the parent terminal handler).
2. `setRunning(false)` re-renders WorkspacePage → fresh `notify` → fresh `handleJobDone` → fresh `onTerminal` → fresh `fireTerminal`.
3. Effect dep changed → cleanup + re-run. `job?.status` is still `"running"` (the invalidate's refetch hasn't resolved yet) so the existing `_isTerminal(job.status)` guard misses.
4. The new subscribe receives the server's PR #329 cached terminal replay → another `onCompleted` → another `invalidateQueries` → another cascade. Loop continues until the refetch finally lands `"completed"`.

## Fix

Three layers of defense, all in `frontend/src/hooks/`:

1. **Stabilise `useBackgroundNotification`** — wrap the returned function in `useCallback` so the parent callback chain stays referentially stable across re-renders. Removes the cascade trigger entirely.
2. **`terminalFiredRef.current === jobId` early-return in the WS effect** — even if some other parent path destabilises a callback, the hook now refuses to re-subscribe once it has observed terminal for this `jobId`. Hook-local invariant, no dependency on parents.
3. **`terminalInvalidatedRef`** — sibling guard so a duplicate WS terminal (live + replay race) never fires `invalidateQueries` twice in the same `jobId` mount lifecycle.

`fireTerminal` and `terminalInvalidatedRef` are both reset on `jobId` change so a fresh job can still subscribe and invalidate.

## Invariants

- **INV-1**: once a terminal message is observed for `jobId`, the hook MUST NOT call `connectJobProgress` again for that `jobId`, regardless of how many times the WS effect re-runs from unstable parent callbacks.
- **INV-2**: `invalidateQueries({queryKey: queryKeys.job(jobId)})` and `invalidateQueries({queryKey: queryKeys.jobs()})` each fire at most once per terminal observation per `jobId` mount lifecycle.
- **INV-3 (preserved)**: the first WS subscription for a fresh `jobId` still happens even when `job?.status` is `undefined`, so a fast-completing re-tune child does not lose its terminal via PR #329's late-subscriber replay.

## Failure Paths Covered

- [x] Normal completion (running → completed)
- [x] Cancellation (running → cancelled, polling-fallback path)
- [x] WS error (running → failed, onError path)
- [x] Re-tune child first observed at terminal (PR #329 replay path)
- [x] `jobId` switch resets both refs (INV-3)
- [ ] Network drop during running → reconnect: out of scope; the fix only hardens the hook AFTER terminal has been observed. The reconnect path (`scheduleReconnect`) is unchanged.

## Test plan

- [x] New regression tests in `useJobProgress.test.ts`:
  - `does NOT re-subscribe WS when onTerminal reference changes after terminal observed`
  - `invalidateQueries fires at most twice per terminal observation (job + jobs)`
  - `re-subscribes for a fresh jobId after terminal was observed for a different jobId`
- [x] All 1756 frontend tests pass (`pnpm vitest run`)
- [x] Biome clean (`pnpm check`)
- [x] Build green (`pnpm build`)
- [x] Manual smoke: Tune iris→target on the dev server, post-terminal GETs to `/api/jobs/{id}` = 1