### PR TITLE
feat(integration): fit-load round-trip CI gate (#346 Phase C / P-0095)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
       # Local runs do NOT retry so flakiness stays visible. Quarantined
       # tests are excluded from this blocking job (default addopts in
       # pyproject.toml) and run separately in `backend-quarantine`.
-      - run: uv run pytest --cov=src/lizystudio --cov-report=term-missing --cov-fail-under=80 --reruns 2 --reruns-delay 1 -q
+      # Integration tests (P-0095) live in their own job; ignore the
+      # directory here so we do not double-run a 14s suite on every PR.
+      - run: uv run pytest --ignore=tests/integration --cov=src/lizystudio --cov-report=term-missing --cov-fail-under=80 --reruns 2 --reruns-delay 1 -q
 
   # Non-blocking quarantine job — captures signal on tests marked
   # `@pytest.mark.quarantine` without failing the PR. Skip cleanly when
@@ -50,6 +52,23 @@ jobs:
           # Intentionally swallow non-zero exit — continue-on-error
           # already tolerates failure, but the job status will still be
           # marked green in GitHub UI via continue-on-error.
+
+  # Backend fit -> save -> load round-trip integration tests (P-0095 /
+  # Issue #346 Phase C). Real LizyMLAdapter is exercised end-to-end
+  # against the captured fixture configs so shape-evolution bugs of
+  # the Issue #345 class are caught before merge. Runs in its own job
+  # so the ~14s suite parallelises with `backend (3.10)/(3.11)` and
+  # does not inflate their wall time. Required check (configure in
+  # GitHub branch protection alongside backend / frontend / e2e).
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - run: uv sync
+      - run: uv run pytest tests/integration -v --reruns 2 --reruns-delay 1
 
   frontend:
     runs-on: ubuntu-latest

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2930,3 +2930,64 @@ terminal メッセージ（completed / error）が subscribe タイミングに�
 
 - 2026-05-01 **Approved** — Proposal-only PR #333 が merge されたことで Proposal 自体は accept。実装は #334 で landing 予定（PR が merge されたら本記録の通り close）。実装 PR には Acceptance criteria 全項目の verify ログを記載済み（local: bench mean ≈ 13.5 s / stddev ≈ 1.5 s on 3 rounds, skip via addopts effective, mypy / ruff / format clean）
 
+### P-0095: Backend fit→load round-trip integration test as a required CI gate（Issue #346 Phase C）
+
+- **Date:** 2026-05-03 起票
+- **Related:** Issue #346 Phase C / PR #348 (Phase A fixtures) / PR #349-#351 (Phase B 3 layers) / Issue #345 (Plot 500 / lizyml inner_valid round-trip)、ROADMAP §7
+
+#### Motivation
+
+Issue #345 は GUI に shipping して初めて発覚した: `LizyMLAdapter.fit()` で作ったモデルを `Model.load` で読み戻すと `inner_valid: group_holdout` 系の config が reject されていた。**ユニットテストは fit を in-memory で検証するだけで、file system 経由の save → load round-trip を一度も exercise していなかった**ので、CI を擦り抜けた。同じクラスの shape-evolution バグを今後 CI で捕捉する仕組みが必要。
+
+PR #348/#349/#350/#351 (Phase A + B) で `fit_result.json` の shape regression は 3 層 (pivot / hook / component) で lock 済み。残るは **モデル本体 (`.pkl` + `metadata.json`) を save → load する round-trip** の領域。
+
+#### Purpose
+
+- 各 fixture シナリオで `create_model → fit → export_model → load_model → get_available_plots` を end-to-end で実行し、例外が出ないことと plot リストが非空であることを CI で継続的に検証する
+- 将来 lizyml が minor bump して metadata schema が変わったら CI が即座に fail する状態にする
+
+#### Impact
+
+- 新規ディレクトリ: `tests/integration/`（既存 `tests/regression/`, `tests/bench/`, `tests/contract/` と同じ階層）
+- 新規ファイル: `tests/integration/test_fit_load_round_trip.py`（~120 LOC）
+- 新規 CI job: `integration` を `.github/workflows/ci.yml` に追加（**required check**、`pull_request` トリガー）
+- 既存 `backend (3.10)/(3.11)` job が `tests/integration/` を二重実行しないよう `--ignore=tests/integration` を追加
+- pytest 既定動作変更なし: integration tests は default `uv run pytest` でも回る (fixture 小さいので 30s 程度) が、CI 上は `backend` job と分離して並列実行
+- runtime 依存変更なし
+
+#### Compatibility
+
+- 既存 backend / runtime コードに変更なし
+- Phase A の fixtures (`tests/fixtures/lizyml/*/data.csv` + `config.json`) を再利用するので追加データ不要
+- CI 標準 PR の `backend (3.10)/(3.11)` ジョブの実行時間は不変（`--ignore` により integration は別 job のみ）
+
+#### Alternatives considered
+
+- **(a) 既存 `backend (3.10)/(3.11)` ジョブに含める** — 拒否。並列実行できなくなり PR feedback が遅くなる。integration の slowness が unit test の retries に巻き込まれるのも避けたい
+- **(b) Nightly に置く** — 拒否。merge gate でないと regression が develop に入ってから初めて気付く（Issue #345 で既に経験）
+- **(c) lizyml 側にこのテストを置く** — 拒否。LizyStudio の Adapter / Service 経由の round-trip が壊れる可能性は LizyStudio 側でしか captured できない
+
+→ LizyStudio 側に新 required CI check として追加する
+
+#### Acceptance criteria（実装 PR で達成）
+
+- [ ] `tests/integration/test_fit_load_round_trip.py` 新規作成
+  - `binary_no_cal` / `binary_isotonic` / `regression` の 3 シナリオを parametrize
+  - 各シナリオで `data.csv` + `config.json` を読み込み → `LizyMLAdapter.create_model()` → `fit()` → `export_model()` → `ModelCache.load()` → `get_available_plots()` を順に実行し、例外なく plot リストが非空であることを assert
+- [ ] `tune` シナリオは Out of scope（`tune_result.json` round-trip は別 surface）
+- [ ] `.github/workflows/ci.yml` に `integration` job を追加（required check 設定は GitHub 側で別途有効化する手順を PR description に明記）
+- [ ] 既存 `backend (3.10)/(3.11)` job が `--ignore=tests/integration` を含み、二重実行しない
+- [ ] CI 標準パスの `backend (3.10)/(3.11)` 実行時間が増えない
+- [ ] Local: `uv run pytest tests/integration/ -v` で 3/3 pass、所要時間 < 60s
+- [ ] mypy / ruff / format clean
+
+#### Out of scope（follow-up Proposal）
+
+- **tune scenario の round-trip** — `tune_result.json` の shape lock + best-params re-fit の round-trip は別 Proposal で追加
+- **Plot data shape contract test** — `get_available_plots` の戻り値 (string list) だけでなく `backend.plot()` の戻り値の shape 契約は別 Proposal
+- **Multi-backend integration** — 第 2 backend の round-trip は backend 選定後に別 Proposal
+
+#### Decision
+
+- 2026-05-03 **Proposed** — 実装 PR と同じ PR 内に Proposal commit を含めて起票。Acceptance criteria 全項目の verify ログを実装コミットメッセージ / PR description に記載予定
+

--- a/tests/integration/test_fit_load_round_trip.py
+++ b/tests/integration/test_fit_load_round_trip.py
@@ -1,0 +1,96 @@
+"""Integration tests for the fit -> save -> load round-trip (P-0095).
+
+Issue #346 Phase C. Each scenario runs ``LizyMLAdapter`` through the full
+``create_model -> fit -> export_model -> ModelCache.load -> get_available_plots``
+pipeline on real fixture data so shape-evolution bugs of the Issue #345
+class are caught at CI time.
+
+Issue #345 shipped because every existing test exercised ``fit`` only
+in-memory; no test ever wrote the model to disk and read it back through
+the same ``LizyMLAdapter`` instance. A single such test would have failed
+immediately on the ``inner_valid: group_holdout`` config that broke
+``Model.load`` under lizyml 0.9.0.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from lizystudio.backends.lizyml.adapter import LizyMLAdapter
+from lizystudio.backends.types import DataRef
+from lizystudio.services.job_results import ModelCache, get_available_plots
+from lizystudio.services.jobs import Job
+
+FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "lizyml"
+
+
+def _job_for(scenario: str, model_dir: Path, config: dict) -> Job:
+    """Construct the minimal ``Job`` shape that ``ModelCache.load`` needs.
+
+    ``Job`` is a dataclass with several required fields; only
+    ``backend_name`` + ``model_path`` actually drive ``ModelCache.load``,
+    but we populate the rest with realistic values so any future helper
+    that consults them keeps working.
+    """
+    return Job(
+        job_id=f"integration_{scenario}",
+        status="completed",
+        backend_name="lizyml",
+        config=config,
+        data_ref=DataRef(
+            source_type="path",
+            path=str(FIXTURE_ROOT / scenario / "data.csv"),
+            filename="data.csv",
+            fingerprint="integration-fixture",
+            shape=(0, 0),
+        ),
+        job_type="fit",
+        created_at="2026-05-03T00:00:00+00:00",
+        completed_at="2026-05-03T00:00:01+00:00",
+        model_path=str(model_dir),
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("scenario", ["binary_no_cal", "binary_isotonic", "regression"])
+def test_fit_save_load_get_available_plots(scenario: str, tmp_path: Path) -> None:
+    """End-to-end fit -> save -> load -> available_plots round-trip.
+
+    Asserts that:
+    - ``LizyMLAdapter.fit`` completes without exception on the real
+      fixture config
+    - ``export_model`` writes artifacts the same adapter can re-load
+      via ``ModelCache.load -> backend.load_model``
+    - ``get_available_plots`` returns a non-empty list against the
+      reloaded model (this is the exact call that 500'd in Issue #345)
+    """
+    fixture_dir = FIXTURE_ROOT / scenario
+    df = pd.read_csv(fixture_dir / "data.csv")
+    config: dict = json.loads((fixture_dir / "config.json").read_text())
+
+    backend = LizyMLAdapter()
+    model = backend.create_model(config, df)
+    fit_result = backend.fit(model)
+    assert fit_result is not None, f"fit returned None for {scenario}"
+
+    model_dir = tmp_path / "model"
+    exported_path = backend.export_model(model, str(model_dir))
+    assert Path(exported_path).exists(), (
+        f"export_model returned {exported_path!r} but path does not exist"
+    )
+
+    job = _job_for(scenario, Path(exported_path), config)
+    cache = ModelCache()
+    plots = get_available_plots(job, backend, cache)
+
+    assert plots, f"empty plot list for {scenario}"
+    # Every scenario must surface the shared baseline plots so the
+    # frontend dropdown isn't empty after a successful fit.
+    assert "learning-curve" in plots, (
+        f"learning-curve missing from {plots!r} for {scenario}"
+    )
+    assert "importance" in plots, f"importance missing from {plots!r} for {scenario}"


### PR DESCRIPTION
## Summary

Phase C of #346: introduce a backend `fit → save → load → get_available_plots`
round-trip integration test as a **new required CI gate**, so the class of
shape-evolution bug behind Issue #345 is caught at PR time instead of after
deployment.

Builds on #348 (Phase A fixtures) + #349 / #350 / #351 (Phase B 3-layer
frontend lock).

Change-gate Proposal: **P-0095** in `HISTORY.md`.

## Commits

| Commit | Type | Purpose |
|---|---|---|
| `d44a7ba` | docs(history) | Add Proposal P-0095 |
| `51e6fc2` | test(integration) | Implement `tests/integration/test_fit_load_round_trip.py` |
| `aaca4a1` | ci(workflows) | Add `integration` job + `--ignore=tests/integration` for backend job |

## What it covers

`tests/integration/test_fit_load_round_trip.py` parametrizes 3 fixture
scenarios captured in #348 and runs each through the **same code path
production users hit**:

```
LizyMLAdapter.create_model(config, df)
  → backend.fit(model)
  → backend.export_model(model, model_dir)
  → ModelCache.load(job, backend) → backend.load_model(...)
  → get_available_plots(job, backend, cache)
```

Asserts:
- `fit_result is not None`
- `export_model` returns a path that exists
- `get_available_plots` returns a non-empty list
- Both `learning-curve` and `importance` are present (the shared baseline
  the frontend dropdown depends on)

This single test would have failed in CI on lizyml 0.9.0 the moment
Issue #345 was introduced.

## Tune scenario is out of scope

The `tune` fixture exercises `tune_result.json` round-trip, which is a
different surface than `fit_result.json`. Adding it would need a separate
Proposal because it covers `best_params` re-fit semantics. Phase A
captured the tune fixture so it can be wired in later without re-doing
the capture.

## CI wiring

- New job `integration` runs `uv run pytest tests/integration -v --reruns 2 --reruns-delay 1` on every PR
- Backend job (`backend (3.10)/(3.11)`) gets `--ignore=tests/integration`
  so it doesn't double-run the suite
- **Required check**: configure in GitHub branch protection alongside
  existing `backend` / `frontend` / `e2e-chromium` after this PR merges
  (the workflow file alone doesn't make a check required)

## Acceptance (per #346 Phase C / P-0095)

- [x] `tests/integration/test_fit_load_round_trip.py` covers binary_no_cal /
  binary_isotonic / regression
- [x] tune scenario explicitly out of scope, fixture preserved for later
- [x] `integration` job added to `.github/workflows/ci.yml`
- [x] `backend (3.10)/(3.11)` ignores `tests/integration` (test count
  unchanged: 1251)
- [x] `mypy / ruff / format` clean

## Test plan

- [x] `uv run pytest tests/integration/ -v` — 3/3 passed (~14s first run, ~6s cached)
- [x] `uv run pytest --ignore=tests/integration --co -q` — 1251 collected
  (matches develop baseline before integration test was added)
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean (151 files)
- [x] `uv run mypy src/lizystudio/` clean (54 source files)

## Follow-up reminder

After this PR lands, please add `integration` to the required-status-check
list in repo Branch Protection settings so it actually gates merges. The
workflow file change alone marks the job as part of the run but does not
make it blocking.

Refs #346
