### PR TITLE
test(jobs): add invalidate-count budget assertions (post-#339 audit)

### DIFF
--- a/frontend/src/api/queries/queries.test.ts
+++ b/frontend/src/api/queries/queries.test.ts
@@ -157,6 +157,9 @@ describe("useRetuneJob", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: queryKeys.job("j1"),
     });
+    // Post-#339 budget assertion: exactly the two invalidates declared
+    // in onSuccess — no future cascade silently adds a third.
+    expect(invalidateSpy).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -182,6 +185,8 @@ describe("useResumeJob", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: queryKeys.job("j1"),
     });
+    // Post-#339 budget assertion: matches useRetuneJob — exactly two.
+    expect(invalidateSpy).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -208,5 +213,21 @@ describe("useRunInference", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: queryKeys.infHistoryAll(),
     });
+    // Post-#339 budget assertion: single invalidate (infHistoryAll).
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Post-#339 budget assertion — invalidator helper fires exactly once
+// ---------------------------------------------------------------------------
+
+describe("useJobsInvalidator — budget", () => {
+  it("invokes invalidateQueries exactly once per call", () => {
+    const { wrapper, qc } = makeWrapper();
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { result } = renderHook(() => useJobsInvalidator(), { wrapper });
+    result.current();
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/hooks/useJobLifecycle.test.ts
+++ b/frontend/src/hooks/useJobLifecycle.test.ts
@@ -132,4 +132,61 @@ describe("useJobLifecycle", () => {
 
     expect(clearA).toBe(clearB);
   });
+
+  // --------------------------------------------------------------------
+  // Post-#339 budget assertion — cancel must invalidate exactly twice
+  // --------------------------------------------------------------------
+  it("cancel invalidates exactly the job + jobs queries (no extras)", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const customWrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: qc }, children);
+
+    const { result } = renderHook(() => useJobLifecycle({ jobId: "j1" }), {
+      wrapper: customWrapper,
+    });
+    await waitFor(() => expect(result.current.job?.status).toBe("running"));
+    invalidateSpy.mockClear();
+
+    await act(async () => {
+      await result.current.cancel();
+    });
+
+    // Two invalidates from the cancel finally-block: job(jobId) + jobs().
+    // Any extra invalidate signals an unintended cascade (e.g. a future
+    // change adding a third invalidateQueries call without auditing the
+    // count) and would fail this guard immediately.
+    expect(invalidateSpy).toHaveBeenCalledTimes(2);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["job", "j1"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["jobs"] });
+  });
+
+  it("cancel rejection still invalidates exactly twice (Issue #237 + budget)", async () => {
+    (cancelJob as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("500"),
+    );
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const customWrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: qc }, children);
+
+    const { result } = renderHook(() => useJobLifecycle({ jobId: "j1" }), {
+      wrapper: customWrapper,
+    });
+    await waitFor(() => expect(result.current.job?.status).toBe("running"));
+    invalidateSpy.mockClear();
+
+    await act(async () => {
+      await result.current.cancel();
+    });
+
+    // Even on cancel API failure the finally-block still fires both
+    // invalidates exactly once each — matches the Issue #237 contract
+    // (UI must not stay stuck in "Cancelling...") with no double-fire.
+    expect(invalidateSpy).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Summary

Test-only hardening following the Issue #339 retro. The bug spent ~30 GETs per Tune polling-storm despite the touched test files passing. The retro's three feedback memories (count/budget assertions, symmetry audit, combinatorial coverage) drove an audit; this PR addresses the **count/budget** lens for the highest-risk mutation and lifecycle hooks.

No production code changes — only `toHaveBeenCalledTimes(N)` assertions added to the existing test suites where they were missing.

## Why this matters

Pre-audit, every mutation/lifecycle test asserted **which** keys were invalidated (`toHaveBeenCalledWith({queryKey: ...})`) but not **how many times**. A future refactor that accidentally double-invalidates (e.g. by hooking `onSuccess` AND a parent's `useEffect` to the same cache key) would land green. The Issue #339 cascade was exactly this class of bug.

## Changes

- **`useJobLifecycle.cancel`** — `cancel()` invalidates `job(jobId)` + `jobs()` in `finally`. Now asserted: exactly 2 calls. Mirrored in the Issue #237 reject path so an extra invalidate from a future cascade can't hide there either.
- **`useRetuneJob` / `useResumeJob` `onSuccess`** — both fire `invalidate(jobs())` + `invalidate(job(jobId))`. Asserted: exactly 2 calls each.
- **`useRunInference.onSuccess`** — fires `invalidate(infHistoryAll())`. Asserted: exactly 1 call.
- **`useJobsInvalidator()`** — single-invalidate helper. Asserted: exactly 1 call when the returned function is invoked.

## Audit findings NOT addressed in this PR (and why)

From the same audit:

- **`SearchSpaceRow` choice mode + `objective` special field** — flagged as HIGH but verified false positive on read. Choice mode summary intentionally renders `entry.choices.join(", ")` as a preview; the actual editing happens in the expanded `ChoiceInput` panel which receives the correct `availableOptions` from `getChoiceOptions("objective")`. No bug.
- **`ws/progress.py` queue overflow** — flagged as HIGH but already comprehensively covered by `tests/regression/test_reg_0151_progress_queue_bounded.py` (maxsize, slow consumer overflow, terminal preservation, drop counter). False positive.

## Test plan

- [x] `pnpm vitest run` — 1759 pass / 0 fail (was 1756 pre-PR; +3 new assertions distributed across existing test cases)
- [x] `pnpm check` (Biome) — clean
- [ ] CI green