### PR TITLE
fix(workspace): hide redundant SHAP Summary tab in Workspace Plot panel (#393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Hide redundant `SHAP Summary` tab in Workspace Plot panel (#393)** —
+  Workspace previously surfaced SHAP both as a standalone `SHAP Summary`
+  tab and as `Importance` with `kind=shap`, which rendered identical
+  figures. The Workspace tab strip now filters out `shap-summary` so
+  SHAP is reachable only via the `Importance` tab's kind selector.
+  Inference's `SHAP Summary` accordion (#373) is unaffected — it does
+  not consume `PlotSection` and continues to render the dedicated
+  surface. `docs/plot-matrix.md` symmetry rule 1 generalised to allow
+  the `{tuning, shap-summary}` Workspace exclusion set.
+
 ## [0.4.0] - 2026-05-05
 
 The **Wide DataFrame** release. Phase B (PR-B1 — PR-B5) closes the

--- a/docs/plot-matrix.md
+++ b/docs/plot-matrix.md
@@ -33,7 +33,7 @@ same PR.
 | `probability-histogram`    | `probability_histogram_plot`| `Prob Hist`       | binary + cal enabled | |
 | `residuals`                | `residuals_plot`            | `Residuals`       | regression          | |
 | `importance`               | `importance_plot`           | `Importance`      | all                 | accepts `kind={split,gain,shap}`; `top_n` query (P-0097) |
-| `shap-summary`             | `importance_plot`           | `SHAP Summary`    | all + shap installed| alias of `importance_plot(kind="shap")` (Issue #373) |
+| `shap-summary`             | `importance_plot`           | _(see notes)_     | all + shap installed| alias of `importance_plot(kind="shap")` (Issue #373). NOT in Workspace `PLOT_LABELS` (Issue #393): Workspace surfaces SHAP via `Importance kind=shap`; Inference renders the SHAP Summary accordion (`ResultsPredOnly` / `ResultsWithGT`) which does not consume `PlotSection`. |
 | `tuning`                   | `tuning_plot`               | _(in TuneTrialsSection)_ | tune jobs    | NOT in `PLOT_LABELS` — rendered by `TuneTrialsSection`, intentionally absent from the tab strip |
 
 ### Source map
@@ -51,9 +51,11 @@ same PR.
 
 ## Symmetry rules (must hold)
 
-1. **Adapter ⊇ frontend (with one exception)**: every key in `PLOT_LABELS` must be a key in `_PLOT_DISPATCH`. The lone exception is `tuning`, which is dispatched by the adapter but rendered by `TuneTrialsSection` rather than the tab strip — the inverse direction (`_PLOT_DISPATCH \ {tuning} ⊆ PLOT_LABELS`) holds.
+1. **Adapter ⊇ frontend (with documented exclusions)**: every key in `PLOT_LABELS` must be a key in `_PLOT_DISPATCH`. The inverse direction (`_PLOT_DISPATCH \ EXCLUDED ⊆ PLOT_LABELS`) holds, where `EXCLUDED = {tuning, shap-summary}`. Both are dispatched by the adapter but intentionally absent from the Workspace tab strip:
+   - `tuning` is rendered by `TuneTrialsSection`.
+   - `shap-summary` is reachable from Workspace via `Importance kind=shap` (Issue #393); Inference renders SHAP via a dedicated accordion (Issue #373) which does not consume `PlotSection`. Both exclusions are enforced by the `availablePlots` filter in `PlotSection.tsx`.
 2. **availability_plots ⊆ _PLOT_DISPATCH**: every plot ID returned by `available_plots()` must dispatch correctly. `shap-summary` is conditionally probed via a try/except on `importance(kind="shap")` because shap is an optional dependency.
-3. **Frontend always falls back to kebab-case**: when `PLOT_LABELS[id]` is missing, the tab strip renders `id` directly (`PlotSection.tsx:147`). This is graceful, but invisible — anyone shipping a plot must update the label table to keep the UI polished.
+3. **Frontend always falls back to kebab-case**: when `PLOT_LABELS[id]` is missing, the tab strip renders `id` directly. This is graceful, but invisible — anyone shipping a plot must update the label table to keep the UI polished. (Excluded ids in rule 1 never reach the rendering branch because they are filtered out before lookup.)
 
 ### Verification
 
@@ -84,3 +86,4 @@ The adapter side is unit-tested in `tests/test_lizyml_evaluation_mixin.py` (one 
 ## History
 
 - **2026-05-05** — file created as part of PR-B4 (R-3.3 audit). `shap-summary` was missing from `PLOT_LABELS` and rendered as raw kebab-case in the tab strip; PR-B4 fixed the label and pinned the symmetry rule above.
+- **2026-05-05 (later, PR-C1 / Issue #393)** — `shap-summary` removed from `PLOT_LABELS` and added to the Workspace exclusion filter. SHAP is now reachable via `Importance kind=shap` only on the Workspace surface; Inference's SHAP Summary accordion (Issue #373) is unaffected because it does not consume `PlotSection`. Symmetry rule 1 generalised: the exclusion set is `{tuning, shap-summary}`.

--- a/frontend/src/components/workspace/PlotSection.test.tsx
+++ b/frontend/src/components/workspace/PlotSection.test.tsx
@@ -56,6 +56,29 @@ describe("PlotSection", () => {
     expect(screen.getByText("Importance")).toBeInTheDocument();
   });
 
+  // Issue #393: Workspace exposes SHAP through Importance kind=shap;
+  // the standalone shap-summary tab would be redundant. Inference uses
+  // a separate accordion (#373) and does not consume this component.
+  it('filters out "shap-summary" from plot tabs (use Importance kind=shap instead)', () => {
+    render(
+      <PlotSection
+        {...defaultProps}
+        plots={["roc-curve", "importance", "shap-summary"]}
+      />,
+    );
+    expect(screen.queryByText("SHAP Summary")).toBeNull();
+    expect(screen.queryByText("shap-summary")).toBeNull();
+    expect(screen.getByText("ROC")).toBeInTheDocument();
+    expect(screen.getByText("Importance")).toBeInTheDocument();
+  });
+
+  it("returns null when plots array only contains excluded ids", () => {
+    const { container } = render(
+      <PlotSection {...defaultProps} plots={["tuning", "shap-summary"]} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
   it("shows loading message when isLoading is true", () => {
     render(<PlotSection {...defaultProps} isLoading={true} />);
     expect(screen.getByText("Loading plot...")).toBeInTheDocument();

--- a/frontend/src/components/workspace/PlotSection.tsx
+++ b/frontend/src/components/workspace/PlotSection.tsx
@@ -24,6 +24,13 @@ import { SegmentGroup } from "./SegmentGroup";
 // docs/plot-matrix.md tracks the full inventory + symmetry checks;
 // any new plot type added on either side must land in both maps in
 // the same PR.
+//
+// Two backend plot IDs are intentionally absent from this map:
+//   - tuning       — rendered by TuneTrialsSection, not the tab strip.
+//   - shap-summary — Workspace exposes SHAP via `Importance kind=shap`
+//                    (Issue #393). Inference renders SHAP via a
+//                    dedicated accordion (Issue #373) which does not
+//                    use this component.
 const PLOT_LABELS: Record<string, string> = {
   "learning-curve": "Learning Curve",
   "oof-distribution": "OOF Dist",
@@ -32,9 +39,6 @@ const PLOT_LABELS: Record<string, string> = {
   "probability-histogram": "Prob Hist",
   residuals: "Residuals",
   importance: "Importance",
-  "shap-summary": "SHAP Summary",
-  // tuning is intentionally omitted — it is rendered by
-  // TuneTrialsSection, not the per-plot tab strip.
 };
 
 const KIND_LABELS: Record<string, string> = {
@@ -93,8 +97,14 @@ export function PlotSection({
   importanceTopN,
   onImportanceTopNChange,
 }: PlotSectionProps) {
-  // Exclude "tuning" — shown in TuneTrialsSection, not in plot tabs
-  const availablePlots = plots.filter((p) => p !== "tuning");
+  // Exclude "tuning" — shown in TuneTrialsSection, not in plot tabs.
+  // Exclude "shap-summary" (#393) — SHAP is reachable via the
+  // Importance tab's `kind=shap` selector; the standalone tab is
+  // redundant in Workspace. Inference renders SHAP via a dedicated
+  // accordion (#373) and does not consume this component.
+  const availablePlots = plots.filter(
+    (p) => p !== "tuning" && p !== "shap-summary",
+  );
 
   // Resolve which data to display
   const isLearningCurve = selectedPlot === "learning-curve";


### PR DESCRIPTION
## Summary

- Workspace exposed SHAP through two paths that rendered the same figure: the `SHAP Summary` tab and `Importance` with `kind=shap`. The duplicate tab was UX clutter (discovered during v0.4.0 GUI verification on 2026-05-05).
- Drop `shap-summary` from the Workspace tab strip via the existing `availablePlots` filter; remove it from `PLOT_LABELS` so the symmetry rule mirrors the existing `tuning` carve-out.
- Inference is unaffected — the `SHAP Summary` accordion in `ResultsPredOnly` / `ResultsWithGT` (Issue #373) does not consume `PlotSection`.

Closes #393.

## Acceptance criteria

- [x] Workspace Plot panel does NOT show `SHAP Summary` tab when SHAP is available.
- [x] Workspace `Importance` tab keeps the kind selector with `shap` option (unchanged).
- [x] Inference result panels still render the `SHAP Summary` accordion (#373 untouched — `PlotSection` not consumed there).
- [x] `docs/plot-matrix.md` updated (inventory row + symmetry rule 1 now allows `{tuning, shap-summary}` exclusion set + history entry).
- [x] Vitest case in `PlotSection.test.tsx` asserts `shap-summary` is hidden from the tab strip; combined null-render case covers `{tuning, shap-summary}` only input.

## Test plan

- [x] `pnpm test PlotSection` — 23/23 pass.
- [x] `pnpm test` — 1814/1814 (one unrelated WSL2 + Node 18 pool worker timeout on `SetupPanel.test.tsx`; isolated rerun 25/25 PASS — known flake from prior handoff §5.7).
- [x] `pnpm check` (biome) — clean.
- [x] `npx tsc --noEmit` — clean.
- [x] `pnpm build` — green (5,743kB chunk warning is pre-existing).
- [ ] CI on PR — pending.

## Notes

- Tier-1 follow-up to v0.4.0; targets v0.4.1 patch release.
- LizyML #101 (sMAPE / WAPE) shipped in v0.11.0 unblocking PR-C2 (#394) which will land separately.
