### PR TITLE
[docs-only] docs(contributing): add Test fixtures section (#346 Phase E)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,27 @@ Every PR must pass these checks before merge:
 | Types | `mypy src/lizystudio/` | TypeScript strict via `pnpm build` |
 | Tests | `pytest` (80%+ coverage) | `vitest run --coverage` |
 
+## Test fixtures
+
+When adding a new transform, parser, or schema mapper, the **first test case
+must use a fixture captured from a real production run**, not hand-written
+synthetic data. Synthetic data verifies logic but cannot track shape
+evolution; PR #344 and Issue #345 both shipped to GUI because tests
+asserted against shapes that had drifted from what production wrote.
+
+- **Frontend** consumers: import from [`frontend/src/__fixtures__/lizyml/`](frontend/src/__fixtures__/lizyml/)
+- **Backend** consumers: read from [`tests/fixtures/lizyml/<scenario>/`](tests/fixtures/lizyml/)
+
+Re-capture is manual (GUI-driven) and required when `lizyml` minor/major
+bumps or when the API/Service layer changes how artifacts are written. The
+procedure is in [`tests/fixtures/lizyml/README.md`](tests/fixtures/lizyml/README.md).
+The manual GUI flow is intentional: a scripted re-capture would bypass
+the API/Service layer that determines what production users actually
+write to disk — exactly the layering this fixture set is meant to lock down.
+
+See Issue #346 for the rollout (4 fixture scenarios on lizyml 0.9.1,
+3-layer frontend lock, fit→load round-trip CI gate at P-0095).
+
 ## Change gate
 
 Changes to public APIs, data contracts, or architecture require a **Proposal** in


### PR DESCRIPTION
[docs-only]

## Summary

Phase E of #346: add a `Test fixtures` section to `CONTRIBUTING.md` so the
fixture-driven workflow established in #348 / #349 / #350 / #351 / #352 / #353
is discoverable from a single contributor-facing entry point.

The new section covers:
- Why fixtures (PR #344 + Issue #345 caused by synthetic-only test data)
- Where they live (frontend mirror + backend source-of-truth)
- When to re-capture (lizyml minor/major bump, or API/Service layer
  changes how artifacts are written)
- Why manual GUI capture is intentional (a scripted re-capture would
  bypass the very layers the fixture set is meant to lock down)
- Pointer to Issue #346 for the full rollout

## Issue #346 closure

This is the final phase of #346:

| Phase | PR | Status |
|---|---|---|
| A — fixture capture (4 scenarios) | #348 | ✅ |
| B 1/3 — pivot layer | #349 | ✅ |
| B 2/3 — hook layer | #350 | ✅ |
| B 3/3 — component layer | #351 | ✅ |
| C — fit→load round-trip CI gate (P-0095) | #352 | ✅ |
| D — negative-invariant audit | #353 | ✅ |
| **E — CONTRIBUTING.md** | this PR | ⏳ |

## Test plan

- [x] `git diff` reviewed; section reads cleanly in GitHub markdown preview
- [x] All inline links resolve to repo paths (verified manually)
- [x] No backend / frontend code changes — pure docs

## CI cost

This is a docs-only PR (per
[git-workflow.md docs-only rules](https://github.com/nbx-liz/LizyStudio/blob/develop/CONTRIBUTING.md)).
The full CI matrix runs by default but should be unaffected because no
source files changed.

Closes #346
