### PR TITLE
chore(deps): bump lizyml 0.10.0 -> 0.11.0 (sMAPE / WAPE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Bump `lizyml` minimum to `0.11.0` (<0.12.0)** — adopts upstream
+  sMAPE / WAPE regression metrics (LizyML H-0071 / #101). The new
+  metrics surface automatically through `MetricRegistry` lookup, so
+  `tuning.optuna.params.direction` chips and learning curve filters
+  list `smape` / `wape` for `task=regression` without further wiring.
+  Defensive fallback list in `lizystudio.backends.lizyml_metrics`
+  extended to include the two new metrics for parity. Unblocks the
+  PR-C2 (#394) `severity=warning` + `suggested_fix` work, which can
+  now propose `smape` as a zero-tolerant replacement for `mape` when
+  the dataset target contains zeros.
+
 ## [0.4.0] - 2026-05-05
 
 The **Wide DataFrame** release. Phase B (PR-B1 — PR-B5) closes the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "lizyml[plots,tuning,calibration,explain]>=0.10.0,<0.11.0",
+    "lizyml[plots,tuning,calibration,explain]>=0.11.0,<0.12.0",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.34",
     "python-multipart>=0.0.18",

--- a/src/lizystudio/backends/lizyml_metrics.py
+++ b/src/lizystudio/backends/lizyml_metrics.py
@@ -47,7 +47,17 @@ def get_eval_metrics_by_task() -> dict[str, list[str]]:
             # Fallback for older LizyML versions
             metrics = {
                 "regression": _sort_with_preferred(
-                    ["mae", "mape", "rmse", "huber", "r2", "rmsle"], "regression"
+                    [
+                        "mae",
+                        "mape",
+                        "rmse",
+                        "huber",
+                        "r2",
+                        "rmsle",
+                        "smape",
+                        "wape",
+                    ],
+                    "regression",
                 ),
                 "binary": _sort_with_preferred(
                     [

--- a/uv.lock
+++ b/uv.lock
@@ -560,7 +560,7 @@ wheels = [
 
 [[package]]
 name = "lizyml"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
@@ -574,9 +574,9 @@ dependencies = [
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/a2/fb4677239cbc84bb9ba15155329b9a585ace6bb1e4fa2625d9b438632561/lizyml-0.10.0.tar.gz", hash = "sha256:1b3560ffb2ea1e1b7b6a2bc8af0d8394df20a361a27e67be2fc760b24c1615f0", size = 651238, upload-time = "2026-05-04T05:38:36.111Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/42/5f01ee21c9614b719b5fc2539ea2c9e7a83ef80cbb762be6fa445c7525d0/lizyml-0.11.0.tar.gz", hash = "sha256:0e7a388d5926e16e14cd7ea9b8cedc6f85ac4718bc311bd44675f81be646ed09", size = 658004, upload-time = "2026-05-05T06:29:46.325Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/61/eea1bbaef13ab14e393471d83e30e82b8366bf73e360f26741e6c4b87d58/lizyml-0.10.0-py3-none-any.whl", hash = "sha256:909bcfe86fb9fc158b1f0cc9b7b3f2721d1b1d456f4a4a3eb854104f34f943df", size = 156728, upload-time = "2026-05-04T05:38:34.463Z" },
+    { url = "https://files.pythonhosted.org/packages/52/08/44d7be636c38f5b1edc2fa6cedee8da872ea02cf99eecfdc62aa1face2db/lizyml-0.11.0-py3-none-any.whl", hash = "sha256:0380a67fc87398ad0e2bec453393aab59a9aba2e9c0d5a2bee4546114dbe7e97", size = 157480, upload-time = "2026-05-05T06:29:44.466Z" },
 ]
 
 [package.optional-dependencies]
@@ -628,7 +628,7 @@ dev = [
 requires-dist = [
     { name = "cloudpickle", specifier = ">=3.0" },
     { name = "fastapi", specifier = ">=0.115" },
-    { name = "lizyml", extras = ["calibration", "explain", "plots", "tuning"], specifier = ">=0.10.0,<0.11.0" },
+    { name = "lizyml", extras = ["calibration", "explain", "plots", "tuning"], specifier = ">=0.11.0,<0.12.0" },
     { name = "prometheus-client", specifier = ">=0.20" },
     { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },


### PR DESCRIPTION
## Summary

- Bump `lizyml[plots,tuning,calibration,explain]` minimum from `>=0.10.0,<0.11.0` to `>=0.11.0,<0.12.0`.
- LizyML 0.11.0 introduces **sMAPE** and **WAPE** — zero-tolerant percentage-style regression metrics that close the gap left by MAPE on datasets where `y_true` may contain zeros (LizyML H-0071, nbx-liz/LizyML#101).
- LizyStudio's metric registry lookup is dynamic (`get_eval_metrics_by_task()` reads `lizyml.metrics.registry._TASK_METRICS`), so the two new metrics flow through to the SPA's tuning direction chips and learning curve filter selectors automatically — no UI wiring change required.
- The defensive fallback list in `lizystudio.backends.lizyml_metrics` is extended to include the new names for parity (used only when the registry import fails).

This change unblocks **PR-C2 / #394** which can now propose `smape` as a `suggested_fix` when MAPE is incompatible with the loaded dataset (regression target containing zeros).

## Test plan

- [x] `uv sync` — lizyml 0.10.0 → 0.11.0 installed cleanly.
- [x] Smoke check: `get_eval_metrics_by_task()['regression']` now lists `['rmse', 'huber', 'mae', 'mape', 'r2', 'rmsle', 'smape', 'wape']`. `get_metric_directions()` returns `smape=minimize`, `wape=minimize`.
- [x] `uv run ruff check src/ tests/` — clean.
- [x] `uv run ruff format --check src/ tests/` — clean.
- [x] `uv run mypy src/lizystudio/backends/lizyml_metrics.py` — no issues.
- [x] `uv run pytest -x -q` — **1326 passed, 10 skipped** (parity with v0.4.0 baseline).
- [ ] CI on PR — pending.

## Related

- Companion: nbx-liz/LizyML#101 (sMAPE / WAPE upstream implementation, shipped 0.11.0)
- Follow-up: #394 (Validate API auto-disable uncomputable metrics with `suggested_fix=smape`)
- Sibling tier-1: #393 (PR-C1 / PR #397, queued for merge)
