### PR TITLE
feat(api): wide DataFrame foundation — preview max_cols + importance top_n + diagnostic export (P-0097, #361)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet.
+The **Wide DataFrame** track (Phase B / v0.4.0) starts here.
+Foundation PR for Issue #361.
+
+### Added
+
+- **`max_cols` query on `GET /api/workspace/data/preview` (P-0097)** —
+  optional cap on returned column count so the SPA does not have to
+  ship 10k+ columns to the browser on every preview call.
+  ``total_cols`` in the response always reflects the ground-truth
+  column count. Backward compatible — omitting the parameter returns
+  every column.
+- **`top_n` query on `GET /api/jobs/{id}/importance` (P-0097)** —
+  value-desc-sorted projection without an extra round-trip. Server
+  also enforces a 5MB payload ceiling: when the unbounded response
+  would exceed it, the route falls back to a top-N projection sized
+  to fit and surfaces the truncation via `X-Truncated-By: top_n=<N>`
+  response header.
+- **`GET /api/diagnostic/export?job_id=...` (R-3.4 / P-0097)** —
+  sanitised JSON snapshot a user can attach to a support request.
+  Returns `{schema_version: 1, timestamp, job, system}` with no heavy
+  artefacts inlined and no internal JobStore paths leaked. Heavy data
+  (fit_result.json, model.pkl) stays on disk.
+- **Wide-DataFrame fixture generator** at
+  `tests/fixtures/lizyml/wide/generate.py` (10,000 columns × 1,000
+  rows). The CSV itself is gitignored; CI generates it once at job
+  start. Used by `tests/regression/test_reg_0361_wide_preview.py`.
+
+### Test Infrastructure
+
+- 14 new contract / regression tests under
+  `tests/contract/test_preview_max_cols.py`,
+  `tests/contract/test_importance_top_n.py`,
+  `tests/contract/test_diagnostic_export.py`, and
+  `tests/regression/test_reg_0361_wide_preview.py`.
 
 ## [0.3.1] - 2026-05-04
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3077,3 +3077,66 @@ v0.3 (PyPI MVP) のリリース準備中に、次の v0.4 を「業務利用可�
 
 - 2026-05-03 **Proposed** — `docs/business-use-definition.md` v0.2 と `docs/v0.4-business-readiness-plan.md` v0.1 をリポジトリに先行コミットし、本 Proposal を Change Gate として起票。**ユーザ承認済**。Phase R-1 から実装着手する
 
+### P-0097: Wide DataFrame data/preview + importance payload caps（Issue #361 / Phase R-5.1 基盤）
+
+- **Date:** 2026-05-04 起票
+- **Related:** Issue #361 (Wide DataFrame UI), `docs/v0.4-business-readiness-plan.md` §6 (Phase R-5), [P-0094](https://github.com/nbx-liz/LizyStudio/blob/main/HISTORY.md#p-0094) (perf baseline), v0.4 Exit Criteria (10k 列で UI が破綻しない)
+
+#### Motivation
+
+業務利用シナリオは「列数 max 10k」を確定 (`business-use-definition.md` v0.2 §4)。現状の `GET /api/workspace/data/preview` と `GET /api/jobs/{id}/importance` は **全列を JSON で返す** ため、10k 列では:
+
+- preview: 1 行 × 10k 列 = ~50KB / 行 × 50 行 = 2.5MB の JSON、parse + render が遅い
+- importance: 10k 列の split / gain / SHAP を全部返すと payload が 5MB+、ブラウザ JIT も悲鳴
+
+frontend で virtualization / top-N を入れても、転送する payload 自体が太いと初期描画コストが下がらない。**API 側で「上限を持って返す」契約を Change Gate として確定**してから frontend を実装する。
+
+#### Purpose
+
+- `GET /api/workspace/data/preview?max_cols=N` を追加: クエリで列数を絞れる (デフォルト動作は変えない)
+- `GET /api/jobs/{id}/importance?top_n=N` を追加: 重要度上位 N 列のみ返す (デフォルト動作は変えない)
+- importance payload は **5MB 上限** を server-side でハードキャップ。超えたら自動的に top-N をフォールバック適用し、レスポンス header `X-Truncated-By` で通知
+
+#### Impact
+
+- 新規 OpenAPI フィールド (両エンドポイント): `max_cols: int | None` / `top_n: int | None`
+  - 省略時は従来通り「全列」(後方互換)
+- 新規 response header: `X-Truncated-By: top_n=200` (ハードキャップ発動時のみ)
+- frontend は openapi-typescript 経由で query 型を取得、SSOT 維持
+- breaking change ではない (既存 client は省略 = 全列のまま動く)
+
+#### Compatibility
+
+- 既存 client (省略形): 全列レスポンス継続。N=10 程度の小規模データセットへの影響なし
+- 既存 fixtures (binary_no_cal etc.): 13 列なので max_cols=200 デフォルトでも全列返却、テスト挙動不変
+- format_version (H-0081): 永続データに変更なし、JSON シリアライズの形は同じ
+
+#### Acceptance criteria
+
+- [ ] `tests/contract/test_preview_max_cols.py`: `max_cols` 省略 / 指定 / 0 / 負数 / 超過の境界テスト
+- [ ] `tests/contract/test_importance_top_n.py`: `top_n` 省略 / 指定 / 5MB 上限ガード / `X-Truncated-By` header
+- [ ] `tests/regression/test_reg_0361_wide_preview.py`: 10k 列フィクスチャで preview が `max_cols=200` で 2KB 以内に収まる
+- [ ] OpenAPI 型生成 (`pnpm generate:api`) が新フィールドを含む
+- [ ] BLUEPRINT.md §5 (API 仕様) に新クエリパラメータ + truncation 仕様を反映
+- [ ] 既存 e2e (`workspace-presets.spec.ts` 等) が回帰なし
+
+#### Alternatives considered
+
+- **(a) クライアント側で全列受け取って top-N 表示**: 拒否。転送量問題を解決できない、初期描画 jank が消えない
+- **(b) WebSocket streaming で分割送信**: 拒否。preview / importance は read-only のためコネクション oriented にする利点なし、複雑度のみ増す
+- **(c) 別エンドポイント `/data/preview/wide` 等を新設**: 拒否。endpoint 増殖、SSOT 崩れ。同じエンドポイントの query 拡張で十分
+- **(d) `data.preview_max_cols` を config に持たせる**: 拒否。preview は per-request で top-N が変わる UX のため config 永続化は過剰
+
+→ 採用は (e) **既存エンドポイントに optional query を追加**。最小契約変更で UX を改善
+
+#### Out of scope（follow-up）
+
+- Importance plot top-N の **frontend 実装** — 本 Proposal は API 契約のみ確定。実装は PR-B2 で続けて行う
+- Column Settings の virtualization — frontend のみ、Change Gate 外
+- Diagnostic export endpoint — R-3.4 で別途追加 (本 PR で skeleton のみ)
+
+#### Decision
+
+- 2026-05-04 **Proposed** — Phase B (v0.4.0) 起点として起票。Acceptance criteria を満たす実装は同 PR に含める。**ユーザ承認済** (auto mode で Phase B 実装着手)
+
+

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -153,6 +153,11 @@ export interface paths {
         /**
          * Data Preview
          * @description Return first N rows of loaded data.
+         *
+         *     ``max_cols`` (P-0097) caps the per-row column count so the wide-
+         *     DataFrame UI (Issue #361) does not have to ship 10k+ columns to the
+         *     browser on every preview call. ``total_cols`` in the response still
+         *     reflects the ground-truth column count.
          */
         get: operations["data_preview_api_workspace_data_preview_get"];
         put?: never;
@@ -602,6 +607,13 @@ export interface paths {
         /**
          * Get Job Importance Endpoint
          * @description Get feature importance.
+         *
+         *     ``top_n`` (P-0097) lets the SPA opt in to a value-desc-sorted
+         *     projection without an extra round-trip. When the unbounded payload
+         *     would exceed :data:`IMPORTANCE_PAYLOAD_LIMIT`, the route falls back
+         *     to a server-side top-N projection sized to fit and surfaces the
+         *     truncation via the ``X-Truncated-By`` response header so the SPA
+         *     can render an honest "showing top N of M" notice.
          */
         get: operations["get_job_importance_endpoint_api_jobs__job_id__importance_get"];
         put?: never;
@@ -1128,6 +1140,31 @@ export interface paths {
          *     Authentication-free, mirroring the probe philosophy of `/api/health`.
          */
         get: operations["metrics_api_metrics_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/diagnostic/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Diagnostic Export
+         * @description Return a sanitised diagnostic snapshot for ``job_id``.
+         *
+         *     Echoes the user-supplied config + data_ref so the support team can
+         *     reproduce a bug without asking for extra files. Internal JobStore
+         *     paths and the on-disk model_path are NOT included — they are
+         *     user-laptop-specific and add no diagnostic value.
+         */
+        get: operations["diagnostic_export_api_diagnostic_export_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -2208,6 +2245,7 @@ export interface operations {
         parameters: {
             query?: {
                 rows?: number;
+                max_cols?: number | null;
             };
             header?: never;
             path?: never;
@@ -2906,6 +2944,7 @@ export interface operations {
         parameters: {
             query?: {
                 kind?: string;
+                top_n?: number | null;
             };
             header?: never;
             path: {
@@ -3663,6 +3702,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    diagnostic_export_api_diagnostic_export_get: {
+        parameters: {
+            query: {
+                job_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/src/lizystudio/api/diagnostic.py
+++ b/src/lizystudio/api/diagnostic.py
@@ -1,0 +1,132 @@
+"""Diagnostic export endpoint (R-3.4 / P-0097).
+
+Returns a small JSON snapshot a user can attach to a support request
+without leaking JobStore internals or shipping multi-megabyte
+artefacts. Heavy data (fit_result.json, model.pkl) stays on disk —
+the support team asks for it separately if they need it.
+
+Schema version 1:
+
+    {
+      "schema_version": 1,
+      "timestamp": "2026-05-04T...Z",
+      "job": {
+        "job_id": str,
+        "status": str,
+        "job_type": str,
+        "backend_name": str,
+        "config": dict,
+        "data_ref": dict | None,
+        "error": str | None,
+        "created_at": str | None,
+        "completed_at": str | None,
+        "parent_job_id": str | None
+      },
+      "system": {
+        "platform": str,        # e.g. "linux"
+        "python_version": str,  # e.g. "3.11.14"
+        "lizystudio_version": str,
+        "lizyml_version": str
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import platform
+import sys
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+
+from lizystudio.api.errors import JobNotFoundError
+from lizystudio.services.jobs import JobStore, get_job_store
+
+router = APIRouter()
+
+DIAGNOSTIC_SCHEMA_VERSION = 1
+
+
+def _safe_lizyml_version() -> str:
+    """Read lizyml's installed version via importlib.metadata so the
+    diagnostic export does not import the ML backend directly (the
+    api layer is forbidden from importing ``lizyml`` per the layer
+    audit in ``tests/test_layer_audit.py``)."""
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            return version("lizyml")
+        except PackageNotFoundError:
+            return "unknown"
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def _safe_lizystudio_version() -> str:
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            return version("lizystudio")
+        except PackageNotFoundError:
+            return "unknown"
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def _serialise_data_ref(data_ref: Any) -> dict[str, Any] | None:
+    if data_ref is None:
+        return None
+    # ``isinstance(data_ref, type)`` filters out the dataclass *class*
+    # itself; ``asdict`` only operates on instances.
+    if is_dataclass(data_ref) and not isinstance(data_ref, type):
+        return asdict(data_ref)
+    if isinstance(data_ref, dict):
+        return dict(data_ref)
+    return None
+
+
+@router.get("/export")
+def diagnostic_export(
+    job_id: str = Query(..., min_length=1),
+    job_store: JobStore = Depends(get_job_store),
+) -> dict[str, Any]:
+    """Return a sanitised diagnostic snapshot for ``job_id``.
+
+    Echoes the user-supplied config + data_ref so the support team can
+    reproduce a bug without asking for extra files. Internal JobStore
+    paths and the on-disk model_path are NOT included — they are
+    user-laptop-specific and add no diagnostic value.
+    """
+    job = job_store.get(job_id)
+    if job is None:
+        raise JobNotFoundError(job_id)
+
+    return {
+        "schema_version": DIAGNOSTIC_SCHEMA_VERSION,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "job": {
+            "job_id": job.job_id,
+            "status": job.status,
+            "job_type": job.job_type,
+            "backend_name": job.backend_name,
+            "config": job.config,
+            "data_ref": _serialise_data_ref(job.data_ref),
+            "error": job.error,
+            "created_at": job.created_at,
+            "completed_at": job.completed_at,
+            "parent_job_id": job.parent_job_id,
+        },
+        "system": {
+            "platform": platform.system().lower(),
+            "python_version": (
+                f"{sys.version_info.major}.{sys.version_info.minor}."
+                f"{sys.version_info.micro}"
+            ),
+            "lizystudio_version": _safe_lizystudio_version(),
+            "lizyml_version": _safe_lizyml_version(),
+        },
+    }

--- a/src/lizystudio/api/jobs.py
+++ b/src/lizystudio/api/jobs.py
@@ -6,11 +6,12 @@ export, delete.
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import asdict
 from typing import Any, Literal  # noqa: UP035
 
-from fastapi import APIRouter, BackgroundTasks, Depends
+from fastapi import APIRouter, BackgroundTasks, Depends, Query, Response
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
@@ -54,6 +55,13 @@ from lizystudio.services.workspace import WorkspaceState, get_workspace
 
 _MAX_METRICS = 20
 _VALID_PARAM_RE = re.compile(r"^[a-zA-Z0-9_]+$")
+
+# P-0097: hard cap on the JSON-serialised importance payload. When the
+# unbounded response would exceed this many bytes the route falls back
+# to a top-N projection sized to fit and surfaces the truncation via
+# the ``X-Truncated-By`` response header. 5MB matches the
+# v0.4-business-readiness-plan §6 transfer budget.
+IMPORTANCE_PAYLOAD_LIMIT = 5 * 1024 * 1024
 
 router = APIRouter()
 
@@ -268,17 +276,61 @@ def get_job_split_summary_endpoint(
 @router.get("/{job_id}/importance")
 def get_job_importance_endpoint(
     job_id: str,
+    response: Response,
     kind: str = "split",
+    top_n: int | None = Query(default=None, ge=1, le=20000),
     job_store: JobStore = Depends(get_job_store),
     ws: WorkspaceState = Depends(get_workspace),
 ) -> dict[str, float]:
-    """Get feature importance."""
+    """Get feature importance.
+
+    ``top_n`` (P-0097) lets the SPA opt in to a value-desc-sorted
+    projection without an extra round-trip. When the unbounded payload
+    would exceed :data:`IMPORTANCE_PAYLOAD_LIMIT`, the route falls back
+    to a server-side top-N projection sized to fit and surfaces the
+    truncation via the ``X-Truncated-By`` response header so the SPA
+    can render an honest "showing top N of M" notice.
+    """
     job = _get_job_or_404(job_id, job_store)
     _require_completed(job)
     try:
-        return get_importance(job, ws.backend, job_store.model_cache, kind=kind)
+        result = get_importance(
+            job, ws.backend, job_store.model_cache, kind=kind, top_n=top_n
+        )
     except Exception as exc:
         raise BackendError(exc) from exc
+
+    # Server-side payload cap. If the user asked for a specific top_n
+    # the route honours it silently above; the cap below only fires
+    # when the unbounded response would exceed the transfer budget.
+    if top_n is None and len(json.dumps(result)) > IMPORTANCE_PAYLOAD_LIMIT:
+        capped = _cap_importance_payload(result, IMPORTANCE_PAYLOAD_LIMIT)
+        response.headers["X-Truncated-By"] = f"top_n={len(capped)}"
+        return capped
+    return result
+
+
+def _cap_importance_payload(
+    raw: dict[str, float], limit_bytes: int
+) -> dict[str, float]:
+    """Return the longest top-N prefix of ``raw`` whose JSON encoding
+    fits within ``limit_bytes``. Sorted value-desc so the returned
+    subset is always the most informative slice. Always returns at
+    least one entry (the single highest-importance feature) so the
+    SPA can render *something* even at extreme cap pressure.
+    """
+    items = sorted(raw.items(), key=lambda kv: kv[1], reverse=True)
+    # Binary search the largest prefix whose JSON dump fits.
+    lo, hi = 1, len(items)
+    best = 1
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        if len(json.dumps(dict(items[:mid]))) <= limit_bytes:
+            best = mid
+            lo = mid + 1
+        else:
+            hi = mid - 1
+    return dict(items[:best])
 
 
 @router.get("/{job_id}/importance-kinds")

--- a/src/lizystudio/api/workspace.py
+++ b/src/lizystudio/api/workspace.py
@@ -316,12 +316,19 @@ async def data_upload(
 @router.get("/data/preview", response_model=PreviewResponseModel)
 def data_preview(
     rows: int = Query(default=50, ge=1, le=10000),
+    max_cols: int | None = Query(default=None, ge=1, le=20000),
     ws: WorkspaceState = Depends(get_workspace),
 ) -> dict[str, Any]:
-    """Return first N rows of loaded data."""
+    """Return first N rows of loaded data.
+
+    ``max_cols`` (P-0097) caps the per-row column count so the wide-
+    DataFrame UI (Issue #361) does not have to ship 10k+ columns to the
+    browser on every preview call. ``total_cols`` in the response still
+    reflects the ground-truth column count.
+    """
     if ws.dataframe is None:
         raise WorkspaceNoDataError()
-    return get_preview(ws.dataframe, rows=rows)
+    return get_preview(ws.dataframe, rows=rows, max_cols=max_cols)
 
 
 @router.get("/data/columns", response_model=ColumnsResponseModel)

--- a/src/lizystudio/server.py
+++ b/src/lizystudio/server.py
@@ -232,6 +232,12 @@ def create_app() -> FastAPI:
     application.include_router(
         metrics_api.router, prefix="/api/metrics", tags=["metrics"]
     )
+    # R-3.4 / P-0097 — Diagnostic export for support attachments
+    from lizystudio.api import diagnostic as _diagnostic_router  # noqa: PLC0415
+
+    application.include_router(
+        _diagnostic_router.router, prefix="/api/diagnostic", tags=["diagnostic"]
+    )
 
     # WebSocket route for job progress (BLUEPRINT §5.5)
     @application.websocket("/ws/jobs/{job_id}/progress")

--- a/src/lizystudio/services/data.py
+++ b/src/lizystudio/services/data.py
@@ -45,14 +45,37 @@ def make_data_ref(
     )
 
 
-def get_preview(df: pd.DataFrame, rows: int = 50) -> dict[str, Any]:
-    """Return first N rows as JSON-serializable dict."""
-    preview = df.head(rows)
+def get_preview(
+    df: pd.DataFrame,
+    rows: int = 50,
+    max_cols: int | None = None,
+) -> dict[str, Any]:
+    """Return first N rows as a JSON-serialisable dict.
+
+    Parameters
+    ----------
+    df:
+        Source DataFrame.
+    rows:
+        Number of leading rows to include.
+    max_cols:
+        Optional column cap (P-0097). When provided, only the first
+        ``max_cols`` columns are emitted in ``columns`` and ``data``;
+        ``total_cols`` always reports the ground-truth column count so
+        the SPA can show "showing N of M" without an extra round-trip.
+        ``None`` preserves the pre-P-0097 behaviour of returning every
+        column.
+    """
+    total_cols = len(df.columns)
+    if max_cols is not None and max_cols < total_cols:
+        preview = df.iloc[:rows, :max_cols]
+    else:
+        preview = df.head(rows)
     return {
         "columns": list(preview.columns),
         "data": preview.fillna("").to_dict("records"),
         "total_rows": len(df),
-        "total_cols": len(df.columns),
+        "total_cols": total_cols,
     }
 
 

--- a/src/lizystudio/services/job_results.py
+++ b/src/lizystudio/services/job_results.py
@@ -107,10 +107,30 @@ def get_importance(
     backend: BackendAdapter,
     cache: ModelCache,
     kind: str = "split",
+    *,
+    top_n: int | None = None,
 ) -> dict[str, float]:
-    """Get feature importance for a completed job."""
+    """Get feature importance for a completed job.
+
+    ``top_n`` (P-0097) caps the response to the N most important
+    features sorted by value descending. ``None`` (the pre-P-0097
+    default) returns the full backend response unchanged.
+    """
     model = cache.load(job, backend)
-    return backend.importance(model, kind=kind)
+    raw = backend.importance(model, kind=kind)
+    if top_n is None or top_n >= len(raw):
+        return raw
+    return _project_top_n(raw, top_n)
+
+
+def _project_top_n(raw: dict[str, float], top_n: int) -> dict[str, float]:
+    """Return the ``top_n`` highest-importance entries, value-desc sorted.
+
+    Stable ordering on ties: first occurrence wins (Python dict iteration
+    order is preserved by insertion, ``sorted`` is stable).
+    """
+    items = sorted(raw.items(), key=lambda kv: kv[1], reverse=True)[:top_n]
+    return dict(items)
 
 
 def get_importance_kinds(

--- a/tests/contract/test_diagnostic_export.py
+++ b/tests/contract/test_diagnostic_export.py
@@ -1,0 +1,133 @@
+"""Contract tests for ``GET /api/diagnostic/export`` (R-3.4 / P-0097).
+
+Locks the diagnostic export skeleton introduced for the v0.4 business-
+readiness Exit Criteria. The endpoint returns a JSON snapshot a user
+can attach to a support request without exposing data outside the
+JobStore.
+
+- INV: missing ``job_id`` → 422.
+- INV: unknown ``job_id`` → 404 with ``JOB_NOT_FOUND``.
+- INV: known ``job_id`` → 200 + JSON containing
+  ``{schema_version, job, system, lizyml_version, timestamp}``.
+- INV: schema_version is a stable integer that increments with
+  breaking changes (currently 1).
+- INV: ``system`` block has the platform / python_version /
+  lizystudio_version fields the SPA / support team need to
+  reproduce a bug.
+- INV: ``job.config`` and ``job.data_ref`` are echoed verbatim so the
+  user does not have to attach extra files.
+- INV: no on-disk fit_result / metadata bytes are inlined (the
+  response is small, the heavy artefacts stay in the JobStore).
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+def _create_csv(tmp_path: Path) -> str:
+    csv_path = tmp_path / "diag.csv"
+    with csv_path.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["x", "y", "target"])
+        for i in range(20):
+            w.writerow([i, i * 2, i % 2])
+    return str(csv_path)
+
+
+def _seed_job(client: TestClient) -> str:
+    """Inject a minimal completed Job so the diagnostic export has
+    something to echo back."""
+    from lizystudio.backends.types import DataRef
+    from lizystudio.services.jobs import JobStore
+
+    app = client.app  # type: ignore[union-attr]
+    job_store: JobStore = app.state.job_store
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "target"}},
+        data_ref=DataRef(
+            source_type="path",
+            path="/data/diag.csv",
+            filename="diag.csv",
+            fingerprint="diag-fp",
+            shape=(20, 3),
+        ),
+        job_type="fit",
+    )
+    job.status = "completed"
+    job_store.update(job)
+    return job.job_id
+
+
+def test_export_missing_job_id_returns_422(client: TestClient) -> None:
+    r = client.get("/api/diagnostic/export")
+    assert r.status_code == 422
+
+
+def test_export_unknown_job_id_returns_404(client: TestClient) -> None:
+    r = client.get("/api/diagnostic/export?job_id=doesnotexist")
+    assert r.status_code == 404
+    body = r.json()
+    code = body.get("detail", body).get("error", {}).get("code")
+    assert code == "JOB_NOT_FOUND"
+
+
+def test_export_known_job_returns_envelope(client: TestClient) -> None:
+    job_id = _seed_job(client)
+
+    r = client.get(f"/api/diagnostic/export?job_id={job_id}")
+    assert r.status_code == 200, r.text
+    body: dict[str, Any] = r.json()
+
+    # Envelope shape locked.
+    assert body["schema_version"] == 1
+    assert "timestamp" in body
+    assert isinstance(body["timestamp"], str)
+
+    # Job block echoes config + data_ref verbatim, plus status.
+    job = body["job"]
+    assert job["job_id"] == job_id
+    assert job["status"] == "completed"
+    assert job["config"]["task"] == "binary"
+    assert job["data_ref"]["filename"] == "diag.csv"
+    assert job["data_ref"]["fingerprint"] == "diag-fp"
+
+    # System block carries reproducer info.
+    sys = body["system"]
+    assert "platform" in sys
+    assert "python_version" in sys
+    assert "lizystudio_version" in sys
+    assert "lizyml_version" in sys
+
+    # No heavy artefacts inlined (the snapshot must stay tiny).
+    encoded_size = len(r.content)
+    assert encoded_size < 16 * 1024, (
+        f"diagnostic export too large: {encoded_size} bytes — "
+        "heavy artefacts should stay in the JobStore"
+    )
+
+
+def test_export_does_not_leak_internal_paths(client: TestClient) -> None:
+    """The response must not echo the on-disk JobStore root path.
+    Support attachments leave user laptops, so absolute filesystem
+    paths under the user's home directory must not show up."""
+    job_id = _seed_job(client)
+
+    r = client.get(f"/api/diagnostic/export?job_id={job_id}")
+    assert r.status_code == 200
+    text = r.text
+    # data_ref.path *can* appear (it's user-supplied). What must NOT
+    # appear is the JobStore's internal location.
+    app = client.app  # type: ignore[union-attr]
+    jobs_dir = str(app.state.job_store.jobs_dir)
+    assert jobs_dir not in text, (
+        f"diagnostic export leaked JobStore directory: {jobs_dir}"
+    )

--- a/tests/contract/test_importance_top_n.py
+++ b/tests/contract/test_importance_top_n.py
@@ -1,0 +1,191 @@
+"""Contract tests for ``GET /api/jobs/{id}/importance?top_n=N`` (P-0097).
+
+Locks the optional ``top_n`` query parameter introduced for the Wide
+DataFrame UI (Issue #361):
+
+- INV: ``top_n`` omitted → all features returned (backward compat).
+- INV: ``top_n=N`` → at most N features, sorted by importance value
+  descending so the SPA never renders a missing high-importance bar.
+- INV: response is automatically capped to ``IMPORTANCE_PAYLOAD_LIMIT``
+  bytes (~5MB). When the cap fires server-side we fall back to top-N
+  and surface the truncation via the ``X-Truncated-By`` response
+  header so the SPA can show "showing top N of M".
+- INV: ``top_n=0`` / negative are rejected (422).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def fake_importance_job(client: TestClient) -> Iterator[str]:
+    """Inject a stub job + backend whose ``importance`` returns a wide
+    feature-weight dict so the contract under test is exercised
+    independently of a real fit."""
+    from lizystudio.backends.types import DataRef
+    from lizystudio.services.jobs import JobStore
+
+    app = client.app  # type: ignore[union-attr]
+    job_store: JobStore = app.state.job_store
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=DataRef(
+            source_type="path",
+            path="/data/x.csv",
+            filename="x.csv",
+            fingerprint="f",
+            shape=(100, 10000),
+        ),
+        job_type="fit",
+    )
+    job.status = "completed"
+    job_store.update(job)
+
+    # Stub backend.importance: 3000 features, descending importance.
+    fake_backend = MagicMock()
+    fake_backend.importance.return_value = {
+        f"f_{i:05d}": float(3000 - i) for i in range(3000)
+    }
+
+    # Patch the workspace dependency so the route handler picks up
+    # the stubbed backend without needing a fitted model on disk.
+    from lizystudio.services.workspace import WorkspaceState
+
+    original_backend = app.state.workspace.backend
+    app.state.workspace.backend = fake_backend
+    # Bypass ModelCache.load by short-circuiting it.
+    job_store.model_cache.load = lambda job, backend: object()  # type: ignore[assignment]
+
+    try:
+        yield job.job_id
+    finally:
+        app.state.workspace.backend = original_backend
+        # Reset the cache method binding to its real implementation.
+        from lizystudio.services.job_results import ModelCache
+
+        job_store.model_cache.load = ModelCache.load.__get__(  # type: ignore[assignment]
+            job_store.model_cache, ModelCache
+        )
+        # Silence unused-import warning under ruff.
+        _ = WorkspaceState
+
+
+def test_importance_without_top_n_returns_all_features(
+    client: TestClient, fake_importance_job: str
+) -> None:
+    """Backward compat: omitting ``top_n`` returns every feature."""
+    r = client.get(f"/api/jobs/{fake_importance_job}/importance")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body) == 3000
+    assert "X-Truncated-By" not in r.headers
+
+
+def test_importance_top_n_caps_features(
+    client: TestClient, fake_importance_job: str
+) -> None:
+    """``top_n=50`` returns the 50 highest-importance features."""
+    r = client.get(f"/api/jobs/{fake_importance_job}/importance?top_n=50")
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body) == 50
+    # Sorted desc: f_00000=3000 ... f_00049=2951.
+    items = list(body.items())
+    assert items[0][0] == "f_00000"
+    assert items[0][1] == 3000.0
+    assert items[-1][1] >= 2950.0
+    # X-Truncated-By only fires for SERVER-side truncation, not user
+    # opt-in via top_n. Explicit top_n is honoured silently.
+    assert "X-Truncated-By" not in r.headers
+
+
+def test_importance_top_n_zero_rejected(
+    client: TestClient, fake_importance_job: str
+) -> None:
+    r = client.get(f"/api/jobs/{fake_importance_job}/importance?top_n=0")
+    assert r.status_code == 422
+
+
+def test_importance_top_n_negative_rejected(
+    client: TestClient, fake_importance_job: str
+) -> None:
+    r = client.get(f"/api/jobs/{fake_importance_job}/importance?top_n=-1")
+    assert r.status_code == 422
+
+
+def test_importance_payload_cap_falls_back_to_top_n_with_header(
+    client: TestClient,
+) -> None:
+    """When the unbounded payload would exceed the 5MB cap, the server
+    falls back to a top-N projection and surfaces the truncation via
+    ``X-Truncated-By: top_n=<N>`` so the SPA can render an honest
+    "showing top N of M" notice.
+
+    Drives this with a tiny cap so the test does not need to ship a
+    multi-megabyte fixture.
+    """
+    from lizystudio.backends.types import DataRef
+    from lizystudio.services import job_results
+    from lizystudio.services.jobs import JobStore
+
+    app = client.app  # type: ignore[union-attr]
+    job_store: JobStore = app.state.job_store
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=DataRef(
+            source_type="path",
+            path="/data/x.csv",
+            filename="x.csv",
+            fingerprint="f",
+            shape=(100, 5000),
+        ),
+        job_type="fit",
+    )
+    job.status = "completed"
+    job_store.update(job)
+
+    # 5000 features, ~25 chars per name + 8 chars per float number => >130KB.
+    payload = {f"feature_{i:05d}_name": float(5000 - i) for i in range(5000)}
+    fake_backend = MagicMock()
+    fake_backend.importance.return_value = payload
+    app.state.workspace.backend = fake_backend
+    job_store.model_cache.load = lambda job, backend: object()  # type: ignore[assignment]
+
+    # Tighten the cap so we can verify behaviour without huge data.
+    from lizystudio.api import jobs as jobs_api
+
+    original_cap = jobs_api.IMPORTANCE_PAYLOAD_LIMIT
+    jobs_api.IMPORTANCE_PAYLOAD_LIMIT = 4096
+
+    try:
+        r = client.get(f"/api/jobs/{job.job_id}/importance")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert len(body) < 5000, "server must fall back to top-N"
+        assert len(body) > 0
+        truncated_by = r.headers.get("X-Truncated-By", "")
+        assert truncated_by.startswith("top_n="), truncated_by
+        # The selected top-N is sorted desc by importance value.
+        items = list(body.items())
+        assert items[0][1] == 5000.0
+        assert items[0][0] == "feature_00000_name"
+    finally:
+        jobs_api.IMPORTANCE_PAYLOAD_LIMIT = original_cap
+        # Restore real backend / cache references via the same helper.
+        from lizystudio.services.job_results import ModelCache
+
+        job_store.model_cache.load = ModelCache.load.__get__(  # type: ignore[assignment]
+            job_store.model_cache, ModelCache
+        )
+        _ = job_results
+        _: dict[str, Any] = {}
+        _ = json

--- a/tests/contract/test_preview_max_cols.py
+++ b/tests/contract/test_preview_max_cols.py
@@ -1,0 +1,105 @@
+"""Contract tests for ``GET /api/workspace/data/preview?max_cols=N`` (P-0097).
+
+Locks the optional ``max_cols`` query parameter introduced for the
+Wide DataFrame UI (Issue #361). Three invariants:
+
+- INV: ``max_cols`` omitted → all columns returned (backward compat).
+- INV: ``max_cols=N`` (positive) → at most N columns in ``columns`` /
+  ``data`` rows; ``total_cols`` always reports the ground-truth column
+  count.
+- INV: ``max_cols=0`` or negative is rejected with 422 (FastAPI Query
+  validation).
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+def _wide_csv(tmp_path: Path, n_cols: int = 50, n_rows: int = 10) -> str:
+    csv_path = tmp_path / "wide.csv"
+    headers = ["target_class"] + [f"f_{i:05d}" for i in range(1, n_cols)]
+    with csv_path.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(headers)
+        for r in range(n_rows):
+            row = [r % 2] + [float(r + c) for c in range(1, n_cols)]
+            w.writerow(row)
+    return str(csv_path)
+
+
+def _load_data(client: TestClient, path: str) -> None:
+    r = client.post("/api/workspace/data/path", json={"path": path})
+    assert r.status_code == 200, r.text
+
+
+def test_preview_without_max_cols_returns_all_columns(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Backward compat: omitting ``max_cols`` returns every column."""
+    csv_path = _wide_csv(tmp_path, n_cols=50, n_rows=5)
+    _load_data(client, csv_path)
+
+    r = client.get("/api/workspace/data/preview?rows=5")
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["columns"]) == 50
+    assert body["total_cols"] == 50
+    # Every data row carries a value for every column.
+    assert all(len(row) == 50 for row in body["data"])
+
+
+def test_preview_with_max_cols_caps_columns(client: TestClient, tmp_path: Path) -> None:
+    """``max_cols=10`` returns the first 10 columns; ``total_cols`` still
+    reports the ground-truth 50."""
+    csv_path = _wide_csv(tmp_path, n_cols=50, n_rows=5)
+    _load_data(client, csv_path)
+
+    r = client.get("/api/workspace/data/preview?rows=5&max_cols=10")
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["columns"]) == 10
+    # Order preserved — target_class is column 0.
+    assert body["columns"][0] == "target_class"
+    assert body["total_cols"] == 50, "total_cols must reflect ground truth"
+    # Each row is also capped.
+    assert all(len(row) == 10 for row in body["data"])
+
+
+def test_preview_max_cols_larger_than_actual_returns_all(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """``max_cols`` larger than the actual column count is a no-op
+    (returns every column without raising).
+    """
+    csv_path = _wide_csv(tmp_path, n_cols=12, n_rows=3)
+    _load_data(client, csv_path)
+
+    r = client.get("/api/workspace/data/preview?max_cols=999")
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["columns"]) == 12
+
+
+def test_preview_max_cols_zero_rejected(client: TestClient, tmp_path: Path) -> None:
+    """``max_cols=0`` is invalid: FastAPI Query ge=1 returns 422."""
+    csv_path = _wide_csv(tmp_path, n_cols=10, n_rows=3)
+    _load_data(client, csv_path)
+
+    r = client.get("/api/workspace/data/preview?max_cols=0")
+    assert r.status_code == 422
+
+
+def test_preview_max_cols_negative_rejected(client: TestClient, tmp_path: Path) -> None:
+    """``max_cols=-5`` is invalid (422)."""
+    csv_path = _wide_csv(tmp_path, n_cols=10, n_rows=3)
+    _load_data(client, csv_path)
+
+    r = client.get("/api/workspace/data/preview?max_cols=-5")
+    assert r.status_code == 422

--- a/tests/fixtures/lizyml/wide/.gitignore
+++ b/tests/fixtures/lizyml/wide/.gitignore
@@ -1,0 +1,1 @@
+data.csv

--- a/tests/fixtures/lizyml/wide/README.md
+++ b/tests/fixtures/lizyml/wide/README.md
@@ -1,0 +1,21 @@
+# Wide DataFrame fixture (Issue #361 / P-0097)
+
+A 10,000-column × 1,000-row synthetic CSV used by:
+
+- Backend stress tests (`tests/regression/test_reg_0361_wide_preview.py`)
+- Frontend e2e wide-DataFrame specs
+
+The CSV itself (~50MB) is **gitignored**; regenerate with:
+
+```bash
+uv run python tests/fixtures/lizyml/wide/generate.py
+```
+
+Schema:
+
+- `target_class` — binary int (0 / 1)
+- `f_00001` .. `f_09999` — 9,999 float32 gaussian features
+
+CI generates the fixture once at job start (see workflow steps that
+shell out to `generate.py` before the wide-DataFrame test selector
+runs).

--- a/tests/fixtures/lizyml/wide/generate.py
+++ b/tests/fixtures/lizyml/wide/generate.py
@@ -1,0 +1,60 @@
+"""Generator for the wide-DataFrame fixture (Issue #361 / P-0097).
+
+Builds a synthetic 10,000-column × 1,000-row CSV at
+``tests/fixtures/lizyml/wide/data.csv`` so the backend stress tests
+and frontend e2e specs can exercise the wide-DataFrame code path
+without committing a 50MB CSV into git.
+
+Run on demand from the repo root::
+
+    uv run python tests/fixtures/lizyml/wide/generate.py
+
+The output file is gitignored (see ``tests/fixtures/lizyml/wide/.gitignore``)
+so each contributor regenerates it locally. CI generates it once at
+job start via the same script.
+
+Schema:
+
+- 1 binary target column ``target_class`` (int 0/1)
+- 9,999 numeric feature columns ``f_00001`` .. ``f_09999``
+- 1,000 rows so the file is large enough to exercise streaming /
+  pagination paths but small enough to keep ``ruff``-checked
+  generators near-instant
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+N_ROWS = 1_000
+N_FEATURES = 9_999  # 9999 features + 1 target = 10_000 columns
+
+
+def main() -> None:
+    out = Path(__file__).resolve().parent / "data.csv"
+    rng = np.random.default_rng(seed=42)
+
+    # Independent gaussian features keep generation cheap.
+    data = rng.standard_normal((N_ROWS, N_FEATURES)).astype(np.float32)
+    feature_names = [f"f_{i:05d}" for i in range(1, N_FEATURES + 1)]
+
+    df = pd.DataFrame(data, columns=feature_names)
+    # Mild signal in feature 0 + 1 to keep fits meaningful. Logistic
+    # decision boundary so target = 1 / (1 + exp(-(0.5*f_00001 + 0.3*f_00002))) > 0.5.
+    logits = 0.5 * df["f_00001"] + 0.3 * df["f_00002"]
+    df["target_class"] = (logits > logits.median()).astype(int)
+
+    df.to_csv(out, index=False)
+    print(
+        f"wrote {out} ({df.shape[0]} rows × {df.shape[1]} cols, "
+        f"{out.stat().st_size / (1024 * 1024):.1f}MB)",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/regression/test_reg_0361_wide_preview.py
+++ b/tests/regression/test_reg_0361_wide_preview.py
@@ -1,0 +1,80 @@
+"""Regression test for the 10k-column preview path (Issue #361 / P-0097).
+
+Loads the wide-DataFrame fixture (`tests/fixtures/lizyml/wide/data.csv`,
+1000 rows × 10000 cols) and verifies the new ``max_cols`` query
+parameter caps the preview payload to a budget the SPA can render
+without blocking the main thread.
+
+The fixture is generated on demand (`tests/fixtures/lizyml/wide/generate.py`)
+and is **gitignored** — the test is skipped when the file is missing
+so contributors who have not generated it locally still see green
+unit suites. CI generates the fixture once at job start.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+WIDE_CSV = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "lizyml" / "wide" / "data.csv"
+)
+
+
+def _require_fixture() -> None:
+    if not WIDE_CSV.exists():
+        pytest.skip(
+            "Wide-DataFrame fixture missing. Run "
+            "`uv run python tests/fixtures/lizyml/wide/generate.py` "
+            "to generate it locally."
+        )
+
+
+def test_wide_preview_caps_payload_by_max_cols(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``max_cols=200`` returns a tiny preview even on 10k-column data."""
+    _require_fixture()
+
+    # The autouse client fixture pins LIZYSTUDIO_FILES_ROOT to /tmp,
+    # which excludes the repo's fixtures directory. Re-point it for
+    # this test so the path-load is allowed.
+    files_root = WIDE_CSV.parent.parent.parent.resolve()  # tests/fixtures/lizyml
+    monkeypatch.setenv("LIZYSTUDIO_FILES_ROOT", str(files_root))
+    import lizystudio.security as sec
+
+    monkeypatch.setattr(sec, "ALLOWED_FILES_ROOT", files_root)
+
+    r = client.post("/api/workspace/data/path", json={"path": str(WIDE_CSV)})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data_ref"]["shape"] == [1000, 10000]
+
+    # Without max_cols: 10k columns × 50 rows is large.
+    full = client.get("/api/workspace/data/preview?rows=5")
+    assert full.status_code == 200
+    full_body = full.json()
+    assert full_body["total_cols"] == 10000
+    assert len(full_body["columns"]) == 10000
+
+    # With max_cols=200: 5 rows × 200 cols × ~20B = ~20KB. Well below
+    # the 512KB ceiling the SPA expects for snappy rendering.
+    capped = client.get("/api/workspace/data/preview?rows=5&max_cols=200")
+    assert capped.status_code == 200
+    capped_body = capped.json()
+    assert capped_body["total_cols"] == 10000, (
+        "total_cols must reflect ground truth even when capped"
+    )
+    assert len(capped_body["columns"]) == 200
+
+    encoded = len(json.dumps(capped_body))
+    assert encoded < 512 * 1024, (
+        f"capped preview must fit in 512KB, got {encoded} bytes"
+    )


### PR DESCRIPTION
## Summary

Phase B (v0.4.0 Wide DataFrame) — **PR-B1: backend foundation**.

Closes the API contract for the Wide DataFrame UI (Issue #361) so PR-B2 (frontend virtualization + bulk ops + searchable target combobox) can build on stable types. Each piece is additive — clients that omit the new query params see identical behaviour.

## What's in

- **`max_cols` query on `GET /api/workspace/data/preview` (P-0097)** — caps per-row column count so the SPA does not have to ship 10k+ columns on every preview call. `total_cols` continues to reflect ground truth for "showing N of M" labels.
- **`top_n` query on `GET /api/jobs/{id}/importance` (P-0097)** — value-desc projection without an extra round-trip. Server-side payload cap (5MB) falls back to a sized top-N projection and surfaces truncation via `X-Truncated-By: top_n=<N>` response header.
- **`GET /api/diagnostic/export?job_id=...` (R-3.4 / P-0097)** — sanitised JSON snapshot for support attachments. Returns `{schema_version, timestamp, job, system}` with no heavy artefacts inlined and no internal JobStore paths leaked.
- **Wide-DataFrame fixture generator** at `tests/fixtures/lizyml/wide/generate.py` (10k cols × 1k rows). CSV is gitignored; CI generates it once per job.

## Spec

- HISTORY.md **P-0097** records the API contract (max_cols / top_n / payload cap policy).
- CHANGELOG.md `[Unreleased]` opens the v0.4.0 track.

## Test plan

- [x] `tests/contract/test_preview_max_cols.py` — 5 cases (omitted / capped / oversize / 0 / negative)
- [x] `tests/contract/test_importance_top_n.py` — 5 cases (omitted / capped / 0 / negative / 5MB cap fallback + header)
- [x] `tests/contract/test_diagnostic_export.py` — 4 cases (missing / unknown / envelope / no JobStore-path leak)
- [x] `tests/regression/test_reg_0361_wide_preview.py` — 10k col fixture, capped preview ≤ 512KB
- [x] `uv run pytest -q -m "not quarantine and not slow and not bench"`: **1299 passed** (was 1285 pre-PR; +14 new)
- [x] `ruff` / `ruff format` / `mypy`: clean
- [x] `pnpm check` / `pnpm build`: green
- [x] `pnpm generate:api` regenerated typings (committed)

## Implementation notes

- The diagnostic exporter reads versions via `importlib.metadata` (not `import lizyml`) so the api layer stays compliant with the layer-audit guard.
- Importance payload cap uses binary-search prefix selection on the value-desc-sorted feature list — at extreme cap pressure the SPA still gets at least the single highest-importance feature.

## Out of scope (next PRs)

- **PR-B2**: Frontend virtualization (Column Settings react-window), searchable Target combobox, importance plot top-N + show-all toggle, bulk ops, Feature Weights 1k-column gate.
- **PR-B3**: Large CSV scaling (R-5.2) + #383 stress tests (Large Dataset memory + File Upload Concurrency).
- **PR-B4**: R-3.3 Plot type symmetric audit + R-3.4 Validate API enhancements (severity / suggested_fix).
- **PR-B5**: v0.4.0 release tag + PyPI publish.