### PR TITLE
test(metrics): rewire pivotMetrics tests to real fit_result fixtures (#346 Phase B 1/3)

### DIFF
--- a/frontend/src/lib/metrics.test.ts
+++ b/frontend/src/lib/metrics.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it } from "vitest";
+import binaryIsotonicFit from "../__fixtures__/lizyml/fit_result_binary_isotonic.json";
+import binaryNoCalFit from "../__fixtures__/lizyml/fit_result_binary_no_cal.json";
+import regressionFit from "../__fixtures__/lizyml/fit_result_regression.json";
+import tuneFit from "../__fixtures__/lizyml/fit_result_tune.json";
 import { pivotMetrics } from "./metrics";
+
+const BINARY_METRIC_NAMES = [
+  "auc",
+  "accuracy",
+  "auc_pr",
+  "brier",
+  "ece",
+  "f1",
+  "logloss",
+  "precision_at_k",
+] as const;
+const REGRESSION_METRIC_NAMES = [
+  "huber",
+  "mae",
+  "mape",
+  "r2",
+  "rmse",
+  "rmsle",
+] as const;
 
 describe("pivotMetrics", () => {
   it("pivots wrapped backend metrics (single top-level key)", () => {
@@ -83,5 +106,66 @@ describe("pivotMetrics", () => {
     const result = pivotMetrics(raw);
     expect(result.auc).toEqual({ is: 0.95, oos: 0.88, oos_std: 0.01 });
     expect(result.logloss).toEqual({ is: 0.2, oos: 0.35, oos_std: 0.02 });
+  });
+});
+
+// Production-artifact regression coverage (Issue #346 Phase B). Each test
+// pivots a fit_result.json captured from a real GUI run so future shape
+// drift in lizyml or LizyStudio's API/Service layer trips the assertion
+// before reaching users.
+describe("pivotMetrics with real fit_result fixtures", () => {
+  it("pivots a real binary fit (no calibration) — 8 metrics, finite values", () => {
+    const result = pivotMetrics(binaryNoCalFit.metrics);
+    for (const name of BINARY_METRIC_NAMES) {
+      expect(result[name], `metric ${name} missing`).toBeDefined();
+      expect(Number.isFinite(result[name].is)).toBe(true);
+      expect(Number.isFinite(result[name].oos)).toBe(true);
+    }
+    // is/oos values must come from the only top-level "raw" subtree.
+    expect(result.auc.is).toBe(binaryNoCalFit.metrics.raw.if_mean.auc);
+    expect(result.auc.oos).toBe(binaryNoCalFit.metrics.raw.oof.auc);
+  });
+
+  // Locks PR #344 regression: when calibration is enabled the backend
+  // emits ``metrics: {raw: {...}, calibrated: {...}}`` and pivotMetrics
+  // must unwrap the canonical ``raw`` subtree. Previously the
+  // ``keys.length === 1`` guard refused to unwrap, leaving every metric
+  // NaN and the Score / Metric panel empty.
+  it("unwraps the canonical 'raw' subtree on a real calibrated fit", () => {
+    const result = pivotMetrics(binaryIsotonicFit.metrics);
+    for (const name of BINARY_METRIC_NAMES) {
+      expect(result[name], `metric ${name} missing`).toBeDefined();
+      expect(Number.isFinite(result[name].is)).toBe(true);
+      expect(Number.isFinite(result[name].oos)).toBe(true);
+    }
+    // Anti-confusion: is/oos must come from raw, NOT calibrated. The
+    // fixture's calibrated.oof.auc differs from raw.oof.auc, so a
+    // pivot that picked up calibrated would fail this assertion.
+    const rawAuc = binaryIsotonicFit.metrics.raw.if_mean.auc;
+    const rawOofAuc = binaryIsotonicFit.metrics.raw.oof.auc;
+    const calOofAuc = binaryIsotonicFit.metrics.calibrated.oof.auc;
+    expect(rawOofAuc).not.toBe(calOofAuc);
+    expect(result.auc.is).toBe(rawAuc);
+    expect(result.auc.oos).toBe(rawOofAuc);
+  });
+
+  it("pivots a real regression fit — 6 metrics, finite values", () => {
+    const result = pivotMetrics(regressionFit.metrics);
+    for (const name of REGRESSION_METRIC_NAMES) {
+      expect(result[name], `metric ${name} missing`).toBeDefined();
+      expect(Number.isFinite(result[name].is)).toBe(true);
+      expect(Number.isFinite(result[name].oos)).toBe(true);
+    }
+    expect(result.rmse.is).toBe(regressionFit.metrics.raw.if_mean.rmse);
+    expect(result.r2.oos).toBe(regressionFit.metrics.raw.oof.r2);
+  });
+
+  it("pivots a real tune fit — same 8 binary metrics on tuned best params", () => {
+    const result = pivotMetrics(tuneFit.metrics);
+    for (const name of BINARY_METRIC_NAMES) {
+      expect(result[name], `metric ${name} missing`).toBeDefined();
+      expect(Number.isFinite(result[name].is)).toBe(true);
+      expect(Number.isFinite(result[name].oos)).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Phase B (1/3) of #346: rewire `frontend/src/lib/metrics.test.ts` to use the
real `fit_result.json` fixtures landed in #348. Four new fixture-driven
tests on top of the existing 7 synthetic tests:

- `binary_no_cal` — 8 binary metrics finite, is/oos read from raw subtree
- `binary_isotonic` — **locks PR #344 regression**: the fixture's
  `calibrated.oof.auc` differs from `raw.oof.auc`, so any future regression
  that re-broke unwrapping (and started picking up calibrated) would fail
  the assertion. Prior to PR #344 this would have caught the empty Score
  panel before it shipped.
- `regression` — 6 regression metrics (rmse/mae/r2/...) finite, rmse/r2
  cross-check raw values
- `tune` — same 8 binary metrics on tuned best params

## Why keep the synthetic tests too

The 7 hand-written tests cover boundary cases (NaN slots, empty metrics,
alternate `is/oos` key names) that real fixtures cannot exercise without
fabricating shapes that don't appear in production. Per
`feedback_production_artifact_fixtures.md`, fixtures complement synthetic
data — they don't replace it.

## Acceptance (per #346 Phase B)

- [x] `metrics.test.ts` consumes fixtures from `frontend/src/__fixtures__/lizyml/`
- [x] Calibrated case asserts unwrap from `raw`, not `calibrated`
- [x] All metric scenarios (binary, regression, tune) covered

## Test plan

- [x] `pnpm vitest run src/lib/metrics.test.ts` — 11 passed (7 + 4)
- [x] `pnpm check` (biome) clean
- [x] `pnpm build` (tsc + vite) succeeded

## Out of scope

- Phase B (2/3): `useJobResultData.test.ts` rewire — separate PR
- Phase B (3/3): `ResultsCompletedView.test.tsx` rewire — separate PR
- Phase C: backend fit→load round-trip integration test — separate PR
- Phase D: negative-invariant test name audit — `metrics.test.ts:57` is
  on its checklist (`"does not unwrap when multiple top-level keys exist"`),
  to be addressed in the dedicated Phase D PR

Refs #346
