### PR TITLE
fix(inference): wire shap-summary plot through LizyMLAdapter dispatch (#373)

### DIFF
--- a/src/lizystudio/backends/lizyml/evaluation_mixin.py
+++ b/src/lizystudio/backends/lizyml/evaluation_mixin.py
@@ -90,6 +90,11 @@ class EvaluationMixin:
         "calibration": "calibration_plot",
         "probability-histogram": "probability_histogram_plot",
         "tuning": "tuning_plot",
+        # Issue #373: ``shap-summary`` is an alias of ``importance_plot``
+        # with ``kind="shap"`` baked in. lizyml's importance_plot already
+        # supports kind={"split","gain","shap"} (lizyml.Model.importance_plot
+        # signature, verified against 0.9.1). No new lizyml method needed.
+        "shap-summary": "importance_plot",
     }
 
     def plot(self, model: Any, plot_type: str, **kwargs: Any) -> PlotData:
@@ -104,6 +109,11 @@ class EvaluationMixin:
             call_kwargs["metrics"] = kwargs["metrics"]
         if plot_type == "importance" and "kind" in kwargs:
             call_kwargs["kind"] = kwargs["kind"]
+        if plot_type == "shap-summary":
+            # Force kind="shap" regardless of caller-supplied kwargs;
+            # ``shap-summary`` is the dedicated SHAP-only entry point
+            # (see _PLOT_DISPATCH note on Issue #373).
+            call_kwargs["kind"] = "shap"
         fig = getattr(model, method_name)(**call_kwargs)
         return PlotData(plotly_json=fig.to_json())
 
@@ -126,6 +136,18 @@ class EvaluationMixin:
             plots.append("tuning")
         except Exception:  # noqa: BLE001
             logger.debug("tuning_plot not available", exc_info=True)
+        # Issue #373: probe shap importance defensively. Mirrors the
+        # tuning_plot pattern: lizyml raises LizyMLError when shap is
+        # not installed (OPTIONAL_DEP_MISSING) or when the loaded
+        # model lacks ``analysis_context`` (MODEL_NOT_FIT). We use
+        # ``importance(kind='shap')`` rather than ``importance_plot``
+        # because it returns a small dict, avoiding a full Plotly
+        # figure build for a feature-detection probe.
+        try:
+            model.importance(kind="shap")
+            plots.append("shap-summary")
+        except Exception:  # noqa: BLE001
+            logger.debug("shap importance not available", exc_info=True)
         return plots
 
     def export_model(self, model: Any, path: str) -> str:

--- a/tests/contract/test_frontend_plot_keys.py
+++ b/tests/contract/test_frontend_plot_keys.py
@@ -1,0 +1,59 @@
+"""Contract: every plot-type string the frontend hard-codes must be a
+registered key in ``LizyMLAdapter._PLOT_DISPATCH``.
+
+Issue #373 (and earlier #370) traced to a frontend → backend mismatch
+where the UI requested a plot type the backend never advertised. The
+gating layer (``available_plots``) silently dropped the request, so
+the bug only surfaced as a missing UI section. This contract test
+locks the structural guarantee that any plot key wired into a frontend
+``fetchInferencePlot(...)`` / ``fetchJobPlot(...)`` call has a
+matching dispatch entry, catching the next mismatch at CI time.
+
+The list below is intentionally hand-maintained from a grep across
+``frontend/src/api/`` and ``frontend/src/hooks/`` because:
+
+* Plot keys delivered dynamically via ``available_plots`` (e.g.
+  ``roc-curve``, ``calibration``) are out of scope — the backend
+  itself decides whether to advertise them, so a missing dispatch
+  entry would be caught by the existing ``available_plots`` tests.
+* Hard-coded frontend keys (those not gated on backend advertisement)
+  are the failure mode this test pins.
+
+When adding a new fetcher in the frontend, add the key here. CI will
+fail until the backend dispatch grows the matching entry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lizystudio.backends.lizyml.adapter import LizyMLAdapter
+
+pytestmark = pytest.mark.unit
+
+
+# Hard-coded plot keys passed to fetchJobPlot / fetchInferencePlot in
+# the frontend. Sources verified 2026-05-04:
+#
+# * frontend/src/hooks/useJobResultData.ts:122  fetchJobPlot("learning-curve")
+# * frontend/src/hooks/useJobResultData.ts:196  fetchJobPlot("importance")
+# * frontend/src/hooks/useJobResultData.ts:211  fetchJobPlot("tuning")
+# * frontend/src/api/inference.ts:155            fetchInferencePlot("shap-summary")
+_FRONTEND_HARDCODED_PLOT_KEYS: frozenset[str] = frozenset(
+    {
+        "learning-curve",
+        "importance",
+        "tuning",
+        "shap-summary",
+    }
+)
+
+
+def test_every_frontend_hardcoded_plot_key_has_dispatch_entry() -> None:
+    dispatch = set(LizyMLAdapter._PLOT_DISPATCH)
+    missing = _FRONTEND_HARDCODED_PLOT_KEYS - dispatch
+    assert not missing, (
+        f"Frontend hard-codes plot keys that have no _PLOT_DISPATCH entry: "
+        f"{sorted(missing)}. Add them to LizyMLAdapter._PLOT_DISPATCH or "
+        f"remove the dead frontend fetcher."
+    )

--- a/tests/regression/test_reg_0355_inference_unknown_plot_404.py
+++ b/tests/regression/test_reg_0355_inference_unknown_plot_404.py
@@ -47,15 +47,23 @@ def test_evaluation_mixin_unknown_plot_raises_typed_error() -> None:
     "client asked for an unsupported plot" from "the underlying
     plot-generating code blew up". A typed exception lets the API map
     the former to 404 while leaving genuine backend failures as 500.
+
+    Issue #373: the original test used ``"shap-summary"`` as the
+    deliberately-unknown sample, but #373 added that key to the
+    dispatch (lizyml ``importance_plot(kind="shap")`` alias). We now
+    use a string that is structurally guaranteed to never become a
+    real plot type so this regression test stays meaningful.
     """
     mixin = EvaluationMixin()
     fake_model = MagicMock()
+    unknown_plot = "definitely-not-a-real-plot-type"
+    assert unknown_plot not in EvaluationMixin._PLOT_DISPATCH  # sanity
 
     with pytest.raises(PlotNotAvailableError) as exc_info:
-        mixin.plot(fake_model, "shap-summary")
+        mixin.plot(fake_model, unknown_plot)
 
     err = exc_info.value
-    assert err.plot_type == "shap-summary"
+    assert err.plot_type == unknown_plot
     assert isinstance(err.available, list)
     assert "learning-curve" in err.available  # known supported plot
     # Bare ValueError must NOT be raised — that was the old behaviour

--- a/tests/test_backends_lizyml.py
+++ b/tests/test_backends_lizyml.py
@@ -372,6 +372,65 @@ def test_available_plots_with_tuning() -> None:
     assert "tuning" in plots
 
 
+# --- Issue #373: shap-summary plot wiring ---
+
+
+def test_available_plots_includes_shap_summary_when_supported() -> None:
+    """available_plots() advertises 'shap-summary' when the model can
+    compute fold-averaged SHAP importances (Issue #373).
+
+    Mirrors the existing tuning probe pattern: we call
+    ``model.importance(kind='shap')`` defensively and skip when it
+    raises (shap missing, no analysis_context, etc).
+    """
+    adapter = LizyMLAdapter()
+    model = _make_mock_model(task="binary")
+    # Defensive: importance(kind='shap') succeeds → shap is available
+    model.importance.return_value = {"f1": 0.3, "f2": 0.5, "f3": 0.2}
+    plots = adapter.available_plots(model)
+    assert "shap-summary" in plots
+
+
+def test_available_plots_omits_shap_summary_when_not_supported() -> None:
+    """available_plots() omits 'shap-summary' when the SHAP probe raises.
+
+    Replicates the OPTIONAL_DEP_MISSING / MODEL_NOT_FIT cases lizyml
+    raises from importance(kind='shap') when shap is missing or the
+    fit lacks analysis_context.
+    """
+    adapter = LizyMLAdapter()
+    model = _make_mock_model(task="binary")
+    model.importance.side_effect = RuntimeError("OPTIONAL_DEP_MISSING")
+    plots = adapter.available_plots(model)
+    assert "shap-summary" not in plots
+
+
+def test_plot_shap_summary_dispatches_to_importance_plot_with_kind_shap() -> None:
+    """plot('shap-summary') resolves to importance_plot(kind='shap').
+
+    Reuses lizyml's existing ``importance_plot(kind='shap', top_n=20)``
+    method (Model.importance_plot supports kind=split/gain/shap). No
+    new lizyml method is required.
+    """
+    adapter = LizyMLAdapter()
+    mock_model = MagicMock()
+    mock_fig = MagicMock()
+    mock_fig.to_json.return_value = "{}"
+    mock_model.importance_plot.return_value = mock_fig
+
+    result = adapter.plot(mock_model, "shap-summary")
+
+    mock_model.importance_plot.assert_called_once_with(kind="shap")
+    assert isinstance(result, PlotData)
+
+
+def test_plot_dispatch_table_includes_shap_summary() -> None:
+    """``shap-summary`` must be a registered key in _PLOT_DISPATCH so
+    PlotNotAvailableError lists it under ``available`` (Issue #373).
+    """
+    assert "shap-summary" in LizyMLAdapter._PLOT_DISPATCH
+
+
 def test_fit_invokes_on_progress() -> None:
     adapter = LizyMLAdapter()
     mock_model = MagicMock()


### PR DESCRIPTION
## Summary

Closes #373. Wires `shap-summary` through `LizyMLAdapter`. The frontend already had the gate (added in #355 / #356), but the backend never advertised the key — so the SHAP Summary accordion silently never rendered. lizyml 0.9.1 already ships the underlying `Model.importance_plot(kind="shap")`, so the fix is adapter-only.

## Diagnostic — why this was sleeping

* `frontend/src/api/inference.ts:155` calls `fetchInferencePlot(_, _, "shap-summary")`.
* `frontend/src/components/inference/Results{PredOnly,WithGT}.tsx` gates the accordion on `availablePlots?.includes("shap-summary")`.
* `LizyMLAdapter._PLOT_DISPATCH` (`src/lizystudio/backends/lizyml/evaluation_mixin.py:84`) had **no** `shap-summary` entry; `available_plots()` never appended it. Gate stays closed → accordion never renders.
* Same class as #370 (`prediction-distribution` mismatch). The contract test added here catches the next instance at CI time.

## Changes

### Backend (`src/lizystudio/backends/lizyml/evaluation_mixin.py`)
- `_PLOT_DISPATCH["shap-summary"] -> "importance_plot"` — alias entry; lizyml's `importance_plot` already supports `kind="shap"` (verified against 0.9.1).
- `plot()` forces `call_kwargs["kind"] = "shap"` for `"shap-summary"`, ignoring caller-supplied `kind` so the dispatch is unambiguous.
- `available_plots()` probes `model.importance(kind="shap")` defensively (mirrors the existing `tuning_plot` probe). Uses `importance(...)` rather than `importance_plot(...)` because the former returns a small dict — cheap for feature detection. Skips on `OPTIONAL_DEP_MISSING` / `MODEL_NOT_FIT`.

### Tests
- `tests/test_backends_lizyml.py`: four new unit tests covering dispatch entry presence, kwargs injection, and the available-plots probe (success + raise paths).
- `tests/contract/test_frontend_plot_keys.py` *(new)*: pins every plot key the frontend hard-codes against `_PLOT_DISPATCH`. Currently locks `{learning-curve, importance, tuning, shap-summary}`. Adding a new fetcher in the frontend without a matching dispatch entry will fail CI here.

### Out of scope
- Frontend untouched (already correct).
- No lizyml change required.
- No OpenAPI surface change → `api-types-drift` clean (`pnpm generate:api` produced no diff).

## Test plan

- [x] `uv run pytest tests/test_backends_lizyml.py tests/contract/ -q` → **127 passed**
- [x] `uv run ruff check` + `ruff format --check` + `mypy` clean on touched files
- [x] `pnpm build` clean
- [x] Browser smoke (Playwright MCP):
  - `GET /api/jobs/job_47a57770/plots` → includes `"shap-summary"`
  - `GET /api/jobs/job_47a57770/plot/shap-summary` → 200, Plotly JSON titled `Feature Importance (SHAP)`
  - SHAP Summary accordion renders on `/inference?job_id=...`; clicking expands a bar chart with 10 features.
- [ ] CI green (pending)

## Invariants

- INV-1: For every plot key `K` hard-coded in the frontend, `K ∈ LizyMLAdapter._PLOT_DISPATCH` (locked by `tests/contract/test_frontend_plot_keys.py`).
- INV-2: `available_plots()` advertises `"shap-summary"` iff the model can compute fold-averaged SHAP importance (`model.importance(kind="shap")` returns without raising).
- INV-3: `plot("shap-summary")` always calls `importance_plot(kind="shap")`, regardless of caller-supplied kwargs.

## Failure paths covered

- [x] Normal completion (`available_plots` advertises, `plot` returns Plotly JSON)
- [x] `shap` package missing → probe raises → `shap-summary` omitted from advertised list
- [x] Loaded model with no `analysis_context` → probe raises → omitted
- [x] Frontend adds a new hardcoded key without backend dispatch → contract test fails

EOF
