### PR TITLE
fix(workspace): replace Load Preset Select with menu-driven popover (#369)

### DIFF
--- a/frontend/src/components/workspace/ModelPanelActions.test.tsx
+++ b/frontend/src/components/workspace/ModelPanelActions.test.tsx
@@ -1,0 +1,104 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { ConfigPreset } from "@/hooks/useConfigPresets";
+import { ModelPanelActions } from "./ModelPanelActions";
+
+function renderWithTooltip(ui: React.ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
+vi.mock("@/api/workspace", () => ({
+  getConfigDownloadUrl: () => "/api/workspace/config/download",
+}));
+
+vi.mock("./RawConfigDialog", () => ({
+  RawConfigDialog: ({ trigger }: { trigger: React.ReactNode }) => (
+    <div data-testid="raw-config-dialog">{trigger}</div>
+  ),
+}));
+
+afterEach(cleanup);
+
+const PRESETS: ConfigPreset[] = [
+  {
+    name: "preset-A",
+    config: { task: "binary" } as Record<string, unknown>,
+    createdAt: "2026-05-03T00:00:00Z",
+  },
+  {
+    name: "preset-B",
+    config: { task: "regression" } as Record<string, unknown>,
+    createdAt: "2026-05-03T00:00:00Z",
+  },
+];
+
+const baseProps = {
+  running: false,
+  config: { task: "binary" } as Record<string, unknown>,
+  canUndo: false,
+  canRedo: false,
+  presets: PRESETS,
+  onImport: vi.fn(),
+  onUndo: vi.fn(),
+  onRedo: vi.fn(),
+  onOpenSavePreset: vi.fn(),
+  onLoadPreset: vi.fn(),
+};
+
+describe("ModelPanelActions / LoadPresetMenu (Issue #369)", () => {
+  it("does not render the Load Preset menu when no presets are saved", () => {
+    renderWithTooltip(<ModelPanelActions {...baseProps} presets={[]} />);
+    expect(
+      screen.queryByRole("button", { name: "Load preset" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders one menuitem per preset", async () => {
+    const user = userEvent.setup();
+    renderWithTooltip(<ModelPanelActions {...baseProps} />);
+    await user.click(screen.getByRole("button", { name: "Load preset" }));
+
+    const items = screen.getAllByRole("menuitem");
+    expect(items).toHaveLength(PRESETS.length);
+    expect(items[0]).toHaveTextContent("preset-A");
+    expect(items[1]).toHaveTextContent("preset-B");
+  });
+
+  // Issue #369: the original Select component swallowed re-clicks on
+  // the same value. The menuitem-based replacement must always fire
+  // ``onLoadPreset`` when the user clicks a preset, even if it was the
+  // last one applied.
+  it("fires onLoadPreset every time the same preset is clicked", async () => {
+    const user = userEvent.setup();
+    const onLoadPreset = vi.fn();
+    renderWithTooltip(
+      <ModelPanelActions {...baseProps} onLoadPreset={onLoadPreset} />,
+    );
+
+    // First click
+    await user.click(screen.getByRole("button", { name: "Load preset" }));
+    await user.click(screen.getByRole("menuitem", { name: "preset-A" }));
+    expect(onLoadPreset).toHaveBeenCalledTimes(1);
+    expect(onLoadPreset).toHaveBeenLastCalledWith("preset-A");
+
+    // Re-open and click the SAME preset again — must re-fire.
+    await user.click(screen.getByRole("button", { name: "Load preset" }));
+    await user.click(screen.getByRole("menuitem", { name: "preset-A" }));
+    expect(onLoadPreset).toHaveBeenCalledTimes(2);
+    expect(onLoadPreset).toHaveBeenLastCalledWith("preset-A");
+  });
+
+  it("closes the menu after a preset is selected", async () => {
+    const user = userEvent.setup();
+    renderWithTooltip(<ModelPanelActions {...baseProps} />);
+
+    await user.click(screen.getByRole("button", { name: "Load preset" }));
+    expect(screen.getAllByRole("menuitem").length).toBeGreaterThan(0);
+    await user.click(screen.getByRole("menuitem", { name: "preset-B" }));
+
+    // The popover should auto-dismiss after selection.
+    expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/workspace/ModelPanelActions.tsx
+++ b/frontend/src/components/workspace/ModelPanelActions.tsx
@@ -6,17 +6,23 @@
  * handlers come from useModelPanelData via props.
  */
 
-import { Download, FileText, FileUp, Redo2, Save, Undo2 } from "lucide-react";
-import { useRef } from "react";
+import {
+  ChevronDown,
+  Download,
+  FileText,
+  FileUp,
+  Redo2,
+  Save,
+  Undo2,
+} from "lucide-react";
+import { useRef, useState } from "react";
 import { getConfigDownloadUrl } from "@/api/workspace";
 import { Button } from "@/components/ui/button";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   Tooltip,
   TooltipContent,
@@ -135,21 +141,7 @@ export function ModelPanelActions({
           Save Preset
         </Button>
         {presets.length > 0 && (
-          <Select onValueChange={onLoadPreset}>
-            <SelectTrigger
-              aria-label="Load preset"
-              className="h-8 w-36 text-xs"
-            >
-              <SelectValue placeholder="Load Preset" />
-            </SelectTrigger>
-            <SelectContent>
-              {presets.map((p) => (
-                <SelectItem key={p.name} value={p.name}>
-                  {p.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <LoadPresetMenu presets={presets} onLoadPreset={onLoadPreset} />
         )}
         <RawConfigDialog
           config={config}
@@ -162,5 +154,57 @@ export function ModelPanelActions({
         />
       </div>
     </div>
+  );
+}
+
+/**
+ * Load Preset menu. Issue #369.
+ *
+ * The pre-fix component used a Radix ``Select``, which does not fire
+ * ``onValueChange`` when the user picks the same option that is
+ * already "selected" — making it impossible to re-apply a preset
+ * after the config drifted. Replace the action-shaped flow with a
+ * Popover-driven menu where each preset is a button that always
+ * fires ``onLoadPreset`` on click.
+ */
+function LoadPresetMenu({
+  presets,
+  onLoadPreset,
+}: {
+  presets: ConfigPreset[];
+  onLoadPreset: (name: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          aria-label="Load preset"
+          aria-haspopup="menu"
+          className="h-8 w-36 justify-between text-xs"
+        >
+          <span>Load Preset</span>
+          <ChevronDown className="ml-1 h-3 w-3 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-48 p-1" align="start" role="menu">
+        {presets.map((p) => (
+          <button
+            key={p.name}
+            type="button"
+            role="menuitem"
+            className="w-full rounded px-2 py-1.5 text-left text-xs hover:bg-accent"
+            onClick={() => {
+              onLoadPreset(p.name);
+              setOpen(false);
+            }}
+          >
+            {p.name}
+          </button>
+        ))}
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/frontend/tests/e2e/workspace-presets.spec.ts
+++ b/frontend/tests/e2e/workspace-presets.spec.ts
@@ -96,8 +96,11 @@ test.describe("Workspace preset Save → Load reflection (B-6)", () => {
       page.getByText(`Preset "${PRESET_NAME}" saved`),
     ).toBeVisible({ timeout: 5000 });
 
-    // The Load Preset dropdown should now appear with the saved name.
-    const loadPresetTrigger = page.getByRole("combobox", {
+    // The Load Preset menu trigger should now appear. Issue #369:
+    // the trigger used to be a Select combobox whose ``onValueChange``
+    // suppressed re-applies of the same preset; the menu replacement
+    // exposes a button whose menu items always fire on click.
+    const loadPresetTrigger = page.getByRole("button", {
       name: "Load preset",
     });
     await expect(loadPresetTrigger).toBeVisible({ timeout: 3000 });
@@ -131,7 +134,9 @@ test.describe("Workspace preset Save → Load reflection (B-6)", () => {
       (body) => deepGet(body, "split.n_splits") === 5,
     );
     await loadPresetTrigger.click();
-    await page.getByRole("option", { name: PRESET_NAME, exact: true }).click();
+    await page
+      .getByRole("menuitem", { name: PRESET_NAME, exact: true })
+      .click();
     const loadBody = await loadPut;
     expect(deepGet(loadBody, "split.n_splits")).toBe(5);
     // Issue #276 guard: preset merges with current data section so


### PR DESCRIPTION
## Summary

The Load Preset combobox in `ModelPanelActions` used a Radix `Select`, which does not fire `onValueChange` when the user picks the option that is already "selected". Once the user applied preset X, there was no way to re-apply X via the dropdown -- the documented "save a known-good config, experiment, then revert" workflow silently broke after the first revert.

Replace the Select with a Popover-based menu where each preset is a button that always fires `onLoadPreset` on click. The shape of the API surface is unchanged (`onLoadPreset(name)`) so `useConfigPresets` and the downstream config funnel keep working unchanged.

## Test plan

- [x] `pnpm test --run src/components/workspace/ModelPanelActions.test.tsx` -- 4 new tests passing.
- [x] `pnpm test --run` -- full suite 1788 passed.
- [x] `pnpm build` -- green.
- [x] `pnpm check` -- Biome lint/format clean.
- [x] Manual: load `tests/fixtures/lizyml/binary_no_cal/data.csv` + Survived target + click Load Preset -> `audit-preset-r3` **twice** in succession. DevTools shows two PUTs to `/api/workspace/config` with `split.method = "time_series"` (the preset's value), confirming the second click re-applies just like the first.

## Why menu over forcing the Select to re-fire

Two alternatives existed:

1. Wrap the Select with a custom handler that resets the internal value to `""` between selections so the next click is treated as a "new" selection.
2. Replace with a menu where each item is genuinely action-shaped.

Option 2 matches the user intent more honestly: "Load preset" is an **action**, not a stateful selection. The menu pattern also naturally supports any future addition (rename, delete, export-this-preset) without re-architecting the component. Implementation is a thin Popover plus button menuitems -- no new shadcn dependency required (we already vendor `popover.tsx`).

## Related

- Issue #369 was filed during GUI Verification Round 3 Step 3 alongside #370 (prediction-distribution plot key).
- Adjacent to #358 (CV strategy latch + 2-second TTL): with this fix, the TTL becomes a defensive belt-and-braces; without this fix, the TTL was the only failsafe keeping Load Preset usable after a rejected user-driven CV change.

Closes #369
