### PR TITLE
chore(deps): bump lizyml 0.9.0 -> 0.9.1 (closes #345)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -560,7 +560,7 @@ wheels = [
 
 [[package]]
 name = "lizyml"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
@@ -574,9 +574,9 @@ dependencies = [
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/74/3a4275bb82da96109e881496dc9929eb37ab298209d35027d7a22151bb90/lizyml-0.9.0.tar.gz", hash = "sha256:11648172e0e9ec7b96eb2837159ef58a9c8265b085d934c91e8dc0842b448eda", size = 633317, upload-time = "2026-04-11T15:58:33.52Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/8a/9fba48ad82db1c75d5b62aa6c218ed64542dbb19906c829f6ee684a76498/lizyml-0.9.1.tar.gz", hash = "sha256:a72c41e8cadac8f1eb7d1d0f4ef1918aab3b9a08b16d1d0d29a06649884c4e7d", size = 639370, upload-time = "2026-05-02T11:16:06.823Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/ac/07abdfa6b62bf132b60398ec42fe8d7ff553c7ec9011bd3cc17659731ff0/lizyml-0.9.0-py3-none-any.whl", hash = "sha256:e8eaacde5efd50b3a7c10f7431f69edbd378bd725117cd24b2454abf8ec9f49a", size = 151674, upload-time = "2026-04-11T15:58:31.921Z" },
+    { url = "https://files.pythonhosted.org/packages/66/82/df816fc0413974a8a8bd233f2585b0b2230d5c56a75fa0c66229ebe00357/lizyml-0.9.1-py3-none-any.whl", hash = "sha256:c7977ed789575a9b8b3f1360d56efcf02f22bb25b46d77927965f60e7726e987", size = 152420, upload-time = "2026-05-02T11:16:05.487Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Picks up LizyML 0.9.1 (released today) which ships [nbx-liz/LizyML#96](https://github.com/nbx-liz/LizyML/pull/96) — the fix for [nbx-liz/LizyML#95](https://github.com/nbx-liz/LizyML/issues/95) (the upstream issue I filed earlier today).

In 0.9.1, ``validation_ratio`` is a **computed field** that mirrors ``inner_valid.ratio``. Previously it was a stored field with default ``0.1`` that round-tripped through ``model_dump()`` and tripped the validator's "specify only one" guard for any non-``holdout`` ``inner_valid`` discriminant.

## Resolves

- [nbx-liz/LizyStudio#345](https://github.com/nbx-liz/LizyStudio/issues/345) — Plot panel + Fold split summary returned HTTP 500 because ``Model.load`` rejected every model fit with ``inner_valid: group_holdout`` (the GUI default for ``group_kfold`` cv).

## Verification

Verified locally that the previously-broken artifact loads cleanly under 0.9.1:

```python
from lizyml.core.model import Model
m = Model.load("/path/to/job_ed4a2f60/model")
# SUCCESS — was raising LizyMLError [CONFIG_INVALID] under 0.9.0
print(m._cfg.training.early_stopping)
# enabled=True rounds=150
# inner_valid=GroupHoldoutInnerValidConfig(method='group_holdout', ratio=0.1, random_state=42)
# validation_ratio=0.1   ← now a computed field, not a stored conflict
```

The ``job_ed4a2f60`` artifact was captured during the 2026-05-02 manual smoke that originally surfaced the bug. Loading it under 0.9.1 returns a valid ``Model`` with no exceptions.

## Test plan

- [x] ``uv sync --frozen`` — lizyml 0.9.0 → 0.9.1 installed cleanly
- [x] ``uv run pytest`` — 1244 passed / 7 skipped
- [x] ``uv run ruff check . && uv run ruff format --check .`` — clean
- [x] ``uv run mypy src/lizystudio/`` — clean
- [x] Manual: ``Model.load`` on the previously-broken ``job_ed4a2f60`` artifact succeeds
- [ ] CI green
- [ ] Manual GUI smoke after merge: fit a binary classification with calibration off + ``inner_valid: group_holdout``, confirm Plot dropdown populates and Fold split summary renders.

## Out of scope

- Issue #346 (test fixture strategy + round-trip integration test) — would have caught this class of bug pre-emptively. Phase C of #346 explicitly calls for an integration test that does fit→save→load→get_available_plots; if that had been wired up under 0.9.0 we'd have caught the issue locally before any user smoke. Tracked separately.
- The "production-artifact fixtures" + "negative-invariant test name smell" memories already record the lessons. Implementation lives in #346.

## Pin range

The constraint in ``pyproject.toml`` (``>=0.9.0,<0.10.0``) already admits 0.9.1. Only the lock file needed bumping. No code changes.