### PR TITLE
chore(release): v0.3.1 prep — CHANGELOG fill + #27/#28 regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,196 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet.
+The **Stability & Refactor** release. Six weeks of post-v0.3.0 bug
+fixes, internal refactors, and test infrastructure work absorbed into a
+single patch release. Highlights: Workspace ConfigForm cross-hook write
+race fully resolved (P-0092 single write funnel), inference plot type
+hardening (Issue #355 / #373), Tailwind CSS v4 migration (#125), real
+lizyml artefact fixtures with a fit→load round-trip CI gate (P-0095),
+performance baseline harness (P-0094), on-disk `format_version`
+migration chain (H-0081), atomic versioned JSON writes (H-0082), and
+the openapi-fetch frontend client migration (H-0080).
+
+No breaking changes for end users. Workspace state and persisted jobs
+from v0.3.0 continue to load via the new migration chain.
+
+### Added
+
+- **Workspace write funnel (P-0092)** — `useConfigSync` is now the
+  single PUT serialiser for `/config`. All four upstream writers
+  (`ConfigForm` auto-reset, `useTargetSelection`, `useModelPanelData`,
+  `handleApplyToFit`) route through the funnel hook with explicit
+  state machine transitions. Closes the cross-hook competing-write
+  race that had been patched four times since P-0086.
+- **On-disk `format_version` (H-0081)** — every persisted JSON
+  artefact now carries a `format_version` and is loaded through a
+  migration chain. Sets up forward-compat for v0.4+ schema changes.
+- **Atomic versioned JSON writer (H-0082)** — `write_versioned_json`
+  uses `os.replace` for tear-resistant writes; partial-write states
+  no longer corrupt persisted state across SIGKILL or power loss.
+- **fit→load round-trip CI gate (P-0095, Issue #346)** — fit→artefact
+  → reload integration test promoted to a required CI check, locking
+  the metric-extraction shape evolution that produced #344 / #345.
+  Backed by hand-captured real lizyml artefacts under
+  `tests/fixtures/lizyml/<scenario>/` (4 scenarios).
+- **Performance baseline harness (P-0094, Issue #27 (a))** —
+  `pytest-benchmark` integrated into the test suite (`tests/bench/`),
+  skipped by default (`--benchmark-skip` in addopts), surfaced via
+  Nightly opt-in workflow with JSON artefact upload for future
+  regression detection.
+- **WebSocket terminal-message replay (P-0093, Issue #327)** — late
+  subscribers now receive the cached terminal message so reconnecting
+  clients converge to the correct final state without polling.
+- **Workspace running-lock (Issue #279)** — `PUT/PATCH /config`
+  returns 409 while a Fit/Tune job is active, preventing config
+  drift mid-run. Carve-out for terminal slot holders preserves
+  user undo/retune flow.
+- **`/api/workspace/fit` and `/api/workspace/tune` accept optional
+  `config` body (P-0086, Issue #251)** — frontend can now send the
+  latest merged config in the same request, eliminating the
+  PUT-then-FIT race window. Backward compatible: omitting the body
+  uses the server-side persisted config as before.
+- **Architecture overview docs (`docs/architecture-overview.md`)** —
+  Mermaid diagrams (System Context, Container View, Module Layering,
+  Job Lifecycle State Machine, 4 sequence diagrams) for new-reader
+  onboarding ahead of BLUEPRINT.md.
+- **Visual regression goldens for theme** (H-0078) — committed
+  `__screenshots__` produced on the Nightly runner; raw Tailwind
+  color guard script (B-9 Part 2 / H-0079) blocks regressions.
+- **Issue #346 fixture strategy (Phases A-E)** — 4 scenarios of real
+  fit_result.json / metadata.json captured, fixture-driven coverage
+  added at metric / hook / component layers, contributing-guide
+  section on fixtures published.
+
+### Changed
+
+- **Tailwind CSS v3 → v4 migration (Issue #125, PR #378)** —
+  `tailwindcss@^4.2.4` with `@tailwindcss/vite` plugin; `@theme`
+  block migrated; build remains on Vite. PostCSS pipeline simplified.
+  Initial install requires `pnpm install --force` once for native
+  binding.
+- **Frontend API client migration to openapi-fetch (H-0080, C-6
+  Phases 1-5)** — `apiFetch` retired across `files.ts`, `inference.ts`,
+  `workspace.ts`, `jobs.ts`. `client.ts` now exports a typed
+  `apiClient`; CI lint rule (`no-apifetch-guard`) blocks regressions.
+- **CORS env allowlist + WS origin cache (H-0083, Issue #233/#234)** —
+  CORS allowlist read from `LIZYSTUDIO_ALLOWED_ORIGINS`; WebSocket
+  origin validation now caches resolved hosts.
+- **Per-app `MetricsRegistry` and `ModelCache` (A-9 / H-0075,
+  H-0084)** — both moved off module-globals onto
+  `app.state` / `JobStore`; eliminates cross-app pollution in tests
+  and embedded deployments.
+- **Job persistence layout centralised in `JobStore.path_for`
+  (A-10, H-0073)** — services no longer hand-construct on-disk paths.
+- **`useDataPanel` split (B-5, H-0077)** — `useTargetSelection`
+  extracted to remove the cross-hook write contention surface that
+  P-0092 then formalised into the funnel.
+- **`ModelPanel` split into hook + 3 sub-components (B-3)** — pure
+  presentational components; data flow through dedicated hooks.
+- **JobSummary / JobDetail / UiSchema typed at API boundary
+  (C-4 / C-5a / H-0071 / H-0072)** — single source of truth from
+  the FastAPI Pydantic models all the way to React props.
+- **CV strategy fields auto-derived from UiSchema (C-5b)** — retires
+  `CV_STRATEGY_FIELDS` / `METRICS_BY_TASK` hardcoded fallbacks.
+- **WebSocket message Pydantic discriminated union (C-3, H-0069)** —
+  WS payloads validated against typed schemas at both ends.
+- **Sdist size 5 MB → 1.8 MB** — `[tool.hatch.build.targets.sdist]`
+  added with explicit `include`/`exclude`; `frontend/`, `tests/`,
+  `.github/`, BLUEPRINT.md / HISTORY.md / PLAN.md no longer
+  shipped to PyPI.
+
+### Fixed
+
+- **Inference `shap-summary` 500 → wired through LizyMLAdapter
+  dispatch (Issue #373, PR #377)** — uses `lizyml`'s built-in
+  `importance_plot(kind="shap")`; previously surfaced as 500 because
+  the adapter raised on the unknown plot type.
+- **Inference upload-mode tempfile path (Issue #374, PR #375)** —
+  `/api/inference/run` now accepts the tempfile path produced by
+  the upload flow rather than rejecting it as out-of-tree.
+- **Inference unknown plot type → 404 not 500 (Issue #355, PR #356)** —
+  unknown plot types now return a normal 404 so the frontend can
+  gate gracefully.
+- **Probability histogram + distribution panel gating (Issue #370)** —
+  no longer triggers a 500 when the distribution data is unavailable.
+- **Load Preset replaced by menu-driven popover (Issue #369)** —
+  removes the `<Select>` form-binding race that mis-applied presets.
+- **DataPanel hydrates from server-persisted state on reload
+  (Issue #363)** — refreshing the workspace tab no longer wipes
+  the loaded data file.
+- **CV strategy latched against stale cache reverts (Issue #358)** —
+  user-picked `cv_strategy` is no longer overwritten by mid-flight
+  cache invalidation.
+- **Inference dropdown derives `#N` from `allJobs` not
+  `completedJobs` (Issue #359)** — running jobs now appear in the
+  dropdown with the correct ordinal.
+- **`oos_std` derivation falls back to `oof_per_fold` (Issue #364)** —
+  variance shows for older artefacts that lack `oof_std`.
+- **Polling-storm after Tune terminal halted (Issue #339, PR #341)** —
+  `useBackgroundNotification` no longer returns a fresh callback
+  each render; post-terminal GETs reduced from 30 to 1.
+- **Tune objective `Choice` empty + WS progress send-after-close
+  (Issues #337, #338)** — empty Choice no longer crashes the Tune
+  flow; WS progress writes guarded against post-close races.
+- **Metrics: unwrap `raw` subtree when calibrated metrics also
+  present (PR #344)** — single-source ROC curve when both raw and
+  calibrated metrics exist.
+- **`InferenceStore.list` skips corrupt records + pred-column guard
+  (Issue #241)** — one bad record no longer breaks the listing API.
+- **Workspace silent-late validation failures surfaced
+  (Issues #268, #269, #270)** — the user now sees the validation
+  error instead of a stuck UI.
+- **`BlockedGroupKFold` payload nests `blocks/groups` (Issue #278)** —
+  matches the server-side Pydantic model shape.
+- **`SearchSpaceRow` button-in-button a11y violation (Issue #274)** —
+  `<button>` wrapper replaced with `<div role="button">`.
+- **Single-PUT task switch via `buildSyncedConfig` (Issue #272)** —
+  task switching no longer fires PUT bursts that race with each other.
+- **`FeatureWeightsEditor` excludes target + excluded features
+  (P-0091, Issue #277)** — picker no longer shows the target column
+  or already-excluded features.
+- **UI schema ↔ Pydantic invariant locked (P-0087, Issues #258/#259)** —
+  contract tests under `tests/contract/` lock the drift; closes the
+  UI Fit 422 class.
+- **Subprocess child stdout redirected to `execution.log`
+  (Issue #328)** — child process logs now reach disk; previously
+  swallowed by the parent.
+- **WS late-subscriber replay (P-0093, Issue #327)** — see Added.
+- **a11y: `aria-label` on `FeatureWeightsEditor` Switch** —
+  screen-reader announces the toggle purpose.
+
+### Deprecated
+
+- **`apiFetch` removal (H-0080 Phase 5)** — no longer exported from
+  `frontend/src/api/client.ts`. New code must use `apiClient`.
+- **`CV_STRATEGY_FIELDS` / `METRICS_BY_TASK` hardcoded fallbacks** —
+  retired in favour of UiSchema-driven SSOT (C-5b).
+
+### Security
+
+- **CORS env allowlist (H-0083)** — origins no longer hardcoded to
+  development defaults; production deployments must set
+  `LIZYSTUDIO_ALLOWED_ORIGINS`.
+- **WebSocket origin validation cache (H-0083)** — guards against
+  origin-spoof reconnect storms.
+- **Atomic JSON writes (H-0082)** — partial-write states from
+  SIGKILL or power loss can no longer corrupt persisted job /
+  workspace state.
+
+### Test Infrastructure
+
+- **Real-artefact fixtures (Issue #346 Phase A)** — `tests/fixtures/
+  lizyml/{binary_no_cal,binary_cal,multiclass,regression}/` ship
+  hand-captured `fit_result.json` / `metadata.json` from a clean
+  `lizyml` run. Fixture loaders under `tests/fixtures/_loader.py`.
+- **fit→load round-trip CI gate (P-0095, Issue #346 Phase C)** — runs
+  on every PR; blocks merge on metric-extraction drift.
+- **`pytest-benchmark` baseline harness (P-0094, Issue #27 (a))** —
+  Nightly-only by default; JSON artefact upload for trend tracking.
+- **Branch protection on develop / main** — 8 required checks
+  (backend 3.10 / 3.11, frontend lint / test / build, e2e
+  functional, type-drift, no-apifetch-guard) enforced as of
+  Issue #346 Phase C kickoff (2026-05-02).
 
 ## [0.3.0] - 2026-04-19
 

--- a/tests/regression/test_reg_0027e_concurrent_job_submission.py
+++ b/tests/regression/test_reg_0027e_concurrent_job_submission.py
@@ -1,0 +1,179 @@
+"""Stress tests for concurrent ``create_and_claim_active`` (Issue #27 (e)).
+
+``test_reg_0070`` covers the *serial* two-caller path. This file
+escalates to ``N`` threads racing the same JobStore concurrently and
+asserts the post-conditions:
+
+- INV: at most ONE thread sees a non-None ``Job`` returned.
+- INV: no orphan job directory is created on disk for the losing
+  threads — ``create_and_claim_active`` is the single critical
+  section that checks-the-slot + creates-the-job + claims-the-slot.
+- INV: after the winner releases, a second wave of N threads can
+  again elect exactly one winner.
+- INV: the on-disk ``meta.json`` count equals the number of winners
+  across all waves (no torn writes, no duplicate dirs).
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from lizystudio.backends.types import DataRef
+from lizystudio.services.jobs import JobStore
+
+pytestmark = pytest.mark.unit
+
+
+def _data_ref() -> DataRef:
+    return DataRef(
+        source_type="path",
+        path="/data/x.csv",
+        filename="x.csv",
+        fingerprint="f",
+        shape=(10, 2),
+    )
+
+
+def _race_create_and_claim(
+    store: JobStore, n: int, start_barrier: threading.Barrier
+) -> list[bool]:
+    """Spawn ``n`` threads; every thread blocks on ``start_barrier``
+    until all are ready, then races for the active slot. Returns a
+    list of bools: ``True`` for the winners.
+    """
+    wins: list[bool] = [False] * n
+
+    def worker(i: int) -> None:
+        start_barrier.wait()
+        job = store.create_and_claim_active(
+            backend_name="lizyml",
+            config={"task": "binary"},
+            data_ref=_data_ref(),
+            job_type="fit",
+        )
+        wins[i] = job is not None
+
+    threads = [
+        threading.Thread(target=worker, args=(i,), daemon=True) for i in range(n)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10.0)
+        assert not t.is_alive(), "worker thread failed to join in time"
+
+    return wins
+
+
+def test_n_threads_elect_exactly_one_winner(tmp_path: Path) -> None:
+    """20 threads call ``create_and_claim_active`` simultaneously;
+    exactly one returns a Job, the other 19 return ``None``.
+    """
+    store = JobStore(tmp_path)
+    n = 20
+    barrier = threading.Barrier(n)
+
+    wins = _race_create_and_claim(store, n=n, start_barrier=barrier)
+
+    assert sum(wins) == 1, f"expected 1 winner across {n} threads, got {sum(wins)}"
+    assert store.active_job_id is not None
+
+
+def test_losing_threads_do_not_leave_orphan_job_dirs(tmp_path: Path) -> None:
+    """The 19 losing threads must NOT create a meta.json on disk.
+    Counts directory entries under ``tmp_path`` and asserts exactly
+    one job directory exists after the race.
+    """
+    store = JobStore(tmp_path)
+    n = 20
+    barrier = threading.Barrier(n)
+
+    _race_create_and_claim(store, n=n, start_barrier=barrier)
+
+    job_dirs = [p for p in tmp_path.iterdir() if p.is_dir()]
+    assert len(job_dirs) == 1, (
+        f"expected exactly 1 job dir after race, got {len(job_dirs)}: "
+        f"{[p.name for p in job_dirs]}"
+    )
+    assert (job_dirs[0] / "meta.json").exists(), "winner must persist meta.json"
+
+
+def test_two_waves_each_elect_one_winner(tmp_path: Path) -> None:
+    """After the first winner releases the slot, a second wave of
+    racers must again elect exactly one winner. Verifies the slot
+    state is fully reset and the JobStore behaves identically across
+    repeated rounds.
+    """
+    store = JobStore(tmp_path)
+    n = 10
+
+    wins1 = _race_create_and_claim(store, n=n, start_barrier=threading.Barrier(n))
+    assert sum(wins1) == 1
+    winner1 = store.active_job_id
+    assert winner1 is not None
+
+    store.release_active(winner1)
+    assert store.active_job_id is None
+
+    wins2 = _race_create_and_claim(store, n=n, start_barrier=threading.Barrier(n))
+    assert sum(wins2) == 1
+    winner2 = store.active_job_id
+    assert winner2 is not None and winner2 != winner1
+
+    # On-disk: exactly two job dirs (winner1 + winner2).
+    job_dirs = sorted(p.name for p in tmp_path.iterdir() if p.is_dir())
+    assert len(job_dirs) == 2, f"expected 2 job dirs after two waves, got: {job_dirs}"
+
+
+def test_release_during_race_does_not_double_admit(tmp_path: Path) -> None:
+    """Edge: the slot holder releases mid-race. The losing threads
+    that arrive BEFORE the release must still get None; the threads
+    that arrive AFTER the release elect a single new winner.
+
+    Drives this by having a holder thread release after a short delay
+    while a fresh wave is contending for the slot. The total count of
+    "winners" across the wave is always exactly one — the slot is
+    serialised by ``_active_lock``, and the late-arriver winner picks
+    up where the original holder left off.
+    """
+    store = JobStore(tmp_path)
+    holder = store.create_and_claim_active(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=_data_ref(),
+        job_type="fit",
+    )
+    assert holder is not None
+
+    n = 10
+    start = threading.Barrier(n + 1)
+    wins: list[bool] = [False] * n
+
+    def worker(i: int) -> None:
+        start.wait()
+        job = store.create_and_claim_active(
+            backend_name="lizyml",
+            config={"task": "binary"},
+            data_ref=_data_ref(),
+            job_type="fit",
+        )
+        wins[i] = job is not None
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    start.wait()
+    # Release the slot once the wave has begun racing.
+    store.release_active(holder.job_id)
+
+    for t in threads:
+        t.join(timeout=10.0)
+
+    # Exactly one wave entrant successfully claims the freed slot;
+    # everyone else races against it and gets None.
+    assert sum(wins) == 1, (
+        f"expected 1 wave winner after release-during-race, got {sum(wins)}"
+    )

--- a/tests/regression/test_reg_0027f_ws_concurrent_connections.py
+++ b/tests/regression/test_reg_0027f_ws_concurrent_connections.py
@@ -1,0 +1,208 @@
+"""Stress tests for WebSocket fan-out under concurrent subscribers (Issue #27 (f)).
+
+``test_progress.test_multiple_subscribers`` covers the basic 2-3
+subscriber case. This file scales to 20+ concurrent subscribers and
+adds connection/disconnection churn during active broadcasting:
+
+- INV: every live subscriber receives every progress message broadcast
+  while it is subscribed (modulo the bounded-queue overflow policy).
+- INV: subscribers added/removed during a live broadcast leave the
+  broadcaster state consistent — no leaked queues, no fan-out crash.
+- INV: terminal messages reach every subscriber that is connected
+  at send time (per :class:`ProgressBroadcaster` INV-1).
+- INV: subscribers attached AFTER the terminal observe the cached
+  terminal via the replay path (per P-0093) — even when 20 of them
+  reconnect at once.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from lizystudio.ws.progress import ProgressBroadcaster
+
+pytestmark = pytest.mark.unit
+
+
+def _run(coro: Any) -> Any:
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def test_20_subscribers_each_receive_terminal() -> None:
+    """20 concurrent subscribers on the same job_id all receive the
+    completed terminal. No subscriber is left in 'running' forever.
+    """
+    broadcaster = ProgressBroadcaster()
+    n = 20
+
+    async def run() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+        queues = [broadcaster.subscribe("job_fanout") for _ in range(n)]
+
+        broadcaster.send_progress("job_fanout", current=1, total=2, message="x")
+        broadcaster.send_completed("job_fanout", "Done!")
+        await asyncio.sleep(0)
+
+        for i, q in enumerate(queues):
+            msgs: list[dict[str, Any]] = []
+            while not q.empty():
+                msgs.append(q.get_nowait())
+            types = [m["type"] for m in msgs]
+            assert "completed" in types, f"subscriber #{i} missed terminal: {types}"
+
+    _run(run())
+
+
+def test_subscribers_joining_during_broadcast_observe_subsequent_messages() -> None:
+    """A subscriber that joins mid-broadcast must receive every
+    message broadcast AFTER its subscribe() call. Earlier messages
+    that fired before subscribe() are not retroactively delivered
+    (no replay for non-terminal progress per the cache policy).
+    """
+    broadcaster = ProgressBroadcaster()
+
+    async def run() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+
+        q_early = broadcaster.subscribe("job_join")
+        broadcaster.send_progress("job_join", current=1, total=3, message="a")
+        await asyncio.sleep(0)
+
+        # Join mid-stream.
+        q_late = broadcaster.subscribe("job_join")
+        broadcaster.send_progress("job_join", current=2, total=3, message="b")
+        broadcaster.send_progress("job_join", current=3, total=3, message="c")
+        await asyncio.sleep(0)
+
+        early_msgs: list[dict[str, Any]] = []
+        while not q_early.empty():
+            early_msgs.append(q_early.get_nowait())
+        late_msgs: list[dict[str, Any]] = []
+        while not q_late.empty():
+            late_msgs.append(q_late.get_nowait())
+
+        early_currents = [m["current"] for m in early_msgs]
+        late_currents = [m["current"] for m in late_msgs]
+        # Early sub saw all three.
+        assert early_currents == [1, 2, 3], early_msgs
+        # Late sub missed message 1 but caught 2 and 3.
+        assert late_currents == [2, 3], late_msgs
+
+    _run(run())
+
+
+def test_subscriber_churn_does_not_corrupt_broadcaster_state() -> None:
+    """Repeated subscribe/unsubscribe cycles interleaved with
+    broadcasts must leave ``_queues`` consistent: every entry maps to
+    a live queue, and no zombie keys remain.
+    """
+    broadcaster = ProgressBroadcaster()
+
+    async def run() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+
+        keep_q = broadcaster.subscribe("job_churn")
+
+        # 10 churn cycles interleaved with broadcasts.
+        for i in range(10):
+            ephemeral_q = broadcaster.subscribe("job_churn")
+            broadcaster.send_progress("job_churn", current=i, total=10, message=".")
+            await asyncio.sleep(0)
+            broadcaster.unsubscribe("job_churn", ephemeral_q)
+
+        broadcaster.send_completed("job_churn", "Done!")
+        await asyncio.sleep(0)
+
+        # The keeper subscriber received every progress and the terminal.
+        msgs: list[dict[str, Any]] = []
+        while not keep_q.empty():
+            msgs.append(keep_q.get_nowait())
+        assert sum(1 for m in msgs if m["type"] == "progress") == 10
+        assert any(m["type"] == "completed" for m in msgs)
+
+        # _queues retains only the keeper.
+        live = broadcaster._queues.get("job_churn", [])
+        assert live == [keep_q], f"churn left zombie subscribers: {len(live)} entries"
+
+        broadcaster.unsubscribe("job_churn", keep_q)
+        # After everyone leaves, the entry is GC'd.
+        assert "job_churn" not in broadcaster._queues
+
+    _run(run())
+
+
+def test_burst_reconnect_after_terminal_all_get_replay() -> None:
+    """20 subscribers reconnect simultaneously after the terminal was
+    sent. Each must see the cached terminal via the P-0093 replay
+    path so the UI on every tab converges to the correct final state
+    without polling.
+    """
+    broadcaster = ProgressBroadcaster()
+
+    async def run() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+
+        # Terminal sent before anyone is subscribed.
+        broadcaster.send_completed("job_burst", "Done!")
+        await asyncio.sleep(0)
+
+        # 20 simultaneous reconnects.
+        queues = [broadcaster.subscribe("job_burst") for _ in range(20)]
+
+        for i, q in enumerate(queues):
+            msgs: list[dict[str, Any]] = []
+            while not q.empty():
+                msgs.append(q.get_nowait())
+            types = [m["type"] for m in msgs]
+            assert "completed" in types, (
+                f"reconnect #{i} did not see cached terminal: {types}"
+            )
+
+    _run(run())
+
+
+def test_independent_jobs_do_not_cross_pollinate() -> None:
+    """Subscribers across different ``job_id``s must NOT see each
+    other's messages. Guards against a regression where a shared
+    queue list bug let job_a progress leak to job_b subscribers.
+    """
+    broadcaster = ProgressBroadcaster()
+
+    async def run() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+
+        q_a = [broadcaster.subscribe("job_a") for _ in range(5)]
+        q_b = [broadcaster.subscribe("job_b") for _ in range(5)]
+
+        broadcaster.send_progress("job_a", current=1, total=1, message="A")
+        broadcaster.send_completed("job_a", "A done")
+        broadcaster.send_progress("job_b", current=1, total=1, message="B")
+        broadcaster.send_completed("job_b", "B done")
+        await asyncio.sleep(0)
+
+        for q in q_a:
+            messages: list[dict[str, Any]] = []
+            while not q.empty():
+                messages.append(q.get_nowait())
+            for m in messages:
+                assert m["job_id"] == "job_a", (
+                    f"job_a subscriber received foreign job_id: {m}"
+                )
+
+        for q in q_b:
+            messages = []
+            while not q.empty():
+                messages.append(q.get_nowait())
+            for m in messages:
+                assert m["job_id"] == "job_b", (
+                    f"job_b subscriber received foreign job_id: {m}"
+                )
+
+    _run(run())

--- a/tests/regression/test_reg_0028a_ws_disconnect_reconnect.py
+++ b/tests/regression/test_reg_0028a_ws_disconnect_reconnect.py
@@ -1,0 +1,235 @@
+"""Regression tests for WebSocket disconnect/reconnect resilience (Issue #28 (a)).
+
+Builds on top of:
+
+- ``test_reg_0162_ws_backpressure_disconnect`` — single-disconnect cleanup.
+- ``test_progress.TestTerminalReplayCache`` — terminal replay cache (P-0093).
+
+This file fills the remaining sub-area (a) coverage gaps that those
+files do not directly exercise:
+
+- INV: a mid-stream reconnect (disconnect after partial progress) sees
+  subsequent broadcast messages on the *new* queue, never on the dead
+  one.
+- INV: N rapid reconnect cycles for the same ``job_id`` do not leak
+  subscriber entries in :class:`ProgressBroadcaster`.
+- INV: a terminal sent during the disconnect window is replayed in
+  full on reconnect, including the progress that preceded it.
+- INV: reconnect under producer load (broadcast rate ≈ MAX_QUEUE_SIZE)
+  preserves the terminal even when the dead queue is full at the
+  moment of disconnect.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import WebSocketDisconnect
+
+from lizystudio.ws.progress import (
+    MAX_QUEUE_SIZE,
+    ProgressBroadcaster,
+    websocket_progress,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _run(coro: Any) -> Any:
+    """Drive a coroutine on a fresh loop (mirrors test_reg_0162)."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _make_websocket() -> MagicMock:
+    ws = MagicMock()
+    ws.accept = AsyncMock()
+    ws.send_text = AsyncMock()
+    ws.close = AsyncMock()
+    ws.headers = {}
+    return ws
+
+
+def test_midstream_reconnect_receives_subsequent_progress() -> None:
+    """A consumer that disconnects after partial progress and reconnects
+    must receive subsequent broadcast messages on the *new* subscriber
+    queue, not the abandoned one. Without this guarantee the UI shows
+    'running' forever after a transient WS drop.
+    """
+    broadcaster = ProgressBroadcaster()
+
+    async def run() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+
+        # First subscriber receives progress 1/3, then disconnects.
+        q1 = broadcaster.subscribe("job_mid")
+        broadcaster.send_progress("job_mid", current=1, total=3, message="t1")
+        await asyncio.sleep(0)
+        first_msg = q1.get_nowait()
+        assert first_msg["current"] == 1
+
+        broadcaster.unsubscribe("job_mid", q1)
+
+        # Producer keeps emitting while the consumer is offline.
+        broadcaster.send_progress("job_mid", current=2, total=3, message="t2")
+        await asyncio.sleep(0)
+
+        # Reconnect.
+        q2 = broadcaster.subscribe("job_mid")
+
+        # Subsequent progress lands on q2, NOT q1.
+        broadcaster.send_progress("job_mid", current=3, total=3, message="t3")
+        await asyncio.sleep(0)
+
+        msgs_q2: list[dict[str, Any]] = []
+        while not q2.empty():
+            msgs_q2.append(q2.get_nowait())
+        currents = [m["current"] for m in msgs_q2 if m.get("type") == "progress"]
+        assert 3 in currents, f"reconnected subscriber missed t3: {msgs_q2}"
+
+        # The dead queue receives nothing further.
+        assert q1.empty()
+
+    _run(run())
+
+
+def test_n_reconnect_cycles_do_not_leak_subscribers() -> None:
+    """Repeated subscribe/unsubscribe cycles for the same ``job_id``
+    must not grow the broadcaster's internal queue list. Without this,
+    a flaky network connection running 50 reconnects/min would fill
+    the registry with stale entries until the producer thread iterated
+    over them on every send().
+    """
+    broadcaster = ProgressBroadcaster()
+
+    async def run() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+        for _ in range(20):
+            q = broadcaster.subscribe("job_cycle")
+            broadcaster.send_progress("job_cycle", current=1, total=1, message=".")
+            await asyncio.sleep(0)
+            broadcaster.unsubscribe("job_cycle", q)
+
+        # After 20 cycles the registry has zero entries for this job.
+        assert broadcaster._queues.get("job_cycle") in (None, [])
+
+    _run(run())
+
+
+def test_terminal_during_disconnect_replays_on_reconnect() -> None:
+    """The producer fires ``progress`` then ``completed`` while the
+    consumer is offline. Reconnect must observe the cached ``completed``
+    so the client converges to the correct final state without polling.
+    """
+    broadcaster = ProgressBroadcaster()
+
+    async def run() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+
+        q1 = broadcaster.subscribe("job_drop")
+        broadcaster.send_progress("job_drop", current=1, total=2, message="t1")
+        await asyncio.sleep(0)
+        broadcaster.unsubscribe("job_drop", q1)
+
+        # All remaining traffic happens during the disconnect window.
+        broadcaster.send_progress("job_drop", current=2, total=2, message="t2")
+        broadcaster.send_completed("job_drop", "Done!")
+        await asyncio.sleep(0)
+
+        # Reconnect — the cached terminal is replayed.
+        q2 = broadcaster.subscribe("job_drop")
+        msgs: list[dict[str, Any]] = []
+        while not q2.empty():
+            msgs.append(q2.get_nowait())
+        types = [m["type"] for m in msgs]
+        assert "completed" in types, f"reconnect missed the cached terminal: {types}"
+
+    _run(run())
+
+
+def test_reconnect_when_dead_queue_was_full_still_delivers_terminal() -> None:
+    """If the producer floods the original queue past ``MAX_QUEUE_SIZE``
+    and then sends a terminal *after* the consumer disconnects, the
+    reconnecting subscriber still receives the terminal via the cache.
+
+    Guards against a regression where the eviction logic on a full
+    queue could clobber the cached terminal entry.
+    """
+    broadcaster = ProgressBroadcaster()
+
+    async def run() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+        q1 = broadcaster.subscribe("job_full")
+
+        # Saturate q1 well beyond capacity.
+        for i in range(MAX_QUEUE_SIZE * 2):
+            broadcaster.send_progress(
+                "job_full", current=i, total=MAX_QUEUE_SIZE * 2, message="x"
+            )
+        await asyncio.sleep(0)
+        assert q1.qsize() <= MAX_QUEUE_SIZE
+
+        # Disconnect, then send the terminal.
+        broadcaster.unsubscribe("job_full", q1)
+        broadcaster.send_completed("job_full", "Done!")
+        await asyncio.sleep(0)
+
+        # Reconnect; cache replay must surface the terminal.
+        q2 = broadcaster.subscribe("job_full")
+        msgs: list[dict[str, Any]] = []
+        while not q2.empty():
+            msgs.append(q2.get_nowait())
+        assert any(m["type"] == "completed" for m in msgs), (
+            f"reconnect after queue saturation missed the terminal: {msgs}"
+        )
+
+    _run(run())
+
+
+def test_disconnect_midstream_via_handler_then_reconnect() -> None:
+    """Integration-level: drive the actual ``websocket_progress``
+    handler twice. First connection disconnects mid-progress; second
+    connection (reconnect) receives the cached terminal even though it
+    was sent while the first connection was tearing down.
+    """
+    broadcaster = ProgressBroadcaster()
+
+    ws1 = _make_websocket()
+    ws2 = _make_websocket()
+
+    async def run() -> None:
+        broadcaster.set_loop(asyncio.get_event_loop())
+
+        # First WS connection: starts streaming, disconnects on send_text.
+        task1 = asyncio.create_task(websocket_progress(ws1, "job_handler", broadcaster))
+        await asyncio.sleep(0.01)
+        ws1.send_text.side_effect = WebSocketDisconnect(code=1001)
+        broadcaster.send_progress("job_handler", current=1, total=2, message="partial")
+        await asyncio.wait_for(task1, timeout=2.0)
+
+        # While the client is offline the producer completes.
+        broadcaster.send_completed("job_handler", "Done!")
+        await asyncio.sleep(0)
+
+        # Second WS connection (reconnect): handler exits cleanly after
+        # delivering the cached terminal.
+        task2 = asyncio.create_task(websocket_progress(ws2, "job_handler", broadcaster))
+        await asyncio.wait_for(task2, timeout=2.0)
+
+        sent_payloads = [
+            json.loads(call.args[0]) for call in ws2.send_text.call_args_list
+        ]
+        types = [p.get("type") for p in sent_payloads]
+        assert "completed" in types, f"reconnected client did not see terminal: {types}"
+
+        # Both subscriptions cleaned up.
+        assert "job_handler" not in broadcaster._queues
+
+    _run(run())

--- a/tests/regression/test_reg_0028b_browser_reload_hydration.py
+++ b/tests/regression/test_reg_0028b_browser_reload_hydration.py
@@ -1,0 +1,179 @@
+"""Regression tests for browser-reload state hydration (Issue #28 (b)).
+
+Per BLUEPRINT.md, the server-side ``WorkspaceState`` is the source of
+truth that survives a browser reload — the SPA queries
+``GET /api/workspace/status`` on mount and rehydrates Data Panel state
+from it (PR #367 / Issue #363).
+
+These tests lock the *backend* contract that the rehydration flow
+depends on:
+
+- After a successful data load, ``GET /status`` reflects ``has_data``
+  + ``data_ref`` (filename + shape).
+- The status endpoint is **idempotent** — repeated GETs return the
+  same payload, since "browser reload" boils down to a fresh GET.
+- After a config PUT, ``has_config`` flips and persists across GETs.
+- ``has_result`` stays ``False`` even when data + config are present:
+  per BLUEPRINT.md §4.2.3, results are volatile and never restored
+  from disk.
+- ``workspace/reset`` clears all three flags atomically.
+- ``data_ref`` carries the *resolved* filename (not the user-typed
+  path) so the SPA can show a stable label after symlink swaps.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+def _create_csv(tmp_path: Path, rows: int = 30) -> str:
+    csv_path = tmp_path / "train.csv"
+    with csv_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["id", "age", "target"])
+        for i in range(rows):
+            writer.writerow([i, 20 + i, i % 2])
+    return str(csv_path)
+
+
+def _valid_config(client: TestClient) -> dict:
+    res = client.get("/api/workspace/config/defaults?task=binary&target=target")
+    assert res.status_code == 200
+    return res.json()
+
+
+def test_status_initial_state_is_empty(client: TestClient) -> None:
+    """Without any data load, status returns the empty hydration shape."""
+    r = client.get("/api/workspace/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["has_data"] is False
+    assert body["has_config"] is False
+    assert body["has_result"] is False
+    assert body["data_ref"] is None
+    assert body["current_job_id"] is None
+
+
+def test_status_reflects_data_after_load(client: TestClient, tmp_path: Path) -> None:
+    """Loading a file must surface in the next ``GET /status`` so the
+    SPA's ``useWorkspaceStatus`` query can rehydrate Data Panel.
+    """
+    csv_path = _create_csv(tmp_path, rows=50)
+    r = client.post("/api/workspace/data/path", json={"path": csv_path})
+    assert r.status_code == 200
+
+    r = client.get("/api/workspace/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["has_data"] is True
+    assert body["has_config"] is False
+    assert body["has_result"] is False
+    assert body["data_ref"] is not None
+    assert body["data_ref"]["filename"] == "train.csv"
+    assert body["data_ref"]["shape"] == [50, 3]
+
+
+def test_status_is_idempotent_across_reloads(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """A "browser reload" is just another ``GET /status``. Three
+    sequential reads must return identical payloads — the endpoint
+    must not mutate or consume state.
+    """
+    csv_path = _create_csv(tmp_path)
+    client.post("/api/workspace/data/path", json={"path": csv_path})
+    config = _valid_config(client)
+    client.put("/api/workspace/config", json=config)
+
+    payloads = [client.get("/api/workspace/status").json() for _ in range(3)]
+    assert payloads[0] == payloads[1] == payloads[2]
+    assert payloads[0]["has_data"] is True
+    assert payloads[0]["has_config"] is True
+
+
+def test_status_reflects_config_after_put(client: TestClient, tmp_path: Path) -> None:
+    """``has_config`` flips on a successful PUT and persists across
+    subsequent reads, so a SPA reload after the user edited the form
+    sees the persisted config.
+    """
+    csv_path = _create_csv(tmp_path)
+    client.post("/api/workspace/data/path", json={"path": csv_path})
+
+    before = client.get("/api/workspace/status").json()
+    assert before["has_config"] is False
+
+    config = _valid_config(client)
+    r = client.put("/api/workspace/config", json=config)
+    assert r.status_code == 200 and r.json()["saved"] is True
+
+    after = client.get("/api/workspace/status").json()
+    assert after["has_config"] is True
+    # data_ref unchanged: config write must not clobber the data load.
+    assert after["data_ref"] == before["data_ref"]
+
+
+def test_has_result_stays_false_until_a_job_completes(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """BLUEPRINT.md §4.2.3: workspace results are volatile and never
+    restored from disk — even after a full data + config load,
+    ``has_result`` must remain ``False`` until a Fit/Tune job finishes
+    in the same process. This regression test guards against accidental
+    persistence (e.g. someone wiring ``workspace_fit_result`` into the
+    versioned-JSON storage).
+    """
+    csv_path = _create_csv(tmp_path)
+    client.post("/api/workspace/data/path", json={"path": csv_path})
+    config = _valid_config(client)
+    client.put("/api/workspace/config", json=config)
+
+    body = client.get("/api/workspace/status").json()
+    assert body["has_data"] is True
+    assert body["has_config"] is True
+    assert body["has_result"] is False
+
+
+def test_reset_clears_all_status_flags(client: TestClient, tmp_path: Path) -> None:
+    """A user-initiated reset must clear data, config, and any result
+    flag in one shot so a subsequent reload sees the empty state.
+    """
+    csv_path = _create_csv(tmp_path)
+    client.post("/api/workspace/data/path", json={"path": csv_path})
+    config = _valid_config(client)
+    client.put("/api/workspace/config", json=config)
+
+    populated = client.get("/api/workspace/status").json()
+    assert populated["has_data"] is True
+    assert populated["has_config"] is True
+
+    r = client.post("/api/workspace/reset")
+    assert r.status_code == 200
+
+    cleared = client.get("/api/workspace/status").json()
+    assert cleared["has_data"] is False
+    assert cleared["has_config"] is False
+    assert cleared["has_result"] is False
+    assert cleared["data_ref"] is None
+
+
+def test_data_ref_filename_is_resolved_basename(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """The status payload exposes the resolved filename (basename),
+    not the user-typed path. This keeps the SPA's hydration code from
+    showing the absolute path and makes the label stable across
+    symlink swaps that the server resolves at load time.
+    """
+    csv_path = _create_csv(tmp_path)
+    client.post("/api/workspace/data/path", json={"path": csv_path})
+
+    body = client.get("/api/workspace/status").json()
+    assert body["data_ref"]["filename"] == "train.csv"
+    # filename is a bare basename, never a path component.
+    assert "/" not in body["data_ref"]["filename"]

--- a/tests/regression/test_reg_0028c_data_pipeline_resilience.py
+++ b/tests/regression/test_reg_0028c_data_pipeline_resilience.py
@@ -1,0 +1,180 @@
+"""Regression tests for data-pipeline resilience (Issue #28 (c)).
+
+Three failure paths from the original issue:
+
+- "Data file deleted after load but before fit" — verify the in-memory
+  dataframe still drives downstream calls, and that re-loading the
+  same path now surfaces ``404 PATH_NOT_FOUND`` rather than leaking a
+  stale OS error.
+- "Temporary upload file cleanup after reset" — workspace reset must
+  unlink every tracked tempfile so ``/tmp`` does not fill up across
+  long sessions.
+- "Tempfile cleanup on upload-failure mid-load" — a corrupt CSV must
+  not leave a tempfile behind.
+
+P-0095 / Issue #346 already covers the "partial meta.json write"
+case via the fit→load round-trip CI gate, so it is *not* duplicated
+here.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+def _create_csv(tmp_path: Path, rows: int = 30) -> Path:
+    csv_path = tmp_path / "train.csv"
+    with csv_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["id", "age", "target"])
+        for i in range(rows):
+            writer.writerow([i, 20 + i, i % 2])
+    return csv_path
+
+
+def test_load_path_then_delete_keeps_in_memory_view(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Once the dataframe lands in ``WorkspaceState.dataframe`` it is
+    independent of the source file. Deleting the file on disk after
+    a successful load must not break the in-memory view used by
+    preview / columns / fit.
+    """
+    csv_path = _create_csv(tmp_path)
+    r = client.post("/api/workspace/data/path", json={"path": str(csv_path)})
+    assert r.status_code == 200
+
+    # Source file vanishes (rm by an external process).
+    csv_path.unlink()
+
+    # In-memory operations remain available.
+    r = client.get("/api/workspace/data/preview?rows=5")
+    assert r.status_code == 200
+    assert len(r.json()["data"]) == 5
+
+    r = client.get("/api/workspace/data/columns")
+    assert r.status_code == 200
+    assert "target" in [c["name"] for c in r.json()["columns"]]
+
+    # Status is still populated.
+    body = client.get("/api/workspace/status").json()
+    assert body["has_data"] is True
+    assert body["data_ref"]["filename"] == "train.csv"
+
+
+def test_load_path_after_delete_returns_path_not_found(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """A second ``POST /data/path`` against a now-missing file must
+    return ``PATH_NOT_FOUND`` (HTTP 400 per the project error
+    contract) rather than leaking a 500 from a deeper IOError.
+    Guards the user-facing message: the SPA surfaces the body
+    verbatim.
+    """
+    csv_path = _create_csv(tmp_path)
+    client.post("/api/workspace/data/path", json={"path": str(csv_path)})
+    csv_path.unlink()
+
+    r = client.post("/api/workspace/data/path", json={"path": str(csv_path)})
+    assert r.status_code == 400
+    body = r.json()
+    # The project's StudioError envelope: {detail: {error: {code, message}}}.
+    error = body.get("detail", body).get("error", {})
+    assert error.get("code") == "PATH_NOT_FOUND", body
+    assert "not found" in error.get("message", "").lower()
+
+
+def test_reset_unlinks_tracked_upload_tempfile(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """``/api/workspace/reset`` must unlink every tempfile tracked on
+    the WorkspaceState. Without this guarantee, repeatedly uploading
+    + resetting in a long session would fill ``/tmp``.
+    """
+    csv_path = _create_csv(tmp_path)
+    with csv_path.open("rb") as f:
+        r = client.post(
+            "/api/workspace/data/upload",
+            files={"file": ("train.csv", f, "text/csv")},
+        )
+    assert r.status_code == 200
+    tmp_name = r.json()["data_ref"]["path"]
+    assert Path(tmp_name).exists(), "upload should stage a tempfile on disk"
+    # Tempfile lives under the OS temp root, not the user-loaded dir.
+    assert tmp_name.startswith("/tmp/")
+
+    r = client.post("/api/workspace/reset")
+    assert r.status_code == 200
+
+    assert not Path(tmp_name).exists(), (
+        f"reset must unlink tracked tempfile, still present: {tmp_name}"
+    )
+
+
+def test_corrupt_upload_does_not_leak_tempfile(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """A file that fails to parse must not leave a tempfile behind.
+    A ``.parquet`` extension with non-parquet bytes triggers the
+    ``load_dataframe`` exception path; the handler must unlink the
+    staged tempfile before re-raising as ``FILE_INVALID``.
+    """
+    tmp_root = Path("/tmp")
+    before = sorted(tmp_root.glob("lizystudio_*"))
+
+    bad_payload = io.BytesIO(b"this is plainly not a parquet file\n" * 4)
+    r = client.post(
+        "/api/workspace/data/upload",
+        files={
+            "file": (
+                "garbage.parquet",
+                bad_payload,
+                "application/octet-stream",
+            ),
+        },
+    )
+    assert r.status_code in (400, 422), r.text
+
+    after = sorted(tmp_root.glob("lizystudio_*"))
+    new_files = set(after) - set(before)
+    assert not new_files, (
+        f"corrupt upload leaked tempfile(s): {sorted(p.name for p in new_files)}"
+    )
+
+
+def test_repeated_uploads_track_independent_tempfiles(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Two successful uploads in the same session must each be tracked
+    so reset cleans both. Guards against a regression where the second
+    upload overwrites the tracked-list entry for the first and leaves
+    the original tempfile orphaned.
+    """
+    csv_path = _create_csv(tmp_path)
+    paths: list[str] = []
+    for _ in range(2):
+        with csv_path.open("rb") as f:
+            r = client.post(
+                "/api/workspace/data/upload",
+                files={"file": ("train.csv", f, "text/csv")},
+            )
+        assert r.status_code == 200
+        paths.append(r.json()["data_ref"]["path"])
+
+    # The second upload supersedes the first as the active dataframe,
+    # but both tempfiles must still exist on disk pre-reset.
+    assert paths[0] != paths[1], "uploads should mint distinct tempfiles"
+    for p in paths:
+        assert Path(p).exists(), f"upload tempfile vanished pre-reset: {p}"
+
+    # reset() unlinks both tracked tempfiles.
+    client.post("/api/workspace/reset")
+    for p in paths:
+        assert not Path(p).exists(), f"reset failed to unlink upload tempfile {p}"


### PR DESCRIPTION
## Summary

Phase A of the v0.3.1 patch release prep. Bundles six self-contained
commits: one CHANGELOG fill + five new regression-test files. No
behaviour changes.

- **A-1** `docs(changelog)`: fills `[Unreleased]` from 267 post-v0.3.0
  commits, categorised per Keep a Changelog (Added / Changed / Fixed /
  Deprecated / Security / Test Infrastructure).
- **A-2** `test_reg_0028a_ws_disconnect_reconnect.py` (5 tests) —
  Issue #28 (a). Mid-stream reconnect, N-cycle non-leak,
  terminal-during-disconnect replay, full queue + cache survival,
  end-to-end via `websocket_progress` handler.
- **A-3** `test_reg_0028b_browser_reload_hydration.py` (7 tests) —
  Issue #28 (b). Locks the backend `GET /status` contract that PR #367
  frontend hydration depends on.
- **A-4** `test_reg_0028c_data_pipeline_resilience.py` (5 tests) —
  Issue #28 (c). File deletion after load, `/data/path` after delete
  returns `PATH_NOT_FOUND`, reset unlinks tracked tempfiles, corrupt
  upload no-leak, repeated uploads tracked independently.
- **A-5e** `test_reg_0027e_concurrent_job_submission.py` (4 tests) —
  Issue #27 (b) stress harness, sub-area (e). Escalates `test_reg_0070`
  to N=20 racing threads. No orphan job dirs, two-wave reuse,
  release-during-race.
- **A-5f** `test_reg_0027f_ws_concurrent_connections.py` (5 tests) —
  Issue #27 (b) stress harness, sub-area (f). 20-subscriber fan-out,
  mid-stream join, churn during broadcast, burst reconnect after
  terminal, no cross-job pollination.

## Issue closure on merge

- `#28 (a) (b) (c)` complete; `#28 (d) Server Restart` remains blocked
  on `#360`. Issue #28 stays OPEN until #360 lands.
- `#27 (a) microbench` already shipped via P-0094.
- `#27 (e) (f)` complete via this PR.
- `#27 (g) Large Dataset memory profiling` and `(h) File Upload
  Concurrency` deferred to v0.4.0 per the release plan.

## Out-of-scope (recorded explicitly)

- "Partial meta.json write" — covered by P-0095.
- "Tempfile cleanup after server restart" — needs persistence of the
  tracked-list across process death. Deferred to v0.4.0.

## Verification

- `uv run pytest -q -m "not quarantine and not slow and not bench"`:
  **1280 passed, 6 skipped, 7 deselected** (≈ 110s).
- `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy
  src/lizystudio/`: clean.
- `pnpm check` / `pnpm test --run`: 279 files biome-clean, **1799
  Vitest tests** green.
- `pnpm build`: succeeded (existing chunk-size warning preserved).
- `uv build` + `uvx twine check dist/*`: PASSED.
- New tests verified individually (5 + 7 + 5 + 4 + 5 = 26 cases).

## Test plan

- [x] `pytest tests/regression/test_reg_0028a_ws_disconnect_reconnect.py`
- [x] `pytest tests/regression/test_reg_0028b_browser_reload_hydration.py`
- [x] `pytest tests/regression/test_reg_0028c_data_pipeline_resilience.py`
- [x] `pytest tests/regression/test_reg_0027e_concurrent_job_submission.py`
- [x] `pytest tests/regression/test_reg_0027f_ws_concurrent_connections.py`
- [x] Full backend + frontend suites green
- [x] sdist + wheel `twine check` green

## Next

Once merged, develop → main release PR + `git tag v0.3.1 && git push
origin v0.3.1` to publish to PyPI per the workflow in
`docs/pypi-release-readiness-2026-05-03.md` §4.