### PR TITLE
fix(inference): derive dropdown #N from allJobs not completedJobs (#359)

### DIFF
--- a/frontend/src/components/inference/SetupPanel.stories.tsx
+++ b/frontend/src/components/inference/SetupPanel.stories.tsx
@@ -36,6 +36,7 @@ function makeJob(overrides: Partial<JobSummary>): JobSummary {
 export const NoModels: Story = {
   args: {
     completedJobs: [],
+    allJobs: [],
     selectedJobId: null,
     history: [],
     selectedInfId: null,
@@ -49,6 +50,10 @@ export const ModelSelected: Story = {
       makeJob({ job_id: "job-1", model_name: "LGBMClassifier" }),
       makeJob({ job_id: "job-2", model_name: "LGBMRegressor" }),
     ],
+    allJobs: [
+      makeJob({ job_id: "job-1", model_name: "LGBMClassifier" }),
+      makeJob({ job_id: "job-2", model_name: "LGBMRegressor" }),
+    ],
     selectedJobId: "job-1",
     history: [],
     selectedInfId: null,
@@ -59,6 +64,7 @@ export const ModelSelected: Story = {
 export const Running: Story = {
   args: {
     completedJobs: [makeJob({ job_id: "job-1" })],
+    allJobs: [makeJob({ job_id: "job-1" })],
     selectedJobId: "job-1",
     history: [],
     selectedInfId: null,

--- a/frontend/src/components/inference/SetupPanel.test.tsx
+++ b/frontend/src/components/inference/SetupPanel.test.tsx
@@ -35,6 +35,7 @@ describe("SetupPanel", () => {
 
   const baseProps = {
     completedJobs: [] as JobSummary[],
+    allJobs: [] as JobSummary[],
     selectedJobId: null,
     onSelectJob: vi.fn(),
     history: [] as InferenceRecord[],
@@ -118,6 +119,54 @@ describe("SetupPanel", () => {
   it("shows target detected when targetCol is provided", () => {
     render(<SetupPanel {...baseProps} targetCol="price" />);
     expect(screen.getByText(/Target.*'price'.*detected/)).toBeInTheDocument();
+  });
+
+  // Issue #359: Inference dropdown ``#N`` must be derived against the
+  // full ``allJobs`` list so it matches what JobsPage shows for the
+  // same job_id, even when failed/cancelled jobs sit between
+  // completed ones.
+  it("renders dropdown #N derived from allJobs (not completedJobs)", async () => {
+    const user = userEvent.setup();
+    const completedTop = {
+      job_id: "j-top",
+      job_type: "fit",
+      status: "completed",
+      backend_name: "lizyml",
+      model_name: "lgbm",
+      created_at: "2025-01-03T00:00:00Z",
+      completed_at: "2025-01-03T00:01:00Z",
+      error: null,
+      primary_score: 0.7,
+      parent_job_id: null,
+    } as JobSummary;
+    const failedMiddle = {
+      ...completedTop,
+      job_id: "j-mid-failed",
+      status: "failed" as const,
+      primary_score: null,
+    } as JobSummary;
+    const completedBottom = {
+      ...completedTop,
+      job_id: "j-bottom",
+      status: "completed" as const,
+      primary_score: 0.5,
+    } as JobSummary;
+    const allJobs = [completedTop, failedMiddle, completedBottom];
+    const completedJobs = [completedTop, completedBottom];
+    render(
+      <SetupPanel
+        {...baseProps}
+        allJobs={allJobs}
+        completedJobs={completedJobs}
+      />,
+    );
+    await user.click(screen.getByLabelText("Select completed job"));
+    // top completed job sits at allJobs idx 0 -> #3
+    expect(screen.getByText(/#3 fit lgbm/)).toBeInTheDocument();
+    // bottom completed job sits at allJobs idx 2 -> #1 (NOT #2 which
+    // would be the buggy completedJobs-only derivation)
+    expect(screen.getByText(/#1 fit lgbm/)).toBeInTheDocument();
+    expect(screen.queryByText(/#2 fit lgbm/)).not.toBeInTheDocument();
   });
 
   it("shows score info for selected job with primary_score", () => {

--- a/frontend/src/components/inference/SetupPanel.tsx
+++ b/frontend/src/components/inference/SetupPanel.tsx
@@ -17,12 +17,17 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { FileBrowser } from "@/components/workspace/FileBrowser";
+import { getJobNumber } from "@/lib/job-number";
 import { HistoryList } from "./HistoryList";
 
 type SourceType = "path" | "upload";
 
 interface SetupPanelProps {
   completedJobs: JobSummary[];
+  // Issue #359: dropdown numbering must be derived against the full
+  // all-jobs list, not the filtered ``completedJobs``, otherwise
+  // ``#N`` drifts from the JobsPage label.
+  allJobs: JobSummary[];
   selectedJobId: string | null;
   onSelectJob: (jobId: string) => void;
   history: InferenceRecord[];
@@ -39,6 +44,7 @@ interface SetupPanelProps {
 
 export function SetupPanel({
   completedJobs,
+  allJobs,
   selectedJobId,
   onSelectJob,
   history,
@@ -100,8 +106,8 @@ export function SetupPanel({
             <SelectValue placeholder="Select a completed job" />
           </SelectTrigger>
           <SelectContent>
-            {completedJobs.map((job, idx) => {
-              const num = completedJobs.length - idx;
+            {completedJobs.map((job) => {
+              const num = getJobNumber(job, allJobs);
               const modelName = extractModelName(job);
               return (
                 <SelectItem key={job.job_id} value={job.job_id}>

--- a/frontend/src/components/jobs/JobList.tsx
+++ b/frontend/src/components/jobs/JobList.tsx
@@ -16,6 +16,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { getJobNumber } from "@/lib/job-number";
 import { cn } from "@/lib/utils";
 
 type StatusFilter = "all" | "completed" | "running" | "failed";
@@ -72,12 +73,6 @@ function getJobScore(job: JobSummary): string {
   if (job.status === "failed" || job.status === "cancelled") return "\u2014";
   if (job.primary_score != null) return job.primary_score.toFixed(3);
   return "\u2014";
-}
-
-function getJobNumber(job: JobSummary, allJobs: JobSummary[]): number {
-  // Jobs are sorted newest first; job number = total - index
-  const idx = allJobs.findIndex((j) => j.job_id === job.job_id);
-  return allJobs.length - idx;
 }
 
 function formatTimeAgo(dateStr: string): string {

--- a/frontend/src/lib/job-number.test.ts
+++ b/frontend/src/lib/job-number.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { JobSummary } from "@/api/types";
+import { getJobNumber } from "./job-number";
+
+function fakeJob(id: string, status: JobSummary["status"]): JobSummary {
+  return {
+    job_id: id,
+    status,
+    backend_name: "lizyml",
+    job_type: "fit",
+    created_at: "2026-05-03T00:00:00Z",
+    completed_at: null,
+    error: null,
+    model_name: "lgbm",
+    primary_score: status === "completed" ? 0.5 : null,
+    parent_job_id: null,
+  };
+}
+
+describe("getJobNumber", () => {
+  // Issue #359: Inference dropdown drift. Jobs are sorted newest-first
+  // in the API response. ``getJobNumber`` returns the absolute job
+  // number (total - idx) so every page renders the same ``#N`` for the
+  // same job, regardless of whether the page filters its list to only
+  // ``completed`` jobs.
+  it("returns 1-indexed numbering against the full all-jobs list (newest first)", () => {
+    const all: JobSummary[] = [
+      fakeJob("c", "completed"), // idx 0 -> #3
+      fakeJob("b", "completed"), // idx 1 -> #2
+      fakeJob("a", "completed"), // idx 2 -> #1
+    ];
+    expect(getJobNumber(all[0], all)).toBe(3);
+    expect(getJobNumber(all[1], all)).toBe(2);
+    expect(getJobNumber(all[2], all)).toBe(1);
+  });
+
+  // The bug-of-record: when only the completed jobs are passed, a
+  // failed/cancelled job in the middle of the all-jobs list pulls the
+  // numbering out of sync with what JobsPage shows. The fix is to
+  // always derive against the full list.
+  it("matches JobsPage numbering when failed/cancelled jobs sit between completed ones", () => {
+    const all: JobSummary[] = [
+      fakeJob("e", "completed"), // #5
+      fakeJob("d", "failed"), //    #4
+      fakeJob("c", "completed"), // #3
+      fakeJob("b", "cancelled"), // #2
+      fakeJob("a", "completed"), // #1
+    ];
+    expect(getJobNumber(all[0], all)).toBe(5);
+    expect(getJobNumber(all[2], all)).toBe(3);
+    expect(getJobNumber(all[4], all)).toBe(1);
+  });
+
+  it("returns 0 when the job is not present in the list", () => {
+    const all: JobSummary[] = [fakeJob("a", "completed")];
+    const stranger = fakeJob("z", "completed");
+    expect(getJobNumber(stranger, all)).toBe(0);
+  });
+});

--- a/frontend/src/lib/job-number.ts
+++ b/frontend/src/lib/job-number.ts
@@ -1,0 +1,23 @@
+/**
+ * Compute the user-facing ``#N`` for a job.
+ *
+ * Jobs are returned newest-first by the API. The number shown to the
+ * user is the absolute position from the bottom — i.e. ``allJobs.length
+ * - idx``, where ``idx`` is the position in the full all-jobs list.
+ *
+ * Pages that filter their list (e.g. Inference, which only shows
+ * ``completed`` jobs in its model dropdown) MUST still derive the
+ * number against the full all-jobs list. Otherwise the same job_id
+ * gets a different ``#N`` on different pages, silently mis-attributing
+ * inference results to the wrong fit (Issue #359).
+ *
+ * Returns ``0`` when the job is not in the list (e.g. transient state
+ * during cache reconciliation).
+ */
+import type { JobSummary } from "@/api/types";
+
+export function getJobNumber(job: JobSummary, allJobs: JobSummary[]): number {
+  const idx = allJobs.findIndex((j) => j.job_id === job.job_id);
+  if (idx < 0) return 0;
+  return allJobs.length - idx;
+}

--- a/frontend/src/pages/InferencePage.tsx
+++ b/frontend/src/pages/InferencePage.tsx
@@ -13,6 +13,7 @@ import { ResultsWithGT } from "@/components/inference/ResultsWithGT";
 import { SetupPanel } from "@/components/inference/SetupPanel";
 import { useJobIdParam } from "@/hooks/useJobIdParam";
 import { getTargetColumn } from "@/lib/job-config";
+import { getJobNumber } from "@/lib/job-number";
 
 export function InferencePage() {
   const [selectedInfId, setSelectedInfId] = useState<string | null>(null);
@@ -105,13 +106,15 @@ export function InferencePage() {
     return idx >= 0 ? history.length - idx : 0;
   }, [selectedInfId, history]);
 
-  // Compute job label
+  // Compute job label.
+  // Issue #359: derive the ``#N`` against the full all-jobs list (not
+  // ``completedJobs``) so the label matches what JobsPage shows.
   const jobLabel = useMemo(() => {
     const job = completedJobs.find((j) => j.job_id === selectedJobId);
     if (!job) return "";
-    const num = completedJobs.length - completedJobs.indexOf(job);
+    const num = getJobNumber(job, allJobs);
     return `Job #${num} ${job.model_name}`;
-  }, [selectedJobId, completedJobs]);
+  }, [selectedJobId, completedJobs, allJobs]);
 
   // Fetch job detail to get config.data.target for ground-truth detection
   const { data: jobDetail } = useJob(selectedJobId);
@@ -124,6 +127,7 @@ export function InferencePage() {
       <div className="w-[360px] shrink-0 border-r">
         <SetupPanel
           completedJobs={completedJobs}
+          allJobs={allJobs}
           selectedJobId={selectedJobId}
           onSelectJob={handleSelectJob}
           history={history}


### PR DESCRIPTION
## Summary

- The Inference Model dropdown was numbering jobs as `completedJobs.length - idx`, while JobsPage uses `allJobs.length - idx`. With any failed/cancelled job in the history the two views drifted, silently mis-attributing inference results to the wrong fit.
- Extract `getJobNumber(job, allJobs)` to `lib/job-number.ts` so both pages share one derivation.
- Pass `allJobs` to `SetupPanel` alongside the existing `completedJobs` filter. The dropdown still hides failed/cancelled jobs, but their position in the all-jobs list is preserved so `#N` matches JobsPage exactly.
- `InferencePage.jobLabel` gets the same treatment. `JobList` drops its local helper in favour of the shared one.

## Test plan

- [x] `pnpm test --run src/lib/job-number.test.ts src/components/inference/SetupPanel.test.tsx src/pages/InferencePage.test.tsx src/components/jobs/JobList.test.tsx` — 51 passed
- [x] `pnpm test --run` — full suite 1778/1778 passed
- [x] `pnpm build` — green
- [x] `pnpm check` — Biome lint/format clean
- [x] Manual: backend restart, open `/inference` with a history that has 42 jobs (3 cancelled, 1 failed). Dropdown now shows `#42, #39, #38, #37, ..., #31, #30, ...` — skipping cancelled #41 / #40 / failed #32 — exactly matching JobsPage labels for the same `job_id`.

## Why option 2 (frontend-only fix)

The Issue called out two options: backend-authoritative `job_num` (Option 1) vs frontend-only derivation (Option 2). This PR takes Option 2 because it ships in <30 min with no schema/migration cost, and the shared `getJobNumber` helper centralises the derivation so future filtered views can't drift again. Option 1 (backend-authoritative `job_num` field) remains a worthwhile follow-up for stronger guarantees across deletions; tracked separately if the team wants to take it further.

Closes #359
