### PR TITLE
chore(release): finalize CHANGELOG header for v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Nothing yet.
+
+## [0.3.1] - 2026-05-04
+
 The **Stability & Refactor** release. Six weeks of post-v0.3.0 bug
 fixes, internal refactors, and test infrastructure work absorbed into a
 single patch release. Highlights: Workspace ConfigForm cross-hook write


### PR DESCRIPTION
Tiny prep PR before the develop -> main release PR. Moves the accumulated `[Unreleased]` block under a dated `[0.3.1] - 2026-05-04` header so the release tag carries a frozen changelog. Restores `[Unreleased]` as the empty placeholder for post-0.3.1 work.