### PR TITLE
fix(inference): use probability-histogram + gate distribution panel on availability (#370)

### DIFF
--- a/frontend/src/components/inference/ResultsPredOnly.test.tsx
+++ b/frontend/src/components/inference/ResultsPredOnly.test.tsx
@@ -116,7 +116,10 @@ describe("ResultsPredOnly", () => {
     expect(screen.getByTestId("predictions-table")).toBeInTheDocument();
   });
 
-  it("renders Prediction Distribution heading", () => {
+  // Issue #370: the section is gated on the backend's available plot
+  // list — only renders when ``probability-histogram`` is advertised.
+  it("renders Prediction Distribution heading when probability-histogram is available", async () => {
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["probability-histogram"]);
     const record = makeRecord();
     renderWithQuery(
       <ResultsPredOnly
@@ -127,7 +130,44 @@ describe("ResultsPredOnly", () => {
       />,
     );
 
-    expect(screen.getByText("Prediction Distribution")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Prediction Distribution")).toBeInTheDocument();
+    });
+  });
+
+  it("hides Prediction Distribution heading when probability-histogram is unavailable (e.g. regression)", async () => {
+    vi.mocked(fetchInferencePlot).mockClear();
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce([
+      "learning-curve",
+      "residuals",
+    ]);
+    const record = makeRecord();
+    renderWithQuery(
+      <ResultsPredOnly
+        record={record}
+        infNumber={1}
+        jobLabel="job"
+        history={[record]}
+      />,
+    );
+
+    // Give react-query time to settle the available-plots fetch.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(
+      screen.queryByText("Prediction Distribution"),
+    ).not.toBeInTheDocument();
+    // The frontend MUST NOT have requested the distribution plot
+    // (no ``prediction-distribution`` 404 in DevTools).
+    expect(fetchInferencePlot).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "probability-histogram",
+    );
+    expect(fetchInferencePlot).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "prediction-distribution",
+    );
   });
 
   it("does not render Comparison section when no other records exist", () => {
@@ -304,6 +344,10 @@ describe("ResultsPredOnly", () => {
   // --- PredDistributionPlot conditional branches (lines 194-195) ---
 
   it("renders PlotlyChart inside PredDistributionPlot when data is available", async () => {
+    // Issue #370: section now gates on the backend's available plot
+    // list, so the test must advertise ``probability-histogram``
+    // before the inference plot fetch fires.
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["probability-histogram"]);
     vi.mocked(fetchInferencePlot).mockResolvedValueOnce({
       plotly_json: '{"data":[]}',
     });
@@ -321,6 +365,13 @@ describe("ResultsPredOnly", () => {
     await waitFor(() => {
       expect(screen.getByTestId("plotly-chart")).toBeInTheDocument();
     });
+    // Issue #370: the request MUST go to ``probability-histogram``,
+    // not the legacy non-existent ``prediction-distribution`` key.
+    expect(fetchInferencePlot).toHaveBeenCalledWith(
+      record.inf_id,
+      record.job_id,
+      "probability-histogram",
+    );
   });
 
   it("renders nothing for PredDistributionPlot when data is null", () => {

--- a/frontend/src/components/inference/ResultsPredOnly.tsx
+++ b/frontend/src/components/inference/ResultsPredOnly.tsx
@@ -79,11 +79,14 @@ export function ResultsPredOnly({
         <PredictionsTable infId={record.inf_id} jobId={record.job_id} />
       </section>
 
-      {/* Prediction Distribution */}
-      <section className="mb-6">
-        <h4 className="mb-2 text-sm font-medium">Prediction Distribution</h4>
-        <PredDistributionPlot infId={record.inf_id} jobId={record.job_id} />
-      </section>
+      {/* Prediction Distribution.
+          Issue #370: gate the section on the backend's available plot
+          list so the panel only renders when the underlying plot type
+          actually exists (binary => ``probability-histogram``;
+          regression has no equivalent today). Without the gate the
+          frontend used to request the non-existent
+          ``prediction-distribution`` and emit a 404 on every record. */}
+      <PredDistributionSection infId={record.inf_id} jobId={record.job_id} />
 
       {/* Comparison */}
       {otherRecords.length > 0 && (
@@ -173,28 +176,50 @@ function formatStatName(key: string): string {
   return key.charAt(0).toUpperCase() + key.slice(1);
 }
 
-/** Prediction distribution plot section. */
-function PredDistributionPlot({
+/**
+ * Inference distribution section. Issue #370.
+ *
+ * The frontend used to hardcode ``prediction-distribution`` as the
+ * plot type, but the backend's ``LizyMLAdapter._PLOT_DISPATCH``
+ * registers binary classification's distribution under
+ * ``probability-histogram`` (and regression has no equivalent at all).
+ * The mismatch produced a 404 on every Inference render plus a stale
+ * "Prediction Distribution" heading with no plot underneath.
+ *
+ * The section now gates on the backend's available-plots list (same
+ * pattern as the SHAP gate added for Issue #355) so:
+ *   - binary fits => render the histogram from ``probability-histogram``
+ *   - regression / unsupported => hide the entire section, no 404, no
+ *     empty heading.
+ */
+function PredDistributionSection({
   infId,
   jobId,
 }: {
   infId: string;
   jobId: string;
 }) {
+  const { data: availablePlots } = useJobPlots(jobId);
+  const distributionPlotType = availablePlots?.includes("probability-histogram")
+    ? "probability-histogram"
+    : null;
   const { data, isLoading } = useInferencePlot(
     infId,
     jobId,
-    "prediction-distribution",
-    { retry: false },
+    distributionPlotType ?? "",
+    { retry: false, enabled: distributionPlotType != null },
   );
-
-  if (isLoading) {
-    return (
-      <p className="text-xs text-muted-foreground">Loading distribution...</p>
-    );
-  }
-  if (!data) return null;
-  return <PlotlyChart plotlyJson={data.plotly_json} />;
+  if (distributionPlotType == null) return null;
+  return (
+    <section className="mb-6">
+      <h4 className="mb-2 text-sm font-medium">Prediction Distribution</h4>
+      {isLoading ? (
+        <p className="text-xs text-muted-foreground">Loading distribution...</p>
+      ) : data ? (
+        <PlotlyChart plotlyJson={data.plotly_json} />
+      ) : null}
+    </section>
+  );
 }
 
 /** SHAP summary + warnings as accordion sections. */

--- a/frontend/src/components/inference/ResultsWithGT.test.tsx
+++ b/frontend/src/components/inference/ResultsWithGT.test.tsx
@@ -92,7 +92,11 @@ describe("ResultsWithGT", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders Prediction Distribution accordion trigger", () => {
+  // Issue #370: the accordion item is now gated on the backend's
+  // ``probability-histogram`` availability. Tests that exercise the
+  // section MUST advertise that plot via ``fetchJobPlots``.
+  it("renders Prediction Distribution accordion trigger when probability-histogram is available", async () => {
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["probability-histogram"]);
     const record = makeRecord();
     renderWithQuery(
       <ResultsWithGT
@@ -103,7 +107,35 @@ describe("ResultsWithGT", () => {
       />,
     );
 
-    expect(screen.getByText("Prediction Distribution")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Prediction Distribution")).toBeInTheDocument();
+    });
+  });
+
+  it("hides Prediction Distribution accordion when probability-histogram is unavailable (e.g. regression)", async () => {
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce([
+      "learning-curve",
+      "residuals",
+    ]);
+    const record = makeRecord();
+    renderWithQuery(
+      <ResultsWithGT
+        record={record}
+        infNumber={1}
+        jobLabel="job"
+        targetCol="target"
+      />,
+    );
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(
+      screen.queryByText("Prediction Distribution"),
+    ).not.toBeInTheDocument();
+    expect(fetchInferencePlot).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "prediction-distribution",
+    );
   });
 
   it("renders Predictions accordion trigger", () => {
@@ -315,13 +347,15 @@ describe("ResultsWithGT", () => {
 
   // Lines 169-187: PredDistributionPlot shows loading then chart
   it("renders prediction distribution loading state initially", async () => {
-    // Keep fetchInferencePlot pending so isLoading stays true briefly
+    // Issue #370: the accordion is gated on probability-histogram
+    // availability and the inference plot fetch now uses that key.
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["probability-histogram"]);
     let resolve: (v: unknown) => void;
     const pending = new Promise((res) => {
       resolve = res;
     });
     vi.mocked(fetchInferencePlot).mockImplementation((_, __, plotName) => {
-      if (plotName === "prediction-distribution") return pending as never;
+      if (plotName === "probability-histogram") return pending as never;
       return Promise.resolve(null) as never;
     });
 
@@ -335,10 +369,12 @@ describe("ResultsWithGT", () => {
       />,
     );
 
-    // The accordion is collapsed by default; PredDistributionPlot still mounts
-    // and issues the query. Since the promise is pending, isLoading is true.
-    // We verify the component renders without crashing here.
-    expect(screen.getByText("Prediction Distribution")).toBeInTheDocument();
+    // The accordion is collapsed by default; PredDistributionAccordion still
+    // mounts and issues the query. Since the promise is pending, isLoading is
+    // true. We verify the component renders without crashing here.
+    await waitFor(() => {
+      expect(screen.getByText("Prediction Distribution")).toBeInTheDocument();
+    });
 
     // Resolve to avoid hanging
     resolve!(null);
@@ -440,15 +476,17 @@ describe("ResultsWithGT", () => {
     resolveShap!(null);
   });
 
-  // Lines 176-187: PredDistributionPlot — open accordion to trigger content render
+  // Issue #370: PredDistributionAccordion — open accordion to trigger content render.
+  // Backend now exposes the binary distribution under ``probability-histogram``.
   it("renders loading text in prediction distribution while query is pending", async () => {
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["probability-histogram"]);
     const user = userEvent.setup();
     let resolveDist: (v: unknown) => void;
     const pendingDist = new Promise((res) => {
       resolveDist = res;
     });
     vi.mocked(fetchInferencePlot).mockImplementation((_, __, plotName) => {
-      if (plotName === "prediction-distribution") return pendingDist as never;
+      if (plotName === "probability-histogram") return pendingDist as never;
       return Promise.resolve(null) as never;
     });
 
@@ -463,6 +501,9 @@ describe("ResultsWithGT", () => {
     );
 
     // Open the Prediction Distribution accordion
+    await waitFor(() => {
+      expect(screen.getByText("Prediction Distribution")).toBeInTheDocument();
+    });
     await user.click(screen.getByText("Prediction Distribution"));
 
     await waitFor(() => {
@@ -473,10 +514,18 @@ describe("ResultsWithGT", () => {
   });
 
   it("renders PlotlyChart in prediction distribution after data resolves", async () => {
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["probability-histogram"]);
     const user = userEvent.setup();
-    vi.mocked(fetchInferencePlot).mockResolvedValue({
-      plotly_json: '{"data":[]}',
-    } as never);
+    // Resolve only the probability-histogram fetch — leave other plot
+    // types as the default null so we don't accidentally render
+    // multiple plotly charts in the same panel and trip the
+    // "Found multiple elements" assertion.
+    vi.mocked(fetchInferencePlot).mockImplementation((_, __, plotName) => {
+      if (plotName === "probability-histogram") {
+        return Promise.resolve({ plotly_json: '{"data":[]}' }) as never;
+      }
+      return Promise.resolve(null) as never;
+    });
 
     const record = makeRecord();
     renderWithQuery(
@@ -488,11 +537,24 @@ describe("ResultsWithGT", () => {
       />,
     );
 
-    // Open the Prediction Distribution accordion to mount PredDistributionPlot content
+    // Open the Prediction Distribution accordion to mount the content.
+    await waitFor(() => {
+      expect(screen.getByText("Prediction Distribution")).toBeInTheDocument();
+    });
     await user.click(screen.getByText("Prediction Distribution"));
 
+    // When probability-histogram is the only available plot, the top
+    // "Plots" section auto-selects it AND the accordion renders it,
+    // producing two plotly-chart instances. We assert at-least-one
+    // for resilience.
     await waitFor(() => {
-      expect(screen.getByTestId("plotly-chart")).toBeInTheDocument();
+      expect(screen.getAllByTestId("plotly-chart").length).toBeGreaterThan(0);
     });
+    // Issue #370 invariant: the request goes to ``probability-histogram``.
+    expect(fetchInferencePlot).toHaveBeenCalledWith(
+      record.inf_id,
+      record.job_id,
+      "probability-histogram",
+    );
   });
 });

--- a/frontend/src/components/inference/ResultsWithGT.tsx
+++ b/frontend/src/components/inference/ResultsWithGT.tsx
@@ -124,14 +124,17 @@ export function ResultsWithGT({
         </section>
       )}
 
-      {/* Accordion sections */}
+      {/* Accordion sections.
+          Issue #370: ``PredDistributionAccordion`` reads the
+          backend's available-plots list and only renders the section
+          when the matching plot type exists, so a regression fit (or
+          any task without ``probability-histogram``) no longer shows
+          an empty accordion or fires a 404. */}
       <Accordion type="multiple">
-        <AccordionItem value="pred-distribution">
-          <AccordionTrigger>Prediction Distribution</AccordionTrigger>
-          <AccordionContent>
-            <PredDistributionPlot infId={record.inf_id} jobId={record.job_id} />
-          </AccordionContent>
-        </AccordionItem>
+        <PredDistributionAccordion
+          infId={record.inf_id}
+          jobId={record.job_id}
+        />
 
         <AccordionItem value="predictions">
           <AccordionTrigger>Predictions</AccordionTrigger>
@@ -159,27 +162,47 @@ export function ResultsWithGT({
   );
 }
 
-/** Prediction distribution plot loaded lazily inside an accordion. */
-function PredDistributionPlot({
+/**
+ * Prediction distribution accordion section. Issue #370.
+ *
+ * Gates on the backend's available-plots list — same pattern as
+ * the SHAP gate from Issue #355. Binary classification exposes
+ * ``probability-histogram``; regression has no equivalent today,
+ * so the entire accordion item is omitted instead of rendering an
+ * empty body and a 404 in DevTools.
+ */
+function PredDistributionAccordion({
   infId,
   jobId,
 }: {
   infId: string;
   jobId: string;
 }) {
+  const { data: availablePlots } = useJobPlots(jobId);
+  const distributionPlotType = availablePlots?.includes("probability-histogram")
+    ? "probability-histogram"
+    : null;
   const { data, isLoading } = useInferencePlot(
     infId,
     jobId,
-    "prediction-distribution",
+    distributionPlotType ?? "",
+    { retry: false, enabled: distributionPlotType != null },
   );
-
-  if (isLoading) {
-    return (
-      <p className="text-xs text-muted-foreground">Loading distribution...</p>
-    );
-  }
-  if (!data) return null;
-  return <PlotlyChart plotlyJson={data.plotly_json} />;
+  if (distributionPlotType == null) return null;
+  return (
+    <AccordionItem value="pred-distribution">
+      <AccordionTrigger>Prediction Distribution</AccordionTrigger>
+      <AccordionContent>
+        {isLoading ? (
+          <p className="text-xs text-muted-foreground">
+            Loading distribution...
+          </p>
+        ) : data ? (
+          <PlotlyChart plotlyJson={data.plotly_json} />
+        ) : null}
+      </AccordionContent>
+    </AccordionItem>
+  );
 }
 
 /** SHAP summary accordion item — renders only when SHAP data is available.


### PR DESCRIPTION
## Summary

The Inference results panels (`ResultsPredOnly`, `ResultsWithGT`) hardcoded the plot type `prediction-distribution` when fetching the binary classification distribution histogram. The backend's `LizyMLAdapter._PLOT_DISPATCH` only registers the equivalent under `probability-histogram`; the mismatch produced a 404 on every inference render plus a stale "Prediction Distribution" panel header / accordion item with no plot underneath.

Switch the inference plot fetch to `probability-histogram` and gate the entire section on the backend's available-plots list (same pattern as the SHAP gate from Issue #355). When the job does not advertise `probability-histogram` (regression fit, or binary without calibration on the current lizyml backend), the section is hidden entirely instead of rendering an empty heading and emitting a 404 in DevTools.

## Test plan

- [x] `pnpm test --run src/components/inference/ResultsPredOnly.test.tsx src/components/inference/ResultsWithGT.test.tsx` -- 42 passed (3 new positive + 2 new negative cases).
- [x] `pnpm test --run` -- full suite 1786 passed.
- [x] `pnpm build` -- green.
- [x] `pnpm check` -- Biome lint/format clean.
- [x] Manual: open `/inference?job_id=<binary_tune_no_cal>` -> DevTools shows zero 404s, "Prediction Distribution" header correctly hidden because the job does not advertise `probability-histogram` (it requires calibration on the current backend).

## Why gate on availability instead of always switching the key

The backend's `available_plots` is the source of truth for "what this fit can render". For a non-calibrated binary fit it omits `probability-histogram`; for regression it never lists it. Asking unconditionally and relying on a 404 to hide the panel was the pre-fix shape (#355 already mapped these 404s to the right HTTP code). This PR removes the noise at the source.

## Follow-ups (out of scope)

- The backend's `available_plots` only includes `probability-histogram` when calibration is enabled (see `evaluation_mixin.py:121`). It is reasonable to also expose it for non-calibrated binary fits, but that decision belongs to the backend (lizyml) team and is logged here for visibility.

Closes #370
