### PR TITLE
feat(api,docs): Validate severity/suggested_fix + plot matrix audit (PR-B4 / R-3.3 / R-3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,24 @@ Foundation PR for Issue #361.
   picker is not the right interaction model at that scale; the guard
   surfaces the limit instead of silently breaking the UI.
 
+### Backend (PR-B4 — Plot symmetric audit + Validate API enhancement)
+
+- **Validate API now carries `severity` + `suggested_fix` (R-3.4)** —
+  `POST /api/workspace/config/validate` and the inline validation in
+  `PUT /api/workspace/config` now return error dicts with two new
+  fields: `severity` (`"error" | "warning" | "info"`) and
+  `suggested_fix` (string or `null`). Backend Pydantic errors default
+  to `severity="error"` and `suggested_fix=null`; the workspace-aware
+  `n_splits > n_rows` validator surfaces a concrete fix string
+  (e.g. `"Set Folds (split.n_splits) to 100 or fewer."`). The legacy
+  `path` and `message` fields are unchanged so older frontend builds
+  continue to work.
+- **Plot symmetric audit (R-3.3)** — added `docs/plot-matrix.md`, the
+  single source of truth for the plot inventory across the LizyML
+  adapter, the API, and the frontend. The audit caught `shap-summary`
+  missing from `PLOT_LABELS` (rendered as raw kebab-case in the tab
+  strip); fixed in this PR with the symmetry rule pinned in the doc.
+
 ### Backend (PR-B3 — Large CSV scaling + #383 stress tests)
 
 - **Chunked CSV load with fail-fast memory guard (P-0098)** —

--- a/docs/plot-matrix.md
+++ b/docs/plot-matrix.md
@@ -1,0 +1,86 @@
+# Plot Matrix — backend / frontend symmetry
+
+**Status**: ✅ shipped 2026-05-05 (PR-B4 / R-3.3)
+**Owner**: Phase B / v0.4.0 plot audit
+**Related**: PR #385 (PR-B1), PR #386 (PR-B2), `BLUEPRINT.md` §5 plots, `docs/v0.4-business-readiness-plan.md` §6 (R-3.3)
+
+The plot subsystem spans three layers: the LizyML adapter
+(`src/lizystudio/backends/lizyml/evaluation_mixin.py`) declares which
+plot types exist and how to render them; the JobStore + jobs API
+(`src/lizystudio/api/jobs.py`) ships `GET /api/jobs/{id}/plots` and
+`GET /api/jobs/{id}/plot/{plot_type}`; the frontend
+(`frontend/src/components/workspace/PlotSection.tsx`) renders the
+labels and tab strip. **A plot type that exists in one layer but not
+the others is a silent UX bug** — the frontend either falls back to
+showing the raw kebab-case ID, or the backend returns 404 for a tab
+the user can see.
+
+This file is the single source of truth for the inventory + per-row
+symmetry checks. Every plot-touching PR must update both this matrix
+*and* the relevant code; new plot types land in all layers in the
+same PR.
+
+---
+
+## Inventory (as of 2026-05-05, post PR-B3)
+
+| Plot ID                    | Adapter dispatch            | Frontend label    | Task scope          | Notes |
+|----------------------------|-----------------------------|-------------------|---------------------|-------|
+| `learning-curve`           | `plot_learning_curve`       | `Learning Curve`  | all                 | accepts `metrics` filter |
+| `oof-distribution`         | `plot_oof_distribution`     | `OOF Dist`        | all                 | |
+| `roc-curve`                | `roc_curve_plot`            | `ROC`             | binary              | |
+| `calibration`              | `calibration_plot`          | `Calibration`     | binary + cal enabled | |
+| `probability-histogram`    | `probability_histogram_plot`| `Prob Hist`       | binary + cal enabled | |
+| `residuals`                | `residuals_plot`            | `Residuals`       | regression          | |
+| `importance`               | `importance_plot`           | `Importance`      | all                 | accepts `kind={split,gain,shap}`; `top_n` query (P-0097) |
+| `shap-summary`             | `importance_plot`           | `SHAP Summary`    | all + shap installed| alias of `importance_plot(kind="shap")` (Issue #373) |
+| `tuning`                   | `tuning_plot`               | _(in TuneTrialsSection)_ | tune jobs    | NOT in `PLOT_LABELS` — rendered by `TuneTrialsSection`, intentionally absent from the tab strip |
+
+### Source map
+
+| Layer | File | Symbol |
+|---|---|---|
+| Adapter dispatch | `src/lizystudio/backends/lizyml/evaluation_mixin.py` | `_PLOT_DISPATCH` |
+| Adapter availability probe | `src/lizystudio/backends/lizyml/evaluation_mixin.py` | `available_plots()` |
+| API list endpoint | `src/lizystudio/api/jobs.py` | `GET /api/jobs/{id}/plots` |
+| API render endpoint | `src/lizystudio/api/jobs.py` | `GET /api/jobs/{id}/plot/{plot_type}` |
+| Frontend labels | `frontend/src/components/workspace/PlotSection.tsx` | `PLOT_LABELS` |
+| Importance kind labels | `frontend/src/components/workspace/PlotSection.tsx` | `KIND_LABELS` |
+
+---
+
+## Symmetry rules (must hold)
+
+1. **Adapter ⊇ frontend (with one exception)**: every key in `PLOT_LABELS` must be a key in `_PLOT_DISPATCH`. The lone exception is `tuning`, which is dispatched by the adapter but rendered by `TuneTrialsSection` rather than the tab strip — the inverse direction (`_PLOT_DISPATCH \ {tuning} ⊆ PLOT_LABELS`) holds.
+2. **availability_plots ⊆ _PLOT_DISPATCH**: every plot ID returned by `available_plots()` must dispatch correctly. `shap-summary` is conditionally probed via a try/except on `importance(kind="shap")` because shap is an optional dependency.
+3. **Frontend always falls back to kebab-case**: when `PLOT_LABELS[id]` is missing, the tab strip renders `id` directly (`PlotSection.tsx:147`). This is graceful, but invisible — anyone shipping a plot must update the label table to keep the UI polished.
+
+### Verification
+
+The adapter side is unit-tested in `tests/test_lizyml_evaluation_mixin.py` (one case per `_PLOT_DISPATCH` entry). The frontend side has snapshot coverage in `frontend/src/components/workspace/PlotSection.test.tsx`. There is no automated cross-layer drift check today — the matrix above plus the source map are the contract.
+
+---
+
+## How to add a new plot type
+
+1. Implement the rendering on the lizyml side (or wherever the new backend lives).
+2. Add the dispatch entry to `_PLOT_DISPATCH` and probe in `available_plots()` if the prerequisite is conditional (optional dependency, task type).
+3. Add a unit test exercising the new dispatch entry.
+4. Add the human label to `PLOT_LABELS` (and `KIND_LABELS` if it needs sub-kinds).
+5. Add a row to the inventory table above.
+6. If the new plot has its own toolbar (top-N, kind selector, metric filter), wire the props through `JobResultsBody.tsx` → `PlotSection.tsx`.
+7. Capture a Storybook snapshot if the plot has unique visual chrome.
+
+---
+
+## How to remove / rename a plot type
+
+1. Add a deprecation comment + removal target version to the relevant `_PLOT_DISPATCH` entry.
+2. Keep the entry around for **one** minor release to give users time to remove it from their muscle memory.
+3. After the grace release: drop from `_PLOT_DISPATCH`, drop from `PLOT_LABELS`, drop the row here, and add a `BREAKING` line to `CHANGELOG.md`.
+
+---
+
+## History
+
+- **2026-05-05** — file created as part of PR-B4 (R-3.3 audit). `shap-summary` was missing from `PLOT_LABELS` and rendered as raw kebab-case in the tab strip; PR-B4 fixed the label and pinned the symmetry rule above.

--- a/frontend/src/components/workspace/PlotSection.tsx
+++ b/frontend/src/components/workspace/PlotSection.tsx
@@ -19,6 +19,11 @@ import {
 import { PlotlyChart } from "./PlotlyChart";
 import { SegmentGroup } from "./SegmentGroup";
 
+// PR-B4 / R-3.3: PLOT_LABELS must mirror the backend's
+// _PLOT_DISPATCH (src/lizystudio/backends/lizyml/evaluation_mixin.py).
+// docs/plot-matrix.md tracks the full inventory + symmetry checks;
+// any new plot type added on either side must land in both maps in
+// the same PR.
 const PLOT_LABELS: Record<string, string> = {
   "learning-curve": "Learning Curve",
   "oof-distribution": "OOF Dist",
@@ -27,6 +32,9 @@ const PLOT_LABELS: Record<string, string> = {
   "probability-histogram": "Prob Hist",
   residuals: "Residuals",
   importance: "Importance",
+  "shap-summary": "SHAP Summary",
+  // tuning is intentionally omitted — it is rendered by
+  // TuneTrialsSection, not the per-plot tab strip.
 };
 
 const KIND_LABELS: Record<string, string> = {

--- a/src/lizystudio/services/workspace.py
+++ b/src/lizystudio/services/workspace.py
@@ -162,7 +162,15 @@ def get_default_config(ws: WorkspaceState, task: str, target: str) -> dict[str, 
 def validate_config(ws: WorkspaceState, config: dict[str, Any]) -> list[dict[str, Any]]:
     """Validate a config dict against the backend.
 
-    Normalizes Pydantic v2 error dicts to ``{path, message}`` for the frontend.
+    PR-B4 / R-3.4: each error dict now carries ``severity`` and
+    ``suggested_fix`` fields in addition to the legacy ``path`` and
+    ``message``. Backend Pydantic errors default to
+    ``severity="error"`` and ``suggested_fix=None`` because the schema
+    has no canned repair text; workspace-aware validators
+    (``_workspace_split_errors``) supply both fields directly.
+
+    Normalizes Pydantic v2 error dicts to
+    ``{path, message, severity, suggested_fix}`` for the frontend.
     """
     raw_errors = ws.backend.validate_config(config)
     normalized: list[dict[str, Any]] = []
@@ -171,7 +179,14 @@ def validate_config(ws: WorkspaceState, config: dict[str, Any]) -> list[dict[str
         path = ".".join(str(p) for p in loc) if loc else err.get("path", "")
         message = err.get("msg", err.get("message", ""))
         if path or message:
-            normalized.append({"path": path, "message": message})
+            normalized.append(
+                {
+                    "path": path,
+                    "message": message,
+                    "severity": "error",
+                    "suggested_fix": None,
+                }
+            )
     # Issue #268: workspace-aware validation. n_splits > n_rows is
     # accepted by Pydantic (no row-count knowledge inside the schema)
     # but explodes ~5s after Fit with sklearn's
@@ -212,6 +227,8 @@ def _workspace_split_errors(
                 f"samples in the loaded dataset (n_rows={n_rows}). "
                 f"Reduce Folds to at most {n_rows}."
             ),
+            "severity": "error",
+            "suggested_fix": (f"Set Folds (split.n_splits) to {n_rows} or fewer."),
         }
     ]
 

--- a/tests/contract/test_validate_severity_and_suggested_fix.py
+++ b/tests/contract/test_validate_severity_and_suggested_fix.py
@@ -1,0 +1,140 @@
+"""Validate API severity + suggested_fix contract (PR-B4 / R-3.4).
+
+The pre-PR-B4 ``validate_config`` returned ``[{path, message}]``. PR-B4
+extends each error dict with two structured fields the frontend can
+render directly:
+
+- ``severity``: one of ``"error" | "warning" | "info"``. Errors block
+  Fit/Tune; warnings surface a yellow banner but allow the user to
+  proceed; info entries are tooltip-level guidance.
+- ``suggested_fix``: optional human-readable next-action string. ``None``
+  when the validator does not know how to repair the field.
+
+This file pins the schema of the new fields so frontend ergonomics do
+not silently regress when validators are added or refactored.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.unit
+
+
+def _get_valid_binary_config(client: TestClient) -> dict[str, Any]:
+    res = client.get("/api/workspace/config/defaults?task=binary&target=y")
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def test_validate_error_dict_has_severity_field(client: TestClient) -> None:
+    """Every entry in the validation errors list must carry ``severity``.
+
+    The default for backend Pydantic errors is ``"error"`` because they
+    block Fit/Tune; this test fails today (severity field absent) and
+    passes once the service layer adds it.
+    """
+    res = client.post(
+        "/api/workspace/config/validate",
+        json={"task": "invalid_task"},
+    )
+    assert res.status_code == 200, res.text
+    errors = res.json()["errors"]
+    assert len(errors) > 0
+    for err in errors:
+        assert "severity" in err, f"validation entry missing severity: {err}"
+        assert err["severity"] in ("error", "warning", "info")
+
+
+def test_validate_error_dict_has_suggested_fix_field(client: TestClient) -> None:
+    """Every entry must include the optional ``suggested_fix`` field.
+
+    The field is allowed to be ``None`` (validator has no canned
+    repair) but the *key* must always be present so the frontend
+    renders a stable shape.
+    """
+    res = client.post(
+        "/api/workspace/config/validate",
+        json={"task": "invalid_task"},
+    )
+    assert res.status_code == 200, res.text
+    errors = res.json()["errors"]
+    assert len(errors) > 0
+    for err in errors:
+        assert "suggested_fix" in err, f"validation entry missing suggested_fix: {err}"
+        assert err["suggested_fix"] is None or isinstance(err["suggested_fix"], str)
+
+
+def test_workspace_split_error_carries_suggested_fix(
+    client: TestClient,
+) -> None:
+    """The ``n_splits > n_rows`` validator owns its suggested fix.
+
+    The legacy message already says "Reduce Folds to at most {n_rows}"
+    — PR-B4 surfaces that in the dedicated ``suggested_fix`` field so
+    the frontend can render it as a CTA button rather than scraping
+    the prose.
+    """
+    # Stage a small dataset so the workspace-aware split validator
+    # can compute a meaningful row-count gap.
+    import csv
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        writer = csv.writer(f)
+        writer.writerow(["a", "b", "y"])
+        for i in range(10):
+            writer.writerow([i, i + 1, i % 2])
+        csv_path = f.name
+
+    res = client.post("/api/workspace/data/path", json={"path": csv_path})
+    assert res.status_code == 200, res.text
+
+    # Build a config with n_splits > n_rows so the workspace
+    # validator fires.
+    config = _get_valid_binary_config(client)
+    config["split"]["n_splits"] = 999
+    res = client.post("/api/workspace/config/validate", json=config)
+    assert res.status_code == 200, res.text
+    errors = res.json()["errors"]
+
+    split_errors = [e for e in errors if e["path"] == "split.n_splits"]
+    assert len(split_errors) == 1, errors
+    err = split_errors[0]
+    assert err["severity"] == "error"
+    assert err["suggested_fix"] is not None
+    # The suggested fix should mention a concrete number to set, not
+    # just paraphrase the problem.
+    assert "10" in err["suggested_fix"], err["suggested_fix"]
+
+
+def test_validate_response_schema_stays_backward_compatible(
+    client: TestClient,
+) -> None:
+    """Adding ``severity`` / ``suggested_fix`` must not drop the legacy
+    ``path`` / ``message`` keys — older frontend builds still read those.
+    """
+    res = client.post(
+        "/api/workspace/config/validate",
+        json={"task": "invalid_task"},
+    )
+    errors = res.json()["errors"]
+    assert len(errors) > 0
+    for err in errors:
+        assert "path" in err
+        assert "message" in err
+
+
+def test_validate_no_errors_returns_empty_list(client: TestClient) -> None:
+    """Sanity: a clean config returns valid=True + no errors. The new
+    fields don't appear when there's nothing to surface.
+    """
+    defaults = _get_valid_binary_config(client)
+    res = client.post("/api/workspace/config/validate", json=defaults)
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["valid"] is True
+    assert body["errors"] == []


### PR DESCRIPTION
## Summary

PR-B4 of the **Wide DataFrame** track (Phase B / v0.4.0). Builds on PR #385 (PR-B1), PR #386 (PR-B2), and PR #387 (PR-B3).

1. **Validate API enhancement** (R-3.4) — error dicts from `POST /api/workspace/config/validate` and the inline validation in `PUT /api/workspace/config` now carry two new fields:
   - `severity`: `"error" | "warning" | "info"` (default `"error"`)
   - `suggested_fix`: human-readable next-action string or `null`

   Backend Pydantic errors default to `severity="error"` / `suggested_fix=null`. The workspace-aware `n_splits > n_rows` validator surfaces a concrete fix string (e.g. `"Set Folds (split.n_splits) to 100 or fewer."`). The legacy `path` / `message` keys are unchanged so older frontend builds continue to work.

2. **Plot symmetric audit** (R-3.3) — new `docs/plot-matrix.md` is the single source of truth for the plot inventory across the LizyML adapter (`_PLOT_DISPATCH`), the jobs API (`/api/jobs/{id}/plots`), and the frontend (`PLOT_LABELS`). Pins the symmetry rules so future plot additions land in all layers in one PR.

3. **PLOT_LABELS asymmetry fix** — the audit caught `shap-summary` missing from `PLOT_LABELS` (rendered as raw kebab-case in the tab strip). Added `shap-summary: "SHAP Summary"` plus a contextual comment pointing at the matrix doc. `tuning` is intentionally absent (rendered by `TuneTrialsSection`).

Diagnostic export (R-3.4 sub-item) was already shipped as a real implementation in PR-B1 (#385); the 4 contract tests in `tests/contract/test_diagnostic_export.py` already cover the envelope / 404 / 422 / path-leak invariants.

## Test Plan

- [x] `uv run pytest -x -q` — 1326 pass / 10 skipped (was 1321 + 5 new)
- [x] `pnpm test` — 1837 pass / 0 fail
- [x] `pnpm check` (biome) — clean
- [x] `tsc -b` — clean
- [x] `pnpm build` — clean
- [x] `uv run ruff check . && ruff format --check . && mypy src/lizystudio/services/workspace.py` — all clean

## Phase B status

- ✅ PR-B1 (#385) — API foundation
- ✅ PR-B2 (#386) — Frontend Wide UI
- ✅ PR-B3 (#387) — Large CSV scaling + #383 stress tests
- ✅ **PR-B4 (this PR) — Plot matrix audit + Validate API enhancement**
- 🔲 PR-B5 — v0.4.0 release tag + PyPI publish (requires user approval)