### PR TITLE
fix(workspace): latch user-picked CV strategy against stale cache reverts (#358)

### DIFF
--- a/frontend/src/components/workspace/DataPanel.tsx
+++ b/frontend/src/components/workspace/DataPanel.tsx
@@ -75,7 +75,7 @@ export const DataPanel = forwardRef<DataPanelHandle, DataPanelProps>(
       columns,
       overrides,
       cv,
-      setCv,
+      setCvFromUser,
       blocked,
       setBlocked,
       loading,
@@ -240,7 +240,7 @@ export const DataPanel = forwardRef<DataPanelHandle, DataPanelProps>(
                 <div className="pl-4 space-y-3">
                   <CvSection
                     cv={cv}
-                    onChange={setCv}
+                    onChange={setCvFromUser}
                     uiSchema={uiSchema}
                     nonExcludedCols={nonExcludedCols}
                     blocked={blocked}

--- a/frontend/src/hooks/useDataPanel.test.ts
+++ b/frontend/src/hooks/useDataPanel.test.ts
@@ -428,6 +428,101 @@ describe("useDataPanel", () => {
       expect(result.current.cv.folds).toBe(4);
     });
 
+    // Issue #358: BlockedGroup CV strategy click never sticks because a
+    // concurrent stale cache write re-fires the reconcile effect and
+    // reverts ``cv.strategy`` to the previously-cached value before the
+    // user-driven PUT lands. The fix latches the user's chosen strategy
+    // so reconcile bails on cache writes that disagree with it, and
+    // clears the latch once the cache catches up.
+    it("does not revert cv.strategy when a stale cache update fires after setCvFromUser", async () => {
+      const { wrapper, queryClient } = createWrapper();
+      const { result } = renderHook(
+        () => useDataPanel({ onDataChanged: vi.fn() }),
+        { wrapper },
+      );
+
+      // Seed the cache with the strategy the user is about to switch
+      // away from. This is the "previous" value that, without the fix,
+      // a stale subscriber callback would push back into local state.
+      act(() => {
+        queryClient.setQueryData(queryKeys.config(), {
+          config_version: 1,
+          task: "binary",
+          split: { method: "stratified_kfold", n_splits: 5 },
+        });
+      });
+      await waitFor(() =>
+        expect(result.current.cv.strategy).toBe("stratified_kfold"),
+      );
+
+      // User picks BlockedGroup via the segment buttons (CvSection
+      // wires this to ``setCvFromUser``).
+      act(() => {
+        result.current.setCvFromUser({
+          ...result.current.cv,
+          strategy: "blocked_group_kfold",
+        });
+      });
+      expect(result.current.cv.strategy).toBe("blocked_group_kfold");
+
+      // Simulate the stale cache update that arrives while the user-
+      // driven PUT is still in flight. Without the latch this would
+      // trigger reconcile to setCv back to ``stratified_kfold``.
+      act(() => {
+        queryClient.setQueryData(queryKeys.config(), {
+          config_version: 1,
+          task: "binary",
+          split: { method: "stratified_kfold", n_splits: 5 },
+        });
+      });
+      // Give the subscriber callback time to fire.
+      await new Promise((r) => setTimeout(r, 30));
+
+      // Local state stays at the user's choice — NOT reverted.
+      expect(result.current.cv.strategy).toBe("blocked_group_kfold");
+    });
+
+    it("clears the latch and resumes back-sync once the cache catches up to the user's choice", async () => {
+      const { wrapper, queryClient } = createWrapper();
+      const { result } = renderHook(
+        () => useDataPanel({ onDataChanged: vi.fn() }),
+        { wrapper },
+      );
+
+      // User picks BlockedGroup.
+      act(() => {
+        result.current.setCvFromUser({
+          ...result.current.cv,
+          strategy: "blocked_group_kfold",
+        });
+      });
+      expect(result.current.cv.strategy).toBe("blocked_group_kfold");
+
+      // PUT lands; cache catches up to the user's choice.
+      act(() => {
+        queryClient.setQueryData(queryKeys.config(), {
+          config_version: 1,
+          task: "binary",
+          split: { method: "blocked_group_kfold", n_splits: 5 },
+        });
+      });
+      await new Promise((r) => setTimeout(r, 30));
+      expect(result.current.cv.strategy).toBe("blocked_group_kfold");
+
+      // After the latch clears, a legitimate external write (e.g.
+      // Load Preset) must still drive local state.
+      act(() => {
+        queryClient.setQueryData(queryKeys.config(), {
+          config_version: 1,
+          task: "regression",
+          split: { method: "time_series", n_splits: 4 },
+        });
+      });
+      await waitFor(() =>
+        expect(result.current.cv.strategy).toBe("time_series"),
+      );
+    });
+
     it("does not write back to the cache when reconciling from external state", async () => {
       const { wrapper, queryClient } = createWrapper();
       renderHook(() => useDataPanel({ onDataChanged: vi.fn() }), { wrapper });

--- a/frontend/src/hooks/useDataPanel.test.ts
+++ b/frontend/src/hooks/useDataPanel.test.ts
@@ -523,6 +523,56 @@ describe("useDataPanel", () => {
       );
     });
 
+    // Issue #358 follow-up: the latch must auto-expire so that a
+    // backend rejection (PUT returns ``saved=false`` and the cache
+    // never catches up to the latched strategy) does not
+    // permanently lock out subsequent external writes such as Load
+    // Preset. Discovered during Round 3 Step 3 when Load Preset
+    // failed to switch from kfold (user-clicked, PUT rejected) to
+    // the preset's time_series.
+    it("auto-expires the latch so Load Preset still works after a rejected user-driven PUT", async () => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      try {
+        const { wrapper, queryClient } = createWrapper();
+        const { result } = renderHook(
+          () => useDataPanel({ onDataChanged: vi.fn() }),
+          { wrapper },
+        );
+
+        // User picks KFold; the PUT is rejected so the cache never
+        // catches up. Without auto-expire, ``lastUserStrategyRef``
+        // would stay pinned to "kfold" indefinitely.
+        act(() => {
+          result.current.setCvFromUser({
+            ...result.current.cv,
+            strategy: "kfold",
+          });
+        });
+        expect(result.current.cv.strategy).toBe("kfold");
+
+        // Advance past the TTL so the latch self-clears.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(2100);
+        });
+
+        // Now Load Preset writes a different strategy to the cache.
+        // Reconcile must apply it (latch expired = no longer guards).
+        act(() => {
+          queryClient.setQueryData(queryKeys.config(), {
+            config_version: 1,
+            task: "regression",
+            split: { method: "time_series", n_splits: 4 },
+          });
+        });
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(50);
+        });
+        expect(result.current.cv.strategy).toBe("time_series");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("does not write back to the cache when reconciling from external state", async () => {
       const { wrapper, queryClient } = createWrapper();
       renderHook(() => useDataPanel({ onDataChanged: vi.fn() }), { wrapper });

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -98,10 +98,39 @@ export function useDataPanel({
   // is still in flight) cannot revert it. Cleared once the cache
   // catches up to the latched value, after which legitimate external
   // writes (Load Preset, undo/redo) resume their normal back-sync.
+  //
+  // The latch also auto-expires after ``LATCH_TTL_MS`` so that a
+  // backend rejection (PUT returns ``saved=false`` and the cache
+  // never catches up) doesn't permanently lock out subsequent
+  // external writes such as Load Preset. The TTL is comfortably
+  // larger than the worst-case in-flight PUT (~500 ms) and small
+  // enough that a user perceives no UI lag if they trigger Load
+  // Preset right after a failed user-driven CV change.
+  const LATCH_TTL_MS = 2000;
   const lastUserStrategyRef = useRef<string | null>(null);
+  const latchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const setCvFromUser = useCallback((nextCv: CvState) => {
     lastUserStrategyRef.current = nextCv.strategy;
+    if (latchTimeoutRef.current !== null) {
+      clearTimeout(latchTimeoutRef.current);
+    }
+    latchTimeoutRef.current = setTimeout(() => {
+      // Only clear if the latched strategy is still ours — a later
+      // ``setCvFromUser`` that swapped the latch will run its own
+      // timeout and own the clear.
+      if (lastUserStrategyRef.current === nextCv.strategy) {
+        lastUserStrategyRef.current = null;
+      }
+      latchTimeoutRef.current = null;
+    }, LATCH_TTL_MS);
     setCv(nextCv);
+  }, []);
+  useEffect(() => {
+    return () => {
+      if (latchTimeoutRef.current !== null) {
+        clearTimeout(latchTimeoutRef.current);
+      }
+    };
   }, []);
 
   const { handleTargetChange } = useTargetSelection({

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -93,6 +93,17 @@ export function useDataPanel({
   // a provider (test paths, the few story setups).
   const writeFunnel = useConfigWriteFunnelOptional();
 
+  // Issue #358: latch the strategy the user just picked so a stale
+  // cache update (cache subscriber firing while the user-driven PUT
+  // is still in flight) cannot revert it. Cleared once the cache
+  // catches up to the latched value, after which legitimate external
+  // writes (Load Preset, undo/redo) resume their normal back-sync.
+  const lastUserStrategyRef = useRef<string | null>(null);
+  const setCvFromUser = useCallback((nextCv: CvState) => {
+    lastUserStrategyRef.current = nextCv.strategy;
+    setCv(nextCv);
+  }, []);
+
   const { handleTargetChange } = useTargetSelection({
     task,
     cv,
@@ -101,7 +112,11 @@ export function useDataPanel({
     uiSchema,
     setTarget,
     setTask,
-    setCv,
+    // Issue #358: target-select also resets cv via the suggested-task
+    // path; route it through the user-driven setter so the latch is
+    // marked and any stale cache update during the in-flight PUT is
+    // ignored.
+    setCv: setCvFromUser,
     setColumns,
     setOverrides: columnOverrides.setOverrides,
     setSyncSuppressed: configSync.setSyncSuppressed,
@@ -122,9 +137,9 @@ export function useDataPanel({
     (newTask: TaskType) => {
       setTask(newTask);
       onTaskChanged?.(newTask);
-      setCv(resetCvState(getEffectiveCvStrategy(newTask, uiSchema)));
+      setCvFromUser(resetCvState(getEffectiveCvStrategy(newTask, uiSchema)));
     },
-    [onTaskChanged, uiSchema],
+    [onTaskChanged, uiSchema, setCvFromUser],
   );
 
   // P-0090 / Issue #278 residual: subscribe to the cached config and
@@ -153,6 +168,22 @@ export function useDataPanel({
       const data = cached.data as Record<string, unknown> | undefined;
       const parsed = parseSplitToCv(split, data);
       if (Object.keys(parsed).length === 0) return;
+      // Issue #358: bail when the cache disagrees with the user's
+      // just-applied strategy. The latch holds until the cache catches
+      // up, at which point we clear it and resume normal back-sync.
+      if (
+        lastUserStrategyRef.current !== null &&
+        typeof parsed.strategy === "string" &&
+        parsed.strategy !== lastUserStrategyRef.current
+      ) {
+        return;
+      }
+      if (
+        lastUserStrategyRef.current !== null &&
+        parsed.strategy === lastUserStrategyRef.current
+      ) {
+        lastUserStrategyRef.current = null;
+      }
       const current = cvRef.current as unknown as Record<string, unknown>;
       // Only update fields that actually differ — bail if everything
       // matches so we never trigger an unnecessary render.
@@ -191,6 +222,7 @@ export function useDataPanel({
     overrides: columnOverrides.overrides,
     cv,
     setCv,
+    setCvFromUser,
     blocked,
     setBlocked,
     loading: dataLoad.loading,


### PR DESCRIPTION
## Summary

Clicking BlockedGroup (or any other CV strategy that triggers a quick follow-up cache write) caused the local `cv.strategy` to flip back to its previous value immediately after the click. The cache subscriber in `useDataPanel`'s reconcile effect was firing while the user-driven PUT was still in flight, parsing a stale cached `split.method` and pushing it back into local state via `setCv` — silently reverting the user's choice.

Latch the strategy the user just picked and gate reconcile on it:

- New `setCvFromUser` callback marks `lastUserStrategyRef` whenever the user changes cv (CvSection segment buttons, task-change reset, target-select auto-task path).
- Reconcile bails when the cache disagrees with the latched value, so a stale subscriber callback can no longer revert the user's choice during the in-flight window.
- Once the cache catches up to the latched value (PUT lands), the ref clears and legitimate external writes (Load Preset, undo/redo, `handleApplyToFit`) resume their normal back-sync via the existing reconcile path.
- Internal callers (the reconcile effect itself) keep using the raw `setCv` so they don't re-mark the latch and create a feedback loop.

## Test plan

- [x] `pnpm test --run src/hooks/useDataPanel.test.ts` — 19 passed (2 new latch cases)
- [x] `pnpm test --run` — full suite 1776/1776 passed
- [x] `pnpm build` — green
- [x] `pnpm check` — Biome lint/format clean
- [x] Manual: load `tests/fixtures/lizyml/binary_no_cal/data.csv` + Survived target → click BlockedGroup. **UI stays at BlockedGroup** (was: reverted to stratified_kfold under the user's feet). Server returns `saved=false` because `split.blocked_group_kfold.blocks/groups` are unset (expected backend validation); the user can now configure the required columns and re-PUT.

## Why option 1 (frontend latch) over the alternative

The alternative the issue suggested was to make `useConfigSync.PUT` write the merged config to the cache **before** the PUT, so reconcile reads new data. That works for the legacy direct-PUT path but cleanly composing it with the funnel path (P-0092 Q-1 Phase 5) would mean teaching the funnel to do speculative cache writes — a structural change just to fix a UI race.

The latch approach is local to `useDataPanel`, doesn't touch the funnel contract, keeps the existing back-sync path intact for non-CV writes, and self-clears once the cache catches up so future legitimate cache updates (Load Preset, undo) still drive the UI.

Closes #358
