### PR TITLE
fix(inference): accept upload-mode tempfile paths in /api/inference/run (#374)

### DIFF
--- a/docs/gui-verification-handoff-2026-05-03-r3.md
+++ b/docs/gui-verification-handoff-2026-05-03-r3.md
@@ -1,0 +1,173 @@
+# GUI Verification Round 3 + Bug Fix Session — Handoff (2026-05-03)
+
+> **目的**: Round 3 検証 + 当日発見した bug の修正サイクルの引継ぎ。残作業を新セッションで再開するため。
+> **対象**: 次回セッションの Claude (または別開発者)
+
+---
+
+## 0. 30 秒サマリ
+
+- **Round 3 検証完了** (Step 1〜4 のうち高優先項目はすべて完了)
+- **8 件の PR を着手** (うち 5 件マージ済 / 1 件 CI 待ち / 2 件 deferred)
+- **3 件の新規 Issue 起票** (#369/#370/#373)
+- **次セッションは PR #372 マージ確認 → Issue #373 着手 → Round 3 残項目 が起点**
+
+---
+
+## 1. 当日マージ済 PR (develop に取り込まれた変更)
+
+| PR | Issue | タイトル | Status |
+|---|---|---|---|
+| **#365** | #364 | `fix(metrics): derive oos_std from oof_per_fold when oof_std absent` | ✅ MERGED |
+| **#366** | #359 | `fix(inference): derive dropdown #N from allJobs not completedJobs` | ✅ MERGED |
+| **#367** | #363 | `fix(workspace): hydrate Data Panel from server-persisted state on reload` | ✅ MERGED |
+| **#368** | #358 | `fix(workspace): latch user-picked CV strategy against stale cache reverts` (latch + 2s TTL) | ✅ MERGED |
+| **#371** | #370 | `fix(inference): use probability-histogram + gate distribution panel on availability` | ✅ MERGED |
+
+`develop` HEAD: `3c67d18` (= `#371` 直後)。
+
+---
+
+## 2. CI 進行中 / 未マージ PR
+
+| PR | 内容 | 状態 |
+|---|---|---|
+| **#372** | `fix(workspace): replace Load Preset Select with menu-driven popover (#369)` | **BLOCKED** (e2e-chromium IN_PROGRESS) — auto-merge 設定済 |
+
+#372 の経緯:
+- 初回の e2e-chromium で `workspace-presets.spec.ts` が古い Select API を使っていて FAIL
+- フォローアップ commit `e3e35b8 test(e2e): update Load Preset interaction to menu trigger + menuitem` で対応
+- さらに `5e70239 Merge branch 'develop' into ...` で develop の #371 を取り込み
+- 現在再走行中の e2e が green になり次第 auto-merge
+
+**新セッションで最初に確認すべきコマンド**:
+```bash
+gh pr view 372 --json mergedAt,mergeStateStatus --jq '{merged: .mergedAt, state: .mergeStateStatus}'
+```
+- `merged: <timestamp>` ならマージ済み → そのまま進む
+- `state: BLOCKED` で CI 走行中なら待つ
+- `state: CI_FAILED` ならログを確認 (`gh run view <run-id> --log-failed`)
+
+---
+
+## 3. 当日起票した新規 Issue (deferred)
+
+| Issue | タイトル | Severity | Notes |
+|---|---|---|---|
+| **#369** | `fix(workspace): Load Preset combobox cannot re-apply the currently selected preset` | medium | **PR #372 で対応中** (CI 待ち) |
+| **#370** | `fix(inference): UI requests non-existent plot type 'prediction-distribution'` | medium | **PR #371 で対応済 (マージ済)** |
+| **#373** | `fix(inference): SHAP Summary accordion is permanently hidden -- backend never advertises 'shap-summary' plot` | low-medium | **defer** — backend (lizyml) に `shap-summary` plot を追加する必要があり、frontend だけでは閉じない |
+
+---
+
+## 4. Round 3 検証カバレッジ
+
+### Step 1 Critical path (5/5 ✅)
+- 未-01 Tune 実走 → ✅ (Std=NaN は #364 経由で fix)
+- 未-02 Cancel during fit → ✅
+- 未-03 Cancel during tune → ✅
+- 未-04 Reload state restoration → ✅ (#363 経由で fix)
+- 未-05 WebSocket reconnect → ✅ (3 回切断後も自動再接続)
+
+### Step 2 Symmetric audit (3/3 ✅)
+- 未-06 Plot type gating → ✅ jobs.py + inference.py 両方とも `_BackendPlotNotAvailable` → 404 で正しく扱う (post #356)
+- 未-07 Numbering drift → ✅ JobList / JobsPage / ResultsPanel は OK、SetupPanel / InferencePage が drift → #366 で fix
+- 未-08 CV col race → ✅ GroupKFold + group_col / rapid switch も race 観測されず
+
+### Step 3 Functional coverage (11 done)
+| ID | 結果 | 備考 |
+|---|---|---|
+| 未-10 | ✅ | Inference Pred-only mode (Evaluate OFF) |
+| 未-12 | ✅ | History 再選択 |
+| 未-13 | ✅ | Re-tune depth-2 lineage (root → child → grandchild) |
+| 未-14 | ✅ | Export Model (4-file artifact) |
+| 未-15 | ✅ | Export Code (zip with train.py / predict.py / requirements / artifacts) |
+| 未-16 | ✅ | YAML Export (group_col 等が正しく書き出される) |
+| 未-17 | ✅ Save / ❌ Load | Save は OK、Load Preset 同 preset 再適用は #369 で fix |
+| 未-19 | ⚠️ | Bulk Exclude toggle 未実装 (#361 acceptance criteria に含まれる) |
+| 未-20 | ✅ | Type Num/Cat 切替 (Pclass Cat→Num が server に反映) |
+| 未-21 | ✅ | Cmd/Ctrl+K Command Palette |
+| 未-23 | ✅ | Sidebar collapse persistence (`sidebar-collapsed: true`) |
+
+### Step 4 Edge cases (1 done)
+- 未-24 1-row / all-NaN CSV → ✅ part PASS (load 通過、fit-time validation は backend 責務)
+
+### スキップした項目
+- Step 3: 未-09 (Inference Upload mode), 未-11 (Inference comparison — 中断)、未-18 (Feature Weights editor)、未-22 (Onboarding flow — 既に completed = localStorage 確認済)
+- Step 4: 未-25 (非 UTF-8 CSV)、未-26 (1GB+ CSV)、未-27 (Wide DataFrame, #361 でカバー予定)、未-28 (format_version 0)、未-29 (multi-tab)
+
+---
+
+## 5. Browser 状態 / 環境
+
+- **Backend** running on `http://localhost:8501` (pid 不明 / nohup で background)
+- **Frontend bundle**: `src/lizystudio/static/assets/index-DAazKAj3.js` (May 3 23:04 build) — **#370 fix を含まない古いビルド** ⚠️
+- 新セッションで browser 検証する場合は **必ず再ビルド**:
+  ```bash
+  cd /home/rem/repos/LizyStudio/frontend && pnpm build
+  ```
+- Server に persist したジョブ:
+  - `job_47a57770` Tune #42 (binary_no_cal, no calibration)
+  - `job_49beaad6` Tune (#42 の child)
+  - `job_050aa3ea` Tune (#42 の grandchild)
+  - 他 fit/tune 多数 (#39, #38, ..., #29, ...)
+- Inference history:
+  - `inf_f588369f` (with-GT, 13:37)
+  - `inf_52cf729e` (with-GT, 13:21)
+  - `inf_f685144b` (pred-only, 13:20)
+- Workspace に load 済み: `/home/rem/repos/LizyStudio/tests/fixtures/lizyml/binary_no_cal/data.csv`
+- LocalStorage `lizystudio-config-presets` に `audit-preset-r3` (split.method=time_series) が保存済
+
+---
+
+## 6. 既知の小バグ (Issue 起票していないが書き留めておく)
+
+1. **`probability-histogram` plot は calibrated 二値分類のみ available** (`evaluation_mixin.py:121` で `calibration_enabled` 必須)。非 calibrated でもユーザーは予測分布を見たいだろうが、今は出ない。
+   - PR #371 で当面の 404 noise は止めたが、根本的に lizyml backend に「非 calibrated 二値で probability_histogram_plot を生やす」改善が望ましい。
+   - 別 Issue にするかは未定。
+2. **Inference の `probability-histogram` を非 calibrated 二値ジョブに対し直接呼ぶと 500 (LizyMLError)** — `available_plots` ガード越しなら届かないので OK。frontend 経由では発生しない (#370 fix で gated)。
+3. **未-23 Sidebar collapse persistence は localStorage に保存はされるが、reload 直後の "Collapse"⇄"Expand" 状態の即時反映は未確認** — 軽微。
+
+---
+
+## 7. 次セッション開始時の推奨アクション
+
+### A. PR #372 のマージ確認 (最優先)
+```bash
+gh pr view 372 --json mergedAt,mergeStateStatus
+```
+- merged 済 → 進む
+- まだ CI 走行中 → `gh pr checks 372 --watch` で待つ
+- CI 落ちた → ログを `gh run view --log-failed` で読む
+
+### B. 残 Issue / Round 3 残項目から選ぶ
+1. **#373 SHAP Summary plot** (priority-low-medium、backend 改修必須):
+   - `src/lizystudio/backends/lizyml/evaluation_mixin.py` の `_PLOT_DISPATCH` と `available_plots()` に `shap-summary` を追加
+   - lizyml の `model.shap_summary_plot()` メソッドが存在するか先に確認
+2. **Round 3 Step 3 残**: 未-09 / 未-11 / 未-18 — 30〜60 分で spot 検証可能
+3. **Round 3 Step 4 残**: 未-25 (非 UTF-8 CSV) / 未-29 (multi-tab) — エッジケースとして 30 分以内
+4. **v0.4 Phase R-1 着手**: #360 Tune long-run resume — 大型 (multi-PR / multi-week)
+5. **v0.4 Phase R-5 着手**: #361 Wide DataFrame UI — 大型
+
+### C. 次セッションで再現する Browser scenario (任意)
+```bash
+# 1. Backend 起動
+cd /home/rem/repos/LizyStudio
+nohup uv run lizystudio --port 8501 > /tmp/lz.log 2>&1 & disown
+sleep 8
+
+# 2. Frontend 再ビルド (古いバンドルだから)
+cd frontend && pnpm build
+
+# 3. Playwright 経由で http://localhost:8501/ にアクセス
+# (workspace data は server に persist されているので #363 fix で自動 hydrate されるはず — 検証チャンス)
+```
+
+---
+
+## 8. 参考リンク
+
+- 前回セッションの handoff: [`docs/gui-verification-handoff-2026-05-03.md`](gui-verification-handoff-2026-05-03.md) — Round 1 + 2 の結果と Round 3 plan
+- 業務利用定義: [`docs/business-use-definition.md`](business-use-definition.md) v0.2
+- v0.4 業務利用 plan: [`docs/v0.4-business-readiness-plan.md`](v0.4-business-readiness-plan.md)
+- ROADMAP 一元管理: [`docs/ROADMAP.md`](ROADMAP.md)

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -811,6 +811,20 @@ export interface paths {
         /**
          * Inference Run
          * @description Run inference with a path to data (H-0009).
+         *
+         *     Path validation is split by ``source_type``:
+         *
+         *     * ``"path"`` — a user-supplied filesystem path. Must resolve to a
+         *       location under ``ALLOWED_FILES_ROOT`` (default: the user's home
+         *       directory) so the backend never reads files the operator did not
+         *       intend to expose.
+         *     * ``"upload"`` — a server-staged tempfile produced by
+         *       ``POST /api/inference/upload``. The path lives under the OS temp
+         *       dir (typically ``/tmp``), which is outside ``ALLOWED_FILES_ROOT``
+         *       by design. We instead verify the path is tracked in
+         *       ``WorkspaceState._temp_files``, ensuring the request cannot be
+         *       forged with ``source_type="upload"`` against an arbitrary system
+         *       file (Issue #374).
          */
         post: operations["inference_run_api_inference_run_post"];
         delete?: never;

--- a/frontend/src/components/inference/SetupPanel.test.tsx
+++ b/frontend/src/components/inference/SetupPanel.test.tsx
@@ -371,6 +371,58 @@ describe("SetupPanel", () => {
 
     expect(baseProps.onRunInference).toHaveBeenCalledWith({
       dataPath: "/data/test.csv",
+      sourceType: "path",
+      evaluate: true,
+      returnShap: false,
+    });
+  });
+
+  // Issue #374: Upload mode previously dropped the ``sourceType``
+  // between SetupPanel and the API call, so the run request always
+  // carried ``source_type: "path"``. The backend then validated the
+  // upload tempfile against ALLOWED_FILES_ROOT and rejected it.
+  it("forwards sourceType='upload' to onRunInference after upload (Issue #374)", async () => {
+    mockUpload.mockResolvedValue({
+      upload_path: "/tmp/lizystudio_test.csv",
+      filename: "uploaded.csv",
+    });
+    const job = {
+      job_id: "j1",
+      job_type: "fit",
+      status: "completed",
+      backend_name: "lizyml",
+      model_name: "lgbm",
+      created_at: "2025-01-01T00:00:00Z",
+      completed_at: "2025-01-01T00:01:00Z",
+      error: null,
+      primary_score: 0.9,
+      parent_job_id: null,
+    } as JobSummary;
+    const onRunInference = vi.fn();
+
+    const user = userEvent.setup();
+    render(
+      <SetupPanel
+        {...baseProps}
+        onRunInference={onRunInference}
+        completedJobs={[job]}
+        selectedJobId="j1"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Upload" }));
+    const file = new File(["a,b\n1,2"], "uploaded.csv", { type: "text/csv" });
+    const input = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    await waitFor(() => expect(mockUpload).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: /run inference/i }));
+
+    expect(onRunInference).toHaveBeenCalledWith({
+      dataPath: "/tmp/lizystudio_test.csv",
+      sourceType: "upload",
       evaluate: true,
       returnShap: false,
     });

--- a/frontend/src/components/inference/SetupPanel.tsx
+++ b/frontend/src/components/inference/SetupPanel.tsx
@@ -35,6 +35,7 @@ interface SetupPanelProps {
   onSelectInf: (infId: string) => void;
   onRunInference: (params: {
     dataPath: string;
+    sourceType: SourceType;
     evaluate: boolean;
     returnShap: boolean;
   }) => void;
@@ -85,6 +86,7 @@ export function SetupPanel({
   const handleRun = () => {
     onRunInference({
       dataPath,
+      sourceType,
       evaluate,
       returnShap,
     });

--- a/frontend/src/pages/InferencePage.test.tsx
+++ b/frontend/src/pages/InferencePage.test.tsx
@@ -263,12 +263,14 @@ describe("InferencePage", () => {
     // Trigger inference run
     const onRunInference = capturedSetupProps.onRunInference as (params: {
       dataPath: string;
+      sourceType: "path" | "upload";
       evaluate: boolean;
       returnShap: boolean;
     }) => void;
     await act(async () =>
       onRunInference({
         dataPath: "/data/test.csv",
+        sourceType: "path",
         evaluate: false,
         returnShap: false,
       }),
@@ -285,6 +287,53 @@ describe("InferencePage", () => {
 
     await waitFor(() => {
       expect(mockToast.success).toHaveBeenCalledWith("Inference completed");
+    });
+  });
+
+  // Issue #374: Upload mode previously dropped sourceType somewhere
+  // between SetupPanel and InferencePage so the request always carried
+  // ``source_type: "path"``. The backend then rejected the upload
+  // tempfile (under /tmp) against the home-rooted ALLOWED_FILES_ROOT.
+  it("forwards source_type='upload' to /api/inference/run (Issue #374)", async () => {
+    const job = makeJob({ job_id: "job-1" });
+    mockFetchJobs.mockResolvedValue([job]);
+    mockRunInference.mockResolvedValue({
+      inf_id: "inf-up",
+      job_id: "job-1",
+    });
+
+    renderWithProviders(<InferencePage />);
+
+    await waitFor(() => {
+      const jobs = capturedSetupProps.completedJobs as unknown[];
+      expect(jobs).toHaveLength(1);
+    });
+
+    const onSelectJob = capturedSetupProps.onSelectJob as (id: string) => void;
+    act(() => onSelectJob("job-1"));
+
+    const onRunInference = capturedSetupProps.onRunInference as (params: {
+      dataPath: string;
+      sourceType: "path" | "upload";
+      evaluate: boolean;
+      returnShap: boolean;
+    }) => void;
+    await act(async () =>
+      onRunInference({
+        dataPath: "/tmp/lizystudio_abc.csv",
+        sourceType: "upload",
+        evaluate: true,
+        returnShap: false,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockRunInference).toHaveBeenCalledWith({
+        job_id: "job-1",
+        data: { source_type: "upload", path: "/tmp/lizystudio_abc.csv" },
+        return_shap: false,
+        evaluate: true,
+      });
     });
   });
 
@@ -305,12 +354,14 @@ describe("InferencePage", () => {
 
     const onRunInference = capturedSetupProps.onRunInference as (params: {
       dataPath: string;
+      sourceType: "path" | "upload";
       evaluate: boolean;
       returnShap: boolean;
     }) => void;
     await act(async () =>
       onRunInference({
         dataPath: "/data/test.csv",
+        sourceType: "path",
         evaluate: false,
         returnShap: false,
       }),
@@ -342,12 +393,14 @@ describe("InferencePage", () => {
 
     const onRunInference = capturedSetupProps.onRunInference as (params: {
       dataPath: string;
+      sourceType: "path" | "upload";
       evaluate: boolean;
       returnShap: boolean;
     }) => void;
     act(() =>
       onRunInference({
         dataPath: "/data/test.csv",
+        sourceType: "path",
         evaluate: false,
         returnShap: false,
       }),

--- a/frontend/src/pages/InferencePage.tsx
+++ b/frontend/src/pages/InferencePage.tsx
@@ -57,12 +57,17 @@ export function InferencePage() {
   // Run inference mutation
   const mutation = useRunInference();
   const runInferenceAction = useCallback(
-    (params: { dataPath: string; evaluate: boolean; returnShap: boolean }) => {
+    (params: {
+      dataPath: string;
+      sourceType: "path" | "upload";
+      evaluate: boolean;
+      returnShap: boolean;
+    }) => {
       if (!selectedJobId) return;
       mutation.mutate(
         {
           job_id: selectedJobId,
-          data: { source_type: "path", path: params.dataPath },
+          data: { source_type: params.sourceType, path: params.dataPath },
           return_shap: params.returnShap,
           evaluate: params.evaluate,
         },

--- a/src/lizystudio/api/inference.py
+++ b/src/lizystudio/api/inference.py
@@ -90,12 +90,32 @@ def inference_run(
     job_store: JobStore = Depends(get_job_store),
     ws: WorkspaceState = Depends(get_workspace),
 ) -> dict[str, str]:
-    """Run inference with a path to data (H-0009)."""
-    # Validate data path is within allowed root
-    try:
-        validate_path_within(Path(body.data.path), security.ALLOWED_FILES_ROOT)
-    except ValueError as exc:
-        raise PathNotFoundError(str(exc)) from exc
+    """Run inference with a path to data (H-0009).
+
+    Path validation is split by ``source_type``:
+
+    * ``"path"`` — a user-supplied filesystem path. Must resolve to a
+      location under ``ALLOWED_FILES_ROOT`` (default: the user's home
+      directory) so the backend never reads files the operator did not
+      intend to expose.
+    * ``"upload"`` — a server-staged tempfile produced by
+      ``POST /api/inference/upload``. The path lives under the OS temp
+      dir (typically ``/tmp``), which is outside ``ALLOWED_FILES_ROOT``
+      by design. We instead verify the path is tracked in
+      ``WorkspaceState._temp_files``, ensuring the request cannot be
+      forged with ``source_type="upload"`` against an arbitrary system
+      file (Issue #374).
+    """
+    if body.data.source_type == "upload":
+        if not ws.is_tracked_temp_file(body.data.path):
+            raise PathNotFoundError(
+                f"Upload path is not a server-staged tempfile: {body.data.path}"
+            )
+    else:
+        try:
+            validate_path_within(Path(body.data.path), security.ALLOWED_FILES_ROOT)
+        except ValueError as exc:
+            raise PathNotFoundError(str(exc)) from exc
     job = _get_job_or_404(body.job_id, job_store)
     try:
         record = run_inference(

--- a/src/lizystudio/services/workspace.py
+++ b/src/lizystudio/services/workspace.py
@@ -72,6 +72,21 @@ class WorkspaceState:
         Path(path).unlink(missing_ok=True)
         return True
 
+    def is_tracked_temp_file(self, path: str) -> bool:
+        """Return ``True`` when *path* is a server-staged upload tempfile.
+
+        Used by ``/api/inference/run`` to authorise ``source_type=upload``
+        paths without sending them through the user-facing
+        ``ALLOWED_FILES_ROOT`` validation: server tempfiles live under
+        the OS temp dir (typically ``/tmp``), which is intentionally
+        outside the user's home root. Verifying membership in
+        ``_temp_files`` (populated only by ``/api/*/upload`` endpoints)
+        prevents an attacker from bypassing path validation by
+        declaring ``source_type=upload`` with an arbitrary system path.
+        """
+        with self._lock:
+            return path in self._temp_files
+
     def set_data(self, dataframe: pd.DataFrame, data_ref: DataRef) -> None:
         """Load data into the workspace."""
         with self._lock:

--- a/tests/regression/test_reg_0069_inference_upload_cleanup.py
+++ b/tests/regression/test_reg_0069_inference_upload_cleanup.py
@@ -1,10 +1,20 @@
-"""Regression test for HIGH-8: inference upload temp file cleanup.
+"""Regression tests for inference upload-mode lifecycle.
 
-Previously an uploaded file was only removed on ``ws.reset()``,
-leaving ``/tmp`` filling up across repeated uploads. The fix adds
-``WorkspaceState.consume_temp_file`` and calls it from
-``/api/inference/run`` whenever ``source_type == 'upload'``. Path mode
-runs never touch the user's original file.
+Two regressions are pinned here:
+
+* HIGH-8: an uploaded file was only removed on ``ws.reset()``, so
+  ``/tmp`` filled up across repeated uploads. The fix adds
+  ``WorkspaceState.consume_temp_file`` and calls it from
+  ``/api/inference/run`` whenever ``source_type == 'upload'``. Path
+  mode runs never touch the user's original file.
+* Issue #374: ``/api/inference/run`` validated *every* path against
+  ``ALLOWED_FILES_ROOT``, which rejected legitimate ``source_type=
+  upload`` requests (their tempfile lives under ``/tmp``, outside the
+  user's home root). The fix splits validation by ``source_type`` and
+  for ``upload`` instead checks membership in
+  ``WorkspaceState._temp_files`` (server-staged uploads only). The
+  tests therefore must NOT stub ``validate_path_within`` away — the
+  real validation logic is what we are protecting against regressions.
 """
 
 from __future__ import annotations
@@ -50,6 +60,29 @@ def _seed_job(client: TestClient, sample_data_ref: DataRef) -> str:
     return job.job_id
 
 
+def _stub_run_inference(
+    monkeypatch: pytest.MonkeyPatch,
+    sample_data_ref: DataRef,
+    inf_id: str,
+    row_count: int,
+) -> None:
+    from lizystudio.api import inference as inference_api
+    from lizystudio.services.inference import InferenceRecord
+
+    def _fake_run(**kwargs):  # type: ignore[no-untyped-def]
+        return InferenceRecord(
+            inf_id=inf_id,
+            job_id=kwargs["job"].job_id,
+            data_ref=sample_data_ref,
+            has_ground_truth=False,
+            created_at="2026-04-14T00:00:00Z",
+            row_count=row_count,
+            warnings=[],
+        )
+
+    monkeypatch.setattr(inference_api, "run_inference", _fake_run)
+
+
 def test_upload_source_temp_file_is_removed_after_run(
     client: TestClient,
     sample_data_ref: DataRef,
@@ -60,31 +93,17 @@ def test_upload_source_temp_file_is_removed_after_run(
     # Seed a completed job.
     job_id = _seed_job(client, sample_data_ref)
 
-    # Place a real temp CSV inside the workspace-tracked list.
+    # Place a real temp CSV inside the workspace-tracked list. The
+    # path lives under pytest's tmp_path, which is intentionally
+    # outside ALLOWED_FILES_ROOT — Issue #374 ensures upload-mode
+    # bypasses that check via the tracked-temp-file registry.
     app = client.app  # type: ignore[union-attr]
     ws = app.state.workspace
     upload_file = tmp_path / "upload_abc.csv"
     upload_file.write_text("x,y\n1,2\n3,4\n", encoding="utf-8")
     ws.track_temp_file(str(upload_file))
 
-    # Stub out run_inference so we don't need a real backend.
-    from lizystudio.api import inference as inference_api
-    from lizystudio.services.inference import InferenceRecord
-
-    def _fake_run(**kwargs):  # type: ignore[no-untyped-def]
-        return InferenceRecord(
-            inf_id="inf_fake",
-            job_id=kwargs["job"].job_id,
-            data_ref=sample_data_ref,
-            has_ground_truth=False,
-            created_at="2026-04-14T00:00:00Z",
-            row_count=2,
-            warnings=[],
-        )
-
-    monkeypatch.setattr(inference_api, "run_inference", _fake_run)
-    # Also shortcut path validation for the tmp file.
-    monkeypatch.setattr(inference_api, "validate_path_within", lambda p, _root: p)
+    _stub_run_inference(monkeypatch, sample_data_ref, "inf_fake", 2)
 
     res = client.post(
         "/api/inference/run",
@@ -98,7 +117,43 @@ def test_upload_source_temp_file_is_removed_after_run(
     assert not upload_file.exists(), (
         "upload-mode temp file must be deleted after /inference/run"
     )
-    assert str(upload_file) not in ws._temp_files
+    assert not ws.is_tracked_temp_file(str(upload_file))
+
+
+def test_upload_source_untracked_path_is_rejected(
+    client: TestClient,
+    sample_data_ref: DataRef,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """source_type=upload with an untracked path must be rejected (Issue #374).
+
+    Without this guard a forged request like
+    ``{source_type: "upload", path: "/etc/passwd"}`` would slip past
+    the ALLOWED_FILES_ROOT check. The endpoint must verify the path
+    was registered by ``/api/inference/upload`` first.
+    """
+    job_id = _seed_job(client, sample_data_ref)
+
+    # Create a real file but DO NOT track it as a tempfile upload.
+    untracked = tmp_path / "untracked.csv"
+    untracked.write_text("x,y\n1,2\n", encoding="utf-8")
+
+    _stub_run_inference(monkeypatch, sample_data_ref, "inf_should_not_run", 1)
+
+    res = client.post(
+        "/api/inference/run",
+        json={
+            "job_id": job_id,
+            "data": {"source_type": "upload", "path": str(untracked)},
+        },
+    )
+
+    assert res.status_code == 400, res.text
+    body = res.json()
+    assert body["error"]["code"] == "PATH_NOT_FOUND"
+    # Untouched: the request must not have called the run path.
+    assert untracked.exists()
 
 
 def test_path_source_temp_file_is_not_touched(
@@ -115,22 +170,14 @@ def test_path_source_temp_file_is_not_touched(
     df = pd.read_csv(user_file)
     assert len(df) == 1  # sanity
 
-    from lizystudio.api import inference as inference_api
-    from lizystudio.services.inference import InferenceRecord
+    # Re-point ALLOWED_FILES_ROOT at tmp_path so the user-supplied
+    # path validates legitimately (no monkeypatch on
+    # validate_path_within itself — Issue #374 lesson).
+    import lizystudio.security as security_mod
 
-    def _fake_run(**kwargs):  # type: ignore[no-untyped-def]
-        return InferenceRecord(
-            inf_id="inf_fake2",
-            job_id=kwargs["job"].job_id,
-            data_ref=sample_data_ref,
-            has_ground_truth=False,
-            created_at="2026-04-14T00:00:00Z",
-            row_count=1,
-            warnings=[],
-        )
+    monkeypatch.setattr(security_mod, "ALLOWED_FILES_ROOT", tmp_path.resolve())
 
-    monkeypatch.setattr(inference_api, "run_inference", _fake_run)
-    monkeypatch.setattr(inference_api, "validate_path_within", lambda p, _root: p)
+    _stub_run_inference(monkeypatch, sample_data_ref, "inf_fake2", 1)
 
     res = client.post(
         "/api/inference/run",
@@ -142,3 +189,38 @@ def test_path_source_temp_file_is_not_touched(
 
     assert res.status_code == 200, res.text
     assert user_file.exists(), "path-mode file must be left alone"
+
+
+def test_path_source_outside_allowed_root_is_rejected(
+    client: TestClient,
+    sample_data_ref: DataRef,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """source_type='path' must reject paths outside ALLOWED_FILES_ROOT."""
+    job_id = _seed_job(client, sample_data_ref)
+
+    user_file = tmp_path / "outside.csv"
+    user_file.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    # Constrain ALLOWED_FILES_ROOT to a subdir that does NOT contain
+    # the user_file path.
+    sub = tmp_path / "allowed"
+    sub.mkdir()
+    import lizystudio.security as security_mod
+
+    monkeypatch.setattr(security_mod, "ALLOWED_FILES_ROOT", sub.resolve())
+
+    _stub_run_inference(monkeypatch, sample_data_ref, "inf_should_not_run", 1)
+
+    res = client.post(
+        "/api/inference/run",
+        json={
+            "job_id": job_id,
+            "data": {"source_type": "path", "path": str(user_file)},
+        },
+    )
+
+    assert res.status_code == 400, res.text
+    body = res.json()
+    assert body["error"]["code"] == "PATH_NOT_FOUND"


### PR DESCRIPTION
## Summary

- Fixes #374 — Inference page **Upload** data source was broken end-to-end. `POST /api/inference/upload` succeeded, but the subsequent `POST /api/inference/run` returned 400 PATH_NOT_FOUND because the validator rejected the staged tempfile path (under `/tmp`, outside `ALLOWED_FILES_ROOT = ~`).
- Two cooperating bugs:
  1. Backend ran `validate_path_within(... ALLOWED_FILES_ROOT)` unconditionally regardless of `source_type`.
  2. Frontend `InferencePage` hard-coded `source_type: "path"`, dropping `SetupPanel`'s `sourceType` state.
- The existing regression test (`test_reg_0069_inference_upload_cleanup`) passed because it stubbed `validate_path_within` away — a textbook example of `feedback_no_docs_only_pr.md` / `feedback_diagnosis_before_prescription.md` lessons. Tests now exercise the real validator.

## Changes

### Backend
- `src/lizystudio/api/inference.py`: split path validation by `source_type` (path → ALLOWED_FILES_ROOT, upload → tracked-temp-file membership).
- `src/lizystudio/services/workspace.py`: add `is_tracked_temp_file(path)` accessor; lock-protected so concurrent uploads stay safe.

### Frontend
- `frontend/src/components/inference/SetupPanel.tsx`: pass `sourceType` to `onRunInference`.
- `frontend/src/pages/InferencePage.tsx`: forward `sourceType` to `/api/inference/run` request body.

### Tests
- `tests/regression/test_reg_0069_inference_upload_cleanup.py`:
  - Drop the `validate_path_within` monkeypatch (the existing tests passed only because the real validator was stubbed away).
  - Add `test_upload_source_untracked_path_is_rejected` — security regression: a forged `{source_type: "upload", path: "/etc/passwd"}` is rejected at the API boundary.
  - Add `test_path_source_outside_allowed_root_is_rejected` — re-asserts the path-mode root-containment check still works.
- `frontend/src/components/inference/SetupPanel.test.tsx`: assert upload mode forwards `sourceType: "upload"`.
- `frontend/src/pages/InferencePage.test.tsx`: assert request body carries the propagated `source_type`.

### Docs
- Bundles `docs/gui-verification-handoff-2026-05-03-r3.md` (Round 3 GUI verification handoff that surfaced this bug). Per `feedback_no_docs_only_pr` we ship the audit doc with the follow-up fix PR rather than as a standalone docs-only PR.

## Why CI didn't catch it

- The backend regression test suite stubbed `validate_path_within` away in both upload and path tests, so the real validation logic was never exercised.
- No e2e test covered the **Upload** tab on the Inference page.

This PR fixes both gaps.

## Test plan

- [x] Backend: `uv run pytest tests/regression/test_reg_0069_inference_upload_cleanup.py -v` (4 passed)
- [x] Backend: `uv run pytest tests/test_inference_api.py -q` (30 passed)
- [x] Frontend: `pnpm vitest run src/components/inference/SetupPanel.test.tsx src/pages/InferencePage.test.tsx` (36 passed)
- [x] `uv run ruff check` + `ruff format --check` + `mypy` clean on touched files
- [x] `pnpm check` + `pnpm build` clean
- [x] Browser smoke test: select Job #42 → Upload tab → drop binary_no_cal/data.csv → Run Inference → 200 OK with `inf_id`; tempfile cleaned up post-run.
- [ ] CI green (pending)

## Invariants

- INV-1: `/api/inference/run` accepts `body.data.path` only when (a) `source_type=path` AND path is under `ALLOWED_FILES_ROOT`, or (b) `source_type=upload` AND path is in `WorkspaceState._temp_files`.
- INV-2: `WorkspaceState._temp_files` is mutated only under `_lock`; callers must use `track_temp_file` / `consume_temp_file` / `is_tracked_temp_file`.
- INV-3: Frontend `InferencePage.runInferenceAction` forwards `sourceType` verbatim to the API request body's `source_type`.

## Failure paths covered

- [x] Normal completion (upload → run → cleanup)
- [x] Forged source_type=upload with arbitrary path (rejected)
- [x] source_type=path outside allowed root (rejected)
- [ ] Concurrent uploads (out of scope — single-user FastAPI app, lock present)
