### PR TITLE
chore(deps): bump lizyml 0.9.x -> 0.10.0 (string target support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,11 @@ performance baseline harness (P-0094), on-disk `format_version`
 migration chain (H-0081), atomic versioned JSON writes (H-0082), and
 the openapi-fetch frontend client migration (H-0080).
 
-No breaking changes for end users. Workspace state and persisted jobs
-from v0.3.0 continue to load via the new migration chain.
+No breaking changes for end users. Workspace state from v0.3.0
+continues to load via the new migration chain. Note: model `pickle`
+artefacts saved by lizyml 0.9.x are intentionally rejected on load
+under the new lizyml 0.10.0 major.minor — re-fit existing jobs to
+regenerate a 0.10.0 artefact.
 
 ### Added
 
@@ -70,6 +73,15 @@ from v0.3.0 continue to load via the new migration chain.
 
 ### Changed
 
+- **`lizyml` bumped to `>=0.10.0,<0.11.0`** — picks up the
+  TargetEncoder feature (lizyml H-0070 / Issue [#98](https://github.com/nbx-liz/LizyML/issues/98))
+  so non-numeric classification targets (e.g. `species: str` in the
+  penguins dataset) now fit successfully. `Model.predict()` returns
+  predictions in the **original label dtype** (str → str), so
+  `LizyMLAdapter.predict` is updated to split the multiclass 2-D
+  `proba` matrix into per-class `proba_<class>` columns and propagates
+  the original-label `pred` straight through to the inference
+  DataFrame. Existing numeric-target jobs are unchanged.
 - **Tailwind CSS v3 → v4 migration (Issue #125, PR #378)** —
   `tailwindcss@^4.2.4` with `@tailwindcss/vite` plugin; `@theme`
   block migrated; build remains on Vite. PostCSS pipeline simplified.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "lizyml[plots,tuning,calibration,explain]>=0.9.0,<0.10.0",
+    "lizyml[plots,tuning,calibration,explain]>=0.10.0,<0.11.0",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.34",
     "python-multipart>=0.0.18",

--- a/src/lizystudio/backends/lizyml/evaluation_mixin.py
+++ b/src/lizystudio/backends/lizyml/evaluation_mixin.py
@@ -27,7 +27,21 @@ class EvaluationMixin:
         result = model.predict(data, return_shap=return_shap)
         df = pd.DataFrame({"idx": range(len(result.pred)), "pred": result.pred})
         if result.proba is not None:
-            df["proba"] = result.proba
+            proba = result.proba
+            # Binary classifiers return a 1-D probability vector for the
+            # positive class. Multiclass classifiers (lizyml >= 0.10.0
+            # with auto-encoded targets) return a 2-D matrix shaped
+            # ``(n_samples, n_classes)`` — flatten it into per-class
+            # columns so the DataFrame stays 2-D and parquet-friendly.
+            if hasattr(proba, "ndim") and proba.ndim == 2:
+                target_encoder = getattr(model.fit_result, "target_encoder", None)
+                classes = list(getattr(target_encoder, "classes_", ())) or [
+                    str(i) for i in range(proba.shape[1])
+                ]
+                for i, cls in enumerate(classes):
+                    df[f"proba_{cls}"] = proba[:, i]
+            else:
+                df["proba"] = proba
         return PredictionSummary(predictions=df, warnings=list(result.warnings))
 
     def evaluate_table(self, model: Any) -> list[dict[str, Any]]:

--- a/tests/regression/test_reg_0163_api_error_branches.py
+++ b/tests/regression/test_reg_0163_api_error_branches.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import lizyml
 import pytest
 from fastapi.testclient import TestClient
 
@@ -29,6 +30,8 @@ from lizystudio.backends.types import DataRef, TuningSummary
 from lizystudio.services.jobs import JobStore
 
 pytestmark = pytest.mark.integration
+
+_LIZYML_VERSION = lizyml.__version__
 
 
 # ---------------------------------------------------------------------------
@@ -73,7 +76,7 @@ def _make_completed_tune_job(client: TestClient, data_ref: DataRef) -> str:
     job_dir.mkdir(parents=True, exist_ok=True)
     (job_dir / "model.pkl").write_bytes(b"fake pickle payload")
     (job_dir / "model_meta.json").write_text(
-        '{"pickle_schema": 1, "lizyml_version": "0.9.1", '
+        '{"pickle_schema": 1, "lizyml_version": "' + _LIZYML_VERSION + '", '
         '"lightgbm_version": "4.5.0", "optuna_version": "4.0.0", '
         '"saved_at": "2026-04-13T12:00:00+00:00"}'
     )
@@ -293,7 +296,7 @@ def test_resume_rebind_race_deletes_child_and_returns_409(
     job_dir.mkdir(parents=True, exist_ok=True)
     (job_dir / "model.pkl").write_bytes(b"fake")
     (job_dir / "model_meta.json").write_text(
-        '{"pickle_schema": 1, "lizyml_version": "0.9.1", '
+        '{"pickle_schema": 1, "lizyml_version": "' + _LIZYML_VERSION + '", '
         '"lightgbm_version": "4.5.0", "optuna_version": "4.0.0", '
         '"saved_at": "2026-04-13T12:00:00+00:00"}'
     )

--- a/tests/regression/test_reg_string_target_classification.py
+++ b/tests/regression/test_reg_string_target_classification.py
@@ -1,0 +1,205 @@
+"""Regression tests for non-numeric classification targets (lizyml 0.10.0).
+
+Locks the LizyStudio adapter contract under lizyml's H-0070 auto-encoded
+target feature (LizyML Issue #98 / lizyml 0.10.0):
+
+- INV: ``LizyMLAdapter.create_model -> fit`` succeeds for binary +
+  multiclass when the target column is ``str`` / ``pd.StringDtype`` /
+  category. Pre-0.10.0, the same input failed deep in LightGBM with
+  ``pandas dtypes must be int, float or bool``.
+- INV: ``adapter.predict`` returns ``pred`` in the *original label
+  dtype* — predictions for a ``str`` target are ``str`` arrays
+  (e.g. ``["Adelie", "Chinstrap", ...]``), never int codes.
+- INV: ``adapter.predict.proba`` is populated for classification.
+
+The data is generated inline with controlled signal so the synthetic
+features predict the target strongly enough that fit / predict
+produce a deterministic pass under the default LightGBM seed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lizystudio.backends.lizyml.adapter import LizyMLAdapter
+
+pytestmark = pytest.mark.integration
+
+
+def _binary_str_dataset(n: int = 200, seed: int = 0) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    x1 = rng.normal(size=n)
+    x2 = rng.normal(size=n)
+    # Strong linear separator on x1 so classification converges fast.
+    target = np.where(x1 + 0.1 * x2 > 0, "positive", "negative")
+    return pd.DataFrame({"x1": x1, "x2": x2, "label": target})
+
+
+def _multiclass_str_dataset(n: int = 240, seed: int = 0) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    species = np.array(["Adelie", "Chinstrap", "Gentoo"])
+    # 3 well-separated clusters so multiclass is easy to fit.
+    cls = rng.integers(0, 3, size=n)
+    bill = rng.normal(loc=cls * 5.0, scale=0.5, size=n)
+    flipper = rng.normal(loc=cls * 10.0, scale=1.0, size=n)
+    return pd.DataFrame(
+        {
+            "bill_length_mm": bill,
+            "flipper_length_mm": flipper,
+            "species": species[cls],
+        }
+    )
+
+
+def _binary_config() -> dict[str, Any]:
+    return {
+        "config_version": 1,
+        "task": "binary",
+        "data": {
+            "path": "/in-memory/binary.csv",
+            "target": "label",
+            "time_col": None,
+            "group_col": None,
+        },
+        "features": {"exclude": [], "auto_categorical": True, "categorical": []},
+        "split": {
+            "method": "stratified_kfold",
+            "n_splits": 3,
+            "random_state": 42,
+        },
+        "model": {
+            "name": "lgbm",
+            "params": {
+                "metric": ["binary_logloss"],
+                "objective": "binary",
+            },
+            "auto_num_leaves": True,
+            "num_leaves_ratio": 1,
+            "min_data_in_leaf_ratio": 0.01,
+            "min_data_in_bin_ratio": 0.01,
+            "feature_weights": None,
+            "balanced": None,
+        },
+        "training": {
+            "seed": 42,
+            "early_stopping": {
+                "enabled": False,
+                "rounds": 20,
+                "inner_valid": {
+                    "method": "holdout",
+                    "ratio": 0.1,
+                    "stratify": False,
+                    "random_state": 42,
+                },
+            },
+        },
+        "tuning": None,
+        "evaluation": {"metrics": ["accuracy", "logloss"]},
+        "calibration": None,
+        "output_dir": None,
+    }
+
+
+def _multiclass_config() -> dict[str, Any]:
+    cfg = _binary_config()
+    cfg["task"] = "multiclass"
+    cfg["data"]["target"] = "species"
+    cfg["model"]["params"] = {
+        "metric": ["multi_logloss"],
+        "objective": "multiclass",
+    }
+    cfg["evaluation"] = {"metrics": ["accuracy", "logloss"]}
+    return cfg
+
+
+def test_fit_succeeds_with_string_binary_target() -> None:
+    """Binary fit on a string target completes (was a 0.9.x failure)."""
+    df = _binary_str_dataset()
+    adapter = LizyMLAdapter()
+
+    model = adapter.create_model(_binary_config(), df)
+    fit_result = adapter.fit(model)
+
+    assert fit_result is not None
+    assert fit_result.fold_count == 3
+
+
+def test_fit_succeeds_with_string_multiclass_target() -> None:
+    """Multiclass fit on a string target completes (was the user-reported
+    species:str failure)."""
+    df = _multiclass_str_dataset()
+    adapter = LizyMLAdapter()
+
+    model = adapter.create_model(_multiclass_config(), df)
+    fit_result = adapter.fit(model)
+
+    assert fit_result is not None
+    assert fit_result.fold_count == 3
+
+
+def test_predict_returns_original_string_labels_binary() -> None:
+    """``predict.pred`` carries the original string labels, not int codes."""
+    df = _binary_str_dataset()
+    adapter = LizyMLAdapter()
+
+    model = adapter.create_model(_binary_config(), df)
+    adapter.fit(model)
+    summary = adapter.predict(model, df.drop(columns=["label"]))
+
+    pred_values = summary.predictions["pred"].tolist()
+    # Every prediction is one of the two original string labels.
+    assert set(pred_values) <= {"positive", "negative"}, (
+        f"binary predictions leaked non-original labels: "
+        f"{set(pred_values) - {'positive', 'negative'}}"
+    )
+    # Both classes appear at least once given the balanced synthetic data.
+    assert len(set(pred_values)) == 2
+
+
+def test_predict_returns_original_string_labels_multiclass() -> None:
+    """Multiclass predictions decode back to {Adelie, Chinstrap, Gentoo}."""
+    df = _multiclass_str_dataset()
+    adapter = LizyMLAdapter()
+
+    model = adapter.create_model(_multiclass_config(), df)
+    adapter.fit(model)
+    summary = adapter.predict(model, df.drop(columns=["species"]))
+
+    pred_values = summary.predictions["pred"].tolist()
+    expected = {"Adelie", "Chinstrap", "Gentoo"}
+    assert set(pred_values) <= expected, (
+        f"multiclass predictions leaked non-original labels: "
+        f"{set(pred_values) - expected}"
+    )
+    # All three species recovered on this well-separated synthetic set.
+    assert set(pred_values) == expected
+
+
+def test_multiclass_predict_emits_per_class_proba_columns() -> None:
+    """The 2-D ``proba`` from lizyml's multiclass predict is split into
+    per-class columns named ``proba_<class>`` so the result DataFrame
+    stays parquet-friendly. Class column names match
+    ``fit_result.target_encoder.classes_`` order.
+    """
+    df = _multiclass_str_dataset()
+    adapter = LizyMLAdapter()
+
+    model = adapter.create_model(_multiclass_config(), df)
+    adapter.fit(model)
+    summary = adapter.predict(model, df.drop(columns=["species"]))
+
+    columns = list(summary.predictions.columns)
+    assert "pred" in columns
+    # No flat "proba" column when target is multiclass.
+    assert "proba" not in columns
+    # Per-class columns present and sum to ~1 per row.
+    expected_cols = {"proba_Adelie", "proba_Chinstrap", "proba_Gentoo"}
+    assert expected_cols.issubset(columns)
+    proba_sum = summary.predictions[list(expected_cols)].sum(axis=1)
+    assert (proba_sum.between(0.99, 1.01)).all(), (
+        f"per-class proba did not sum to 1: {proba_sum.describe()}"
+    )

--- a/tests/test_retune_api.py
+++ b/tests/test_retune_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import lizyml
 import pytest
 from fastapi.testclient import TestClient
 
@@ -11,6 +12,8 @@ from lizystudio.backends.types import DataRef, TuningSummary
 from lizystudio.services.jobs import JobStore
 
 pytestmark = pytest.mark.integration
+
+_LIZYML_VERSION = lizyml.__version__
 
 
 @pytest.fixture()
@@ -58,7 +61,7 @@ def _make_completed_tune_job(
         job_dir.mkdir(parents=True, exist_ok=True)
         (job_dir / "model.pkl").write_bytes(b"fake pickle payload")
         (job_dir / "model_meta.json").write_text(
-            '{"pickle_schema": 1, "lizyml_version": "0.9.1", '
+            '{"pickle_schema": 1, "lizyml_version": "' + _LIZYML_VERSION + '", '
             '"lightgbm_version": "4.5.0", "optuna_version": "4.0.0", '
             '"saved_at": "2026-04-13T12:00:00+00:00"}'
         )
@@ -278,7 +281,7 @@ def test_retune_accepts_grandchild(
     child_dir = job_store.jobs_dir / child.job_id
     (child_dir / "model.pkl").write_bytes(b"fake pickle payload")
     (child_dir / "model_meta.json").write_text(
-        '{"pickle_schema": 1, "lizyml_version": "0.9.1", '
+        '{"pickle_schema": 1, "lizyml_version": "' + _LIZYML_VERSION + '", '
         '"lightgbm_version": "4.5.0", "optuna_version": "4.0.0", '
         '"saved_at": "2026-04-14T12:00:00+00:00"}'
     )

--- a/uv.lock
+++ b/uv.lock
@@ -560,7 +560,7 @@ wheels = [
 
 [[package]]
 name = "lizyml"
-version = "0.9.1"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
@@ -574,9 +574,9 @@ dependencies = [
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/8a/9fba48ad82db1c75d5b62aa6c218ed64542dbb19906c829f6ee684a76498/lizyml-0.9.1.tar.gz", hash = "sha256:a72c41e8cadac8f1eb7d1d0f4ef1918aab3b9a08b16d1d0d29a06649884c4e7d", size = 639370, upload-time = "2026-05-02T11:16:06.823Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/a2/fb4677239cbc84bb9ba15155329b9a585ace6bb1e4fa2625d9b438632561/lizyml-0.10.0.tar.gz", hash = "sha256:1b3560ffb2ea1e1b7b6a2bc8af0d8394df20a361a27e67be2fc760b24c1615f0", size = 651238, upload-time = "2026-05-04T05:38:36.111Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/82/df816fc0413974a8a8bd233f2585b0b2230d5c56a75fa0c66229ebe00357/lizyml-0.9.1-py3-none-any.whl", hash = "sha256:c7977ed789575a9b8b3f1360d56efcf02f22bb25b46d77927965f60e7726e987", size = 152420, upload-time = "2026-05-02T11:16:05.487Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/61/eea1bbaef13ab14e393471d83e30e82b8366bf73e360f26741e6c4b87d58/lizyml-0.10.0-py3-none-any.whl", hash = "sha256:909bcfe86fb9fc158b1f0cc9b7b3f2721d1b1d456f4a4a3eb854104f34f943df", size = 156728, upload-time = "2026-05-04T05:38:34.463Z" },
 ]
 
 [package.optional-dependencies]
@@ -628,7 +628,7 @@ dev = [
 requires-dist = [
     { name = "cloudpickle", specifier = ">=3.0" },
     { name = "fastapi", specifier = ">=0.115" },
-    { name = "lizyml", extras = ["calibration", "explain", "plots", "tuning"], specifier = ">=0.9.0,<0.10.0" },
+    { name = "lizyml", extras = ["calibration", "explain", "plots", "tuning"], specifier = ">=0.10.0,<0.11.0" },
     { name = "prometheus-client", specifier = ">=0.20" },
     { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },


### PR DESCRIPTION
## Summary

Bumps `lizyml` to `>=0.10.0,<0.11.0` so classification fits accept
non-numeric target columns (object / `pd.StringDtype` / category).
Resolves the user-reported `penguins.species: str` fit failure that
previously surfaced as a bare LightGBM `ValueError`.

Closes the lizyml-side root cause shipped in
[lizyml issue #98 / lizyml 0.10.0](https://github.com/nbx-liz/LizyML/issues/98).

## Changes

- `pyproject.toml`: `lizyml>=0.9.0,<0.10.0` → `>=0.10.0,<0.11.0`. `uv.lock` regenerated.
- `LizyMLAdapter.predict`: handles the new multiclass 2-D `proba` matrix by splitting into per-class columns named `proba_<class>` (sourced from `fit_result.target_encoder.classes_`). Binary path unchanged. Pre-bump this code path was a latent bug — never exercised because no test ran predict on a multiclass model. The 0.10.0 bump made the call reachable, so the fix lands here.
- `tests/regression/test_reg_string_target_classification.py` (new, 5 cases): binary + multiclass fit succeed on str target; `predict.pred` carries the original string labels; multiclass per-class proba columns sum to ~1.
- `tests/test_retune_api.py` and `tests/regression/test_reg_0163_api_error_branches.py`: hardcoded `"lizyml_version": "0.9.1"` in fixture `model_meta.json` sidecars replaced with dynamic `lizyml.__version__`. Future bumps no longer break these test helpers.
- `CHANGELOG.md` `[Unreleased]`: bump entry under Changed; note in the release blurb on pickle compat (model.pkl saved by 0.9.x is rejected — re-fit required).

## Test plan

- [x] `uv run pytest -q -m "not quarantine and not slow and not bench"` → **1285 passed, 6 skipped** (was 1280 pre-bump; +5 new string-target).
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy src/lizystudio/`: clean.
- [x] `pytest tests/integration/test_fit_load_round_trip.py` (P-0095 round-trip gate): 3/3 green on lizyml 0.10.0.
- [x] `pytest tests/test_lizyml_checkpoint.py`: 15/15 green; major.minor mismatch test (0.7 vs 0.10) still rejects as expected.

## Compatibility

- **lizyml `format_version 1 → 2` migration** is transparent (lizyml side). P-0095 fit→load round-trip gate confirms this.
- **LizyStudio pickle compat**: model.pkl artefacts saved by lizyml 0.9.x are intentionally rejected on load (project policy: major.minor must match). Users re-fit existing jobs after the bump. Documented in `CHANGELOG.md`.

## Bundles into v0.3.1

This PR is the second item in the v0.3.1 release scope (first: PR #379).
After merge, the release workflow is:

1. `develop → main` release PR
2. `git tag v0.3.1 && git push origin v0.3.1` to trigger PyPI publish