### PR TITLE
feat(frontend): wide DataFrame UI — virtualization + searchable target + bulk ops + top-N + guard (PR-B2, #361)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,34 @@ Foundation PR for Issue #361.
   rows). The CSV itself is gitignored; CI generates it once at job
   start. Used by `tests/regression/test_reg_0361_wide_preview.py`.
 
+### Frontend (PR-B2 — Wide DataFrame UI)
+
+- **Column Settings virtualization** — `@tanstack/react-virtual`
+  windows the per-column row list once the visible (non-target,
+  filter-matched) count crosses 200. The Workspace can now show the
+  configuration UI for 10,000-column workspaces without freezing
+  scroll on first paint.
+- **Searchable Target combobox** (`SearchableSelect`) — replaces the
+  shadcn Select used for Target column with a cmdk-backed combobox.
+  Substring filter, full keyboard navigation, scales to thousands of
+  options. The Task radios and the rest of the Data Panel are
+  unchanged.
+- **Importance top-N toggle** — Plots panel now exposes a
+  Show 30 / 100 / all toggle for the Importance table. Default is the
+  server-side top-30 projection (uses the new `top_n` query) so the
+  table fits well under the 5MB payload cap; users can opt back into
+  the unbounded list per job.
+- **Bulk Exclude / Include / Set type** — when the Column Settings
+  filter matches one or more columns, a toolbar above the row list
+  lets the user apply Exclude / Include / Set Numeric / Set
+  Categorical to every filtered column in a single state update,
+  collapsing N PUT-coalesce events into one.
+- **Feature Weights 1k-column guard** — the Feature Weights toggle is
+  disabled (with an inline explanatory message) when the workspace
+  has more than 1,000 non-excluded columns. The per-feature weight
+  picker is not the right interaction model at that scale; the guard
+  surfaces the limit instead of silently breaking the UI.
+
 ### Test Infrastructure
 
 - 14 new contract / regression tests under
@@ -41,6 +69,11 @@ Foundation PR for Issue #361.
   `tests/contract/test_importance_top_n.py`,
   `tests/contract/test_diagnostic_export.py`, and
   `tests/regression/test_reg_0361_wide_preview.py`.
+- Frontend Vitest coverage for the wide-DataFrame UI: 28 cases on
+  `ColumnSettingsSection` (virtualization branch + bulk toolbar),
+  9 on `SearchableSelect`, 6 on the importance top-N toggle, 4 on
+  the FeatureWeightsEditor 1k-column guard, and 4 bulk-handler cases
+  on `useColumnOverrides`.
 
 ## [0.3.1] - 2026-05-04
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,8 +28,10 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.99.2",
+    "@tanstack/react-virtual": "^3.13.24",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "fast-deep-equal": "^3.1.3",
     "js-yaml": "^4.1.1",
     "lucide-react": "^1.8.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,12 +11,18 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.99.2
         version: 5.99.2(react@19.2.5)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.24
+        version: 3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
@@ -2041,6 +2047,15 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@tanstack/react-virtual@3.13.24':
+    resolution: {integrity: sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.14.0':
+    resolution: {integrity: sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==}
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -2639,6 +2654,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -7236,6 +7257,14 @@ snapshots:
       '@tanstack/query-core': 5.99.2
       react: 19.2.5
 
+  '@tanstack/react-virtual@3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/virtual-core': 3.14.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@tanstack/virtual-core@3.14.0': {}
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -7856,6 +7885,18 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
+
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   co@4.6.0: {}
 

--- a/frontend/src/api/jobs.test.ts
+++ b/frontend/src/api/jobs.test.ts
@@ -106,6 +106,30 @@ describe("fetchJobImportance", () => {
     await fetchJobImportance("j1", "gain");
     expect(capturedKind).toBe("gain");
   });
+
+  it("forwards top_n when provided (PR-B2 / P-0097)", async () => {
+    let capturedTopN: string | null = null;
+    server.use(
+      http.get("/api/jobs/:jobId/importance", ({ request }) => {
+        capturedTopN = new URL(request.url).searchParams.get("top_n");
+        return HttpResponse.json({});
+      }),
+    );
+    await fetchJobImportance("j1", "gain", { topN: 30 });
+    expect(capturedTopN).toBe("30");
+  });
+
+  it("omits top_n when not provided", async () => {
+    let capturedTopN: string | null = null;
+    server.use(
+      http.get("/api/jobs/:jobId/importance", ({ request }) => {
+        capturedTopN = new URL(request.url).searchParams.get("top_n");
+        return HttpResponse.json({});
+      }),
+    );
+    await fetchJobImportance("j1", "gain");
+    expect(capturedTopN).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/api/jobs.ts
+++ b/frontend/src/api/jobs.ts
@@ -37,9 +37,14 @@ export async function fetchJob(jobId: string): Promise<JobDetail> {
 export async function fetchJobImportance(
   jobId: string,
   kind = "default",
+  options?: { topN?: number },
 ): Promise<ImportanceResponse> {
+  const query: { kind: string; top_n?: number } = { kind };
+  if (typeof options?.topN === "number") {
+    query.top_n = options.topN;
+  }
   const { data } = await apiClient.GET("/api/jobs/{job_id}/importance", {
-    params: { path: { job_id: jobId }, query: { kind } },
+    params: { path: { job_id: jobId }, query },
   });
   // Backend returns ``dict[str, float]`` (no response_model — flat mapping).
   // SSOT-EXEMPT: #236 — adding a wrapping model would change the wire shape.

--- a/frontend/src/api/queryKeys.test.ts
+++ b/frontend/src/api/queryKeys.test.ts
@@ -90,11 +90,18 @@ describe("queryKeys factory — bit-identical to pre-refactor inline keys", () =
       ]);
     });
 
-    it("jobImportance → ['job-importance', id, kind]", () => {
+    it("jobImportance → ['job-importance', id, kind, topN]", () => {
       expect(queryKeys.jobImportance("job_abc", "split")).toEqual([
         "job-importance",
         "job_abc",
         "split",
+        null,
+      ]);
+      expect(queryKeys.jobImportance("job_abc", "split", 30)).toEqual([
+        "job-importance",
+        "job_abc",
+        "split",
+        30,
       ]);
     });
 

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -32,8 +32,8 @@ export const queryKeys = {
   jobPlotImportance: (jobId: string, kind: string) =>
     ["job-plot", jobId, "importance", kind] as const,
   jobPlotTuning: (jobId: string) => ["job-plot", jobId, "tuning"] as const,
-  jobImportance: (jobId: string, kind: string) =>
-    ["job-importance", jobId, kind] as const,
+  jobImportance: (jobId: string, kind: string, topN: number | null = null) =>
+    ["job-importance", jobId, kind, topN] as const,
   jobImportanceKinds: (jobId: string) =>
     ["job-importance-kinds", jobId] as const,
   jobLearningCurveMetrics: (jobId: string) =>

--- a/frontend/src/components/shared/JobResultsBody.tsx
+++ b/frontend/src/components/shared/JobResultsBody.tsx
@@ -62,6 +62,8 @@ export function JobResultsBody({
     importance,
     importancePlot,
     isImportancePlotLoading,
+    importanceTopN,
+    setImportanceTopN,
     splitSummary,
     tuningPlot,
     metrics,
@@ -112,6 +114,8 @@ export function JobResultsBody({
           onImportanceKindChange={setImportanceKind}
           importanceData={importance}
           importancePlot={importancePlot}
+          importanceTopN={importanceTopN}
+          onImportanceTopNChange={setImportanceTopN}
         />
       )}
 

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -1,0 +1,112 @@
+import { SearchIcon } from "lucide-react";
+import { Command as CommandPrimitive } from "cmdk";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "text-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+};

--- a/frontend/src/components/workspace/ColumnSettingsSection.test.tsx
+++ b/frontend/src/components/workspace/ColumnSettingsSection.test.tsx
@@ -1,8 +1,38 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import type { ColumnInfo } from "@/api/types";
 import { ColumnSettingsSection } from "./ColumnSettingsSection";
+
+/**
+ * jsdom always reports zero-sized clientRects, which means
+ * @tanstack/react-virtual measures the scroll viewport as 0 and would
+ * either render nothing or fall back to mounting every row depending
+ * on the version. Stub a non-zero size on the scroll element so the
+ * virtualizer's measurement path matches what real browsers see, and
+ * the wide-DataFrame guard tests can assert "fewer rows than columns
+ * mounted at any one time".
+ */
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get() {
+      return 320;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get() {
+      return 800;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+    configurable: true,
+    get() {
+      return 320;
+    },
+  });
+});
 
 const COLUMNS: ColumnInfo[] = [
   {
@@ -222,5 +252,174 @@ describe("ColumnSettingsSection running lock (P-0089 / Issue #279)", () => {
     await userEvent.click(numBtn);
     expect(onExcludeToggle).not.toHaveBeenCalled();
     expect(onTypeChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("ColumnSettingsSection wide-DataFrame virtualization (PR-B2)", () => {
+  function makeWide(n: number): ColumnInfo[] {
+    const cols: ColumnInfo[] = [];
+    for (let i = 0; i < n; i++) {
+      cols.push({
+        name: `f_${i.toString().padStart(5, "0")}`,
+        dtype: "float64",
+        unique_count: 100,
+        suggested_type: "numeric",
+        suggested_excluded: false,
+      });
+    }
+    return cols;
+  }
+
+  function renderWide(cols: ColumnInfo[]) {
+    render(
+      <ColumnSettingsSection
+        columns={cols}
+        target="target_class"
+        overrides={{}}
+        columnFilter=""
+        onColumnFilterChange={() => {}}
+        expandedCol={null}
+        colStats={{}}
+        summary={{ ...SUMMARY, total: cols.length }}
+        onExcludeToggle={vi.fn()}
+        onTypeChange={vi.fn()}
+        onColumnExpand={vi.fn()}
+      />,
+    );
+  }
+
+  it("uses the virtualized list path above the column threshold", () => {
+    // happy-dom returns 0 for getBoundingClientRect on refs, so the
+    // virtualizer will not actually mount any rows under test. Assert
+    // on the structural marker (the dedicated scroll container + the
+    // total-height spacer) instead, which still proves the virtual
+    // branch was taken.
+    renderWide(makeWide(5000));
+    const scroll = document.querySelector(
+      '[data-testid="column-virtual-scroll"]',
+    );
+    const spacer = document.querySelector(
+      '[data-testid="column-virtual-spacer"]',
+    );
+    expect(scroll).not.toBeNull();
+    expect(spacer).not.toBeNull();
+  });
+
+  it("preserves the total scroll height proportional to column count", () => {
+    renderWide(makeWide(5000));
+    const spacer = document.querySelector(
+      '[data-testid="column-virtual-spacer"]',
+    );
+    expect(spacer).not.toBeNull();
+    const totalHeight = (spacer as HTMLElement).style.height;
+    expect(totalHeight).toMatch(/px$/);
+    const px = Number.parseInt(totalHeight.replace("px", ""), 10);
+    expect(px).toBeGreaterThan(28 * 1000);
+  });
+
+  it("does not switch on the virtualized list below the threshold", () => {
+    renderWide(makeWide(50));
+    const scroll = document.querySelector(
+      '[data-testid="column-virtual-scroll"]',
+    );
+    expect(scroll).toBeNull();
+  });
+
+  it("renders the header row exactly once even at large column counts", () => {
+    renderWide(makeWide(5000));
+    expect(screen.getAllByText("Name").length).toBe(1);
+  });
+});
+
+describe("ColumnSettingsSection bulk operations toolbar (PR-B2)", () => {
+  function renderBulk(
+    overrides: {
+      columnFilter?: string;
+      onBulkExcludeToggle?: (names: string[], checked: boolean) => void;
+      onBulkTypeChange?: (
+        names: string[],
+        type: "numeric" | "categorical",
+      ) => void;
+    } = {},
+  ) {
+    const onBulkExcludeToggle = overrides.onBulkExcludeToggle ?? vi.fn();
+    const onBulkTypeChange = overrides.onBulkTypeChange ?? vi.fn();
+    render(
+      <ColumnSettingsSection
+        columns={COLUMNS}
+        target="age"
+        overrides={{}}
+        columnFilter={overrides.columnFilter ?? ""}
+        onColumnFilterChange={() => {}}
+        expandedCol={null}
+        colStats={{}}
+        summary={SUMMARY}
+        onExcludeToggle={vi.fn()}
+        onTypeChange={vi.fn()}
+        onColumnExpand={vi.fn()}
+        onBulkExcludeToggle={onBulkExcludeToggle}
+        onBulkTypeChange={onBulkTypeChange}
+      />,
+    );
+    return { onBulkExcludeToggle, onBulkTypeChange };
+  }
+
+  it("does not render the toolbar when columnFilter is empty", () => {
+    renderBulk({ columnFilter: "" });
+    expect(screen.queryByTestId("column-bulk-toolbar")).toBeNull();
+  });
+
+  it("renders the toolbar when columnFilter matches at least one column", () => {
+    renderBulk({ columnFilter: "co" }); // matches 'color'
+    expect(screen.getByTestId("column-bulk-toolbar")).toBeInTheDocument();
+    expect(screen.getByTestId("column-bulk-toolbar")).toHaveTextContent(/1/);
+  });
+
+  it("Exclude All calls onBulkExcludeToggle with the filtered names", () => {
+    const { onBulkExcludeToggle } = renderBulk({ columnFilter: "co" });
+    fireEvent.click(screen.getByRole("button", { name: /exclude filtered/i }));
+    expect(onBulkExcludeToggle).toHaveBeenCalledWith(["color"], true);
+  });
+
+  it("Include All calls onBulkExcludeToggle with checked=false", () => {
+    const { onBulkExcludeToggle } = renderBulk({ columnFilter: "co" });
+    fireEvent.click(screen.getByRole("button", { name: /include filtered/i }));
+    expect(onBulkExcludeToggle).toHaveBeenCalledWith(["color"], false);
+  });
+
+  it("Set Numeric calls onBulkTypeChange", () => {
+    const { onBulkTypeChange } = renderBulk({ columnFilter: "co" });
+    fireEvent.click(
+      screen.getByRole("button", { name: /set filtered to numeric/i }),
+    );
+    expect(onBulkTypeChange).toHaveBeenCalledWith(["color"], "numeric");
+  });
+
+  it("Set Categorical calls onBulkTypeChange", () => {
+    const { onBulkTypeChange } = renderBulk({ columnFilter: "co" });
+    fireEvent.click(
+      screen.getByRole("button", { name: /set filtered to categorical/i }),
+    );
+    expect(onBulkTypeChange).toHaveBeenCalledWith(["color"], "categorical");
+  });
+
+  it("toolbar still works when running without bulk callbacks (graceful)", () => {
+    // Optional props — when omitted the toolbar simply hides.
+    render(
+      <ColumnSettingsSection
+        columns={COLUMNS}
+        target="age"
+        overrides={{}}
+        columnFilter="co"
+        onColumnFilterChange={() => {}}
+        expandedCol={null}
+        colStats={{}}
+        summary={SUMMARY}
+        onExcludeToggle={vi.fn()}
+        onTypeChange={vi.fn()}
+        onColumnExpand={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("column-bulk-toolbar")).toBeNull();
   });
 });

--- a/frontend/src/components/workspace/ColumnSettingsSection.tsx
+++ b/frontend/src/components/workspace/ColumnSettingsSection.tsx
@@ -1,3 +1,5 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useMemo, useRef } from "react";
 import type { ColumnInfo, ColumnStatsResponse } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -27,6 +29,20 @@ interface ColumnSettingsSectionProps {
   onTypeChange: (colName: string, type: "numeric" | "categorical") => void;
   onColumnExpand: (colName: string) => void;
   /**
+   * PR-B2 / P-0097: optional bulk handlers used by the wide-DataFrame
+   * UX. When provided AND the user has typed a non-empty filter, the
+   * toolbar above the row list lets them apply the action to every
+   * filtered (non-target) column in a single state update.
+   *
+   * The handlers are optional so callers that have not migrated yet
+   * (Storybook stories, legacy tests) keep working unchanged.
+   */
+  onBulkExcludeToggle?: (colNames: string[], checked: boolean) => void;
+  onBulkTypeChange?: (
+    colNames: string[],
+    type: "numeric" | "categorical",
+  ) => void;
+  /**
    * P-0089 / Issue #279: lock the per-column Exclude / Num / Cat
    * controls while a fit/tune job is running. PUT /config returns
    * 409 server-side; disabling the controls here matches that lock
@@ -34,6 +50,229 @@ interface ColumnSettingsSectionProps {
    * toast.
    */
   disabled?: boolean;
+}
+
+const ROW_HEIGHT_PX = 32;
+const VIRTUAL_OVERSCAN = 8;
+/**
+ * PR-B2 / P-0097: only switch on virtualization once the visible
+ * column count crosses this threshold. Real-world workspaces with
+ * tens of columns get the simpler, fully-mounted list and avoid the
+ * react-virtual measurement overhead; wide-DataFrame workspaces
+ * (Issue #361) get a windowed list with a constant DOM cost.
+ */
+const VIRTUAL_COLUMN_THRESHOLD = 200;
+
+interface ColumnRowProps {
+  col: ColumnInfo;
+  index: number;
+  overrides: Record<string, ColumnOverride>;
+  expandedCol: string | null;
+  colStats: Record<string, ColumnStatsResponse>;
+  onExcludeToggle: (colName: string, checked: boolean) => void;
+  onTypeChange: (colName: string, type: "numeric" | "categorical") => void;
+  onColumnExpand: (colName: string) => void;
+  disabled: boolean;
+}
+
+function ColumnRow({
+  col,
+  index,
+  overrides,
+  expandedCol,
+  colStats,
+  onExcludeToggle,
+  onTypeChange,
+  onColumnExpand,
+  disabled,
+}: ColumnRowProps) {
+  const o = overrides[col.name];
+  const isExcluded = o?.excluded ?? false;
+  const currentType = o?.type ?? col.suggested_type;
+  const isExpanded = expandedCol === col.name;
+  const stats = colStats[col.name];
+  return (
+    <div>
+      {/* Issue #248: row must not be a <button> because it
+          wraps other interactive controls (Checkbox, Num/Cat
+          buttons). Real browsers hoist the inner <button>s
+          out of the outer one, breaking click handling. Use
+          role="button" + tabIndex + keyboard handler so the
+          row stays activatable without nesting interactive
+          content inside a <button>. */}
+      {/* biome-ignore lint/a11y/useSemanticElements: cannot use <button> — nested interactive content */}
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label={col.name}
+        aria-expanded={isExpanded}
+        className={`grid w-full grid-cols-[1fr_60px_60px_100px] items-center gap-x-2 px-3 py-1.5 text-left hover:bg-muted/40 cursor-pointer ${index % 2 === 1 ? "bg-muted/20" : ""}`}
+        onClick={() => onColumnExpand(col.name)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onColumnExpand(col.name);
+          }
+        }}
+        data-testid={`column-row-${col.name}`}
+      >
+        <span className="text-xs truncate">
+          {col.name}
+          {col.exclude_reason === "id" && (
+            <Badge variant="outline" className="ml-1 text-[10px]">
+              ID
+            </Badge>
+          )}
+          {col.exclude_reason === "constant" && (
+            <Badge variant="outline" className="ml-1 text-[10px]">
+              Const
+            </Badge>
+          )}
+        </span>
+        <span className="text-xs">{col.unique_count}</span>
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: stop propagation container */}
+        <div
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          <Checkbox
+            checked={isExcluded}
+            onCheckedChange={(checked) =>
+              onExcludeToggle(col.name, checked === true)
+            }
+            disabled={disabled}
+          />
+        </div>
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: stop propagation container */}
+        <div
+          className="flex gap-0.5"
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          <Button
+            variant={currentType === "numeric" ? "default" : "outline"}
+            size="sm"
+            className="h-6 text-[10px] px-2"
+            disabled={isExcluded || disabled}
+            onClick={() => onTypeChange(col.name, "numeric")}
+          >
+            Num
+          </Button>
+          <Button
+            variant={currentType === "categorical" ? "default" : "outline"}
+            size="sm"
+            className="h-6 text-[10px] px-2"
+            disabled={isExcluded || disabled}
+            onClick={() => onTypeChange(col.name, "categorical")}
+          >
+            Cat
+          </Button>
+        </div>
+      </div>
+      {isExpanded && stats && (
+        <div
+          className="px-3 py-2 bg-muted/10 border-t"
+          data-testid={`column-dist-${col.name}`}
+        >
+          <DistributionBar
+            valueCounts={stats.value_counts}
+            totalCount={stats.total_count}
+          />
+          <p className="text-[10px] text-muted-foreground mt-1">
+            {stats.unique_count} unique, {stats.null_count} null
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface VirtualListProps {
+  visibleColumns: ColumnInfo[];
+  overrides: Record<string, ColumnOverride>;
+  expandedCol: string | null;
+  colStats: Record<string, ColumnStatsResponse>;
+  onExcludeToggle: (colName: string, checked: boolean) => void;
+  onTypeChange: (colName: string, type: "numeric" | "categorical") => void;
+  onColumnExpand: (colName: string) => void;
+  disabled: boolean;
+}
+
+function VirtualColumnList({
+  visibleColumns,
+  overrides,
+  expandedCol,
+  colStats,
+  onExcludeToggle,
+  onTypeChange,
+  onColumnExpand,
+  disabled,
+}: VirtualListProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const virtualizer = useVirtualizer({
+    count: visibleColumns.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: (index) =>
+      expandedCol && visibleColumns[index]?.name === expandedCol
+        ? ROW_HEIGHT_PX + 80
+        : ROW_HEIGHT_PX,
+    overscan: VIRTUAL_OVERSCAN,
+    getItemKey: (index) => visibleColumns[index]?.name ?? index,
+    // jsdom returns 0 for getBoundingClientRect; fall back to a fixed
+    // viewport so unit tests still mount the visible window. Real
+    // browsers ignore this branch because the scroll element measures
+    // > 0 immediately.
+    initialRect: { width: 800, height: 320 },
+  });
+
+  const items = virtualizer.getVirtualItems();
+  return (
+    <div
+      ref={scrollRef}
+      className="max-h-64 overflow-auto"
+      data-testid="column-virtual-scroll"
+    >
+      <div
+        data-testid="column-virtual-spacer"
+        style={{
+          height: `${virtualizer.getTotalSize()}px`,
+          width: "100%",
+          position: "relative",
+        }}
+      >
+        {items.map((vRow) => {
+          const col = visibleColumns[vRow.index];
+          if (!col) return null;
+          return (
+            <div
+              key={col.name}
+              data-index={vRow.index}
+              ref={virtualizer.measureElement}
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                transform: `translateY(${vRow.start}px)`,
+              }}
+            >
+              <ColumnRow
+                col={col}
+                index={vRow.index}
+                overrides={overrides}
+                expandedCol={expandedCol}
+                colStats={colStats}
+                onExcludeToggle={onExcludeToggle}
+                onTypeChange={onTypeChange}
+                onColumnExpand={onColumnExpand}
+                disabled={disabled}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
 }
 
 export function ColumnSettingsSection({
@@ -48,8 +287,20 @@ export function ColumnSettingsSection({
   onExcludeToggle,
   onTypeChange,
   onColumnExpand,
+  onBulkExcludeToggle,
+  onBulkTypeChange,
   disabled = false,
 }: ColumnSettingsSectionProps) {
+  const visibleColumns = useMemo(() => {
+    const lc = columnFilter.toLowerCase();
+    return columns.filter(
+      (c) =>
+        c.name !== target && (lc === "" || c.name.toLowerCase().includes(lc)),
+    );
+  }, [columns, target, columnFilter]);
+
+  const useVirtual = visibleColumns.length > VIRTUAL_COLUMN_THRESHOLD;
+
   return (
     <div className="pl-4">
       {columns.length > 0 && target ? (
@@ -61,7 +312,83 @@ export function ColumnSettingsSection({
             onChange={(e) => onColumnFilterChange(e.target.value)}
             data-testid="column-search"
           />
-          <div className="max-h-64 overflow-auto rounded border">
+          {(onBulkExcludeToggle || onBulkTypeChange) &&
+            columnFilter !== "" &&
+            visibleColumns.length > 0 && (
+              <div
+                data-testid="column-bulk-toolbar"
+                className="mb-2 flex flex-wrap items-center gap-1 rounded-md border border-dashed bg-muted/30 px-2 py-1 text-xs"
+              >
+                <span className="text-muted-foreground">
+                  Apply to {visibleColumns.length} filtered:
+                </span>
+                {onBulkExcludeToggle && (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-6 px-2 text-[10px]"
+                      disabled={disabled}
+                      onClick={() =>
+                        onBulkExcludeToggle(
+                          visibleColumns.map((c) => c.name),
+                          true,
+                        )
+                      }
+                    >
+                      Exclude filtered
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-6 px-2 text-[10px]"
+                      disabled={disabled}
+                      onClick={() =>
+                        onBulkExcludeToggle(
+                          visibleColumns.map((c) => c.name),
+                          false,
+                        )
+                      }
+                    >
+                      Include filtered
+                    </Button>
+                  </>
+                )}
+                {onBulkTypeChange && (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-6 px-2 text-[10px]"
+                      disabled={disabled}
+                      onClick={() =>
+                        onBulkTypeChange(
+                          visibleColumns.map((c) => c.name),
+                          "numeric",
+                        )
+                      }
+                    >
+                      Set filtered to Numeric
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-6 px-2 text-[10px]"
+                      disabled={disabled}
+                      onClick={() =>
+                        onBulkTypeChange(
+                          visibleColumns.map((c) => c.name),
+                          "categorical",
+                        )
+                      }
+                    >
+                      Set filtered to Categorical
+                    </Button>
+                  </>
+                )}
+              </div>
+            )}
+          <div className="rounded border">
             <div className="grid grid-cols-[1fr_60px_60px_100px] gap-x-2 px-3 py-1.5 border-b bg-muted/30">
               <span className="text-xs font-medium text-muted-foreground">
                 Name
@@ -76,120 +403,35 @@ export function ColumnSettingsSection({
                 Type
               </span>
             </div>
-            {columns
-              .filter((c) => c.name !== target)
-              .filter((c) =>
-                columnFilter
-                  ? c.name.toLowerCase().includes(columnFilter.toLowerCase())
-                  : true,
-              )
-              .map((col, idx) => {
-                const o = overrides[col.name];
-                const isExcluded = o?.excluded ?? false;
-                const currentType = o?.type ?? col.suggested_type;
-                const isExpanded = expandedCol === col.name;
-                const stats = colStats[col.name];
-                return (
-                  <div key={col.name}>
-                    {/* Issue #248: row must not be a <button> because it
-                        wraps other interactive controls (Checkbox, Num/Cat
-                        buttons). Real browsers hoist the inner <button>s
-                        out of the outer one, breaking click handling. Use
-                        role="button" + tabIndex + keyboard handler so the
-                        row stays activatable without nesting interactive
-                        content inside a <button>. */}
-                    {/* biome-ignore lint/a11y/useSemanticElements: cannot use <button> — nested interactive content */}
-                    <div
-                      role="button"
-                      tabIndex={0}
-                      aria-label={col.name}
-                      aria-expanded={isExpanded}
-                      className={`grid w-full grid-cols-[1fr_60px_60px_100px] items-center gap-x-2 px-3 py-1.5 text-left hover:bg-muted/40 cursor-pointer ${idx % 2 === 1 ? "bg-muted/20" : ""}`}
-                      onClick={() => onColumnExpand(col.name)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          onColumnExpand(col.name);
-                        }
-                      }}
-                      data-testid={`column-row-${col.name}`}
-                    >
-                      <span className="text-xs truncate">
-                        {col.name}
-                        {col.exclude_reason === "id" && (
-                          <Badge variant="outline" className="ml-1 text-[10px]">
-                            ID
-                          </Badge>
-                        )}
-                        {col.exclude_reason === "constant" && (
-                          <Badge variant="outline" className="ml-1 text-[10px]">
-                            Const
-                          </Badge>
-                        )}
-                      </span>
-                      <span className="text-xs">{col.unique_count}</span>
-                      {/* biome-ignore lint/a11y/noStaticElementInteractions: stop propagation container */}
-                      <div
-                        onClick={(e) => e.stopPropagation()}
-                        onKeyDown={(e) => e.stopPropagation()}
-                      >
-                        <Checkbox
-                          checked={isExcluded}
-                          onCheckedChange={(checked) =>
-                            onExcludeToggle(col.name, checked === true)
-                          }
-                          disabled={disabled}
-                        />
-                      </div>
-                      {/* biome-ignore lint/a11y/noStaticElementInteractions: stop propagation container */}
-                      <div
-                        className="flex gap-0.5"
-                        onClick={(e) => e.stopPropagation()}
-                        onKeyDown={(e) => e.stopPropagation()}
-                      >
-                        <Button
-                          variant={
-                            currentType === "numeric" ? "default" : "outline"
-                          }
-                          size="sm"
-                          className="h-6 text-[10px] px-2"
-                          disabled={isExcluded || disabled}
-                          onClick={() => onTypeChange(col.name, "numeric")}
-                        >
-                          Num
-                        </Button>
-                        <Button
-                          variant={
-                            currentType === "categorical"
-                              ? "default"
-                              : "outline"
-                          }
-                          size="sm"
-                          className="h-6 text-[10px] px-2"
-                          disabled={isExcluded || disabled}
-                          onClick={() => onTypeChange(col.name, "categorical")}
-                        >
-                          Cat
-                        </Button>
-                      </div>
-                    </div>
-                    {isExpanded && stats && (
-                      <div
-                        className="px-3 py-2 bg-muted/10 border-t"
-                        data-testid={`column-dist-${col.name}`}
-                      >
-                        <DistributionBar
-                          valueCounts={stats.value_counts}
-                          totalCount={stats.total_count}
-                        />
-                        <p className="text-[10px] text-muted-foreground mt-1">
-                          {stats.unique_count} unique, {stats.null_count} null
-                        </p>
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
+            {useVirtual ? (
+              <VirtualColumnList
+                visibleColumns={visibleColumns}
+                overrides={overrides}
+                expandedCol={expandedCol}
+                colStats={colStats}
+                onExcludeToggle={onExcludeToggle}
+                onTypeChange={onTypeChange}
+                onColumnExpand={onColumnExpand}
+                disabled={disabled}
+              />
+            ) : (
+              <div className="max-h-64 overflow-auto">
+                {visibleColumns.map((col, idx) => (
+                  <ColumnRow
+                    key={col.name}
+                    col={col}
+                    index={idx}
+                    overrides={overrides}
+                    expandedCol={expandedCol}
+                    colStats={colStats}
+                    onExcludeToggle={onExcludeToggle}
+                    onTypeChange={onTypeChange}
+                    onColumnExpand={onColumnExpand}
+                    disabled={disabled}
+                  />
+                ))}
+              </div>
+            )}
           </div>
         </>
       ) : (

--- a/frontend/src/components/workspace/DataPanel.tsx
+++ b/frontend/src/components/workspace/DataPanel.tsx
@@ -9,13 +9,6 @@ import {
 } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { buildSyncedConfig } from "@/hooks/buildSyncedConfig";
 import {
   TASK_OPTIONS,
@@ -26,6 +19,7 @@ import { ColumnSettingsSection } from "./ColumnSettingsSection";
 import { CvSection } from "./CvSection";
 import { DataSourceSection } from "./DataSourceSection";
 import { FoldPreview } from "./FoldPreview";
+import { SearchableSelect } from "./SearchableSelect";
 import { SegmentGroup } from "./SegmentGroup";
 
 interface DataPanelProps {
@@ -104,6 +98,8 @@ export const DataPanel = forwardRef<DataPanelHandle, DataPanelProps>(
       handleTaskChange,
       handleExcludeToggle,
       handleTypeChange,
+      handleBulkExcludeToggle,
+      handleBulkTypeChange,
       handleColumnExpand,
       hydrateFromServer,
     } = useDataPanel({ onDataChanged, onTaskChanged, uiSchema });
@@ -182,25 +178,17 @@ export const DataPanel = forwardRef<DataPanelHandle, DataPanelProps>(
                 <div className="lzs-form space-y-3 pl-4">
                   <div className="flex items-center gap-2">
                     <Label className="min-w-[60px] text-xs">Target</Label>
-                    <Select
-                      value={target ?? ""}
-                      onValueChange={handleTargetChange}
-                      disabled={allColumnNames.length === 0 || running}
-                    >
-                      <SelectTrigger
-                        aria-label="Target column"
-                        className="h-8 flex-1"
-                      >
-                        <SelectValue placeholder="Select target column" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {allColumnNames.map((name) => (
-                          <SelectItem key={name} value={name}>
-                            {name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <div className="flex-1">
+                      <SearchableSelect
+                        value={target ?? ""}
+                        options={allColumnNames}
+                        onChange={handleTargetChange}
+                        placeholder="Select target column"
+                        ariaLabel="Target column"
+                        disabled={allColumnNames.length === 0 || running}
+                        emptyMessage="No matching columns."
+                      />
+                    </div>
                   </div>
                   <div className="flex items-start gap-2">
                     <Label className="mt-1 min-w-[60px] text-xs">Task</Label>
@@ -249,6 +237,8 @@ export const DataPanel = forwardRef<DataPanelHandle, DataPanelProps>(
                   summary={summary}
                   onExcludeToggle={handleExcludeToggle}
                   onTypeChange={handleTypeChange}
+                  onBulkExcludeToggle={handleBulkExcludeToggle}
+                  onBulkTypeChange={handleBulkTypeChange}
                   onColumnExpand={handleColumnExpand}
                   disabled={running}
                 />

--- a/frontend/src/components/workspace/FeatureWeightsEditor.test.tsx
+++ b/frontend/src/components/workspace/FeatureWeightsEditor.test.tsx
@@ -170,6 +170,70 @@ describe("FeatureWeightsEditor", () => {
     });
   });
 
+  describe("wide-DataFrame guard (PR-B2 / P-0097)", () => {
+    // When the non-excluded column count exceeds 1000, the per-feature
+    // weight UI becomes unusable: the dropdown would render thousands
+    // of <SelectItem>s and the "Add feature..." picker is no longer the
+    // right interaction model. Guard the toggle with an explanatory
+    // tooltip instead, mirroring the wide-DataFrame UX path.
+    function manyCols(n: number): string[] {
+      return Array.from(
+        { length: n },
+        (_, i) => `f_${i.toString().padStart(5, "0")}`,
+      );
+    }
+
+    it("disables the Switch when column count exceeds 1000", () => {
+      renderEditor({
+        weights: null,
+        columns: manyCols(1001),
+        onChange: vi.fn(),
+      });
+      const switchEl = screen.getByRole("switch");
+      expect(switchEl).toBeDisabled();
+    });
+
+    it("does not disable the Switch at exactly 1000 columns", () => {
+      renderEditor({
+        weights: null,
+        columns: manyCols(1000),
+        onChange: vi.fn(),
+      });
+      const switchEl = screen.getByRole("switch");
+      expect(switchEl).not.toBeDisabled();
+    });
+
+    it("exposes a guard message via aria-describedby when guarded", () => {
+      renderEditor({
+        weights: null,
+        columns: manyCols(1500),
+        onChange: vi.fn(),
+      });
+      const switchEl = screen.getByRole("switch");
+      const describedBy = switchEl.getAttribute("aria-describedby");
+      expect(describedBy).toBeTruthy();
+      const msg = document.getElementById(describedBy as string);
+      expect(msg?.textContent).toMatch(/1000/);
+    });
+
+    it("renders the guard message inline so it is queryable in the DOM", () => {
+      renderEditor({
+        weights: null,
+        columns: manyCols(1500),
+        onChange: vi.fn(),
+      });
+      // Use a flexible matcher because the copy combines numbers and prose.
+      expect(screen.getByText(/disabled.*1000.*columns/i)).toBeInTheDocument();
+    });
+
+    it("ignores user clicks on the disabled Switch", () => {
+      const onChange = vi.fn();
+      renderEditor({ weights: null, columns: manyCols(1500), onChange });
+      fireEvent.click(screen.getByRole("switch"));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
   describe("weight change via NumberInput (handleWeightChange — lines 46-51, 79)", () => {
     it("incrementing weight calls onChange with updated value", () => {
       const onChange = vi.fn();

--- a/frontend/src/components/workspace/FeatureWeightsEditor.tsx
+++ b/frontend/src/components/workspace/FeatureWeightsEditor.tsx
@@ -1,5 +1,5 @@
 import { Plus, X } from "lucide-react";
-import { useMemo } from "react";
+import { useId, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -18,12 +18,24 @@ interface FeatureWeightsEditorProps {
   onChange: (weights: Record<string, number> | null) => void;
 }
 
+/**
+ * PR-B2 / P-0097: per-feature weights become unusable in the wide-
+ * DataFrame regime — the Add-feature picker would render thousands of
+ * SelectItems and the typical "type the column name" interaction does
+ * not scale. Lock the toggle above this column count and surface an
+ * inline guard message so users learn the limit instead of getting a
+ * silently-broken UI.
+ */
+const FEATURE_WEIGHTS_COLUMN_LIMIT = 1000;
+
 export function FeatureWeightsEditor({
   weights,
   columns,
   onChange,
 }: FeatureWeightsEditorProps) {
   const enabled = weights !== null;
+  const guardActive = columns.length > FEATURE_WEIGHTS_COLUMN_LIMIT;
+  const guardMessageId = useId();
   const entries = useMemo(
     () => (weights ? Object.entries(weights) : []),
     [weights],
@@ -68,8 +80,18 @@ export function FeatureWeightsEditor({
           checked={enabled}
           onCheckedChange={handleToggle}
           aria-label="Enable feature weights"
+          disabled={guardActive}
+          aria-describedby={guardActive ? guardMessageId : undefined}
         />
       </FormField>
+
+      {guardActive && (
+        <p id={guardMessageId} className="mt-1 text-xs text-muted-foreground">
+          Feature Weights is disabled when the workspace has more than{" "}
+          {FEATURE_WEIGHTS_COLUMN_LIMIT} columns. Reduce the active column count
+          via Column Settings to enable per-feature weighting.
+        </p>
+      )}
 
       {enabled && (
         <div className="mt-2 space-y-1.5">

--- a/frontend/src/components/workspace/PlotSection.test.tsx
+++ b/frontend/src/components/workspace/PlotSection.test.tsx
@@ -197,4 +197,101 @@ describe("PlotSection", () => {
     fireEvent.click(screen.getByRole("radio", { name: "Gain" }));
     expect(onKindChange).toHaveBeenCalledWith("gain");
   });
+
+  describe("importance top-N toggle (PR-B2 / P-0097)", () => {
+    it("renders the toggle when on importance tab and a callback is provided", () => {
+      render(
+        <PlotSection
+          {...defaultProps}
+          selectedPlot="importance"
+          importanceTopN={30}
+          onImportanceTopNChange={vi.fn()}
+        />,
+      );
+      expect(screen.getByTestId("importance-topn-toggle")).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "30" })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "100" })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "all" })).toBeInTheDocument();
+    });
+
+    it("does not render the toggle on a non-importance tab", () => {
+      render(
+        <PlotSection
+          {...defaultProps}
+          selectedPlot="roc-curve"
+          importanceTopN={30}
+          onImportanceTopNChange={vi.fn()}
+        />,
+      );
+      expect(screen.queryByTestId("importance-topn-toggle")).toBeNull();
+    });
+
+    it("does not render the toggle when the callback is omitted", () => {
+      render(
+        <PlotSection
+          {...defaultProps}
+          selectedPlot="importance"
+          importanceTopN={30}
+        />,
+      );
+      expect(screen.queryByTestId("importance-topn-toggle")).toBeNull();
+    });
+
+    it("highlights the current value (number) on the toggle", () => {
+      render(
+        <PlotSection
+          {...defaultProps}
+          selectedPlot="importance"
+          importanceTopN={100}
+          onImportanceTopNChange={vi.fn()}
+        />,
+      );
+      // SegmentGroup uses radiogroup semantics; the active option is
+      // marked with aria-checked / data-state. Verify the active radio
+      // by name.
+      const active = screen.getByRole("radio", { name: "100" });
+      expect(active).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("highlights the 'all' value when topN is null", () => {
+      render(
+        <PlotSection
+          {...defaultProps}
+          selectedPlot="importance"
+          importanceTopN={null}
+          onImportanceTopNChange={vi.fn()}
+        />,
+      );
+      const active = screen.getByRole("radio", { name: "all" });
+      expect(active).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("calls onImportanceTopNChange with parsed number on click", () => {
+      const onChange = vi.fn();
+      render(
+        <PlotSection
+          {...defaultProps}
+          selectedPlot="importance"
+          importanceTopN={30}
+          onImportanceTopNChange={onChange}
+        />,
+      );
+      fireEvent.click(screen.getByRole("radio", { name: "100" }));
+      expect(onChange).toHaveBeenCalledWith(100);
+    });
+
+    it("calls onImportanceTopNChange with null when 'all' is picked", () => {
+      const onChange = vi.fn();
+      render(
+        <PlotSection
+          {...defaultProps}
+          selectedPlot="importance"
+          importanceTopN={30}
+          onImportanceTopNChange={onChange}
+        />,
+      );
+      fireEvent.click(screen.getByRole("radio", { name: "all" }));
+      expect(onChange).toHaveBeenCalledWith(null);
+    });
+  });
 });

--- a/frontend/src/components/workspace/PlotSection.tsx
+++ b/frontend/src/components/workspace/PlotSection.tsx
@@ -58,6 +58,12 @@ interface PlotSectionProps {
   importanceData?: ImportanceResponse;
   /** Importance plot data (kind-independent, always default/split). */
   importancePlot?: PlotResponse;
+  /**
+   * PR-B2 / P-0097: top-N projection for the importance table. `null`
+   * means "show all" (no top_n forwarded).
+   */
+  importanceTopN?: number | null;
+  onImportanceTopNChange?: (n: number | null) => void;
 }
 
 export function PlotSection({
@@ -76,6 +82,8 @@ export function PlotSection({
   onImportanceKindChange,
   importanceData,
   importancePlot,
+  importanceTopN,
+  onImportanceTopNChange,
 }: PlotSectionProps) {
   // Exclude "tuning" — shown in TuneTrialsSection, not in plot tabs
   const availablePlots = plots.filter((p) => p !== "tuning");
@@ -182,6 +190,25 @@ export function PlotSection({
           plotlyJson={activePlotData.plotly_json}
           height={chartHeight}
         />
+      )}
+
+      {/* PR-B2 / P-0097: Top-N / Show-all toggle for the importance table. */}
+      {isImportance && onImportanceTopNChange && (
+        <div
+          data-testid="importance-topn-toggle"
+          className="mb-2 mt-3 flex items-center gap-2 text-xs text-muted-foreground"
+        >
+          <span>Show:</span>
+          <SegmentGroup
+            options={["30", "100", "all"]}
+            value={importanceTopN === null ? "all" : String(importanceTopN)}
+            onChange={(v) =>
+              onImportanceTopNChange(
+                v === "all" ? null : Number.parseInt(v, 10),
+              )
+            }
+          />
+        </div>
       )}
 
       {/* Importance table (below plot) */}

--- a/frontend/src/components/workspace/SearchableSelect.test.tsx
+++ b/frontend/src/components/workspace/SearchableSelect.test.tsx
@@ -1,0 +1,173 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SearchableSelect } from "./SearchableSelect";
+
+describe("SearchableSelect (PR-B2 / wide DataFrame)", () => {
+  it("renders the trigger with the placeholder when no value is selected", () => {
+    render(
+      <SearchableSelect
+        value=""
+        options={["age", "color", "name"]}
+        onChange={vi.fn()}
+        placeholder="Select target column"
+        ariaLabel="Target column"
+      />,
+    );
+    expect(
+      screen.getByRole("combobox", { name: "Target column" }),
+    ).toHaveTextContent("Select target column");
+  });
+
+  it("displays the current value on the trigger when one is selected", () => {
+    render(
+      <SearchableSelect
+        value="color"
+        options={["age", "color", "name"]}
+        onChange={vi.fn()}
+        placeholder="Select target column"
+        ariaLabel="Target column"
+      />,
+    );
+    expect(
+      screen.getByRole("combobox", { name: "Target column" }),
+    ).toHaveTextContent("color");
+  });
+
+  it("opens the listbox when the trigger is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <SearchableSelect
+        value=""
+        options={["age", "color", "name"]}
+        onChange={vi.fn()}
+        placeholder="Select target column"
+        ariaLabel="Target column"
+      />,
+    );
+    await user.click(screen.getByRole("combobox", { name: "Target column" }));
+    // cmdk renders a listbox role inside the popover
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+  });
+
+  it("filters options as the user types", async () => {
+    const user = userEvent.setup();
+    render(
+      <SearchableSelect
+        value=""
+        options={["age", "color", "name"]}
+        onChange={vi.fn()}
+        placeholder="Select target column"
+        ariaLabel="Target column"
+      />,
+    );
+    await user.click(screen.getByRole("combobox", { name: "Target column" }));
+    const input = screen.getByPlaceholderText("Search...");
+    await user.type(input, "co");
+    // Only "color" matches "co"
+    expect(screen.getByRole("option", { name: "color" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "age" })).toBeNull();
+  });
+
+  it("calls onChange and closes the listbox when an option is picked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SearchableSelect
+        value=""
+        options={["age", "color", "name"]}
+        onChange={onChange}
+        placeholder="Select target column"
+        ariaLabel="Target column"
+      />,
+    );
+    await user.click(screen.getByRole("combobox", { name: "Target column" }));
+    await user.click(screen.getByRole("option", { name: "color" }));
+    expect(onChange).toHaveBeenCalledWith("color");
+  });
+
+  it("disables the trigger when disabled=true", () => {
+    render(
+      <SearchableSelect
+        value=""
+        options={["age", "color", "name"]}
+        onChange={vi.fn()}
+        placeholder="Select target column"
+        ariaLabel="Target column"
+        disabled
+      />,
+    );
+    expect(
+      screen.getByRole("combobox", { name: "Target column" }),
+    ).toBeDisabled();
+  });
+
+  it("shows an empty-state message when no options match the query", async () => {
+    const user = userEvent.setup();
+    render(
+      <SearchableSelect
+        value=""
+        options={["age", "color"]}
+        onChange={vi.fn()}
+        placeholder="Select target column"
+        ariaLabel="Target column"
+      />,
+    );
+    await user.click(screen.getByRole("combobox", { name: "Target column" }));
+    const input = screen.getByPlaceholderText("Search...");
+    await user.type(input, "xyz_no_match");
+    expect(screen.getByText(/no .*found/i)).toBeInTheDocument();
+  });
+
+  // cmdk runs its substring filter in pure JS; 5000 entries pushes the
+  // happy-dom event loop past the default 5s vitest budget under heavy
+  // suite load. Bump the per-test timeout — production renders this in
+  // < 50ms because real browsers don't run synchronous DOM polyfills.
+  it("scales to thousands of options without crashing", {
+    timeout: 15000,
+  }, async () => {
+    const user = userEvent.setup();
+    const opts = Array.from(
+      { length: 5000 },
+      (_, i) => `f_${i.toString().padStart(5, "0")}`,
+    );
+    render(
+      <SearchableSelect
+        value=""
+        options={opts}
+        onChange={vi.fn()}
+        placeholder="Select target column"
+        ariaLabel="Target column"
+      />,
+    );
+    await user.click(screen.getByRole("combobox", { name: "Target column" }));
+    // Type a unique substring; cmdk filters in <O(N)> so this completes
+    // quickly even with 5000 entries.
+    const input = screen.getByPlaceholderText("Search...");
+    await user.type(input, "00042");
+    expect(screen.getByRole("option", { name: "f_00042" })).toBeInTheDocument();
+  });
+
+  it("keyboard: ArrowDown then Enter selects the highlighted option", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <SearchableSelect
+        value=""
+        options={["age", "color", "name"]}
+        onChange={onChange}
+        placeholder="Select target column"
+        ariaLabel="Target column"
+      />,
+    );
+    await user.click(screen.getByRole("combobox", { name: "Target column" }));
+    const input = screen.getByPlaceholderText("Search...");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).toHaveBeenCalled();
+    // First option (age) is the default highlight; Enter picks it after
+    // ArrowDown moves to the second (color). Either is acceptable as
+    // long as some option fired.
+    expect(onChange.mock.calls[0][0]).toMatch(/age|color/);
+  });
+});

--- a/frontend/src/components/workspace/SearchableSelect.tsx
+++ b/frontend/src/components/workspace/SearchableSelect.tsx
@@ -1,0 +1,102 @@
+import { Check, ChevronsUpDown } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+interface SearchableSelectProps {
+  value: string;
+  options: readonly string[];
+  onChange: (value: string) => void;
+  placeholder?: string;
+  ariaLabel: string;
+  disabled?: boolean;
+  className?: string;
+  emptyMessage?: string;
+}
+
+/**
+ * PR-B2 / P-0097: searchable single-select used by the wide-DataFrame
+ * UI for picking a Target column out of thousands. Wraps cmdk's
+ * `<Command>` (substring filter, full keyboard nav) inside a Radix
+ * Popover so it slots cleanly into the same layout as the existing
+ * shadcn Select while remaining usable at 10,000+ options.
+ */
+export function SearchableSelect({
+  value,
+  options,
+  onChange,
+  placeholder = "Select an option",
+  ariaLabel,
+  disabled = false,
+  className,
+  emptyMessage = "No matches found.",
+}: SearchableSelectProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-label={ariaLabel}
+          disabled={disabled}
+          className={cn(
+            "h-8 w-full justify-between font-normal",
+            !value && "text-muted-foreground",
+            className,
+          )}
+        >
+          <span className="truncate">{value || placeholder}</span>
+          <ChevronsUpDown className="ml-2 h-3 w-3 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[--radix-popover-trigger-width] min-w-[14rem] p-0"
+        align="start"
+      >
+        <Command>
+          <CommandInput placeholder="Search..." aria-label="Search options" />
+          <CommandList>
+            <CommandEmpty>{emptyMessage}</CommandEmpty>
+            <CommandGroup>
+              {options.map((opt) => (
+                <CommandItem
+                  key={opt}
+                  value={opt}
+                  onSelect={() => {
+                    onChange(opt);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      value === opt ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  {opt}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/hooks/useColumnOverrides.test.ts
+++ b/frontend/src/hooks/useColumnOverrides.test.ts
@@ -180,6 +180,68 @@ describe("useColumnOverrides", () => {
     expect(result.current.summary.manualCount).toBe(0);
   });
 
+  describe("bulk operations (PR-B2 / wide DataFrame)", () => {
+    it("handleBulkExcludeToggle sets excluded=true on every named column in one update", () => {
+      const { result } = renderHook(() =>
+        useColumnOverrides({ columns: COLUMNS, target: "age" }),
+      );
+
+      act(() => {
+        result.current.handleBulkExcludeToggle(["id", "color"], true);
+      });
+
+      expect(result.current.overrides.id?.excluded).toBe(true);
+      expect(result.current.overrides.color?.excluded).toBe(true);
+      // Untouched column stays at its prior value
+      expect(result.current.overrides.const_col?.excluded).toBeUndefined();
+    });
+
+    it("handleBulkExcludeToggle preserves any prior type override", () => {
+      const { result } = renderHook(() =>
+        useColumnOverrides({ columns: COLUMNS, target: "age" }),
+      );
+
+      act(() => {
+        result.current.setOverrides({
+          color: { excluded: false, type: "numeric" },
+        });
+      });
+      act(() => {
+        result.current.handleBulkExcludeToggle(["color"], true);
+      });
+
+      expect(result.current.overrides.color).toEqual({
+        excluded: true,
+        type: "numeric",
+      });
+    });
+
+    it("handleBulkTypeChange sets type on every named column", () => {
+      const { result } = renderHook(() =>
+        useColumnOverrides({ columns: COLUMNS, target: "age" }),
+      );
+
+      act(() => {
+        result.current.handleBulkTypeChange(["color", "id"], "categorical");
+      });
+
+      expect(result.current.overrides.color?.type).toBe("categorical");
+      expect(result.current.overrides.id?.type).toBe("categorical");
+    });
+
+    it("handleBulkExcludeToggle with empty list is a no-op (no state change)", () => {
+      const { result } = renderHook(() =>
+        useColumnOverrides({ columns: COLUMNS, target: "age" }),
+      );
+      const before = result.current.overrides;
+      act(() => {
+        result.current.handleBulkExcludeToggle([], true);
+      });
+      // Reference equality holds because no setOverrides call should fire.
+      expect(result.current.overrides).toBe(before);
+    });
+  });
+
   it("nonExcludedCols filters out target and excluded columns", () => {
     const { result } = renderHook(() =>
       useColumnOverrides({ columns: COLUMNS, target: "age" }),

--- a/frontend/src/hooks/useColumnOverrides.ts
+++ b/frontend/src/hooks/useColumnOverrides.ts
@@ -40,6 +40,42 @@ export function useColumnOverrides({
     }));
   };
 
+  /**
+   * PR-B2 / P-0097: bulk Exclude / Include for the wide-DataFrame UX.
+   * Calling `handleExcludeToggle` once per column triggers N React
+   * state updates and N PUT-coalesce events; this variant collapses
+   * all of them into a single `setOverrides` call so the funnel sees
+   * one change. Empty input is a no-op (returns the same reference)
+   * to keep the toolbar idempotent when the filter matches nothing.
+   */
+  const handleBulkExcludeToggle = useCallback(
+    (colNames: readonly string[], checked: boolean) => {
+      if (colNames.length === 0) return;
+      setOverrides((prev) => {
+        const next = { ...prev };
+        for (const name of colNames) {
+          next[name] = { ...prev[name], excluded: checked };
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const handleBulkTypeChange = useCallback(
+    (colNames: readonly string[], type: "numeric" | "categorical") => {
+      if (colNames.length === 0) return;
+      setOverrides((prev) => {
+        const next = { ...prev };
+        for (const name of colNames) {
+          next[name] = { ...prev[name], type };
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
   const handleColumnExpand = useCallback(
     async (colName: string) => {
       if (expandedCol === colName) {
@@ -106,6 +142,8 @@ export function useColumnOverrides({
     nonExcludedCols,
     handleExcludeToggle,
     handleTypeChange,
+    handleBulkExcludeToggle,
+    handleBulkTypeChange,
     handleColumnExpand,
   };
 }

--- a/frontend/src/hooks/useDataPanel.ts
+++ b/frontend/src/hooks/useDataPanel.ts
@@ -295,6 +295,8 @@ export function useDataPanel({
     handleTaskChange,
     handleExcludeToggle: columnOverrides.handleExcludeToggle,
     handleTypeChange: columnOverrides.handleTypeChange,
+    handleBulkExcludeToggle: columnOverrides.handleBulkExcludeToggle,
+    handleBulkTypeChange: columnOverrides.handleBulkTypeChange,
     handleColumnExpand: columnOverrides.handleColumnExpand,
   };
 }

--- a/frontend/src/hooks/useJobResultData.test.ts
+++ b/frontend/src/hooks/useJobResultData.test.ts
@@ -237,7 +237,9 @@ describe("useJobResultData", () => {
 
     await waitFor(() => {
       expect(fetchJobImportanceKinds).toHaveBeenCalledWith("j1");
-      expect(fetchJobImportance).toHaveBeenCalledWith("j1", "split");
+      expect(fetchJobImportance).toHaveBeenCalledWith("j1", "split", {
+        topN: 30,
+      });
       expect(fetchJobPlot).toHaveBeenCalledWith("j1", "importance", {
         kind: "split",
       });

--- a/frontend/src/hooks/useJobResultData.ts
+++ b/frontend/src/hooks/useJobResultData.ts
@@ -60,6 +60,13 @@ export interface UseJobResultData {
   importance: ImportanceResponse | undefined;
   importancePlot: PlotResponse | undefined;
   isImportancePlotLoading: boolean;
+  /**
+   * PR-B2 / P-0097: top-N projection state for the importance table.
+   * `null` means "show all" (no top_n forwarded). The default of 30
+   * keeps the wide-DataFrame UX responsive.
+   */
+  importanceTopN: number | null;
+  setImportanceTopN: (n: number | null) => void;
   /** Fold split summary. */
   splitSummary: SplitSummaryRow[] | undefined;
   /** Tuning plot (only populated for tune jobs). */
@@ -166,6 +173,11 @@ export function useJobResultData({
   // --------------------------------------------------------------------
   const importanceEnabled = plots?.includes("importance") ?? false;
   const [importanceKind, setImportanceKind] = useState("split");
+  // PR-B2 / P-0097: default to the server-side top-30 projection so the
+  // wide-DataFrame importance table stays under the 5MB payload cap and
+  // renders in a single frame. Users opt back into the unbounded list
+  // via the "Show all" toggle in PlotSection.
+  const [importanceTopN, setImportanceTopN] = useState<number | null>(30);
 
   const { data: importanceKinds } = useQuery({
     queryKey: queryKeys.jobImportanceKinds(job.job_id),
@@ -184,8 +196,17 @@ export function useJobResultData({
   }, [importanceKinds, importanceKind]);
 
   const { data: importance } = useQuery({
-    queryKey: queryKeys.jobImportance(job.job_id, importanceKind),
-    queryFn: () => fetchJobImportance(job.job_id, importanceKind),
+    queryKey: queryKeys.jobImportance(
+      job.job_id,
+      importanceKind,
+      importanceTopN,
+    ),
+    queryFn: () =>
+      fetchJobImportance(
+        job.job_id,
+        importanceKind,
+        importanceTopN != null ? { topN: importanceTopN } : undefined,
+      ),
     enabled: importanceEnabled,
   });
 
@@ -259,6 +280,8 @@ export function useJobResultData({
     importance,
     importancePlot,
     isImportancePlotLoading,
+    importanceTopN,
+    setImportanceTopN,
     splitSummary,
     tuningPlot,
     metrics,


### PR DESCRIPTION
## Summary

PR-B2 of the **Wide DataFrame** track (Phase B / v0.4.0). Builds on PR #385 (PR-B1 backend foundation). Five user-visible features in the Workspace UI:

1. **Column Settings virtualization** (`@tanstack/react-virtual`) — windows the per-column row list once the visible count crosses 200. The workspace now renders the configuration UI for 10,000-column datasets without freezing scroll on first paint.
2. **Searchable Target combobox** (`SearchableSelect`, cmdk + Popover) — replaces the shadcn `<Select>`. Substring filter, full keyboard nav, scales to thousands of options.
3. **Importance top-N toggle** — Plots panel exposes a 30 / 100 / all toggle wired to the new `top_n` query (PR-B1). Default = top-30 server-side projection so the table fits well under the 5MB payload cap.
4. **Bulk Exclude / Include / Set type** — when the Column Settings filter matches one or more columns, a toolbar above the row list applies the action to every filtered column in a single state update.
5. **Feature Weights 1k-column guard** — Switch is disabled with an inline message above 1,000 non-excluded columns (the per-feature picker is not the right model at that scale).

Closes #361.

## Test Plan

- [x] `pnpm test` — 1837 pass / 0 fail
- [x] `pnpm check` — biome clean
- [x] `pnpm build` — production bundle clean
- [x] `tsc -b` — typecheck clean
- [x] Coverage: 93.4% statements / 87.4% branches / 92.4% functions / 94.7% lines (thresholds 80/70/75/80)
- [x] `uv run pytest` — 1305 pass / 7 skipped (no backend changes; verified no regressions)

## Implementation notes

- `useColumnOverrides` gains `handleBulkExcludeToggle(names, checked)` and `handleBulkTypeChange(names, type)` — both collapse into a single `setOverrides` so the write funnel sees one change instead of N.
- `ColumnSettingsSection` extracts a shared `<ColumnRow>` and conditionally mounts either the existing fully-rendered list (when ≤ 200 visible columns) or the virtualized list. Below threshold the existing test surface is preserved unchanged.
- `SearchableSelect` is a generic `cmdk + Popover` combobox; only the Target field uses it for now.
- `fetchJobImportance(jobId, kind, { topN })` and `queryKeys.jobImportance(jobId, kind, topN?)` extended; existing callers default to `topN = null` (full list) — only the new hook state opts in to top-30.

## Phase B status

- ✅ PR-B1 (#385) — API foundation
- ✅ **PR-B2 (this PR) — Frontend Wide UI**
- 🔲 PR-B3 — Large CSV scaling (pandas chunksize) + #383 stress tests
- 🔲 PR-B4 — R-3.3 plot symmetric audit + R-3.4 Validate API
- 🔲 PR-B5 — v0.4.0 release tag + PyPI publish