### PR TITLE
test(model-panel): count budget on the four config invalidate paths (post-#339 MEDIUM)

### DIFF
--- a/frontend/src/hooks/useModelPanelData.test.ts
+++ b/frontend/src/hooks/useModelPanelData.test.ts
@@ -520,6 +520,11 @@ describe("useModelPanelData", () => {
       expect(invalidateSpy).toHaveBeenCalledWith({
         queryKey: queryKeys.config(),
       });
+      // Post-#339 budget assertion — exactly one invalidate from the 409
+      // catch path. A future cascade adding a second invalidate (e.g.
+      // an extra ``invalidateQueries(jobs())`` to refresh the lock owner
+      // job list) would fail this guard before it could ship.
+      expect(invalidateSpy).toHaveBeenCalledTimes(1);
       // Rejected write must not land on history.
       expect(result.current.history.canUndo).toBe(undoBefore);
     });
@@ -626,6 +631,8 @@ describe("useModelPanelData", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: queryKeys.config(),
     });
+    // Post-#339 budget assertion — single invalidate of config().
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
   });
 
   it("handleImport surfaces errors from the server response", async () => {
@@ -754,6 +761,8 @@ describe("useModelPanelData", () => {
       expect(invalidateSpy).toHaveBeenCalledWith({
         queryKey: queryKeys.config(),
       });
+      // Post-#339 budget assertion — single invalidate from saved=false path.
+      expect(invalidateSpy).toHaveBeenCalledTimes(1);
       // Rejected change must not have been recorded in history.
       expect(result.current.history.canUndo).toBe(false);
     });
@@ -794,6 +803,8 @@ describe("useModelPanelData", () => {
       expect(invalidateSpy).toHaveBeenCalledWith({
         queryKey: queryKeys.config(),
       });
+      // Post-#339 budget assertion — single invalidate from funnel-410 path.
+      expect(invalidateSpy).toHaveBeenCalledTimes(1);
       expect(result.current.history.canUndo).toBe(false);
     });
 


### PR DESCRIPTION
## Summary

Follow-up to PR #342 covering the **MEDIUM-severity** findings from the post-#339 audit. After verification, only **1 of 6** medium findings was a real test gap — the other 5 turned out to be false positives where existing coverage was already comprehensive.

The valid finding: `useModelPanelData` fires `invalidateQueries(queryKeys.config())` from four distinct paths but every existing test asserts only `toHaveBeenCalledWith(...)`, never `toHaveBeenCalledTimes(N)`. A refactor that accidentally double-invalidates would land green.

## Changes

Adds `expect(invalidateSpy).toHaveBeenCalledTimes(1)` to four tests in `useModelPanelData.test.ts`:

1. **`handleConfigChange — 409 WORKSPACE_LOCKED handling (#279)`** — direct `updateConfig` reject path with `ApiError(409)`.
2. **`handleImport posts the file and invalidates config cache on success`** — happy-path import.
3. **`handleConfigChange observes saved=false from funnel response and surfaces errors`** — funnel-routed rejection path.
4. **`handleConfigChange surfaces 409 WORKSPACE_LOCKED from funnel result.details`** — funnel-routed lock path.

No production code changes.

## False positives verified during this audit (NOT addressed)

The audit-agent flagged 6 MEDIUM items; verification produced these dismissals:

- **MEDIUM #5 — `useJobProgress` initial onCompleted invalidate count.** Already covered by `useJobProgress.test.ts:356` (`invalidateQueries fires at most twice per terminal observation`) which fires `onCompleted` twice and asserts the dedupe ref keeps the count at 2 — this implicitly proves the single-fire case at 2 calls.
- **MEDIUM #6 — `useJobsInvalidator` / `useRunInference` count assertions.** Bundled into PR #342 already.
- **MEDIUM #8 — `FixedValueEditor` empty-options defensive.** The text-input fallback for `paramType="string" + options=[]` is intentional degradation, not a bug. The two cases where empty options reach FixedValueEditor (`objective` / `metric`) are pre-empted by `SearchSpaceRow`'s special-field branches before reaching this editor.
- **MEDIUM #9 — `CvSection` `FALLBACK_CV_STRATEGY_FIELDS` time-series fallbacks.** All seven CV strategies (kfold, stratified_kfold, group_kfold, stratified_group_kfold, time_series, purged_time_series, group_time_series, blocked_group_kfold) are already exercised by `CvSection.component.test.tsx`, and the `unknown strategy → ["n_splits"]` fallback is locked by `cv-state.test.ts:91`.
- **MEDIUM #10 — `websocket.ts` `onReconnect` count.** `websocket.test.ts:213-265` already asserts exact reconnect counts at multiple boundary points (single reconnect, exponential backoff over three cycles, MAX_RETRIES=10 trigger, and `does not reconnect after completed/error message`).

## Audit accuracy lesson

Across the HIGH+MEDIUM audit (PRs #342 + this one), 4/4 HIGH and 5/6 MEDIUM findings were false positives. Net actionable: 5 valid items out of 10 (50%). Recorded in memory as `feedback_audit_agent_verify_step.md` — "always trace cited file lines or grep for existing regression tests before adding agent findings to a TODO".

## Test plan

- [x] `pnpm vitest run src/hooks/useModelPanelData.test.ts` — 28 pass
- [x] `pnpm vitest run` — 1756 pass / 0 fail (regression-free)
- [x] `pnpm check` (Biome) — clean
- [ ] CI green