### PR TITLE
chore(release): finalize v0.4.0 CHANGELOG header (PR-B5 prep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-The **Wide DataFrame** track (Phase B / v0.4.0) starts here.
-Foundation PR for Issue #361.
+## [0.4.0] - 2026-05-05
+
+The **Wide DataFrame** release. Phase B (PR-B1 — PR-B5) closes the
+v0.4.0 business-readiness Exit Criteria around 10,000-column workspace
+support: the API ships value-bounded preview/importance payloads and a
+diagnostic export, the SPA renders 10k-column Workspaces without
+freezing, the upload path fails fast on oversize CSVs instead of
+OOM-crashing the worker, and the validate envelope carries actionable
+`severity` + `suggested_fix` fields the SPA can render directly.
+
+No breaking changes. The new query parameters (`max_cols`, `top_n`)
+default to the pre-v0.4.0 behaviour when omitted. The error dicts
+returned by `POST /api/workspace/config/validate` add two fields
+without removing the legacy `path` / `message` keys, so older
+frontend builds keep working unchanged.
 
 ### Added
 


### PR DESCRIPTION
## Summary

Bumps the CHANGELOG header from `[Unreleased]` to `[0.4.0] - 2026-05-05` ahead of the v0.4.0 release PR (develop → main). Two-line summary in the new header points at the Wide DataFrame focus of Phase B (PR-B1 — PR-B4) and confirms no breaking changes.

This is the prep PR — it lands on develop. The actual release PR (develop → main) opens immediately after this merges.

## Test Plan

- [x] Documentation-only change; no code touched
- [x] Markdown renders correctly (Keep a Changelog format preserved)
- [x] CI required checks (frontend / backend / e2e / etc.) will run as a sanity net even though no code changed

## Phase B status

- ✅ PR-B1 (#385) — API foundation
- ✅ PR-B2 (#386) — Frontend Wide UI
- ✅ PR-B3 (#387) — Large CSV scaling + #383 stress tests
- ✅ PR-B4 (#388) — Validate API + Plot matrix
- ⏳ **PR-B5 (this PR + the release PR that follows) — v0.4.0 release**