### PR TITLE
fix(inference): map unknown plot type to 404 not 500 (#355)

### DIFF
--- a/frontend/src/api/queries/queries.phase2.test.ts
+++ b/frontend/src/api/queries/queries.phase2.test.ts
@@ -171,6 +171,30 @@ describe("useInferenceShap", () => {
       expect(fetchInferenceShapPlot).toHaveBeenCalledWith("inf1", "j1"),
     );
   });
+
+  it("does not fetch when enabled is false (Issue #355)", async () => {
+    // Pre-fix the SHAP query fired unconditionally on every render and
+    // the backend returned 500 for unsupported plot types. The fix
+    // requires the caller to gate the query on the backend's
+    // ``available_plots`` so we never request a plot the backend
+    // cannot render.
+    const { wrapper } = makeWrapper();
+    renderHook(() => useInferenceShap("inf1", "j1", { enabled: false }), {
+      wrapper,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fetchInferenceShapPlot).not.toHaveBeenCalled();
+  });
+
+  it("fires when enabled is explicitly true", async () => {
+    const { wrapper } = makeWrapper();
+    renderHook(() => useInferenceShap("inf1", "j1", { enabled: true }), {
+      wrapper,
+    });
+    await waitFor(() =>
+      expect(fetchInferenceShapPlot).toHaveBeenCalledWith("inf1", "j1"),
+    );
+  });
 });
 
 describe("useInferenceComparison", () => {

--- a/frontend/src/api/queries/useInference.ts
+++ b/frontend/src/api/queries/useInference.ts
@@ -85,19 +85,27 @@ export function useInferencePlot(
   });
 }
 
-/** SHAP summary plot. Pass ``retry: false`` when the caller treats
- * a missing plot as "no SHAP for this job" instead of a transient
- * error (the pre-refactor default at every call site).
+/** SHAP summary plot.
+ *
+ * Issue #355: callers MUST pass ``enabled: false`` when the backend
+ * does not advertise SHAP in its available-plots list, otherwise the
+ * unconditional fetch produces a 500/404 in the browser console on
+ * every Inference run. ``enabled`` defaults to ``true`` for callers
+ * that already know the plot is supported.
+ *
+ * ``retry: false`` remains the recommended setting: a missing SHAP
+ * plot is "no SHAP for this job", not a transient failure.
  */
 export function useInferenceShap(
   infId: string,
   jobId: string,
-  options?: { retry?: boolean },
+  options?: { retry?: boolean; enabled?: boolean },
 ) {
   return useQuery({
     queryKey: queryKeys.infShap(infId, jobId),
     queryFn: () => fetchInferenceShapPlot(infId, jobId),
     retry: options?.retry,
+    enabled: options?.enabled,
   });
 }
 

--- a/frontend/src/components/inference/ResultsPredOnly.test.tsx
+++ b/frontend/src/components/inference/ResultsPredOnly.test.tsx
@@ -11,6 +11,13 @@ vi.mock("@/api/inference", () => ({
   fetchInferenceShapPlot: vi.fn().mockResolvedValue(null),
 }));
 
+// Issue #355: SHAP fetch is gated on the available_plots returned by
+// /api/jobs/{id}/plots. The mock defaults to "no SHAP available" so
+// the gate stays closed; SHAP-positive tests opt in below.
+vi.mock("@/api/jobs", () => ({
+  fetchJobPlots: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("./PredictionsTable", () => ({
   PredictionsTable: ({ infId, jobId }: { infId: string; jobId: string }) => (
     <div data-testid="predictions-table">
@@ -31,6 +38,7 @@ import {
   fetchInferenceShapPlot,
   type InferenceRecord,
 } from "@/api/inference";
+import { fetchJobPlots } from "@/api/jobs";
 import { ResultsPredOnly } from "./ResultsPredOnly";
 
 function makeRecord(overrides: Partial<InferenceRecord> = {}): InferenceRecord {
@@ -61,6 +69,7 @@ beforeEach(() => {
     current: {},
     other: {},
   });
+  vi.mocked(fetchJobPlots).mockResolvedValue([]);
 });
 
 describe("ResultsPredOnly", () => {
@@ -333,6 +342,7 @@ describe("ResultsPredOnly", () => {
   // --- ShapAndWarningsAccordion coverage (lines 199-250) ---
 
   it("renders SHAP Summary accordion when shap data is available", async () => {
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["shap-summary"]);
     vi.mocked(fetchInferenceShapPlot).mockResolvedValueOnce({
       plotly_json: '{"data":[]}',
     });
@@ -353,6 +363,7 @@ describe("ResultsPredOnly", () => {
   });
 
   it("renders SHAP Summary accordion trigger while loading", async () => {
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["shap-summary"]);
     // Use a never-resolving promise to hold the loading state
     vi.mocked(fetchInferenceShapPlot).mockReturnValueOnce(
       new Promise(() => {}),
@@ -375,6 +386,7 @@ describe("ResultsPredOnly", () => {
   });
 
   it("renders both SHAP Summary and Warnings accordions together", async () => {
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["shap-summary"]);
     vi.mocked(fetchInferenceShapPlot).mockResolvedValueOnce({
       plotly_json: '{"data":[]}',
     });

--- a/frontend/src/components/inference/ResultsPredOnly.tsx
+++ b/frontend/src/components/inference/ResultsPredOnly.tsx
@@ -4,6 +4,7 @@ import {
   useInferenceComparison,
   useInferencePlot,
   useInferenceShap,
+  useJobPlots,
 } from "@/api/queries";
 import {
   Accordion,
@@ -206,10 +207,15 @@ function ShapAndWarningsAccordion({
   jobId: string;
   warnings: string[];
 }) {
+  // Issue #355: gate SHAP fetch on the backend's available_plots so
+  // we never request a plot the backend cannot render (which would
+  // log a 404 in the browser console on every Inference run).
+  const { data: availablePlots } = useJobPlots(jobId);
+  const shapAvailable = availablePlots?.includes("shap-summary") ?? false;
   const { data: shapData, isLoading: shapLoading } = useInferenceShap(
     infId,
     jobId,
-    { retry: false },
+    { retry: false, enabled: shapAvailable },
   );
 
   const hasShap = shapData != null || shapLoading;

--- a/frontend/src/components/inference/ResultsWithGT.test.tsx
+++ b/frontend/src/components/inference/ResultsWithGT.test.tsx
@@ -369,6 +369,9 @@ describe("ResultsWithGT", () => {
 
   // Lines 191-214: ShapAccordionItem renders when shap data is available
   it("renders SHAP Summary accordion when shap data resolves", async () => {
+    // Issue #355: SHAP fetch is gated on available_plots; test must
+    // surface "shap-summary" through fetchJobPlots for the gate to open.
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["shap-summary"]);
     vi.mocked(fetchInferenceShapPlot).mockResolvedValueOnce({
       plotly_json: '{"data":[]}',
     } as never);
@@ -410,6 +413,8 @@ describe("ResultsWithGT", () => {
 
   // Lines 204-206: ShapAccordionItem shows loading text while fetching
   it("renders SHAP Summary loading state while shap is pending", async () => {
+    // Issue #355: gate must be open for the SHAP fetch to fire.
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["shap-summary"]);
     let resolveShap: (v: unknown) => void;
     const pendingShap = new Promise((res) => {
       resolveShap = res;

--- a/frontend/src/components/inference/ResultsWithGT.tsx
+++ b/frontend/src/components/inference/ResultsWithGT.tsx
@@ -182,9 +182,20 @@ function PredDistributionPlot({
   return <PlotlyChart plotlyJson={data.plotly_json} />;
 }
 
-/** SHAP summary accordion item — renders only when SHAP data is available. */
+/** SHAP summary accordion item — renders only when SHAP data is available.
+ *
+ * Issue #355: gate the SHAP fetch on the backend's ``available_plots``
+ * so we never request ``shap-summary`` from a backend that does not
+ * advertise it. Without this gate the lizyml backend returns 404 on
+ * every Inference run, polluting the browser console.
+ */
 function ShapAccordionItem({ infId, jobId }: { infId: string; jobId: string }) {
-  const { data, isLoading } = useInferenceShap(infId, jobId, { retry: false });
+  const { data: availablePlots } = useJobPlots(jobId);
+  const shapAvailable = availablePlots?.includes("shap-summary") ?? false;
+  const { data, isLoading } = useInferenceShap(infId, jobId, {
+    retry: false,
+    enabled: shapAvailable,
+  });
 
   if (!data && !isLoading) return null;
 

--- a/src/lizystudio/api/errors.py
+++ b/src/lizystudio/api/errors.py
@@ -126,6 +126,26 @@ class InferenceNotFoundError(StudioError):
         super().__init__("INFERENCE_NOT_FOUND", f"Inference not found: {inf_id}", 404)
 
 
+class PlotNotAvailableError(StudioError):
+    """HTTP 404 envelope for an unsupported plot type (Issue #355).
+
+    Translated from
+    :class:`lizystudio.backends.exceptions.PlotNotAvailableError` by
+    the inference and jobs plot endpoints. The structured ``details``
+    payload lets the client recover (e.g. fall back to a different
+    plot, or hide the accordion) instead of treating this like a
+    real backend failure.
+    """
+
+    def __init__(self, plot_type: str, available: list[str]) -> None:
+        super().__init__(
+            "PLOT_NOT_AVAILABLE",
+            f"Plot type {plot_type!r} is not available (available: {available})",
+            404,
+            details={"plot_type": plot_type, "available": list(available)},
+        )
+
+
 class ConfigBuildError(StudioError):
     """Config assembly failed (e.g. missing required fields) (H-0041)."""
 

--- a/src/lizystudio/api/inference.py
+++ b/src/lizystudio/api/inference.py
@@ -24,6 +24,7 @@ from lizystudio.api.errors import (
     JobNotCompletedError,
     JobNotFoundError,
     PathNotFoundError,
+    PlotNotAvailableError,
 )
 from lizystudio.api.models import (
     ComparisonStatsResponse,
@@ -33,6 +34,9 @@ from lizystudio.api.models import (
     InferenceUploadResponse,
     PlotResponseModel,
     PredictionsResponse,
+)
+from lizystudio.backends.exceptions import (
+    PlotNotAvailableError as _BackendPlotNotAvailable,
 )
 from lizystudio.security import read_upload_checked, validate_path_within
 from lizystudio.services.inference import (
@@ -221,6 +225,10 @@ def inference_plot(
     try:
         plot_data = get_inference_plot(job, ws.backend, plot_type)
         return {"plotly_json": plot_data.plotly_json}
+    except _BackendPlotNotAvailable as exc:
+        # Issue #355: 404 (client asked for an unsupported plot)
+        # rather than 500 (genuine backend failure).
+        raise PlotNotAvailableError(exc.plot_type, exc.available) from exc
     except Exception as exc:
         raise BackendError(exc) from exc
 

--- a/src/lizystudio/api/jobs.py
+++ b/src/lizystudio/api/jobs.py
@@ -21,6 +21,7 @@ from lizystudio.api.errors import (
     JobNotFoundError,
     JobRunningError,
     ParentHasActiveChildrenError,
+    PlotNotAvailableError,
     StudioError,
 )
 from lizystudio.api.models import (
@@ -32,6 +33,9 @@ from lizystudio.api.models import (
     JobLogResponse,
     JobSummaryResponse,
     PlotResponseModel,
+)
+from lizystudio.backends.exceptions import (
+    PlotNotAvailableError as _BackendPlotNotAvailable,
 )
 from lizystudio.services.export import export_code_as_zip, export_model, export_report
 from lizystudio.services.jobs import (
@@ -354,6 +358,10 @@ def get_job_plot_endpoint(
             job, ws.backend, job_store.model_cache, plot_type, **kwargs
         )
         return {"plotly_json": plot_data.plotly_json}
+    except _BackendPlotNotAvailable as exc:
+        # Issue #355: 404 (client asked for an unsupported plot)
+        # rather than 500 (genuine backend failure).
+        raise PlotNotAvailableError(exc.plot_type, exc.available) from exc
     except Exception as exc:
         raise BackendError(exc) from exc
 

--- a/src/lizystudio/backends/exceptions.py
+++ b/src/lizystudio/backends/exceptions.py
@@ -64,9 +64,35 @@ class IncompatibleFormatVersionError(Exception):
     """
 
 
+class PlotNotAvailableError(Exception):
+    """Raised when a plot type is not in the backend's dispatch table
+    (Issue #355).
+
+    The lizyml ``EvaluationMixin`` dispatch is a closed enumeration;
+    any request for a plot type the backend does not advertise is a
+    client-side mistake (or a frontend that has not yet been told the
+    backend's capabilities). The API layer translates this to HTTP
+    404 with code ``PLOT_NOT_AVAILABLE``, so the caller can recover
+    gracefully without seeing a server-error envelope.
+
+    Pre-fix the backend raised a bare ``ValueError`` here, which the
+    API funnelled through ``except Exception: raise BackendError`` and
+    emitted as a 500 — that hid every Inference run's SHAP fan-out
+    behind a scary console error during the v0.3.0 release rehearsal.
+    """
+
+    def __init__(self, plot_type: str, available: list[str]) -> None:
+        super().__init__(
+            f"Plot type {plot_type!r} is not available (available: {available})"
+        )
+        self.plot_type = plot_type
+        self.available = available
+
+
 __all__ = [
     "CancelledError",
     "CheckpointIncompatibleError",
     "CheckpointPreflightError",
     "IncompatibleFormatVersionError",
+    "PlotNotAvailableError",
 ]

--- a/src/lizystudio/backends/lizyml/evaluation_mixin.py
+++ b/src/lizystudio/backends/lizyml/evaluation_mixin.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pandas as pd
 
+from lizystudio.backends.exceptions import PlotNotAvailableError
 from lizystudio.backends.types import PlotData, PredictionSummary
 
 logger = logging.getLogger(__name__)
@@ -94,8 +95,10 @@ class EvaluationMixin:
     def plot(self, model: Any, plot_type: str, **kwargs: Any) -> PlotData:
         method_name = self._PLOT_DISPATCH.get(plot_type)
         if method_name is None:
-            msg = f"Unknown plot type: {plot_type!r}"
-            raise ValueError(msg)
+            # Issue #355: typed error so the API layer can map this to
+            # HTTP 404 (client asked for an unsupported plot) instead
+            # of letting a bare ValueError bubble up as a 500.
+            raise PlotNotAvailableError(plot_type, list(self._PLOT_DISPATCH))
         call_kwargs: dict[str, Any] = {}
         if plot_type == "learning-curve" and "metrics" in kwargs:
             call_kwargs["metrics"] = kwargs["metrics"]

--- a/tests/regression/test_reg_0355_inference_unknown_plot_404.py
+++ b/tests/regression/test_reg_0355_inference_unknown_plot_404.py
@@ -1,0 +1,253 @@
+"""Regression test for Issue #355: ``/plot/shap-summary`` returned 500.
+
+Before the fix, requesting an unknown plot type from either the
+inference or jobs plot endpoint funnelled the backend's bare
+``ValueError("Unknown plot type: ...")`` through the catch-all
+``except Exception: raise BackendError`` block, producing a 500
+response with code ``BACKEND_ERROR``.
+
+That hid a 4xx-shaped condition (the *client* asked for a plot the
+backend doesn't render) behind a 5xx envelope, which scared new users
+during the v0.3.0 PyPI release rehearsal: every Inference run logged
+a 500 in the browser DevTools console even though the SHAP accordion
+silently hid itself.
+
+The fix introduces a typed
+``lizystudio.backends.exceptions.PlotNotAvailableError`` that the
+lizyml ``EvaluationMixin`` raises when the plot type is not in
+``_PLOT_DISPATCH``. The API layer translates it to a 404 response
+with the structured code ``PLOT_NOT_AVAILABLE`` and a body that lists
+the supported plot types so the client can recover gracefully.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from lizystudio.backends.exceptions import PlotNotAvailableError
+from lizystudio.backends.lizyml.evaluation_mixin import EvaluationMixin
+from lizystudio.backends.types import DataRef, FitSummary
+from lizystudio.services.inference import InferenceRecord, InferenceStore
+from lizystudio.services.jobs import JobStore
+
+pytestmark = pytest.mark.integration
+
+
+# --- Unit-level: backend raises typed error, not bare ValueError ---
+
+
+def test_evaluation_mixin_unknown_plot_raises_typed_error() -> None:
+    """Unknown plot types raise PlotNotAvailableError (not bare ValueError).
+
+    ``ValueError`` is too coarse — the API layer cannot distinguish
+    "client asked for an unsupported plot" from "the underlying
+    plot-generating code blew up". A typed exception lets the API map
+    the former to 404 while leaving genuine backend failures as 500.
+    """
+    mixin = EvaluationMixin()
+    fake_model = MagicMock()
+
+    with pytest.raises(PlotNotAvailableError) as exc_info:
+        mixin.plot(fake_model, "shap-summary")
+
+    err = exc_info.value
+    assert err.plot_type == "shap-summary"
+    assert isinstance(err.available, list)
+    assert "learning-curve" in err.available  # known supported plot
+    # Bare ValueError must NOT be raised — that was the old behaviour
+    assert not isinstance(err, ValueError) or isinstance(err, PlotNotAvailableError)
+
+
+def test_evaluation_mixin_known_plot_does_not_raise() -> None:
+    """Sanity check: a plot type that IS in the dispatch must still
+    look up the method and call it on the model — no early raise.
+    """
+    mixin = EvaluationMixin()
+    fake_model = MagicMock()
+    fake_model.plot_learning_curve.return_value.to_json.return_value = "{}"
+
+    # Should not raise PlotNotAvailableError for a supported type
+    result = mixin.plot(fake_model, "learning-curve")
+    assert result.plotly_json == "{}"
+
+
+# --- API-level: shared fixtures (mirrored from tests/test_inference_api.py) ---
+
+
+@pytest.fixture()
+def sample_data_ref() -> DataRef:
+    return DataRef(
+        source_type="path",
+        path="/data/test.csv",
+        filename="test.csv",
+        fingerprint="abc",
+        shape=(100, 5),
+    )
+
+
+def _create_inference_setup(
+    client: TestClient,
+    sample_data_ref: DataRef,
+) -> tuple[str, str]:
+    """Create a completed job and a mock inference record."""
+    app = client.app  # type: ignore[union-attr]
+    job_store: JobStore = app.state.job_store
+
+    job = job_store.create(
+        backend_name="lizyml",
+        config={
+            "task": "binary",
+            "data": {"target": "y"},
+            "model": {"name": "lightgbm"},
+        },
+        data_ref=sample_data_ref,
+        job_type="fit",
+    )
+    job.status = "completed"
+    job.fit_result = FitSummary(
+        metrics={"raw": {"oof": {"auc": 0.9}, "if_mean": {"auc": 0.95}}},
+        fold_count=5,
+        params=[],
+    )
+    job.model_path = "/fake/model/path"
+    job_store.update(job)
+
+    inf_store = InferenceStore(job_store.jobs_dir)
+    pred_df = pd.DataFrame(
+        {
+            "idx": range(10),
+            "pred": [0.1] * 5 + [0.9] * 5,
+            "proba": [0.1] * 5 + [0.9] * 5,
+        }
+    )
+    record = InferenceRecord(
+        inf_id="inf_test355",
+        job_id=job.job_id,
+        data_ref=sample_data_ref,
+        has_ground_truth=False,
+        created_at="2026-05-03T00:00:00Z",
+        row_count=10,
+        warnings=[],
+    )
+    inf_store.save(record, pred_df)
+
+    return job.job_id, record.inf_id
+
+
+def _patch_backend_to_raise(
+    client: TestClient, plot_type: str, available: list[str]
+) -> object:
+    """Swap the workspace backend with a mock that raises
+    PlotNotAvailableError when plot() is called."""
+    app = client.app  # type: ignore[union-attr]
+    mock_backend = MagicMock()
+    mock_backend.load_model.return_value = MagicMock()
+    mock_backend.plot.side_effect = PlotNotAvailableError(plot_type, available)
+    original = app.state.workspace.backend
+    app.state.workspace.backend = mock_backend
+    return original
+
+
+# --- API: inference plot endpoint ---
+
+
+def test_inference_unknown_plot_returns_404_not_500(
+    client: TestClient, sample_data_ref: DataRef
+) -> None:
+    """``GET /api/inference/{id}/plot/shap-summary`` must return 404.
+
+    Pre-fix this returned 500 with code ``BACKEND_ERROR`` because the
+    bare ``ValueError`` from the backend was caught by ``except
+    Exception``. The fix maps the typed
+    :class:`PlotNotAvailableError` to a 404 with code
+    ``PLOT_NOT_AVAILABLE``.
+    """
+    job_id, inf_id = _create_inference_setup(client, sample_data_ref)
+    available = ["learning-curve", "roc-curve", "importance"]
+    original = _patch_backend_to_raise(client, "shap-summary", available)
+    try:
+        res = client.get(f"/api/inference/{inf_id}/plot/shap-summary?job_id={job_id}")
+    finally:
+        client.app.state.workspace.backend = original  # type: ignore[union-attr]
+
+    assert res.status_code == 404, (
+        f"expected 404 for unknown plot type, got {res.status_code}: {res.text}"
+    )
+    body = res.json()
+    assert body["error"]["code"] == "PLOT_NOT_AVAILABLE"
+    # Body must surface the supported plots so the client can recover
+    assert "available" in body["error"]["details"]
+    assert "learning-curve" in body["error"]["details"]["available"]
+
+
+def test_inference_unknown_plot_response_lists_plot_type(
+    client: TestClient, sample_data_ref: DataRef
+) -> None:
+    """The 404 response must include the requested plot type so logs
+    are actionable when many endpoints fan out simultaneously.
+    """
+    job_id, inf_id = _create_inference_setup(client, sample_data_ref)
+    original = _patch_backend_to_raise(client, "shap-summary", ["learning-curve"])
+    try:
+        res = client.get(f"/api/inference/{inf_id}/plot/shap-summary?job_id={job_id}")
+    finally:
+        client.app.state.workspace.backend = original  # type: ignore[union-attr]
+
+    body = res.json()
+    assert body["error"]["details"]["plot_type"] == "shap-summary"
+
+
+def test_inference_runtime_error_still_returns_500(
+    client: TestClient, sample_data_ref: DataRef
+) -> None:
+    """Genuine backend failures (RuntimeError mid-plot) must still
+    return 500 with ``BACKEND_ERROR`` — the new 404 path is reserved
+    for "this plot type isn't available", not "rendering blew up".
+
+    Otherwise we'd silently downgrade real errors to 4xx and lose the
+    on-call signal.
+    """
+    job_id, inf_id = _create_inference_setup(client, sample_data_ref)
+    app = client.app  # type: ignore[union-attr]
+    mock_backend = MagicMock()
+    mock_backend.load_model.return_value = MagicMock()
+    mock_backend.plot.side_effect = RuntimeError("kaboom")
+    original = app.state.workspace.backend
+    app.state.workspace.backend = mock_backend
+    try:
+        res = client.get(f"/api/inference/{inf_id}/plot/roc-curve?job_id={job_id}")
+    finally:
+        app.state.workspace.backend = original
+
+    assert res.status_code == 500
+    assert res.json()["error"]["code"] == "BACKEND_ERROR"
+
+
+# --- API: jobs plot endpoint (same dispatch, same fix) ---
+
+
+def test_jobs_unknown_plot_returns_404_not_500(
+    client: TestClient, sample_data_ref: DataRef
+) -> None:
+    """``GET /api/jobs/{id}/plot/shap-summary`` must return 404 too.
+
+    The jobs plot endpoint shares the same ``backend.plot()``
+    dispatch and the same bare ``except Exception`` block, so the
+    same fix must apply on both routes.
+    """
+    job_id, _ = _create_inference_setup(client, sample_data_ref)
+    original = _patch_backend_to_raise(
+        client, "shap-summary", ["learning-curve", "roc-curve"]
+    )
+    try:
+        res = client.get(f"/api/jobs/{job_id}/plot/shap-summary")
+    finally:
+        client.app.state.workspace.backend = original  # type: ignore[union-attr]
+
+    assert res.status_code == 404
+    body = res.json()
+    assert body["error"]["code"] == "PLOT_NOT_AVAILABLE"

--- a/tests/test_backends_lizyml.py
+++ b/tests/test_backends_lizyml.py
@@ -1466,14 +1466,26 @@ def test_plot_known_type_returns_plot_data() -> None:
     assert result.plotly_json == '{"data": []}'
 
 
-def test_plot_unknown_type_raises_value_error() -> None:
-    """plot() raises ValueError for unrecognised plot type."""
+def test_plot_unknown_type_raises_plot_not_available() -> None:
+    """plot() raises PlotNotAvailableError for unrecognised plot type
+    so the API layer can map it to HTTP 404 (Issue #355).
+
+    Bare ``ValueError`` was too coarse — the API funneled it through
+    ``except Exception: raise BackendError`` and returned 500, hiding
+    a 4xx-shaped condition behind a server-error envelope.
+    """
     import pytest
+
+    from lizystudio.backends.exceptions import PlotNotAvailableError
 
     adapter = LizyMLAdapter()
     mock_model = MagicMock()
-    with pytest.raises(ValueError, match="Unknown plot type"):
+    with pytest.raises(PlotNotAvailableError) as exc_info:
         adapter.plot(mock_model, "nonexistent-plot")
+
+    err = exc_info.value
+    assert err.plot_type == "nonexistent-plot"
+    assert "learning-curve" in err.available  # known supported plot
 
 
 def test_plot_all_dispatch_keys() -> None:


### PR DESCRIPTION
## Summary

- Map "unknown plot type" from HTTP 500 → 404 by introducing a typed `PlotNotAvailableError` and translating it at the API boundary.
- Frontend gates the SHAP query on the parent job's `available_plots`, so we never request a plot the backend cannot render.

Closes #355.

## Why

Discovered during the v0.3.0 PyPI release-rehearsal GUI walkthrough (2026-05-03). Every Inference run produced a 500 in the browser DevTools console:

```
ValueError: Unknown plot type: 'shap-summary'
  src/lizystudio/backends/lizyml/evaluation_mixin.py:98
```

The React SHAP accordion was firing its query unconditionally — it gracefully hid itself when the response was empty, but the 500 still leaked into the console + server log. New users seeing repeated 500s during a smoke test would lose confidence; first impressions matter for the PyPI release.

## What changed

### Backend
- `backends/exceptions.py`: new `PlotNotAvailableError(plot_type, available)` typed exception
- `backends/lizyml/evaluation_mixin.py`: dispatch lookup raises the typed error instead of bare `ValueError`
- `api/errors.py`: new `PlotNotAvailableError(StudioError)` with status=404, code=`PLOT_NOT_AVAILABLE`, details=`{plot_type, available}`
- `api/inference.py` & `api/jobs.py`: catch the backend exception and re-raise the API exception. Genuine `RuntimeError` mid-render still falls through to the existing `BackendError` 500 path — on-call signal preserved.

### Frontend
- `useInferenceShap` accepts an optional `enabled` flag (default unchanged for callers that already know SHAP is supported).
- `ResultsWithGT.ShapAccordionItem` and `ResultsPredOnly.ShapAndWarningsAccordion` use `useJobPlots` to gate the SHAP fetch on `available_plots.includes("shap-summary")`.

## Invariants

- **INV-1**: Any plot type not in `EvaluationMixin._PLOT_DISPATCH` results in HTTP 404 with code `PLOT_NOT_AVAILABLE` — never 500. (asserted in regression test)
- **INV-2**: Genuine backend failures (RuntimeError mid-plot render) continue to produce HTTP 500 with code `BACKEND_ERROR`. The new 404 path does not subsume real errors. (asserted in regression test)
- **INV-3**: When the backend's `available_plots` does not include `"shap-summary"`, no request to `/plot/shap-summary` is fired by the frontend. (asserted in Vitest)

## Failure paths covered

- [x] Unknown plot type → 404 (typed error path)
- [x] Real backend failure (RuntimeError) → 500 (preserves on-call signal)
- [x] Frontend gate closed → no fetch fires
- [x] Frontend gate open → fetch fires + renders accordion

## Test plan

- [x] `uv run pytest tests/regression/test_reg_0355_inference_unknown_plot_404.py` — 6/6 passed
- [x] `uv run pytest tests/test_backends_lizyml.py tests/test_inference_api.py tests/test_jobs_api.py` — all green (renamed legacy test that asserted bare `ValueError`)
- [x] `uv run pytest -q` — 1252 passed, 7 skipped (full suite)
- [x] `uv run mypy src/lizystudio/` — Success: 54 source files
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `pnpm vitest run` — 1774 tests passed, 119/119 files
- [x] `pnpm check` — biome clean
- [ ] Manual smoke: rerun the v0.3.0 release-rehearsal walkthrough and confirm no 500 in DevTools console after Inference run (will do post-merge during release prep)

## Notes

- This is the third item of the v0.3.0 PyPI release prep. Sdist tightening (5 MB → 1.8 MB) and `.gitignore` for `.benchmarks/` are still un-committed locally and will land in a separate `chore(release)` PR with the architecture/release-readiness docs.
- The intentional contract change (`ValueError` → `PlotNotAvailableError`) is documented in the renamed test and the new exception's docstring, not hidden.
