### PR TITLE
fix(metrics): unwrap 'raw' subtree when calibrated metrics also present

### DIFF
--- a/frontend/src/lib/metrics.test.ts
+++ b/frontend/src/lib/metrics.test.ts
@@ -54,12 +54,34 @@ describe("pivotMetrics", () => {
     expect(Object.keys(result)).toHaveLength(0);
   });
 
-  it("does not unwrap when multiple top-level keys exist", () => {
+  it("does not unwrap when multiple top-level keys exist (no 'raw' subkey)", () => {
     const raw = {
       if_mean: { acc: 0.9 },
       oof: { acc: 0.8 },
     };
     const result = pivotMetrics(raw);
     expect(result.acc).toEqual({ is: 0.9, oos: 0.8, oos_std: Number.NaN });
+  });
+
+  // Regression: when calibration is enabled the backend returns
+  // ``{raw: {...}, calibrated: {...}}`` (TWO top-level keys), and the
+  // earlier ``keys.length === 1`` guard refused to unwrap — every
+  // metric came back as NaN and the Score / Metric panel rendered
+  // empty. The frontend prefers the ``raw`` sub-tree when present.
+  it("unwraps the 'raw' subtree when calibrated is also present", () => {
+    const raw = {
+      raw: {
+        if_mean: { auc: 0.95, logloss: 0.2 },
+        oof: { auc: 0.88, logloss: 0.35 },
+        oof_std: { auc: 0.01, logloss: 0.02 },
+      },
+      calibrated: {
+        if_mean: { auc: 0.97 },
+        oof: { auc: 0.9 },
+      },
+    };
+    const result = pivotMetrics(raw);
+    expect(result.auc).toEqual({ is: 0.95, oos: 0.88, oos_std: 0.01 });
+    expect(result.logloss).toEqual({ is: 0.2, oos: 0.35, oos_std: 0.02 });
   });
 });

--- a/frontend/src/lib/metrics.ts
+++ b/frontend/src/lib/metrics.ts
@@ -1,18 +1,30 @@
 /**
  * Pivot backend metrics structure into ScoreSection format.
- * Backend returns: { "raw": { "if_mean": {auc: 0.9}, "oof": {auc: 0.8}, "oof_std": {auc: 0.01} } }
- * ScoreSection expects: { "auc": { is: 0.9, oos: 0.8, oos_std: 0.01 } }
+ *
+ * Backend returns one of:
+ *   - ``{raw: {if_mean, oof, oof_std}}`` — uncalibrated single tree
+ *   - ``{raw: {...}, calibrated: {...}}`` — calibration enabled.
+ *     Earlier this fell through to the "multiple top-level keys" branch
+ *     and refused to unwrap, leaving every metric as ``NaN`` so the
+ *     Score / Metric panel rendered empty.
+ *   - ``{if_mean, oof, oof_std}`` — flat shape (some legacy callers)
+ *
+ * ScoreSection expects: ``{auc: {is: 0.9, oos: 0.8, oos_std: 0.01}}``.
+ *
+ * Always prefer the canonical ``raw`` sub-tree when present so the
+ * panel reads the same uncalibrated numbers users see during a
+ * non-calibrated fit, regardless of whether ``calibrated`` is also
+ * emitted alongside.
  */
 export function pivotMetrics(
   raw: Record<string, unknown>,
 ): Record<string, Record<string, number>> {
-  // Unwrap the top-level key (e.g. "raw") if present
-  const keys = Object.keys(raw);
+  // Prefer the canonical ``raw`` sub-tree when present (covers both the
+  // single-key and the calibration-enabled multi-key shapes). Fall back
+  // to the top level for the flat shape.
   const nested =
-    keys.length === 1 &&
-    typeof raw[keys[0]] === "object" &&
-    raw[keys[0]] != null
-      ? (raw[keys[0]] as Record<string, unknown>)
+    typeof raw.raw === "object" && raw.raw !== null
+      ? (raw.raw as Record<string, unknown>)
       : raw;
 
   const ifMean = (nested.if_mean ?? nested.is ?? {}) as Record<string, number>;


### PR DESCRIPTION
## Summary

Reported via manual GUI smoke after PR #341 — Score / Metric panel rendered EMPTY for fit jobs with calibration enabled.

Root cause: when calibration is on, lizyml writes ``{raw: {...}, calibrated: {...}}`` to ``fit_result.json``. Two top-level keys. ``pivotMetrics`` only unwrapped when the dict had a single top-level key, so calibrated jobs landed in the "flat shape" branch and read ``if_mean`` / ``oof`` directly off the top-level object (which doesn't have those keys) — every metric became ``NaN`` and ScoreSection / MetricCards rendered empty rows.

Fix: always prefer the canonical ``raw`` subtree when present, regardless of how many siblings (``calibrated``, etc.) accompany it. Falls back to top-level for the legacy flat shape.

## Repro

1. Upload a CSV, set target for binary classification.
2. Enable Calibration in Model panel.
3. Run Fit.
4. **Pre-fix**: ScoreSection renders metric rows but every value is empty / dash.
5. **Post-fix**: ScoreSection renders proper IS / OOS / OOS_std numbers.

## Why the existing tests missed this

This is exactly the **combinatorial branch coverage** anti-pattern documented in `feedback_combinatorial_branch_coverage.md`: the test cases enumerated `{raw: {...}}` (single key) and the legacy flat shape (no `raw` key, multiple keys), but the third reachable shape — `{raw: {...}, calibrated: {...}}` (multiple keys WITH `raw` subkey) — was never written. There was even an `it("does not unwrap when multiple top-level keys exist")` test that documented the broken behavior as INTENDED.

Caught by the "verify-step" channel (real user GUI observation) which `feedback_audit_agent_verify_step.md` flags as the gold-standard discovery path.

## Test plan

- [x] New regression test `unwraps the 'raw' subtree when calibrated is also present` in `frontend/src/lib/metrics.test.ts`.
- [x] Renamed the pre-existing "multiple top-level keys" test to clarify it covers the **flat-without-`raw`** case (no behavior change).
- [x] `pnpm vitest run` — 1760 pass / 0 fail (was 1759; +1 net new test)
- [x] `pnpm check` (Biome) — clean
- [ ] CI green
- [ ] Manual verify after merge: rerun a calibrated binary fit, confirm Score panel populated.

## Out of scope

A separate Plot 500 bug exists on the SAME job (`/api/jobs/{id}/plots` and `/split-summary` return 500 because LizyML 0.9.0's config validator rejects the persisted model — it claims `validation_ratio + inner_valid` cannot coexist, yet LizyML itself injects the default `validation_ratio: 0.1` at fit time and writes both into the model's metadata.json). That requires either an upstream lizyml fix or a LizyStudio adapter workaround on `load_model`. Filing as a separate issue.