### PR TITLE
chore(planning): formalize business-use definition and v0.4 plan (P-0096)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2991,3 +2991,89 @@ PR #348/#349/#350/#351 (Phase A + B) で `fit_result.json` の shape regression 
 
 - 2026-05-03 **Proposed** — 実装 PR と同じ PR 内に Proposal commit を含めて起票。Acceptance criteria 全項目の verify ログを実装コミットメッセージ / PR description に記載予定
 
+### P-0096: 業務利用 (business-use) 定義の確定と v0.4 Exit Criteria への反映
+
+- **Date:** 2026-05-03 起票
+- **Related:** [`docs/business-use-definition.md`](docs/business-use-definition.md) v0.2 / [`docs/v0.4-business-readiness-plan.md`](docs/v0.4-business-readiness-plan.md) v0.1 / Issue #358 (BlockedGroup race) / Issue #359 (job-num drift) / Issue #360 (Tune resume) / Issue #361 (Wide DataFrame UI)
+
+#### Motivation
+
+v0.3 (PyPI MVP) のリリース準備中に、次の v0.4 を「業務利用可能」レベルにする計画提案を行ったが、**「業務利用」の中身が言語化されないまま** Phase 別の作業項目を提案してしまった。
+
+過剰スペック / 不足の両方向に振れるリスクがあったため、「誰が」「どこで」「どのデータで」「どんな期待で」使うかを **先に合意** することにした。`docs/business-use-definition.md` v0.2 をユーザ承認の上で確定させ、その内容を v0.4 計画 (Phase R-1〜R-5) と Exit Criteria に反映する。
+
+#### Purpose
+
+- 業務利用の定義 (利用シナリオ / データ規模 / 同時利用人数 / 機密度 / デプロイ / 失敗許容度 / KPI) を Tier 4 ドキュメントとして固定する
+- 確定された定義に基づき、v0.4 で必要十分な作業項目を Phase R-1〜R-5 に整理する
+- v0.4 Exit Criteria を測定可能な形で文書化する
+
+#### Impact
+
+**確定された業務利用定義** (詳細は `business-use-definition.md` v0.2):
+
+| 項目 | 確定内容 |
+|---|---|
+| 利用シナリオ | 単独データサイエンティストが個人 PC で繰り返し使う |
+| 同時利用人数 | **1 名** |
+| データ規模 (上限) | 1000万行 × 1万列 × 100GB |
+| データ規模 (典型) | 100万行未満 × 数百〜数千列 |
+| デプロイ | 個人PC / 社内 Linux サーバ / Docker / クラウド |
+| 機密度 | 社外秘 (ユーザ環境側で担保、LizyStudio は補助しない) |
+| 自動化 | インタラクティブのみ (scheduler / 通知 不要) |
+| 失敗許容度 | **24h Tune が中断されても resume できること** |
+| 互換性 | format_version 後方互換、Pickle は同 minor 版内のみ保証 |
+| 商用サポート | なし |
+| 顧客提供予定 | なし |
+| 業務利用 KPI | 問題なくモデル開発を行い、Export Code ができている |
+
+**v0.4 計画への反映** (詳細は `v0.4-business-readiness-plan.md` v0.1):
+
+- **Phase R-1 拡張**: 既存の slot release invariant 検証に加え、**Tune long-run resumability (24h+, all termination paths)** を必須化 (Issue #360)。state machine に `paused` 状態を追加 (本 Proposal で確定)
+- **Phase R-2 縮小**: 同時利用 1 名前提のため、マルチタブ衝突検出 / ETag 409 / 「他タブで変更されました」UI を **削除**。WS reconnect とリロード復元のみに集中
+- **Phase R-5 新設**: **Wide DataFrame UI (10k 列対応)** + Large CSV scaling (1GB SLO + 10GB / 100GB feasibility)。BYO RAM 戦略 (Issue #361)
+- **既存 Issue 取り込み**: #358 (BlockedGroup race), #359 (job-num drift) を v0.4 R-1 phase に統合
+- **Out of scope の明文化**: 監査ログ / 認証 / マルチユーザ並行制御 / DB connector / streaming inference / モバイル / SaaS は v0.4-v0.5 で扱わない
+
+**State machine 変更** (Change Gate 対象):
+
+- Tune ジョブに `paused` 状態を追加: `running` → `paused` (interruption) → `resuming` → `running`
+- 完了済 trial の永続化 / dedup 規則を新設 (`completed_trials` の単調増加保証)
+- `job_num` を不変 ID として API レベルで永続化 (Issue #359 の修正、frontend 計算を廃止)
+
+#### Compatibility
+
+- 既存の format_version 1 workspace は引き続き読める (P-0095 の round-trip CI gate で保証)
+- 既存ジョブの再現性: Tune resume 機構は新規ジョブのみに適用 (旧ジョブは現状の挙動を維持)
+- 既存 API 契約: `/api/jobs/` レスポンスに `job_num` フィールドを追加 (additive、既存 client は無視できる)
+- 業務利用定義 §15 で **PyTorch backend** と **LLM 統合** は将来余地として明記したが、v0.4-v0.5 では着手しない (BackendAdapter Protocol の互換性は維持)
+
+#### Alternatives considered
+
+- **(a) 業務利用定義を文書化せず、v0.4 計画を作業ベースで進める** — 拒否。スコープ判断に主観が入り、過剰スペック / 不足の両方向にぶれるリスクが大きい。実際、本 Proposal 起票前に提示した v0.4 計画はマルチユーザ前提で過剰だった
+- **(b) 業務利用定義のみ確定し、計画は別 Proposal で扱う** — 拒否。定義と計画は不可分 (KPI から逆算して Phase 構成が決まる)。1 つの Proposal で両方を Decision に乗せる方が透明性が高い
+- **(c) Tune resume を v0.5 に送る** — 拒否。`business-use-definition.md` §8 で「24h Tune が消えるのは業務利用 NG」と確定。これを v0.4 で満たさないと「業務利用可能」と言えない
+- **(d) Wide DataFrame を v0.5 に送る** — 拒否。10k 列で UI 破綻するなら業務利用が成立しない (KPI Q9 の「問題なくモデル開発を行える」を満たさない)
+
+→ 業務利用定義 + v0.4 計画 (R-1〜R-5) を 1 つの Decision として確定する
+
+#### Acceptance criteria（実装は v0.4 リリースまでに達成）
+
+- [ ] `docs/business-use-definition.md` v0.2 が確定状態でリポジトリに残り、 §0 Decision Sheet が真実
+- [ ] `docs/v0.4-business-readiness-plan.md` v0.1 が確定状態でリポジトリに残る
+- [ ] `PLAN.md` に v0.4-N セクションを追加し、Phase R-1〜R-5 を反映
+- [ ] `ROADMAP.md` Tier 2 INDEX に v0.4 計画と Issue #358-#361 を登録
+- [ ] Issue #358 / #359 / #360 / #361 が v0.4 milestone に紐付け
+- [ ] v0.4 リリース時点で Exit Criteria (`v0.4-business-readiness-plan.md` §7 の 9 項目) すべて GREEN
+
+#### Out of scope（follow-up Proposal）
+
+- **PyTorch backend Adapter** — lizyml 側で PyTorch サポートが提供された後に、別 Proposal で追加
+- **LLM 統合** — 要件 (fine-tune backend / 結果解釈 / feature extraction / AutoML 補助 / text data 処理) が明確化された段階で別 Proposal
+- **DB connector** — 業務シナリオでニーズが多くなった段階で v1.0 以降の Proposal
+- **商用サポート tier** — v1.0 リリース時に検討
+
+#### Decision
+
+- 2026-05-03 **Proposed** — `docs/business-use-definition.md` v0.2 と `docs/v0.4-business-readiness-plan.md` v0.1 をリポジトリに先行コミットし、本 Proposal を Change Gate として起票。**ユーザ承認済**。Phase R-1 から実装着手する
+

--- a/docs/business-use-definition.md
+++ b/docs/business-use-definition.md
@@ -1,0 +1,434 @@
+# 業務利用の定義 — v0.2 (CONFIRMED)
+
+> **Status**: ✅ **CONFIRMED v0.2** (ユーザ承認済み 2026-05-03)
+> **目的**: v0.4 / v0.5 の Exit Criteria を「業務利用可能」と定義するに先立ち、その中身をユーザと合意した結果を記録する。
+> **次のステップ**: 本ドキュメントを Tier 4 (アクティブな個別計画) として固定し、`HISTORY.md` に Proposal P-0096 として Change Gate を通す。確定事項は `PLAN.md` v0.4 / v0.5 セクションに反映する。
+> **改訂履歴**: §18 を参照。
+
+---
+
+## 0. 確定したサマリ (Decision Sheet)
+
+| 項目 | 確定内容 |
+|---|---|
+| 利用シナリオ | **A. 単独データサイエンティストが個人 PC で繰り返し使う** (Q1) |
+| 同時利用人数 | **1名** (§7, Q3) — マルチタブ衝突制御は不要 |
+| データ規模 (上限) | **1000万行 × 1万列 × 100GB** (Q2) |
+| データ規模 (典型) | **100万行未満 × 数百〜数千列** (§4) |
+| データ機密度 | **社外秘** (Q4) — ユーザ環境側で担保、LizyStudio は補助しない |
+| デプロイ | **個人PC / 社内Linuxサーバ / Docker / クラウド** (Q5) |
+| 自動化 | **インタラクティブのみ** (Q6) — scheduler/通知は範囲外 |
+| 失敗許容度 | **長時間 Tune (24h) でも resume できること** (§8, 確認C) |
+| 互換性 | format_version 後方互換、Pickle は同 minor 版内のみ保証 (§12) |
+| 商用サポート | **なし** (Q7) |
+| 顧客提供予定 | **なし** (Q8) |
+| 業務利用 KPI | **問題なくモデル開発を行い、Export Code ができている** (Q9) |
+
+---
+
+## 1. プロジェクトの位置づけ
+
+### 確定内容
+LizyStudio は **「ML 実務者の作業を1段階速くする内製ツール」** である。SaaS でも顧客向けプロダクトでもない。**作業者が自分用のサーバーを立ち上げて、自分のために使う**形態を想定する。
+
+### 含意
+- マルチテナント設計は v1.0 まで不要
+- 課金・利用量計測は範囲外
+- ホストする責任は配布元ではなくユーザ側
+
+---
+
+## 2. ユーザペルソナ
+
+### 確定内容
+**Primary persona**: データサイエンティスト / ML エンジニア。**経験年数1年程度の初学者も含む**が、ライブラリのパラメータは**自分で調査して理解する前提**。
+
+**フォローしないもの**:
+- 完全な ML 初心者向けのチュートリアル機能
+- 「ドラッグ&ドロップで誰でも使える」UX
+
+### 含意
+- 操作のヒント・チュートリアルは「ML を一通りやった人」向けで十分
+- エラーメッセージは技術用語 OK (`Pydantic ValidationError` 等を見せて良い)
+- 「業務担当者用の簡易ビュー」は範囲外
+
+---
+
+## 3. デプロイ形態
+
+### 確定内容
+**主たる形態**:
+1. **個人 PC**: `pip install lizystudio` してローカル起動
+2. **社内共有 Linux サーバ**: 部署のサーバに 1 インスタンス、自分専用に使う
+3. **Docker** (v0.5 提供): 同じ image を個人/社内/クラウドで使い回す
+4. **クラウド** (AWS/GCP/Azure): VM に直接インストール、または Docker で動かす
+
+**範囲外**:
+- マネージド SaaS (lizystudio.com みたいなホスティング)
+- Kubernetes での水平スケール (single-pod のみ)
+- サーバレス
+
+### 含意
+- v0.5 で Docker 公式イメージを GitHub Container Registry に publish
+- HTTPS / 認証は配置側の責任 (リバースプロキシ前段で対応想定)
+- バックアップは workspace ディレクトリ単位の tar で十分
+
+---
+
+## 4. データの性質
+
+### 確定内容
+- **データの出所**: 社内データ (販売実績・顧客属性・製造ログ・センサー時系列等)
+- **機密性**: 社外秘・営業秘密を含み得る (詳細は §10)
+- **規模**:
+  - **典型**: 100万行未満 × 数百〜数千列
+  - **上限**: 1000万行 × 1万列 × 100GB (Q2)
+- **形式**: ローカルファイル (CSV / Parquet) 中心
+- **DB 接続**: 想定なし (将来ニーズが多くなれば検討)
+- **頻度**: 静的データの分析が中心、streaming は範囲外
+
+### スケーリング戦略 — Bring Your Own RAM (BYO RAM)
+
+LizyStudio はチャンク読み・サンプリング・out-of-core 学習などの**複雑な仕掛けは実装しない**。データ規模に応じて**マシンスペックを増強する**前提で運用する。
+
+| データ規模 | 推奨 RAM | 推奨ストレージ | 想定 SLO |
+|---|---|---|---|
+| 〜 100MB | 8 GB | SSD | 全機能サクサク |
+| 〜 1 GB | 16 GB | SSD | Fit 5 分以内 |
+| 〜 10 GB | 64 GB | NVMe SSD | Fit 30 分以内 |
+| 〜 100 GB | 200 GB+ | NVMe SSD | Fit 数時間、I/O 律速可 |
+
+### 含意
+- v0.4 は **1 GB データを 16 GB RAM で完走** を SLO 基準点に置く
+- 100 GB は best-effort ではなく **「適切なハードウェアで完走する」** を保証 (高 RAM サーバを前提)
+- v0.5 で `docs/hardware-sizing.md` を整備
+- DB connector 系は **v1.0 以降の検討事項**
+- セキュリティ要件は「社内ネットワーク内」を前提、ゼロトラスト前提ではない
+
+---
+
+## 5. ワークフローの性質
+
+### 確定内容
+**典型的な使い方**:
+
+```
+朝、データを更新
+  ↓
+Workspace でデータをロード、target を決める
+  ↓
+Fit を 5〜10回回しながらパラメータ調整
+  ↓
+Tune で 30〜100 trial 回す (10〜30分、長時間なら数時間〜1日)
+  ↓
+良い結果を Inference に乗せて検証
+  ↓
+Export Code で Python スクリプト化、別環境で運用
+```
+
+**期間感**:
+- 1モデルの調整: 1日 〜 2週間
+- 完成したモデルの運用: 数ヶ月 〜 1年
+- LizyStudio はモデル**作成期間中**のメインツール、運用フェーズでは Export Code 後の Python スクリプトが主役
+
+### 含意
+- 「Fit を 1日 50 回」が捌ける UX (履歴管理、比較、削除しやすさ)
+- 「2週間前の Fit を見返せる」永続性
+- 「1モデルが本番運用でずっと使われる」前提なので、 Pickle 互換切れは超 重大インシデント
+
+---
+
+## 6. 自動化の範囲
+
+### 確定内容
+**LizyStudio の責務**: モデルの検証と、モデルを再現できるスクリプト (Export Code) の生成まで。
+**それ以降**: ユーザ側で別システムに組み込む。
+
+**含む**:
+- API 経由で別スクリプトから fit を kick (現状もそう)
+- Export Code で生成した Python を CI / cron で自動実行
+- 推論バッチを REST API 経由で呼ぶ
+
+**含まない**:
+- LizyStudio 自身が cron で fit を回す機能 (= scheduler 内蔵)
+- 完了通知 (Slack / Email)
+- パイプライン定義 (DAG, Airflow 連携)
+
+### 含意
+- v0.4-0.5 で「自動化フレンドリーな API」(idempotent, well-documented) は提供
+- スケジューラ・通知系は v1.0 以降に検討
+- ETL パイプライン連携は範囲外
+
+---
+
+## 7. 並行性 (Concurrency)
+
+### 確定内容
+**1 サーバインスタンスに対して**:
+- 同時アクセスユーザ: **1名**
+- 1 ユーザあたりタブ数: 1〜2 (Workspace + Jobs を同時に開く程度)
+- 同時実行 fit/tune: **1 並列で十分** (subprocess 1スロット)、複数並列は不要 (計算機スペック制約)
+
+**保証する不変量**:
+- 同一ユーザの複数タブで状態が破綻しないこと
+- 後勝ち書き込みを許容 (衝突検出は不要)
+
+### 含意 (前バージョンから縮小)
+- ✅ 同一ユーザの複数タブ整合性は維持
+- ❌ 「他タブが workspace を変更しました」UI は **v0.4 から削除** (1名利用なので発生しない)
+- ❌ ETag/version による衝突検出は **v0.4 から削除**
+- ❌ ジョブキュー (queue 1〜N) は **不要**
+- 範囲外: SSE 多人数同時編集、CRDT、リアルタイム協調
+
+---
+
+## 8. 失敗許容度 (Resilience SLO)
+
+### 確定内容
+
+| 失敗カテゴリ | 許容度 | 業務影響 |
+|---|---|---|
+| データ消失 (workspace の data + config) | **絶対 NG** | 30 分の作業が消えれば信頼を失う |
+| 完了ジョブの artefact 消失 | **絶対 NG** | 過去のモデルで再現できなくなる |
+| **進行中ジョブのクラッシュ (短時間 Fit)** | **ギリギリ許容** (リトライできれば) | リトライできれば事故ではない |
+| **進行中ジョブのクラッシュ (長時間 Tune, 数時間〜1日)** | **NG** | 1 日の作業が消えるのは業務的に許容できない |
+| 起動失敗 | NG | ユーザは server 管理者ではない |
+| エラー発生 | OK (ただし復旧経路が見えること) | 復旧できれば事故ではない |
+| 平日業務時間内 10分超ダウン | NG | 仕事が止まる |
+| 平日業務時間外ダウン | 許容 | 翌朝起きていれば良い |
+
+### v0.4 Exit Criteria への昇格
+
+長時間 Tune の resume を **v0.4 必須項目** とする (確認C 合意):
+
+- 任意の終了経路 (SIGKILL / WS切断 / サーバ再起動 / ブラウザ閉じる) で Tune が **resume 可能**
+- 完了済 trial は再実行しない
+- 24時間 Tune が中断されても、resume で次の trial から続行できる
+
+### 含意
+- v0.4 R-1 phase: slot release invariant の網羅検証は維持
+- v0.4 R-1 phase: **Tune long-run resumability を必須化** (新規)
+- v0.4 R-2 phase: WS reconnect は必須 (= 業務時間中のネット瞬断で作業ロストはNG)
+- v0.5 で 30日連続稼働テスト・99.5% 稼働率を Exit Criteria に置く
+
+---
+
+## 9. データ保持・永続性
+
+### 確定内容
+- workspace 単位の data + config + jobs 全てがローカル file system に永続化
+- ジョブ削除はユーザ明示操作のみ (auto-prune は無し)
+- 過去ジョブは **無限に残る前提** (ユーザの自発的管理に任せる)
+- バックアップ: ユーザ自身が `~/.lizystudio/` を tar で取る前提 (v0.5 で公式 CLI 提供)
+
+### 含意
+- v0.4 で diagnostic export endpoint を提供 (個別 job の調査用)
+- v0.5 で公式 backup / restore CLI を提供
+- v1.0 でも auto-archive は **不要** (ユーザ管理に任せる)
+
+---
+
+## 10. セキュリティ要件
+
+### 確定内容
+**Threat model**:
+- **In-scope**: 同一ネットワーク内の意図しない誤操作・誤上書きの防止
+- **In-scope**: 依存ライブラリの CVE 監視 (dependabot / pip-audit)
+- **In-scope**: pickle 経路の path traversal / 悪意ある artefact 読み込み防止 (#67 で着手済)
+- **Out of scope**: 認証 / 認可 (前段リバースプロキシで対応想定)
+- **Out of scope**: 通信暗号化 (HTTPS は配置側の責任)
+- **Out of scope**: 監査ログ (誰がいつ何をしたか)
+
+**機密データ取扱い**:
+- 機密度の高いデータを扱うことがあり得るが、それらの**保護はユーザ環境側で担保**する
+- LizyStudio は **セキュアな環境内での実行を推奨**するが、自身では機密保護機能を提供しない
+
+### 含意
+- v0.4 P-2 で pickle hardening + path traversal 完全監査
+- v0.4 で `pip-audit` / dependabot を CI gate
+- 監査ログ・認証層・暗号化通信は **正式に Out of scope**
+- v1.0 でも実装予定なし (ユーザ環境側で対応)
+
+---
+
+## 11. パフォーマンス SLO (確定)
+
+| 操作 | p95 ターゲット | 根拠 |
+|---|---|---|
+| `GET /api/jobs/` (履歴 100件) | < 200 ms | UI 体感が悪化する閾値 |
+| `GET /api/workspace/config` | < 100 ms | 1クリックで複数回叩かれる |
+| `PUT /api/workspace/config` | < 300 ms | 連続編集時の応答性 |
+| `POST /api/workspace/fit` (起動だけ) | < 500 ms | ジョブ受付の即応性 |
+| Fit 完了 (1GB CSV, 100k 行 × 50列, lgbm, 16GB RAM) | < 5 min | 日常の反復に耐える |
+| Fit 完了 (10GB CSV, 1M 行 × 100列, lgbm, 64GB RAM) | < 30 min | 中規模目標 |
+| Fit 完了 (100GB CSV, 10M 行 × 1k列, lgbm, 200GB RAM) | < 数時間 | 上限目標 (BYO RAM) |
+| WS progress 更新間隔 | < 2 sec | リアルタイム感 |
+| Frontend 初期 load (Cold) | < 3 sec | 業務開始時のストレス |
+
+### 含意
+- v0.4 P-1 で Bench harness を整備し SLO 監視を Nightly CI に組み込む
+- 1GB を SLO 上限基準点に置き、10GB / 100GB は対応するハードウェア前提で測る
+- Frontend bundle 5.7MB → 1MB 以下に code split (v0.5)
+- **1万列 Wide DataFrame** は別枠で UI 含めた検証 (Issue 別途起票)
+
+---
+
+## 12. 互換性ポリシー
+
+### 確定内容
+
+**Format Version (workspace + meta.json)**:
+- マイナー版アップグレード時、過去の workspace は **必ず読める** (forward migration)
+- バージョン跨ぎ migration は最大 N=3 minor 版を保証
+- 古い workspace を新しい CLI が壊さない (= read のみで write しない、read-modify-write 時は format_version を上げる)
+
+**Pickle (model artefact)**:
+- 同じ lizyml minor 版で fit したモデルは LizyStudio 同 minor 版間で必ず読める
+- lizyml minor バンプ時の Pickle 互換は **保証外** (ユーザ側で再 Fit 推奨)、ただし `cloudpickle` の検出ロジックで明示的にエラーにする
+
+**Public API**:
+- `/api/*` の breaking change は SemVer minor 以上、HISTORY.md に Decision 必須
+- `openapi.json` を CI で diff し、未承認の変更は block
+
+### 含意
+- v0.4 R-4 で format_version migration matrix の自動化
+- API breaking change は許可するが透明性を確保
+
+---
+
+## 13. 他システム連携 (Integration)
+
+### 確定内容
+
+**入力**:
+| 入力源 | 現在 | v0.4 | v0.5 | v1.0+ |
+|---|---|---|---|---|
+| ローカル CSV / Parquet | ✅ | ✅ | ✅ | ✅ |
+| Web Upload | ✅ | ✅ | ✅ | ✅ |
+| S3 / GCS / Azure Blob | ❌ | ❌ | ❌ | 検討 |
+| BigQuery / Snowflake / Postgres | ❌ | ❌ | ❌ | 検討 |
+| Excel (.xlsx) | ❌ | ❌ | ❌ | 検討 |
+
+**出力**:
+| 形式 | 現在 | v0.4 | v0.5 |
+|---|---|---|---|
+| Pickle (model) | ✅ | ✅ | ✅ |
+| Predictions CSV | ✅ | ✅ | ✅ |
+| Python script (Export Code) | ✅ | ✅ | ✅ |
+| HTML Report | ✅ | ✅ | ✅ |
+| ONNX | ❌ | ❌ | ❌ |
+
+**API**:
+- REST API 経由で外部から呼べる (現状もそう)
+- Webhook / イベント通知は範囲外
+
+### 含意
+- v0.4-v0.5 で connector 系は触らない
+- API ドキュメント (OpenAPI) は v0.4 で「外部からも使えるレベル」に整備
+
+---
+
+## 14. サポート・運用モデル
+
+### 確定内容
+
+**一次対応** (ユーザ自身):
+- `docs/troubleshooting.md` を読んで自己解決 (v0.5 で整備)
+- `lizystudio diagnose` CLI で診断結果を取得 (v0.4 で提供)
+
+**二次対応** (開発元):
+- GitHub Issue で受付、SLA は best-effort
+- 緊急パッチは critical bug のみ patch リリース
+
+**運用責任**:
+- サーバ起動・停止: ユーザ
+- バックアップ: ユーザ (公式 CLI で支援)
+- アップグレード: ユーザ (`pip install -U lizystudio`)
+- 監視: ユーザ (`/api/metrics` を Prometheus でスクレイプ)
+
+**商用サポート**: 検討していない (Q7)
+
+### 含意
+- v0.4 で `lizystudio diagnose` 相当の機能を実装
+- v0.5 で `docs/operations.md` (運用 runbook) を整備
+- 商用サポート tier は v1.0 でも提供しない方針
+
+---
+
+## 15. 範囲外 (Anti-scope) と将来余地
+
+### v0.4 / v0.5 で確実に Out of scope
+- マルチテナント SaaS、課金、テナント隔離
+- リアルタイム streaming inference (online learning)
+- 大規模深層学習の自前実装
+- AutoML 完全自動探索 (NAS, model selection)
+- データウェアハウス・データレイク連携
+- BI ツール統合 (Tableau, PowerBI, Looker)
+- ワークフローオーケストレーション (Airflow, Dagster)
+- モバイルアプリ
+- 認証・認可・SSO の組み込み (任意の前段プロキシで実現を期待)
+
+### v0.4 / v0.5 で扱う可能性のある拡張領域
+
+#### PyTorch backend
+- **方針**: lizyml 側で PyTorch サポートが提供された後に、LizyStudio 側で `BackendAdapter` を実装する
+- **依存**: lizyml の PyTorch サポート (上流次第)
+- **実装スコープ (lizyml が対応した時点で)**: 既存の Adapter パターンを使って PyTorch backend を追加。GPU 対応は段階的
+- **現時点では LizyStudio 単独では着手しない**
+
+#### LLM 統合
+- **方針**: 必要が出たタイミングで個別 Issue を起票して扱う
+- **現時点で確定された解釈はなし** — 将来要件次第で以下のいずれかが入る可能性:
+  - LLM をモデル backend として fine-tune
+  - LLM で結果を解釈・要約
+  - LLM で feature extraction (前処理)
+  - AutoML 自動化補助
+  - text data の処理経路
+- v0.4 / v0.5 では **要件が明確化された段階で別途計画する**
+
+### 含意
+- 既存の `BackendAdapter` Protocol は将来の PyTorch / その他 backend 受け入れに備えて変更しない (Change Gate 対象)
+- LLM 統合の Issue は本ドキュメントでは起票しない (必要時に起票)
+
+---
+
+## 16. 業務利用 KPI (Q9)
+
+業務利用できているとは、以下が満たされている状態を指す:
+
+- ユーザが**問題なくモデル開発を行える**こと
+- **Export Code が機能し、生成された Python スクリプトが別環境で正しく動く**こと
+
+これを v0.4 / v0.5 リリース時の確認項目とする:
+- v0.4: 開発作業のリスク (データ消失・長時間Tune中断・Wide DataFrame 破綻) を排除
+- v0.5: 周辺整備 (運用 runbook・性能 SLO 監視・診断ツール) で「事故時にチーム内で対応できる」状態へ
+
+---
+
+## 17. このドキュメントの取り扱い
+
+**現在**: ✅ CONFIRMED v0.2
+
+**次のステップ** (合意済):
+1. ✅ 修正版 v0.2 を作成 (本ドキュメント)
+2. 🔜 `HISTORY.md` に Proposal P-0096 として「業務利用定義の確定」を起票し Change Gate を通す
+3. 🔜 `docs/release-readiness-2026-05-03.md` を改訂し、確定された定義に基づく v0.4 / v0.5 計画を作成
+4. 🔜 新規 Issue 起票 (本日は 2件のみ):
+   - `feat: Tune long-run resumability (24h+, all termination paths)` — Phase R-1 拡張
+   - `feat: Wide DataFrame UI support (up to 10k columns)` — Phase R-5 (新設)
+5. 必要が出たタイミングで以下を起票 (本日は起票しない):
+   - hardware sizing docs (v0.5 着手前)
+   - Large CSV scaling (実測ベンチが必要になった時点)
+   - PyTorch backend (lizyml 対応後)
+   - LLM 統合 (要件定義後)
+
+**承認ルート**: `change-gate.md` の運用上、本ドキュメントは Tier 4 (アクティブな個別計画) に位置する。Tier 1 への昇格時に `HISTORY.md` に Proposal P-0096 として正式起票する。
+
+---
+
+## 18. 改訂履歴
+
+| 版 | 日付 | 内容 |
+|---|---|---|
+| v0.1 | 2026-05-03 | Claude による初版ドラフト、各仮説を「修正欄」付きで提示 |
+| **v0.2** | 2026-05-03 | ユーザ回答を取り込み確定。同時利用1名、長時間Tune resume必須、BYO RAM戦略、PyTorchはlizyml後追、LLMは要件定義後に起票 |

--- a/docs/gui-verification-handoff-2026-05-03.md
+++ b/docs/gui-verification-handoff-2026-05-03.md
@@ -1,0 +1,304 @@
+# GUI Verification Handoff — 2026-05-03
+
+> **目的**: 体系的 GUI 検証を**新しいセッション**で継続するための引継ぎ資料。
+> 本ドキュメントだけ読めば、新セッションが cold start から検証を再開できることを目的とする。
+> **対象**: 次回セッションの Claude (または別開発者)
+
+---
+
+## 0. 30秒サマリ
+
+- 本日 (2026-05-03) **Round 1 + Round 2** の GUI 検証を実施し、3件のバグを発見・3件すべて Issue 起票済み (うち 1件は既に PR #356 で fix 済)
+- **未検証領域** が残っており、これを Round 3 で網羅したい
+- ブランチ: `develop` (未コミット変更あり、§5 参照)
+- 直近のスコープ確定: [`docs/business-use-definition.md`](business-use-definition.md) v0.2、[`docs/v0.4-business-readiness-plan.md`](v0.4-business-readiness-plan.md) v0.1
+
+---
+
+## 1. これまでの検証結果
+
+### Round 1 (2026-05-03 朝)
+**発見**: SHAP 500 (Issue #355)
+**修正**: PR #356 で 404 マッピング + Frontend gating、merged
+**詳細**: [`docs/pypi-release-readiness-2026-05-03.md`](pypi-release-readiness-2026-05-03.md)
+
+### Round 2 (2026-05-03 夕方、PR #356 merged 後)
+**発見**:
+- **Issue #358**: BlockedGroup CV strategy click never sticks (stale-state revert PUT)
+- **Issue #359**: Inference Model dropdown job numbers drift from Jobs page when failures exist
+
+**両方未修正**。v0.4 Phase R-1 で対応予定。
+
+### Clean Pass (Round 1 + Round 2 で通過確認済)
+
+✅ A-01〜A-05: Layout / Navigation / 404 / Theme toggle
+✅ B-01: Path mode CSV load (binary + regression)
+✅ B-02: Invalid path → 400 + UI error
+✅ C-01〜C-02: Target select + Task auto-detect
+✅ C-05: CV strategy 切替 (8 種中 7 種)、BlockedGroup のみ #358
+✅ C-06: Fit submit + 完了
+✅ D-01〜D-08: Job リスト + 詳細 + Plot タブ (Learning Curve / ROC / Importance / OOF Dist)
+✅ E-?: Tune タブの UI 構造 (実走は **未**)
+✅ F-01: Job → Inference 自動遷移
+✅ F-03: Inference run with-GT
+✅ F-05: Predictions table + Download CSV
+✅ F-06: Inference history
+✅ F-08: SHAP fix 再確認 (no 500/404)
+✅ H-01〜H-04: Regression task (Residuals plot)
+✅ J-01〜J-03: API health/metrics/ready
+
+---
+
+## 2. Round 3 で検証すべき未確認領域
+
+### 高優先 (Critical path)
+
+| ID | ケース | 補足 |
+|---|---|---|
+| **未-01** | **Tune 実走** (10 trial 程度) | UI 構造のみ確認済、実 trial 実行・tuning plot 描画は未 |
+| **未-02** | **Cancel during running fit** | race condition / slot release |
+| **未-03** | **Cancel during running tune** | 同上、長時間ジョブ用 |
+| **未-04** | **ブラウザリロード後の状態復元** | data + config + 進行中 job (golden path) |
+| **未-05** | **WebSocket 再接続** | DevTools で network throttling して切断テスト |
+
+### 中優先 (前回検出パターンの symmetric audit)
+
+| ID | ケース | 関連 Issue |
+|---|---|---|
+| **未-06** | **Plot type gating の symmetric audit** | #355 と同パターンを `tuning`, `calibration`, `probability-histogram` で確認 |
+| **未-07** | **Numbering の symmetric audit** | #359 と同パターンを Jobs, Lineage, Inference history `#N` で確認 |
+| **未-08** | **CV state race の他パターン** | #358 と類似、Group/Time 系で `group_col` / `time_col` 切替直後 |
+
+### 中優先 (機能網羅性)
+
+| ID | ケース | 補足 |
+|---|---|---|
+| **未-09** | Inference Upload mode (Path のみ確認済) | |
+| **未-10** | Inference Pred-only mode (Evaluate OFF) | |
+| **未-11** | Inference comparison (2 records) | |
+| **未-12** | Inference history からの再選択 | |
+| **未-13** | Re-tune (深さ 2 以上の lineage) | |
+| **未-14** | Export Model 実走 (zip ダウンロード確認) | |
+| **未-15** | Export Code 実走 (Python script ダウンロード) | |
+| **未-16** | YAML Import / Export round-trip | |
+| **未-17** | Save Preset → Load Preset | |
+| **未-18** | Feature Weights エディタ | |
+| **未-19** | Workspace columns: Exclude bulk toggle | |
+| **未-20** | Workspace columns: Type Num/Cat 切替 | |
+| **未-21** | Command palette (Cmd/Ctrl+K) | |
+| **未-22** | Onboarding flow (初回起動時) | |
+| **未-23** | Sidebar collapse persistence | |
+
+### 低優先 (エッジケース)
+
+| ID | ケース |
+|---|---|
+| **未-24** | 1行 / 1列 / 全欠損 CSV |
+| **未-25** | 非UTF-8 CSV |
+| **未-26** | 巨大 CSV (1GB+, 業務利用上限) |
+| **未-27** | Wide DataFrame (1k 列以上、Issue #361 関連) |
+| **未-28** | format_version 0 の旧 workspace |
+| **未-29** | 複数タブで同一 workspace |
+
+---
+
+## 3. 環境セットアップ (新セッションでの再開手順)
+
+### 3.1 リポジトリ確認
+
+```bash
+cd /home/rem/repos/LizyStudio
+git status            # branch: develop, untracked docs/* あり (§5 参照)
+git log --oneline -5  # 直近マージ確認
+```
+
+### 3.2 Frontend ビルド (PR #356 / #357 反映済)
+
+ビルドは前回セッションで完了済。`src/lizystudio/static/` に最新が入っているはず。
+変更があれば再ビルド:
+
+```bash
+cd /home/rem/repos/LizyStudio/frontend
+pnpm build  # ~30秒
+```
+
+### 3.3 Backend 起動
+
+```bash
+cd /home/rem/repos/LizyStudio
+uv run lizystudio --port 8501
+# 別シェル / バックグラウンドで実行
+```
+
+### 3.4 Playwright MCP で接続
+
+`http://localhost:8501/` (または `http://127.0.0.1:8501/` だが MCP の whitelist で localhost 推奨)
+
+---
+
+## 4. テスト用データ
+
+| 用途 | パス |
+|---|---|
+| Binary 分類 (no calibration) | `/home/rem/repos/LizyStudio/tests/fixtures/lizyml/binary_no_cal/data.csv` (418 行 × 13 列) |
+| Binary 分類 (isotonic calibration) | `/home/rem/repos/LizyStudio/tests/fixtures/lizyml/binary_isotonic/data.csv` |
+| Regression | `/home/rem/repos/LizyStudio/tests/fixtures/lizyml/regression/data.csv` |
+| Tune fixture | `/home/rem/repos/LizyStudio/tests/fixtures/lizyml/tune/data.csv` |
+
+**Target columns**:
+- binary_no_cal / binary_isotonic: `Survived`
+- regression: `target`
+
+---
+
+## 5. 現在のリポジトリ状態
+
+### Branch
+`develop` (origin/develop と同期済)
+
+### 未コミットファイル
+```
+?? docs/business-use-definition.md       (v0.2 CONFIRMED)
+?? docs/v0.4-business-readiness-plan.md  (v0.1 DRAFT)
+M  HISTORY.md                            (P-0096 起票分)
+```
+
+これらは **本日の業務利用定義作業の成果物**。GUI 検証 Round 3 には影響しない。
+Round 3 を別ブランチで実施する場合は不要、develop 上で続けるなら考慮不要。
+
+### 開いている PR / Issue
+- PR #356 (SHAP fix) — **MERGED** ✅
+- PR #357 (sdist 整理 + 業務利用 docs) — **MERGED** ✅
+- Issue #355 (SHAP 500) — **CLOSED** ✅
+- Issue #358 (BlockedGroup race) — **OPEN**, v0.4 R-1 候補
+- Issue #359 (Inference job-num drift) — **OPEN**, v0.4 R-1 候補
+- Issue #360 (Tune long-run resumability) — **OPEN**, v0.4 R-1 候補
+- Issue #361 (Wide DataFrame UI) — **OPEN**, v0.4 R-5 候補
+
+---
+
+## 6. 検証マトリクスの形式
+
+### 結果記録テンプレ
+
+各ケースは以下の形式で記録:
+
+```
+| ID | ケース | 結果 | 備考 / Issue |
+|---|---|---|---|
+| 未-01 | Tune 実走 (10 trial) | ✅ / ❌ / ⚠️ | (詳細) |
+```
+
+- ✅ PASS — 期待通り動作
+- ❌ FAIL — バグ、Issue 起票
+- ⚠️ DEGRADED — 動くが UX に問題あり、Issue は任意
+
+### 新規バグ検出時のフロー
+
+1. **Reproduction を最低 2 回確認** (一発で 100% 再現させる)
+2. **Network trace + Console error を取得**
+3. **Root cause 仮説**を立てる (時間があれば、なくても OK)
+4. **Issue 起票** (英語、Severity 付き、関連既存 Issue 参照)
+5. **検証マトリクスに `❌` で記録**、後続の検証は継続
+
+### Issue 起票テンプレ
+
+```
+gh issue create \
+  --title "<type>(<scope>): <one-line summary>" \
+  --body-file /tmp/issue-NNN.md \
+  --label "bug,priority-<low|medium|high>,tier-<2|3|4>,area-<frontend|backend|both>"
+```
+
+過去 issue のテンプレ参考:
+- [#358](https://github.com/nbx-liz/LizyStudio/issues/358) — Stale-state race パターン
+- [#359](https://github.com/nbx-liz/LizyStudio/issues/359) — Numbering drift パターン
+- [#355](https://github.com/nbx-liz/LizyStudio/issues/355) — Plot gating 500 パターン
+
+---
+
+## 7. 既知の制約 / 注意点
+
+### Playwright MCP の癖
+
+- `127.0.0.1` は whitelist 外 → **`localhost` を使う**
+- スクリーンショットの保存先は `/home/rem/repos/LizyStudio/.playwright-mcp/` のみ許可
+- `.playwright-mcp/` は gitignore 済 (commit されない)
+- React の controlled input に programmatic value 設定する場合は:
+  ```js
+  const s=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,'value').set;
+  s.call(inp, 'value');
+  inp.dispatchEvent(new Event('input',{bubbles:true}));
+  inp.dispatchEvent(new Event('change',{bubbles:true}));
+  ```
+
+### Bash hook の制約
+
+- 一部の grep パターン (例: `*.py.*Mixin`) は `dangerous system pattern` として弾かれる → 別パターンで代替
+- PR/Issue/commit メッセージは **英語のみ** (validate-pr-language.sh)
+- `127.0.0.1` 経由の curl は **記憶ファイル書き込みガード** で block されることがある
+- 削除系 (rm -rf) は確認後実行、permission 拒否されたらサブパス分割で再試行
+
+### 既知の Console 警告 (無視して OK)
+
+- `WebSocket connection to 'ws://localhost:8501/ws/jobs/<id>/progress' failed: WebSocket is closed before the connection is established`
+  → Fit が短時間 (~5秒) で完了するときに WS handshake が間に合わない race。Round 1/2 で確認済、機能には影響しない。
+
+---
+
+## 8. Round 3 推奨 plan (案)
+
+### Step 1 (30分): Critical path 重点確認
+未-01 (Tune 実走) → 未-02/03 (Cancel) → 未-04 (Reload restore) → 未-05 (WS reconnect)
+
+### Step 2 (30分): Symmetric audit
+未-06 (Plot gating) → 未-07 (Numbering) → 未-08 (CV race)
+
+### Step 3 (45分): 機能網羅性
+未-09〜未-23 を batch で
+
+### Step 4 (15分): エッジ系
+未-24〜未-29 を可能な範囲で
+
+### Step 5: Triage + Issue 起票 + Final report
+
+合計 2〜3 時間。サーバ起動 + 既存 35 ジョブを使って効率化。
+
+---
+
+## 9. 引継ぎ完了チェックリスト
+
+新セッション開始前に確認:
+
+- [ ] このドキュメントを読み終えた
+- [ ] [`docs/business-use-definition.md`](business-use-definition.md) v0.2 §16 (12 質問への回答) を確認
+- [ ] [`docs/v0.4-business-readiness-plan.md`](v0.4-business-readiness-plan.md) §7 (Exit Criteria 9 項目) を確認
+- [ ] Issue #358 / #359 / #360 / #361 の内容を把握
+- [ ] バックエンド・フロントエンドが起動できる状態
+- [ ] Playwright MCP が利用可能
+
+---
+
+## 10. 関連ドキュメント
+
+| ドキュメント | 役割 |
+|---|---|
+| [`docs/business-use-definition.md`](business-use-definition.md) v0.2 | 業務利用の確定定義 (Tier 4) |
+| [`docs/v0.4-business-readiness-plan.md`](v0.4-business-readiness-plan.md) v0.1 | v0.4 Phase 別実装計画 (Tier 4) |
+| [`docs/pypi-release-readiness-2026-05-03.md`](pypi-release-readiness-2026-05-03.md) | v0.3 リリース準備時の Round 1 監査 |
+| [`docs/architecture-overview.md`](architecture-overview.md) | システム全体像 (Mermaid 図 5 種) |
+| `BLUEPRINT.md` (Tier 1) | 構造・責務・画面定義 |
+| `HISTORY.md` P-0096 (Tier 1) | 業務利用定義の Change Gate Decision |
+
+---
+
+## 11. 次に取り得るアクション
+
+新セッション開始時に、以下のいずれかを起点にできる:
+
+**A**: 「§8 の Step 1 から Round 3 を開始してください」
+**B**: 「§2 の特定領域 (例: 未-01〜未-05) のみ先行で確認してください」
+**C**: 「Issue #358 / #359 の修正に着手したい」 (検証よりも修正優先の場合)
+**D**: 「v0.4 Phase R-1 を開始する」 (検証はここで切り上げ、実装フェーズに移行)
+
+A が標準ルート。

--- a/docs/v0.4-business-readiness-plan.md
+++ b/docs/v0.4-business-readiness-plan.md
@@ -1,0 +1,233 @@
+# v0.4 Business-Readiness Plan
+
+> **Status**: DRAFT v0.1 (2026-05-03 起票)
+> **基底**: [`docs/business-use-definition.md`](business-use-definition.md) v0.2 CONFIRMED
+> **目的**: v0.4 を「業務利用可能」レベルにするための Phase 別実装計画。確定された定義に基づき、必要十分な作業項目を列挙する。
+> **承認**: 本計画を Tier 4 (アクティブな個別計画) として固定するため、`HISTORY.md` に Proposal P-0096 を起票して Change Gate を通す。
+
+---
+
+## 0. v0.4 ゴール
+
+`business-use-definition.md` v0.2 の **業務利用 KPI** (§16) を満たすこと:
+
+> ユーザが**問題なくモデル開発を行える**こと、**Export Code が機能し、生成された Python スクリプトが別環境で正しく動く**こと
+
+これを達成するため、以下 3 つの最大リスクを排除する:
+
+| リスク | 由来 | 対策 Phase |
+|---|---|---|
+| **データ消失** (workspace の data + config) | §8 絶対NG | R-1, R-2 |
+| **長時間 Tune の中断** (24h+ ジョブの全消失) | §8 確定C / Issue #360 | R-1 (拡張) |
+| **Wide DataFrame UI 破綻** (1万列でブラウザ落ちる) | §4 上限 / Issue #361 | R-5 (新設) |
+
+---
+
+## 1. Phase 構成と工数感
+
+| Phase | 内容 | 工数 |
+|---|---|---|
+| R-1 | 状態整合性の徹底 + **Tune resume** | 6 週間 |
+| R-2 | セッション復元 (WS reconnect, browser reload) | 2 週間 |
+| R-3 | エラー復旧 (typed errors, recovery hints) | 3 週間 |
+| R-4 | 互換性ロック (format_version, Pickle compat) | 2 週間 |
+| **R-5** | **Wide DataFrame + Large CSV scaling** (新設) | 3 週間 |
+| **合計** | | **約 16 週間 (4 ヶ月)** |
+
+スケジュールは「ソロ作業」を前提とした見積。チームで取り組む場合は短縮可能。
+
+---
+
+## 2. Phase R-1 — 状態整合性 + Tune Resume (6週間)
+
+### R-1.1 Slot release invariant の網羅検証 (1週間)
+
+| ID | 項目 | 受け入れ基準 |
+|---|---|---|
+| R-1.1.1 | 6 経路で slot 解放 | normal完了 / cancel / exception / SIGKILL / WS切断 / browser閉じる |
+| R-1.1.2 | Test (pytest + Playwright) | 各経路に対応する regression test |
+
+### R-1.2 Cancel race の修復 (1週間)
+
+| ID | 項目 | 受け入れ基準 |
+|---|---|---|
+| R-1.2.1 | Cancel + 完了通知の競合 | count-based assertion で「cancel 押下後の `cancelled` 状態を維持」を証明 |
+| R-1.2.2 | Issue #358 (BlockedGroup race) | 既起票の修正をこの phase に含める |
+
+### R-1.3 Subprocess crash 復旧 (1週間)
+
+| ID | 項目 | 受け入れ基準 |
+|---|---|---|
+| R-1.3.1 | 子プロセス kill -9 → server が `failed (subprocess died)` で記録 | UI に明示、slot release |
+| R-1.3.2 | Atomic meta.json write (tmpfile + fsync + rename) | kill -9 mid-write を simulate して検証 |
+
+### R-1.4 **Tune long-run resumability** (3週間) — Issue #360
+
+| ID | 項目 | 受け入れ基準 |
+|---|---|---|
+| R-1.4.1 | Trial-level checkpoint | 各 trial 完了時に永続化 (Optuna `JournalFileStorage` or 独自 JSON) |
+| R-1.4.2 | Resume on restart | サーバ再起動後 `paused` 状態 → UI から Resume 可能 |
+| R-1.4.3 | Resume on SIGKILL | kill -9 → restart → 続きから |
+| R-1.4.4 | Resume on WS disconnect | 10分超の WS 切断 → 再接続で進捗同期 |
+| R-1.4.5 | No duplicate trials | trial_id ベース dedup |
+| R-1.4.6 | State machine 拡張 (Change Gate) | `paused` 状態を HISTORY.md Proposal で定義 |
+| R-1.4.7 | Regression + E2E test | 5 経路をカバー、24時間 Tune resume の Playwright |
+
+### R-1.5 Issue #359 (job-num drift) (0.5週間)
+
+| ID | 項目 | 受け入れ基準 |
+|---|---|---|
+| R-1.5.1 | API に `job_num` を追加し frontend は計算しない | job_num は不変 ID として永続化 (Change Gate) |
+
+---
+
+## 3. Phase R-2 — セッション復元 (2週間)
+
+業務利用シナリオは **同時利用 1 名** (§7) なのでマルチタブ衝突制御は不要。
+
+### R-2.1 WS 再接続 (1週間)
+
+| ID | 項目 | 受け入れ基準 |
+|---|---|---|
+| R-2.1.1 | Fit/Tune 中ネットワーク断 (10秒) → 復帰後 progress 続行 | 最終 status 一致 |
+| R-2.1.2 | Long-run (24h Tune) 用 reconnect 戦略 | exponential backoff、最大 reconnect interval 5min |
+
+### R-2.2 ブラウザリロード状態復元 (1週間)
+
+| ID | 項目 | 受け入れ基準 |
+|---|---|---|
+| R-2.2.1 | data + config + 進行中 job がリロード後も復元 | Playwright で Visual diff |
+| R-2.2.2 | 未保存変更の警告 | beforeunload で form ダーティ時にユーザに確認 |
+
+### Out of scope (1名利用のため削除)
+- ❌ ETag/version による衝突検出
+- ❌ 「他タブで変更されました」UI
+- ❌ ジョブキュー (queue 1〜N)
+
+---
+
+## 4. Phase R-3 — エラー復旧 (3週間)
+
+### R-3.1 Error code 体系の確立 (1週間)
+
+| ID | 項目 | 受け入れ基準 |
+|---|---|---|
+| R-3.1.1 | `StudioError` に `code`, `recovery_hint`, `is_user_error: bool` を必須化 | 全 `errors.py` を改訂 |
+| R-3.1.2 | Frontend で `recovery_hint` を Toast 第二行に表示 | UX が技術用語+対処法のセット |
+
+### R-3.2 失敗ジョブから復旧 (1週間)
+
+| ID | 項目 | 受け入れ基準 |
+|---|---|---|
+| R-3.2.1 | 失敗ジョブを Re-fit する経路 | Workspace に config を復元 |
+| R-3.2.2 | エラーログ diff UI | `Execution Log` accordion で stack trace 検索可能 |
+| R-3.2.3 | 再現用 config を 1 クリックでクリップボード | デバッグ送信用 |
+
+### R-3.3 Plot type symmetric audit (0.5週間)
+
+| ID | 項目 | 受け入れ基準 |
+|---|---|---|
+| R-3.3.1 | `tuning`, `calibration`, `probability-histogram`, `shap-summary` 全て `available_plots` で gate | Issue #355 と同パターンの試験を全 plot に展開 |
+
+### R-3.4 Validate API 強化 + Diagnostic export (0.5週間)
+
+| ID | 項目 | 受け入れ基準 |
+|---|---|---|
+| R-3.4.1 | Fit 起動前の `config/validate` 強化 | target存在、CV 適合性、一意制約まで検証 |
+| R-3.4.2 | `lizystudio diagnose` CLI / `/api/diagnostics/bundle` | 個人情報 redact 済の zip ダウンロード |
+
+---
+
+## 5. Phase R-4 — 互換性ロック (2週間)
+
+### R-4.1 format_version migration matrix (1週間)
+
+| ID | 項目 | 受け入れ基準 |
+|---|---|---|
+| R-4.1.1 | v0 → v1 → v(future) の順次マイグレーション | pytest で round-trip テスト、CI gate |
+| R-4.1.2 | 過去 workspace を新しい CLI が壊さない | 古い format_version を read のみで保護 |
+
+### R-4.2 Pickle compatibility test (1週間) — P-0095 拡張
+
+| ID | 項目 | 受け入れ基準 |
+|---|---|---|
+| R-4.2.1 | 過去 N=3 minor version の lizyml で fit したモデルが load できる | Nightly CI で実行 |
+| R-4.2.2 | lizyml minor バンプ時の Pickle 互換切れを明示エラー | `cloudpickle` 検出ロジック |
+
+---
+
+## 6. Phase R-5 — Wide DataFrame + Large CSV (3週間, 新設)
+
+業務利用上限 **1000万行 × 1万列 × 100GB** に対して、UI と性能を担保する。**BYO RAM 戦略**で実装は単純化 (チャンク・サンプリング不要)。
+
+### R-5.1 Wide DataFrame UI (2週間) — Issue #361
+
+| ID | 項目 | 受け入れ基準 |
+|---|---|---|
+| R-5.1.1 | Column Settings 仮想スクロール | react-window で 10k 行を遅延レンダ |
+| R-5.1.2 | Column Settings 検索 / フィルタ | substring match 100ms 以内 |
+| R-5.1.3 | Bulk operations | "filter にマッチする全列を Exclude" |
+| R-5.1.4 | Target combobox typeahead | 10k 列から検索選択 |
+| R-5.1.5 | Importance plot top-N | default 30 + "Show all" |
+| R-5.1.6 | Feature Weights 1k 列上限のエラー誘導 | UX dead-end 防止 |
+| R-5.1.7 | 10k 列テスト fixture | 生成スクリプト + e2e test |
+
+### R-5.2 Large CSV scaling (1週間)
+
+| ID | 項目 | 受け入れ基準 |
+|---|---|---|
+| R-5.2.1 | 1GB CSV (1M 行 × 100列) で Fit < 5min on 16GB RAM | CI nightly bench |
+| R-5.2.2 | 10GB feasibility study | 64GB RAM マシンで 1ケース手動測定、結果を docs に記録 |
+| R-5.2.3 | 100GB feasibility study | 200GB+ RAM マシンで 1ケース手動測定 (任意、可能なら) |
+| R-5.2.4 | `docs/hardware-sizing.md` 整備 | 推奨スペック表を業務利用定義 §4 から引用 |
+
+---
+
+## 7. v0.4.0 Exit Criteria (確定)
+
+| 項目 | 基準 | 対応 Phase |
+|---|---|---|
+| データ消失耐性 | 全 6 経路で slot release、meta.json atomic write | R-1.1, R-1.3 |
+| 長時間 Tune resume | 24h Tune が SIGKILL → restart で続く | R-1.4 |
+| ブラウザリロード復元 | data + config + 進行中 job が復元 | R-2.2 |
+| エラー復旧 | 全エラーに recovery_hint、Diagnostic export | R-3 |
+| 互換性 | format_version migration matrix CI gate、Pickle compat test | R-4 |
+| Wide DataFrame | 10k 列で UI が破綻しない | R-5.1 |
+| Large CSV | 1GB on 16GB RAM で Fit 5min 以内 | R-5.2 |
+| 既存 Issue 解消 | #358 (BlockedGroup race), #359 (job-num drift), #360, #361 | R-1, R-5 |
+| **業務利用 KPI** | モデル開発 + Export Code が問題なく完走 | 全 Phase |
+
+---
+
+## 8. v0.5 へ送るもの (Out of v0.4 scope)
+
+`business-use-definition.md` v0.2 で確認したが v0.4 では着手しない:
+
+- 商用サポート (§14, Q7) — 提供しない
+- マルチユーザ並行制御 (§7) — 1 名利用のため不要
+- DB connector (§4, §13) — v1.0 以降検討
+- LLM 統合 — 要件が明確化された時点で起票
+- PyTorch backend — lizyml 側対応後に v0.5 以降で起票
+- 監査ログ・認証層 (§10) — Out of scope (ユーザ環境側で対応)
+
+v0.5 では性能 SLO 監視 (Bench harness 自動化)、運用 runbook、 backup/restore CLI、Docker 公式 image を整備する。
+
+---
+
+## 9. 次のアクション
+
+| 順序 | アクション | 担当 |
+|---|---|---|
+| 1 | `HISTORY.md` に Proposal P-0096 (業務利用定義の確定) を起票 | dev |
+| 2 | `PLAN.md` に v0.4-N セクションを追加し本計画を反映 | dev |
+| 3 | `ROADMAP.md` を更新 (Tier 2 INDEX に本計画と Issue #360/#361 を登録) | dev |
+| 4 | Phase R-1 から着手 (6週間) | dev |
+| 5 | 各 Phase 完了時に Exit Criteria を確認、PR 単位でマージ | dev |
+
+---
+
+## 10. 改訂履歴
+
+| 版 | 日付 | 内容 |
+|---|---|---|
+| v0.1 | 2026-05-03 | 初版。`business-use-definition.md` v0.2 に基づき Phase R-1〜R-5 を確定 |


### PR DESCRIPTION
## Summary

Formalize the business-use scope that v0.4 will be measured against, and the Phase R-1 to R-5 plan derived from it. No source code changes -- this PR is the docs + Change-Gate Decision that anchors the next 16 weeks of v0.4 work.

Started as an alignment-building round during the v0.3 release rehearsal: the prior v0.4 plan was implicitly assuming a multi-user setup that the real scenario does not need, and was missing two business-critical items (24h Tune resume, 10k-column UI) that the real scenario does need.

## What this PR adds

### `docs/business-use-definition.md` (v0.2, CONFIRMED)
12-item Decision Sheet that captures the agreed scenario after a structured Q&A:

| Item | Confirmed |
|---|---|
| Scenario | Single data scientist running a personal server |
| Concurrent users | 1 |
| Data scale (upper bound) | 10M rows x 10k cols x 100GB |
| Data scale (typical) | <1M rows x hundreds-to-thousands cols |
| Deployment | Personal PC / on-prem Linux / Docker / cloud |
| Sensitivity | Confidential (user-environment guarantees, not LizyStudio's job) |
| Automation | Interactive only (no scheduler / notifier) |
| Failure tolerance | 24h Tune must be resumable |
| Compatibility | format_version forward-compat, Pickle within same minor |
| Commercial support | None |
| Customer-facing delivery | None |
| Business-use KPI | Model dev runs cleanly + Export Code is functional |

### `docs/v0.4-business-readiness-plan.md` (v0.1)
- **Phase R-1** (6 weeks) -- slot release invariant + Tune resume + #358 + #359
- **Phase R-2** (2 weeks) -- WS reconnect + browser reload restore. Multi-tab collision detection **dropped** because §7 is single-user.
- **Phase R-3** (3 weeks) -- typed errors with recovery hints + plot-gating symmetric audit + diagnostic export
- **Phase R-4** (2 weeks) -- format_version migration matrix + Pickle compat tests
- **Phase R-5 (NEW, 3 weeks)** -- Wide DataFrame UI (10k columns) + Large CSV scaling (1GB SLO + 10GB/100GB feasibility under BYO-RAM)
- Total ~16 weeks. Exit Criteria has 9 items, each tied to a Phase.

### `docs/gui-verification-handoff-2026-05-03.md`
Handoff for the next-session GUI verification (Round 3). 29 unverified cases ranked high/medium/low, environment setup, test fixtures, Playwright MCP gotchas, Issue templating flow, recommended 4-step plan (~2-3h).

### `HISTORY.md`
Proposal **P-0096** added with full Change-Gate sections. State-machine changes covered:
- Tune `paused` state for resumability
- `completed_trials` monotonicity invariant
- `job_num` becomes an immutable API field (fixes #359 by making it server-authoritative)

## Why this is a single Decision (not split)

Definition + plan are inseparable: the Phase composition is derived from the KPI. Splitting them would invite drift between "what we agreed business-use means" and "what we actually built". P-0096 captures both in one Change-Gate Decision.

## Related Issues

These are tied to Phases by the plan:

| Issue | Phase |
|---|---|
| #358 BlockedGroup CV race | R-1 |
| #359 Inference job-num drift | R-1 |
| #360 Tune long-run resumability | R-1 |
| #361 Wide DataFrame UI | R-5 |

## Out of scope (intentional)

These are explicitly not in v0.4-v0.5 per the confirmed definition:
- PyTorch backend -- gated on upstream lizyml support
- LLM integration -- to be filed when use-case is concretely specified (5 possible interpretations were enumerated in the alignment round)
- DB connectors (BigQuery / Snowflake / Postgres / S3) -- v1.0+
- Audit logs / authentication / encrypted comms -- user-environment responsibility
- Multi-user concurrency / job queue / SaaS / customer-facing delivery

## Test plan

This is a docs-only PR; no test changes. The acceptance criteria of P-0096 itself live in HISTORY.md and will be checked off when the v0.4 milestone is closed:

- [ ] `business-use-definition.md` v0.2 stays in repo and §0 Decision Sheet remains the source of truth
- [ ] `v0.4-business-readiness-plan.md` stays in repo
- [ ] `PLAN.md` v0.4-N section reflects Phase R-1 to R-5 (follow-up PR)
- [ ] `ROADMAP.md` Tier 2 INDEX registers v0.4 plan and #358-#361 (follow-up PR)
- [ ] Issues #358 / #359 / #360 / #361 are pinned to v0.4 milestone (follow-up)
- [ ] At v0.4 release, Exit Criteria (9 items in plan §7) all GREEN

## Notes

This PR exists because two prior commits (PR #356 fix + PR #357 release prep) unlocked the v0.3 release path, and the very next question -- "what does v0.4 even mean?" -- needed an explicit, reviewable answer before any v0.4 implementation work starts. Treating the answer as a Change-Gate Decision lets future PRs cite P-0096 instead of re-litigating the scope mid-implementation.
