### PR TITLE
test(metrics): rename negative-invariant test to positive form (#346 Phase D)

### DIFF
--- a/frontend/src/lib/metrics.test.ts
+++ b/frontend/src/lib/metrics.test.ts
@@ -77,7 +77,17 @@ describe("pivotMetrics", () => {
     expect(Object.keys(result)).toHaveLength(0);
   });
 
-  it("does not unwrap when multiple top-level keys exist (no 'raw' subkey)", () => {
+  // Renamed from "does not unwrap when multiple top-level keys exist (no 'raw'
+  // subkey)" during the Issue #346 Phase D negative-invariant audit. The
+  // earlier name described what the function *avoids* (unwrapping); the
+  // actual user-facing behavior is reading metrics from the top level when
+  // no ``raw`` subtree is present. Keeping the negative framing on this
+  // case is what made PR #344 ship the calibrated-shape bug — pivotMetrics
+  // had a "does not unwrap when multiple top-level keys" guard that the
+  // calibrated shape ``{raw, calibrated}`` triggered, and the test name
+  // implied that was the canonical behavior. Always describe the positive
+  // invariant.
+  it("reads metrics from the top level when no 'raw' subtree is present (flat shape)", () => {
     const raw = {
       if_mean: { acc: 0.9 },
       oof: { acc: 0.8 },


### PR DESCRIPTION
## Summary

Phase D of #346: audit test names for the negative-invariant smell
documented in `feedback_negative_invariant_test_smell.md`. Renames the
single high-confidence smell case (the kickoff's canonical example);
all other matches are legitimate and stay.

## What changed

`frontend/src/lib/metrics.test.ts:80`

```diff
- it("does not unwrap when multiple top-level keys exist (no 'raw' subkey)", ...
+ it("reads metrics from the top level when no 'raw' subtree is present (flat shape)", ...
```

The earlier name described what pivotMetrics *avoids* doing. That
framing is exactly what shipped PR #344's bug to GUI: the function
had a literal `keys.length === 1` guard that "refused to unwrap"
multi-key inputs, and the test name implied that was canonical
behavior. The fix flipped the guard but the test kept selling the
old shape. Renaming forces the description to reflect production
behavior.

A header comment on the test records the audit decision so future
contributors understand why the rename happened.

## Audit categories

`grep -rnE 'does not|doesn'\''t|does NOT'` across `frontend/src/**/*.test.*`
and `tests/**/*.py` surfaced 130+ matches. Triaged into:

| Decision | Count | Examples |
|---|---|---|
| **Keep** | ~145 | • UI empty-state: "does not render Warnings accordion when no warnings exist"<br>• No-op assertion: "does not call onChange when clicking the active option"<br>• Issue-#339 regression cov: "does NOT subscribe when job is already terminal", "does NOT re-subscribe WS when onTerminal reference changes"<br>• Immutability: "does not mutate the original choices array"<br>• Type-driven UI rule: "does NOT show Re-tune on a completed fit job"<br>• Issue-#278 schema-absence sanity: "does NOT inject blocks_col/groups_col into data for blocked_group_kfold" |
| **Rename** | **1** | metrics.test.ts:80 — the kickoff's canonical example |
| **Delete** | 0 | No test was found that locks in accidental wrong behavior the production data demands the opposite of |

## Why so few renames

The smell is specifically: tests whose name describes a guard that
NEGATES the intended behavior, framed as if the negation were canonical
(so a future fix that flips the guard makes the test misleading).

UI/state-driven negations ("does not render X when Y is empty") are
legitimate — empty/disabled-state assertions describe real user
scenarios. Renaming them to positive form would be churn without value.

The PR #344 bug shipped because the negation was at the *invariant*
level (function refuses to do its job), not at the *state* level.
Only one test currently exhibits that pattern, and renaming it is the
deliverable.

## Acceptance (per #346 Phase D)

- [x] Audit run across both test trees
- [x] Each match classified Keep / Rename / Delete
- [x] Smelly cases renamed to positive form
- [x] Audit decision documented (in commit message + PR body + inline
      comment on the renamed test)

## Test plan

- [x] `pnpm vitest run src/lib/metrics.test.ts` — 11 passed
- [x] `pnpm check` (biome) clean

## Out of scope

- Phase E: `CONTRIBUTING.md` "Test fixtures" rule — separate PR

Refs #346
