### PR TITLE
fix(metrics): derive oos_std from oof_per_fold when oof_std absent (#364)

### DIFF
--- a/frontend/src/lib/metrics.test.ts
+++ b/frontend/src/lib/metrics.test.ts
@@ -61,6 +61,51 @@ describe("pivotMetrics", () => {
     expect(result.auc.oos_std).toBeNaN();
   });
 
+  // Issue #364: when the backend omits ``oof_std`` (the canonical shape from
+  // recent lizyml versions only includes ``oof_per_fold``), pivotMetrics must
+  // derive the per-fold standard deviation from ``oof_per_fold`` rather than
+  // returning NaN. Otherwise the metric panel renders ``Std: NaN`` for every
+  // metric on every Tune/Fit, even though the data is right there.
+  it("derives oos_std from oof_per_fold when oof_std is absent", () => {
+    const raw = {
+      raw: {
+        if_mean: { auc: 0.95 },
+        oof: { auc: 0.7 },
+        oof_per_fold: [{ auc: 0.6 }, { auc: 0.7 }, { auc: 0.8 }],
+      },
+    };
+    const result = pivotMetrics(raw);
+    expect(result.auc.is).toBe(0.95);
+    expect(result.auc.oos).toBe(0.7);
+    // population std of [0.6, 0.7, 0.8] ≈ 0.0816497
+    expect(result.auc.oos_std).toBeCloseTo(0.0816497, 5);
+  });
+
+  it("prefers an explicit oof_std over deriving from oof_per_fold", () => {
+    const raw = {
+      raw: {
+        if_mean: { auc: 0.95 },
+        oof: { auc: 0.7 },
+        oof_std: { auc: 0.0123 }, // explicit, must win
+        oof_per_fold: [{ auc: 0.6 }, { auc: 0.7 }, { auc: 0.8 }],
+      },
+    };
+    const result = pivotMetrics(raw);
+    expect(result.auc.oos_std).toBe(0.0123);
+  });
+
+  it("returns NaN for oos_std when fewer than two folds are available", () => {
+    const raw = {
+      raw: {
+        if_mean: { auc: 0.95 },
+        oof: { auc: 0.7 },
+        oof_per_fold: [{ auc: 0.7 }],
+      },
+    };
+    const result = pivotMetrics(raw);
+    expect(result.auc.oos_std).toBeNaN();
+  });
+
   it("handles alternative key names (is/oos/oos_std)", () => {
     const raw = {
       is: { f1: 0.8 },
@@ -130,6 +175,12 @@ describe("pivotMetrics with real fit_result fixtures", () => {
       expect(result[name], `metric ${name} missing`).toBeDefined();
       expect(Number.isFinite(result[name].is)).toBe(true);
       expect(Number.isFinite(result[name].oos)).toBe(true);
+      // Issue #364: per-fold std must be derived from oof_per_fold even
+      // though the production shape no longer ships an explicit oof_std.
+      expect(
+        Number.isFinite(result[name].oos_std),
+        `metric ${name} oos_std should be finite (Issue #364)`,
+      ).toBe(true);
     }
     // is/oos values must come from the only top-level "raw" subtree.
     expect(result.auc.is).toBe(binaryNoCalFit.metrics.raw.if_mean.auc);
@@ -147,6 +198,10 @@ describe("pivotMetrics with real fit_result fixtures", () => {
       expect(result[name], `metric ${name} missing`).toBeDefined();
       expect(Number.isFinite(result[name].is)).toBe(true);
       expect(Number.isFinite(result[name].oos)).toBe(true);
+      expect(
+        Number.isFinite(result[name].oos_std),
+        `metric ${name} oos_std should be finite (Issue #364)`,
+      ).toBe(true);
     }
     // Anti-confusion: is/oos must come from raw, NOT calibrated. The
     // fixture's calibrated.oof.auc differs from raw.oof.auc, so a
@@ -165,6 +220,10 @@ describe("pivotMetrics with real fit_result fixtures", () => {
       expect(result[name], `metric ${name} missing`).toBeDefined();
       expect(Number.isFinite(result[name].is)).toBe(true);
       expect(Number.isFinite(result[name].oos)).toBe(true);
+      expect(
+        Number.isFinite(result[name].oos_std),
+        `metric ${name} oos_std should be finite (Issue #364)`,
+      ).toBe(true);
     }
     expect(result.rmse.is).toBe(regressionFit.metrics.raw.if_mean.rmse);
     expect(result.r2.oos).toBe(regressionFit.metrics.raw.oof.r2);
@@ -176,6 +235,10 @@ describe("pivotMetrics with real fit_result fixtures", () => {
       expect(result[name], `metric ${name} missing`).toBeDefined();
       expect(Number.isFinite(result[name].is)).toBe(true);
       expect(Number.isFinite(result[name].oos)).toBe(true);
+      expect(
+        Number.isFinite(result[name].oos_std),
+        `metric ${name} oos_std should be finite (Issue #364)`,
+      ).toBe(true);
     }
   });
 });

--- a/frontend/src/lib/metrics.ts
+++ b/frontend/src/lib/metrics.ts
@@ -15,7 +15,22 @@
  * panel reads the same uncalibrated numbers users see during a
  * non-calibrated fit, regardless of whether ``calibrated`` is also
  * emitted alongside.
+ *
+ * Issue #364: recent lizyml versions ship per-fold scores under
+ * ``oof_per_fold`` instead of an aggregated ``oof_std``. When
+ * ``oof_std`` is missing, derive the per-metric population standard
+ * deviation from ``oof_per_fold`` so the Std column shows real numbers
+ * rather than NaN.
  */
+function foldStd(values: number[]): number {
+  const finite = values.filter((v) => Number.isFinite(v));
+  if (finite.length < 2) return Number.NaN;
+  const mean = finite.reduce((s, v) => s + v, 0) / finite.length;
+  const variance =
+    finite.reduce((s, v) => s + (v - mean) ** 2, 0) / finite.length;
+  return Math.sqrt(variance);
+}
+
 export function pivotMetrics(
   raw: Record<string, unknown>,
 ): Record<string, Record<string, number>> {
@@ -33,6 +48,9 @@ export function pivotMetrics(
     string,
     number
   >;
+  const oofPerFold = Array.isArray(nested.oof_per_fold)
+    ? (nested.oof_per_fold as Array<Record<string, number>>)
+    : [];
 
   const metricNames = new Set([
     ...Object.keys(ifMean),
@@ -42,10 +60,14 @@ export function pivotMetrics(
 
   const result: Record<string, Record<string, number>> = {};
   for (const name of metricNames) {
+    let stdVal = oofStd[name] ?? Number.NaN;
+    if (!Number.isFinite(stdVal) && oofPerFold.length >= 2) {
+      stdVal = foldStd(oofPerFold.map((fold) => fold[name] ?? Number.NaN));
+    }
     result[name] = {
       is: ifMean[name] ?? Number.NaN,
       oos: oof[name] ?? Number.NaN,
-      oos_std: oofStd[name] ?? Number.NaN,
+      oos_std: stdVal,
     };
   }
   return result;


### PR DESCRIPTION
## Summary

- Recent lizyml versions ship per-fold scores under `oof_per_fold` only; `oof_std` no longer appears in the response. `pivotMetrics` was still reading `oof_std` directly and falling back to NaN, so the Score / Metric panel rendered `Std: NaN` for every metric on every Tune/Fit even though the data needed to compute std was right there.
- Compute the per-metric population standard deviation from `oof_per_fold` when `oof_std` is missing. An explicit `oof_std` still wins for back-compat. Fewer than two folds → NaN.
- Production-artifact tests (Issue #346 Phase B) gain `oos_std` finite assertions for all 4 fixtures so a future shape drift trips the regression.

## Test plan

- [x] `pnpm test --run src/lib/metrics.test.ts` — 14 passed (5 RED before, all GREEN after)
- [x] `pnpm test --run` — full suite 1777/1777 passed
- [x] `pnpm build` — green
- [x] `pnpm check` — Biome lint/format clean
- [x] Manual: restart backend, open `/jobs`, click Tune #42 detail page → all 8 metrics show real Std values (auc=0.0527, accuracy=0.0306, auc_pr=0.0827, brier=0.0181, ece=0.0238, f1=0.2041, logloss=0.0474, precision_at_k=0.1837)

## Why this slipped through

Existing fixture-based tests asserted only `is` and `oos` are finite. The synthetic shape tests passed `oof_std` directly so they never exercised the code path actually used in production. Adding `oos_std` finite assertions to the production-artifact tests (per the negative-invariant lesson from Issue #346) closes that gap.

Closes #364
