### PR TITLE
fix(workspace): hydrate Data Panel from server-persisted state on reload (#363)

### DIFF
--- a/frontend/src/api/queries/index.ts
+++ b/frontend/src/api/queries/index.ts
@@ -34,4 +34,5 @@ export {
   useConfig,
   useConfigSchema,
   useUiSchema,
+  useWorkspaceStatus,
 } from "./useWorkspace";

--- a/frontend/src/api/queries/useWorkspace.ts
+++ b/frontend/src/api/queries/useWorkspace.ts
@@ -11,6 +11,7 @@ import {
   fetchConfig,
   fetchConfigSchema,
   fetchUiSchema,
+  fetchWorkspaceStatus,
 } from "@/api/workspace";
 import { queryKeys } from "../queryKeys";
 
@@ -54,5 +55,20 @@ export function useColumns(options?: { enabled?: boolean }) {
     queryKey: queryKeys.columns(),
     queryFn: () => fetchColumns(),
     enabled: options?.enabled !== false,
+  });
+}
+
+/**
+ * Issue #363: WorkspacePage uses this on mount to discover whether
+ * the server already holds data + config from a previous session, so
+ * the UI can rehydrate instead of forcing the user to re-enter the
+ * CSV path on every reload.
+ */
+export function useWorkspaceStatus(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: queryKeys.workspaceStatus(),
+    queryFn: fetchWorkspaceStatus,
+    enabled: options?.enabled !== false,
+    retry: false,
   });
 }

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -73,4 +73,5 @@ export const queryKeys = {
   backends: () => ["backends"] as const,
   columns: () => ["columns"] as const,
   files: (path: string) => ["files", path] as const,
+  workspaceStatus: () => ["workspace-status"] as const,
 } as const;

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -81,6 +81,27 @@ export async function fetchColumnStats(
   ) as unknown as ColumnStatsResponse;
 }
 
+/**
+ * Workspace status snapshot — used for UI rehydration on reload
+ * (Issue #363).
+ */
+export interface WorkspaceStatus {
+  has_data: boolean;
+  has_config: boolean;
+  has_result: boolean;
+  data_ref: { filename: string; shape: number[] } | null;
+  current_job_id: string | null;
+  files_root: string;
+}
+
+export async function fetchWorkspaceStatus(): Promise<WorkspaceStatus> {
+  const { data } = await apiClient.GET("/api/workspace/status", {});
+  // SSOT-EXEMPT: the generated WorkspaceStatusResponse type uses
+  // optional fields where the runtime value is null; the local
+  // interface normalises them to ``X | null`` for ergonomics.
+  return unwrap(data, "/api/workspace/status") as unknown as WorkspaceStatus;
+}
+
 export async function fetchSplitPreview(): Promise<SplitPreviewResponse> {
   const { data } = await apiClient.GET("/api/workspace/data/split-preview", {});
   return unwrap(

--- a/frontend/src/components/workspace/DataPanel.tsx
+++ b/frontend/src/components/workspace/DataPanel.tsx
@@ -55,6 +55,19 @@ interface DataPanelProps {
  */
 export interface DataPanelHandle {
   getSubmitConfig: () => Promise<Record<string, unknown>>;
+  /**
+   * Issue #363: rehydrate the Data Panel from a server-persisted
+   * Workspace snapshot. WorkspacePage calls this once on mount when
+   * `/api/workspace/status` reports `has_data === true` so the UI
+   * doesn't force the user to re-enter the CSV path on every browser
+   * reload.
+   */
+  hydrateFromServer: (params: {
+    path: string;
+    shape: [number, number];
+    target: string | null;
+    task: TaskType | null;
+  }) => Promise<void>;
 }
 
 export const DataPanel = forwardRef<DataPanelHandle, DataPanelProps>(
@@ -92,6 +105,7 @@ export const DataPanel = forwardRef<DataPanelHandle, DataPanelProps>(
       handleExcludeToggle,
       handleTypeChange,
       handleColumnExpand,
+      hydrateFromServer,
     } = useDataPanel({ onDataChanged, onTaskChanged, uiSchema });
 
     // P-0086: expose a builder that returns the merged config the Fit/Tune
@@ -118,8 +132,18 @@ export const DataPanel = forwardRef<DataPanelHandle, DataPanelProps>(
             strategyFields,
           });
         },
+        hydrateFromServer,
       }),
-      [dataPath, target, task, overrides, cv, blocked, strategyFields],
+      [
+        dataPath,
+        target,
+        task,
+        overrides,
+        cv,
+        blocked,
+        strategyFields,
+        hydrateFromServer,
+      ],
     );
 
     return (

--- a/frontend/src/hooks/useDataLoad.test.ts
+++ b/frontend/src/hooks/useDataLoad.test.ts
@@ -198,6 +198,93 @@ describe("useDataLoad", () => {
     expect(mocks.uploadData).not.toHaveBeenCalled();
   });
 
+  // Issue #363: hydrateFromServer mirrors server-side state into the
+  // local Data Panel without re-POSTing the data, so a browser reload
+  // doesn't force the user to re-enter the CSV path.
+  describe("hydrateFromServer (Issue #363)", () => {
+    it("populates path / sourceType / shape / preview / columns from a server snapshot", async () => {
+      mocks.fetchColumns.mockResolvedValue(COLS_OK);
+      mocks.fetchPreview.mockResolvedValue({
+        columns: ["a"],
+        data: [{ a: 1 }],
+      });
+
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(() => useDataLoad(defaultParams), {
+        wrapper,
+      });
+
+      await act(async () => {
+        await result.current.hydrateFromServer(
+          "/data/x.csv",
+          [418, 13],
+          "Survived",
+        );
+      });
+
+      expect(result.current.sourceType).toBe("path");
+      expect(result.current.dataPath).toBe("/data/x.csv");
+      expect(result.current.shape).toEqual([418, 13]);
+      expect(result.current.preview).toEqual({
+        columns: ["a"],
+        data: [{ a: 1 }],
+      });
+      expect(defaultParams.onColumnsLoaded).toHaveBeenCalledWith(
+        COLS_OK.columns,
+        ["a"],
+      );
+      expect(defaultParams.onDataChanged).toHaveBeenCalled();
+      // ``onReset`` would clear target/task — must NOT fire during
+      // hydration since target is exactly what we're trying to keep.
+      expect(defaultParams.onReset).not.toHaveBeenCalled();
+      // No POST /workspace/data/path round-trip — server already has
+      // the data, hydration is a pure mirror operation.
+      expect(mocks.loadDataFromPath).not.toHaveBeenCalled();
+      // No toast — hydration is a silent restore, not a user action.
+      expect(mocks.toastSuccess).not.toHaveBeenCalled();
+    });
+
+    it("skips empty path silently", async () => {
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(() => useDataLoad(defaultParams), {
+        wrapper,
+      });
+
+      await act(async () => {
+        await result.current.hydrateFromServer("", [0, 0], null);
+      });
+
+      expect(mocks.fetchPreview).not.toHaveBeenCalled();
+      expect(mocks.fetchColumns).not.toHaveBeenCalled();
+      expect(result.current.sourceType).toBe("upload");
+    });
+
+    it("falls back gracefully when fetchPreview fails (no toast)", async () => {
+      mocks.fetchPreview.mockRejectedValue(new Error("preview broken"));
+
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(() => useDataLoad(defaultParams), {
+        wrapper,
+      });
+
+      await act(async () => {
+        await result.current.hydrateFromServer(
+          "/data/x.csv",
+          [418, 13],
+          "Survived",
+        );
+      });
+
+      // Path / shape were applied before the failed fetchPreview, so
+      // the user at least sees that hydration was attempted.
+      expect(result.current.sourceType).toBe("path");
+      expect(result.current.dataPath).toBe("/data/x.csv");
+      expect(result.current.shape).toEqual([418, 13]);
+      // Hydration is silent — failures must not surface a toast.
+      expect(mocks.toastError).not.toHaveBeenCalled();
+    });
+  });
+
   it("initial state is correct", () => {
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useDataLoad(defaultParams), {

--- a/frontend/src/hooks/useDataLoad.ts
+++ b/frontend/src/hooks/useDataLoad.ts
@@ -58,6 +58,55 @@ export function useDataLoad({
     }
   };
 
+  /**
+   * Issue #363: hydrate the local UI from server-side persisted state
+   * after a page reload. Differs from ``handleLoadPathByValue`` in
+   * that it skips the POST /api/workspace/data/path round-trip — the
+   * server already knows the data, we just want to mirror its state
+   * into local React state. Falls back to a normal load if the
+   * preview/columns calls fail (e.g. a stale path no longer
+   * accessible after a server restart).
+   */
+  const hydrateFromServer = async (
+    path: string,
+    initialShape: [number, number],
+    // ``target`` is accepted for symmetry with ``handleLoadPathByValue``
+    // but intentionally NOT forwarded to ``fetchColumns`` — see the
+    // inline comment below.
+    _target: string | null,
+  ) => {
+    if (!path.trim()) return;
+    setSourceType("path");
+    setDataPath(path);
+    setShape(initialShape);
+    try {
+      const prev = await fetchPreview(5);
+      setPreview(prev);
+      // Issue #363: fetch ALL columns (no ``target`` arg) so the
+      // Target combobox can render the previously-selected target as
+      // a selectable option. Passing ``target`` here would have the
+      // server exclude it from the response, leaving the Select
+      // bound to a value that isn't present in its options.
+      const cols = await fetchColumns();
+      onColumnsLoaded(
+        cols.columns,
+        cols.columns.map((c) => c.name),
+      );
+      // ``onDataChanged`` flips ``hasData=true`` in WorkspacePage so
+      // the rest of the panels (CV, model params) start consuming
+      // the cached config. ``onReset`` is intentionally NOT called
+      // here — that would clear target/task which we want to keep.
+      onDataChanged();
+    } catch (err) {
+      // If hydration fetches fail (e.g. CSV moved on disk between
+      // sessions), surface the error but do NOT toast — the user
+      // hasn't taken any action and a noisy toast would be confusing.
+      // The Workspace ends up in its empty default state, which is
+      // correct fallback behaviour.
+      console.warn("Workspace hydration failed:", err);
+    }
+  };
+
   const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -94,5 +143,6 @@ export function useDataLoad({
     loading,
     handleLoadPathByValue,
     handleUpload,
+    hydrateFromServer,
   };
 }

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -177,6 +177,33 @@ export function useDataPanel({
     return unsubscribe;
   }, [queryClient]);
 
+  /**
+   * Issue #363: rehydrate Data Panel state from a server-persisted
+   * Workspace snapshot. Called once on mount when the server reports
+   * ``has_data === true`` so the UI doesn't force the user to re-enter
+   * the CSV path on every browser reload. ``data_ref.shape`` comes
+   * from /api/workspace/status; the path / target / task come from
+   * the cached /api/workspace/config response.
+   */
+  const hydrateFromServer = useCallback(
+    async (params: {
+      path: string;
+      shape: [number, number];
+      target: string | null;
+      task: TaskType | null;
+    }) => {
+      await dataLoad.hydrateFromServer(
+        params.path,
+        params.shape,
+        params.target,
+      );
+      setTarget(params.target);
+      setTask(params.task);
+      onTaskChanged?.(params.task);
+    },
+    [dataLoad, onTaskChanged],
+  );
+
   return {
     sourceType: dataLoad.sourceType,
     setSourceType: dataLoad.setSourceType,
@@ -188,6 +215,7 @@ export function useDataPanel({
     task,
     allColumnNames,
     columns,
+    hydrateFromServer,
     overrides: columnOverrides.overrides,
     cv,
     setCv,

--- a/frontend/src/pages/WorkspacePage.test.tsx
+++ b/frontend/src/pages/WorkspacePage.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, screen } from "@testing-library/react";
+import { act, cleanup, screen, waitFor } from "@testing-library/react";
 import { forwardRef, useImperativeHandle } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "@/test/helpers";
@@ -25,13 +25,28 @@ const {
   },
 }));
 
-const { mockFetchConfig } = vi.hoisted(() => ({
+const { mockFetchConfig, mockFetchWorkspaceStatus } = vi.hoisted(() => ({
   mockFetchConfig: vi.fn().mockResolvedValue({ model: { name: "lgbm" } }),
+  mockFetchWorkspaceStatus: vi.fn().mockResolvedValue({
+    has_data: false,
+    has_config: false,
+    has_result: false,
+    data_ref: null,
+    current_job_id: null,
+    files_root: "/home/rem",
+  }),
 }));
 
 vi.mock("@/api/workspace", () => ({
   fetchConfig: (...args: unknown[]) => mockFetchConfig(...args),
   fetchUiSchema: (...args: unknown[]) => mockFetchUiSchema(...args),
+  // Issue #363: WorkspacePage now probes /api/workspace/status on
+  // mount to drive rehydration. Default to ``has_data: false`` so
+  // existing tests keep their pre-#363 behaviour (Workspace stays in
+  // its empty default state); individual rehydration tests override
+  // by calling ``mockFetchWorkspaceStatus.mockResolvedValueOnce(...)``.
+  fetchWorkspaceStatus: (...args: unknown[]) =>
+    mockFetchWorkspaceStatus(...args),
   runFit: (...args: unknown[]) => mockRunFit(...args),
   runTune: (...args: unknown[]) => mockRunTune(...args),
   updateConfig: (...args: unknown[]) => mockUpdateConfig(...args),
@@ -64,10 +79,22 @@ let capturedResultsPanelProps: Record<string, unknown> = {};
 // is created via ``vi.hoisted`` because vi.mock factories execute before
 // module-scope ``const`` initializers, and because a mutable ref is the
 // idiomatic way to let individual tests swap the value seen by the mock.
-const { submitConfigRef, submitConfigErrorRef } = vi.hoisted(() => ({
-  submitConfigRef: { current: null as Record<string, unknown> | null },
-  submitConfigErrorRef: { current: null as Error | null },
-}));
+const { submitConfigRef, submitConfigErrorRef, hydrateCallsRef } = vi.hoisted(
+  () => ({
+    submitConfigRef: { current: null as Record<string, unknown> | null },
+    submitConfigErrorRef: { current: null as Error | null },
+    // Issue #363: capture every ``hydrateFromServer`` call from the
+    // WorkspacePage effect so individual tests can assert payload + count.
+    hydrateCallsRef: {
+      current: [] as Array<{
+        path: string;
+        shape: [number, number];
+        target: string | null;
+        task: string | null;
+      }>,
+    },
+  }),
+);
 
 vi.mock("@/components/workspace/DataPanel", () => ({
   DataPanel: forwardRef(
@@ -75,6 +102,12 @@ vi.mock("@/components/workspace/DataPanel", () => ({
       props: Record<string, unknown>,
       ref: React.Ref<{
         getSubmitConfig: () => Promise<Record<string, unknown>>;
+        hydrateFromServer: (params: {
+          path: string;
+          shape: [number, number];
+          target: string | null;
+          task: string | null;
+        }) => Promise<void>;
       }>,
     ) => {
       capturedDataPanelProps = props;
@@ -86,6 +119,9 @@ vi.mock("@/components/workspace/DataPanel", () => ({
               throw submitConfigErrorRef.current;
             }
             return submitConfigRef.current ?? ({} as Record<string, unknown>);
+          },
+          hydrateFromServer: async (params) => {
+            hydrateCallsRef.current.push(params);
           },
         }),
         [],
@@ -117,6 +153,17 @@ describe("WorkspacePage", () => {
     capturedResultsPanelProps = {};
     submitConfigRef.current = null;
     submitConfigErrorRef.current = null;
+    hydrateCallsRef.current = [];
+    // Reset rehydration mock to the empty default; tests that need a
+    // populated server snapshot opt in via mockResolvedValueOnce.
+    mockFetchWorkspaceStatus.mockResolvedValue({
+      has_data: false,
+      has_config: false,
+      has_result: false,
+      data_ref: null,
+      current_job_id: null,
+      files_root: "/home/rem",
+    });
 
     Object.defineProperty(window, "matchMedia", {
       writable: true,
@@ -391,6 +438,96 @@ describe("WorkspacePage", () => {
     expect(mockToast.error).toHaveBeenCalledWith(
       "Tune failed: plain string error",
     );
+  });
+
+  // -----------------------------------------------------------------
+  // Issue #363: rehydrate the Workspace from server-persisted state
+  // on mount, so a browser reload no longer forces the user to
+  // re-enter the CSV path / re-pick the target / re-configure CV.
+  // -----------------------------------------------------------------
+  describe("workspace rehydration from server (Issue #363)", () => {
+    it("calls DataPanel.hydrateFromServer when status reports has_data=true", async () => {
+      mockFetchWorkspaceStatus.mockResolvedValue({
+        has_data: true,
+        has_config: true,
+        has_result: false,
+        data_ref: { filename: "data.csv", shape: [418, 13] },
+        current_job_id: null,
+        files_root: "/home/rem",
+      });
+      mockFetchConfig.mockResolvedValue({
+        task: "binary",
+        data: { path: "/home/rem/data/x.csv", target: "Survived" },
+      });
+
+      renderWithProviders(<WorkspacePage />);
+      // status + config are async — wait for the rehydration effect.
+      await waitFor(() => {
+        expect(hydrateCallsRef.current).toHaveLength(1);
+      });
+      expect(hydrateCallsRef.current[0]).toEqual({
+        path: "/home/rem/data/x.csv",
+        shape: [418, 13],
+        target: "Survived",
+        task: "binary",
+      });
+    });
+
+    it("does not call hydrateFromServer when status reports has_data=false", async () => {
+      // mockFetchWorkspaceStatus default already returns has_data=false.
+      renderWithProviders(<WorkspacePage />);
+      // Give the component time to settle; the hydration effect must
+      // remain dormant when the server has no persisted data.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(hydrateCallsRef.current).toHaveLength(0);
+    });
+
+    it("does not re-call hydrateFromServer when status/config refetches with the same payload (latched once)", async () => {
+      mockFetchWorkspaceStatus.mockResolvedValue({
+        has_data: true,
+        has_config: true,
+        has_result: false,
+        data_ref: { filename: "data.csv", shape: [10, 2] },
+        current_job_id: null,
+        files_root: "/home/rem",
+      });
+      mockFetchConfig.mockResolvedValue({
+        task: "regression",
+        data: { path: "/p.csv", target: "y" },
+      });
+
+      renderWithProviders(<WorkspacePage />);
+      await waitFor(() => {
+        expect(hydrateCallsRef.current).toHaveLength(1);
+      });
+      // Trigger a re-render path that the rehydration effect's deps
+      // (workspaceStatus, config) would normally retrigger on. Even
+      // when the queries' identities flip, ``hydratedRef`` must keep
+      // the effect dormant.
+      const onDataChanged = capturedDataPanelProps.onDataChanged as () => void;
+      act(() => onDataChanged());
+      await new Promise((r) => setTimeout(r, 30));
+      expect(hydrateCallsRef.current).toHaveLength(1);
+    });
+
+    it("skips rehydration when config.data.path is missing", async () => {
+      mockFetchWorkspaceStatus.mockResolvedValue({
+        has_data: true,
+        has_config: false,
+        has_result: false,
+        data_ref: { filename: "data.csv", shape: [10, 2] },
+        current_job_id: null,
+        files_root: "/home/rem",
+      });
+      mockFetchConfig.mockResolvedValue({
+        task: null,
+        data: { target: null }, // no path
+      });
+
+      renderWithProviders(<WorkspacePage />);
+      await new Promise((r) => setTimeout(r, 50));
+      expect(hydrateCallsRef.current).toHaveLength(0);
+    });
   });
 
   // -----------------------------------------------------------------

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -1,9 +1,9 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { BarChart3, Database, SlidersHorizontal } from "lucide-react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { getErrorMessage } from "@/api/errors";
-import { useConfig, useUiSchema } from "@/api/queries";
+import { useConfig, useUiSchema, useWorkspaceStatus } from "@/api/queries";
 import { queryKeys } from "@/api/queryKeys";
 import { runFit, runTune } from "@/api/workspace";
 import {
@@ -67,7 +67,17 @@ export function WorkspacePage() {
   const notify = useBackgroundNotification();
 
   const { data: uiSchema } = useUiSchema();
-  const { data: config } = useConfig({ enabled: hasData, retry: false });
+  // Issue #363: probe the server on mount so the UI knows whether a
+  // previous session left data + config persisted. When ``has_data``
+  // is true, we flip the local ``hasData`` flag (via the same
+  // ``handleDataChanged`` callback the manual load path uses) and
+  // hand the snapshot to ``DataPanel.hydrateFromServer`` so the Path
+  // textbox / Target combobox / Column Settings / etc. all repopulate.
+  const { data: workspaceStatus } = useWorkspaceStatus();
+  const { data: config } = useConfig({
+    enabled: hasData || workspaceStatus?.has_data === true,
+    retry: false,
+  });
 
   // P-0092 Q-1 Phase 2: instantiate the write funnel for the entire
   // Workspace tree. ConfigForm's auto-reset effects route through
@@ -109,6 +119,48 @@ export function WorkspacePage() {
     setHasData(true);
     queryClient.invalidateQueries({ queryKey: queryKeys.config() });
   }, [queryClient]);
+
+  // Issue #363: rehydrate the Data Panel exactly once after a reload
+  // when the server reports a persisted snapshot. Subsequent runs are
+  // gated by ``hydratedRef`` so this never re-fires (e.g. on cache
+  // refetch or when the user later loads a different CSV manually).
+  const hydratedRef = useRef(false);
+  useEffect(() => {
+    if (hydratedRef.current) return;
+    if (
+      !workspaceStatus?.has_data ||
+      !workspaceStatus.data_ref ||
+      !config ||
+      !dataPanelRef.current
+    ) {
+      return;
+    }
+    const cfgData = (config as { data?: Record<string, unknown> }).data;
+    const cfgPath = (cfgData?.path as string | undefined) ?? "";
+    const cfgTarget = (cfgData?.target as string | undefined) ?? null;
+    const cfgTask =
+      ((config as { task?: string }).task as
+        | "binary"
+        | "multiclass"
+        | "regression"
+        | undefined) ?? null;
+    if (!cfgPath) return;
+    hydratedRef.current = true;
+    const shape = workspaceStatus.data_ref.shape;
+    dataPanelRef.current
+      .hydrateFromServer({
+        path: cfgPath,
+        shape: [shape[0] ?? 0, shape[1] ?? 0],
+        target: cfgTarget,
+        task: cfgTask,
+      })
+      .catch((err) => {
+        // Guard: if hydration fails (e.g. CSV moved on disk), reset
+        // the latch so a subsequent successful refetch can retry.
+        hydratedRef.current = false;
+        console.warn("Workspace rehydration failed:", err);
+      });
+  }, [workspaceStatus, config]);
 
   const handleTaskChanged = useCallback((t: string | null) => {
     setTask(t);


### PR DESCRIPTION
## Summary

After a browser reload the Workspace UI was reset to its empty default state even though the server still held `workspace_data` + `workspace_config` per BLUEPRINT.md. The user had to re-enter the CSV path, re-pick the target, and re-configure CV / model params on every reload — a v0.4 business-readiness blocker.

Add a `useWorkspaceStatus()` query that runs on mount. When `has_data === true` the WorkspacePage flips `hasData` so `useConfig` enables, then once both responses land the new `DataPanel.hydrateFromServer` imperative method is called exactly once (latched via a ref) to mirror the server-known state into local React state:

- Data Source mode → `path` with the persisted file path
- Shape from `status.data_ref.shape`
- Preview + Column Settings via `fetchPreview` / `fetchColumns`
- Target combobox bound to the previously-selected column
- Task radio reflects `config.task`
- CV strategy is restored by the existing reconcile effect

`fetchColumns` is intentionally called WITHOUT a target argument during hydration: passing `target` makes the server omit it from the response, leaving the Select bound to a value missing from its options. The right-hand Results panel correctly stays empty per BLUEPRINT.md:303-304.

## Test plan

- [x] `pnpm test --run src/hooks/useDataLoad.test.ts src/pages/WorkspacePage.test.tsx` — 48 passed (3 new hydrateFromServer cases + 4 new rehydration integration cases)
- [x] `pnpm test --run` — full suite 1781/1781 passed
- [x] `pnpm build` — green
- [x] `pnpm check` — Biome lint/format clean
- [x] Manual: load `tests/fixtures/lizyml/binary_no_cal/data.csv` + Survived target, then **F5 reload**. Result: Workspace re-renders with Path mode active, full path populated, Survived selected, binary task auto-detected, 12 features in Column Settings, StratifiedKFold preserved — no user action required.

## Why this slipped through

The Workspace state machine never called `/api/workspace/status` and the `useConfig` query was gated on local `hasData` (a chicken-egg). The fix adds the missing probe + rehydration step.

Closes #363
