### PR TITLE
feat(validate): auto-disable uncomputable metrics via severity=warning + suggested_fix (#394)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Validate API auto-disable for incompatible regression metrics
+  (#394)** — `POST /api/workspace/config/validate` and
+  `PUT /api/workspace/config` now return `severity="warning"` entries
+  when the loaded dataset's target column makes a configured metric
+  mathematically impossible: `mape` on a target that contains zeros,
+  `rmsle` on a target with negative values, and `r2` on a constant
+  target. Each entry carries a `suggested_fix` naming the metric to
+  remove; for `mape` the suggestion also points at the new `smape`
+  and `wape` metrics shipped in lizyml 0.11.0 as zero-tolerant
+  replacements. The frontend renders these advisories in a new yellow
+  banner above ConfigForm with the suggestion as a second line, while
+  the existing red banner keeps surfacing blocking errors.
+
 ### Changed
 
+- **Validate response `valid` flag and PUT `saved` flag now honor
+  severity (#394)** — only `severity="error"` entries flip
+  `valid=false` / `saved=false`. Pre-PR-B4 entries with no severity
+  default to `"error"` for backward compatibility, so existing
+  consumers (legacy frontends, scripts piping JSON) see no change.
+  Warnings advise but neither block persistence nor the Fit button —
+  which now gates on `severity=error` count instead of total error
+  count.
 - **Bump `lizyml` minimum to `0.11.0` (<0.12.0)** — adopts upstream
   sMAPE / WAPE regression metrics (LizyML H-0071 / #101). The new
   metrics surface automatically through `MetricRegistry` lookup, so

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -101,9 +101,32 @@ export interface ConfigUpdateResponse {
   saved: boolean;
 }
 
+/**
+ * Validation entry returned by the workspace config validators.
+ *
+ * PR-B4 / R-3.4 introduced ``severity`` and ``suggested_fix``:
+ *
+ * - ``severity`` — ``"error"`` blocks Fit/Tune; ``"warning"`` advises
+ *   but does not block (#394). Both schema-level Pydantic errors and
+ *   the ``n_splits > n_rows`` validator emit ``"error"``; the metric
+ *   compatibility validator emits ``"warning"``.
+ * - ``suggested_fix`` — optional human-readable next-action string.
+ *   ``null`` when the validator does not know how to repair the field.
+ *
+ * Both fields are optional in the type so frontends running against an
+ * older backend still type-check; consumers that gate on severity must
+ * default missing values to ``"error"`` for backward compatibility.
+ */
 export interface ConfigError {
   path: string;
   message: string;
+  severity?: "error" | "warning" | "info";
+  suggested_fix?: string | null;
+}
+
+/** True when the entry should block Fit/Tune (legacy default = error). */
+export function isBlockingError(err: ConfigError): boolean {
+  return (err.severity ?? "error") === "error";
 }
 
 // --- Job types — re-exported from the generated schema (C-4).

--- a/frontend/src/components/workspace/ConfigEditorBody.test.tsx
+++ b/frontend/src/components/workspace/ConfigEditorBody.test.tsx
@@ -66,3 +66,121 @@ describe("ConfigEditorBody — empty Choice banner (Issue #266)", () => {
     expect(banner.textContent).toContain("metric");
   });
 });
+
+describe("ConfigEditorBody — severity-aware error/warning banners (Issue #394)", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders blocking errors in the destructive banner only", () => {
+    renderBody({
+      errors: [
+        {
+          path: "split.n_splits",
+          message: "n_splits=1000 > n_rows=50",
+          severity: "error",
+          suggested_fix: "Set Folds to 50 or fewer.",
+        },
+      ],
+    });
+    expect(screen.getByTestId("config-error-banner")).toBeInTheDocument();
+    expect(screen.queryByTestId("config-warning-banner")).toBeNull();
+  });
+
+  it("renders advisory warnings in the warning banner only", () => {
+    renderBody({
+      errors: [
+        {
+          path: "evaluation.metrics",
+          message: "MAPE is undefined when target column 'y' contains zeros.",
+          severity: "warning",
+          suggested_fix:
+            "Remove 'mape' from evaluation.metrics — or replace with 'smape'.",
+        },
+      ],
+    });
+    const warning = screen.getByTestId("config-warning-banner");
+    expect(warning).toBeInTheDocument();
+    expect(screen.queryByTestId("config-error-banner")).toBeNull();
+    // Both the message and the suggestion render.
+    expect(warning.textContent).toContain("MAPE is undefined");
+    expect(warning.textContent).toContain(
+      "Remove 'mape' from evaluation.metrics",
+    );
+  });
+
+  it("splits a mixed list across both banners", () => {
+    renderBody({
+      errors: [
+        {
+          path: "split.n_splits",
+          message: "n_splits=1000 > n_rows=50",
+          severity: "error",
+          suggested_fix: "Set Folds to 50 or fewer.",
+        },
+        {
+          path: "evaluation.metrics",
+          message: "MAPE is undefined when target column 'y' contains zeros.",
+          severity: "warning",
+          suggested_fix: "Remove 'mape' from evaluation.metrics.",
+        },
+      ],
+    });
+    const error = screen.getByTestId("config-error-banner");
+    const warning = screen.getByTestId("config-warning-banner");
+    expect(error.textContent).toContain("n_splits=1000");
+    expect(error.textContent).not.toContain("MAPE is undefined");
+    expect(warning.textContent).toContain("MAPE is undefined");
+    expect(warning.textContent).not.toContain("n_splits=1000");
+  });
+
+  it("treats missing severity as 'error' (backward compatibility)", () => {
+    renderBody({
+      errors: [
+        {
+          path: "task",
+          message: "Invalid task value",
+        },
+      ],
+    });
+    expect(screen.getByTestId("config-error-banner")).toBeInTheDocument();
+    expect(screen.queryByTestId("config-warning-banner")).toBeNull();
+  });
+
+  it("hides both banners when hasData is false", () => {
+    renderBody({
+      hasData: false,
+      errors: [
+        {
+          path: "split.n_splits",
+          message: "n_splits=1000 > n_rows=50",
+          severity: "error",
+          suggested_fix: null,
+        },
+        {
+          path: "evaluation.metrics",
+          message: "MAPE is undefined",
+          severity: "warning",
+          suggested_fix: "Remove 'mape'.",
+        },
+      ],
+    });
+    expect(screen.queryByTestId("config-error-banner")).toBeNull();
+    expect(screen.queryByTestId("config-warning-banner")).toBeNull();
+  });
+
+  it("renders a warning entry without a suggested_fix", () => {
+    renderBody({
+      errors: [
+        {
+          path: "evaluation.metrics",
+          message: "Some warning text.",
+          severity: "warning",
+        },
+      ],
+    });
+    const warning = screen.getByTestId("config-warning-banner");
+    expect(warning.textContent).toContain("Some warning text.");
+    expect(warning.textContent).not.toContain("Suggestion:");
+  });
+});

--- a/frontend/src/components/workspace/ConfigEditorBody.tsx
+++ b/frontend/src/components/workspace/ConfigEditorBody.tsx
@@ -6,8 +6,8 @@
  * state + change handlers flow in via props.
  */
 
-import { Info } from "lucide-react";
-import type { ConfigError } from "@/api/types";
+import { AlertTriangle, Info } from "lucide-react";
+import { type ConfigError, isBlockingError } from "@/api/types";
 import { ConfigForm } from "./ConfigForm";
 import { TuneTab } from "./TuneTab";
 
@@ -46,6 +46,12 @@ export function ConfigEditorBody({
   columns,
 }: ConfigEditorBodyProps) {
   const visibleErrors = errors.filter((err) => err.path || err.message);
+  // Issue #394 / PR-C2: split entries by severity so warnings (advisory)
+  // render in a yellow banner separate from blocking errors. Pre-PR-B4
+  // backends do not emit ``severity``; ``isBlockingError`` defaults to
+  // "error" in that case, so the existing red banner keeps working.
+  const blockingErrors = visibleErrors.filter(isBlockingError);
+  const warningErrors = visibleErrors.filter((err) => !isBlockingError(err));
   const showEmptyChoiceBanner =
     activeTab === "tune" && emptyChoiceKeys.length > 0;
 
@@ -70,13 +76,42 @@ export function ConfigEditorBody({
           </p>
         </output>
       )}
-      {hasData && visibleErrors.length > 0 && (
-        <div className="mb-4 rounded-md border border-destructive/50 bg-destructive/10 p-3">
-          {visibleErrors.map((err, i) => (
+      {hasData && blockingErrors.length > 0 && (
+        <div
+          className="mb-4 rounded-md border border-destructive/50 bg-destructive/10 p-3"
+          data-testid="config-error-banner"
+          role="alert"
+        >
+          {blockingErrors.map((err, i) => (
             <p key={`err-${i}`} className="text-xs text-destructive">
               {[err.path, err.message].filter(Boolean).join(": ")}
             </p>
           ))}
+        </div>
+      )}
+      {hasData && warningErrors.length > 0 && (
+        <div
+          className="mb-4 rounded-md border border-warning-border bg-warning p-3"
+          data-testid="config-warning-banner"
+          role="status"
+        >
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning-fg" />
+            <div className="flex-1 space-y-2">
+              {warningErrors.map((err, i) => (
+                <div key={`warn-${i}`} className="text-xs">
+                  <p className="font-medium text-warning-fg">
+                    {[err.path, err.message].filter(Boolean).join(": ")}
+                  </p>
+                  {err.suggested_fix && (
+                    <p className="mt-0.5 text-warning-fg/80">
+                      Suggestion: {err.suggested_fix}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       )}
       {showEmptyChoiceBanner && (

--- a/frontend/src/hooks/useModelPanelData.test.ts
+++ b/frontend/src/hooks/useModelPanelData.test.ts
@@ -222,6 +222,80 @@ describe("useModelPanelData", () => {
     expect(result.current.disabledReason).toBe("Load data first");
   });
 
+  // PR-C2 / Issue #394: warnings advise but do not block Fit. Only
+  // severity="error" entries (or pre-PR-B4 entries with no severity)
+  // disable the Fit button. Warnings reach the hook's ``errors`` state
+  // through the debounced validateConfig call after a successful save.
+  it("fitEnabled stays true when only severity=warning entries are present", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(validateConfig).mockResolvedValueOnce({
+      errors: [
+        {
+          path: "evaluation.metrics",
+          message: "MAPE undefined when target contains zeros.",
+          severity: "warning",
+          suggested_fix: "Remove 'mape' from evaluation.metrics.",
+        },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+    } as any);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useModelPanelData({ hasData: true, running: false }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.config).toBeDefined());
+
+    await act(async () => {
+      await result.current.handleConfigChange({ model: { name: "X" } });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    expect(result.current.errors).toHaveLength(1);
+    expect(result.current.errors[0]?.severity).toBe("warning");
+    expect(result.current.fitEnabled).toBe(true);
+    expect(result.current.disabledReason).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it("fitEnabled is false when at least one severity=error entry is present", async () => {
+    vi.mocked(updateConfig).mockResolvedValueOnce({
+      config: { model: {} },
+      errors: [
+        {
+          path: "split.n_splits",
+          message: "n_splits=1000 > n_rows=50",
+          severity: "error",
+          suggested_fix: "Set Folds to 50 or fewer.",
+        },
+        {
+          path: "evaluation.metrics",
+          message: "MAPE undefined when target contains zeros.",
+          severity: "warning",
+          suggested_fix: "Remove 'mape' from evaluation.metrics.",
+        },
+      ],
+      saved: false,
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+    } as any);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useModelPanelData({ hasData: true, running: false }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.config).toBeDefined());
+    await act(async () => {
+      await result.current.handleConfigChange({ model: { name: "X" } });
+    });
+
+    expect(result.current.fitEnabled).toBe(false);
+    expect(result.current.disabledReason).toBe("Fix validation errors first");
+  });
+
   it("tuneEnabled requires a non-empty search space when capability disallows empty", async () => {
     const { wrapper } = makeWrapper();
     const { result } = renderHook(

--- a/frontend/src/hooks/useModelPanelData.ts
+++ b/frontend/src/hooks/useModelPanelData.ts
@@ -23,7 +23,7 @@ import {
   useUiSchema,
 } from "@/api/queries";
 import { queryKeys } from "@/api/queryKeys";
-import type { ConfigError } from "@/api/types";
+import { type ConfigError, isBlockingError } from "@/api/types";
 import { updateConfig, uploadConfig, validateConfig } from "@/api/workspace";
 import { findEmptyChoiceKeys } from "@/components/workspace/search-space-utils";
 import { useConfigHistory } from "@/hooks/useConfigHistory";
@@ -342,7 +342,13 @@ export function useModelPanelData({
   // --------------------------------------------------------------------
   // Derived enable/disable state
   // --------------------------------------------------------------------
-  const fitEnabled = hasData && !!config && !running && errors.length === 0;
+  // Issue #394 / PR-C2: only severity="error" entries block Fit/Tune.
+  // Warnings (e.g. metric-vs-target compatibility) advise but do not
+  // gate the run. Pre-PR-B4 backends do not emit severity, so missing
+  // values default to "error" via ``isBlockingError``.
+  const blockingErrors = errors.filter(isBlockingError);
+  const fitEnabled =
+    hasData && !!config && !running && blockingErrors.length === 0;
   const allowEmptySpace =
     uiSchema?.capabilities?.tune?.allow_empty_space === true;
   const tuningSpace =
@@ -367,7 +373,7 @@ export function useModelPanelData({
     if (running) return "A job is currently running";
     if (!hasData) return "Load data first";
     if (!config) return "Loading configuration...";
-    if (errors.length > 0) return "Fix validation errors first";
+    if (blockingErrors.length > 0) return "Fix validation errors first";
     if (activeTab === "tune" && emptyChoiceKeys.length > 0) {
       return `Add at least one choice to: ${emptyChoiceKeys.join(", ")}`;
     }

--- a/src/lizystudio/api/workspace.py
+++ b/src/lizystudio/api/workspace.py
@@ -480,9 +480,10 @@ def config_update(
     """
     _check_workspace_lock(job_store)
     errors = validate_config(ws, body)
-    if not errors:
+    blocking = [e for e in errors if e.get("severity", "error") == "error"]
+    if not blocking:
         ws.set_config(body)
-    return {"config": body, "errors": errors, "saved": len(errors) == 0}
+    return {"config": body, "errors": errors, "saved": len(blocking) == 0}
 
 
 @router.patch("/config", response_model=ConfigPatchResponse)
@@ -524,7 +525,13 @@ def config_validate(
     if not config:
         raise WorkspaceNoConfigError()
     errors = validate_config(ws, config)
-    return {"valid": len(errors) == 0, "errors": errors}
+    # Issue #394 / PR-C2: warnings advise but do not invalidate a
+    # config — only ``severity="error"`` entries flip ``valid`` to
+    # False. Entries without an explicit severity default to ``"error"``
+    # for backward compatibility (pre-PR-B4 callers still see the
+    # legacy semantics).
+    blocking = [e for e in errors if e.get("severity", "error") == "error"]
+    return {"valid": len(blocking) == 0, "errors": errors}
 
 
 @router.post("/config/upload", response_model=ConfigUpdateResponse)
@@ -543,9 +550,10 @@ async def config_upload(
     except Exception as exc:
         raise ConfigImportError(str(exc)) from exc
     errors = validate_config(ws, config)
-    if not errors:
+    blocking = [e for e in errors if e.get("severity", "error") == "error"]
+    if not blocking:
         ws.set_config(config)
-    return {"config": config, "errors": errors, "saved": len(errors) == 0}
+    return {"config": config, "errors": errors, "saved": len(blocking) == 0}
 
 
 @router.get("/config/download")

--- a/src/lizystudio/services/workspace.py
+++ b/src/lizystudio/services/workspace.py
@@ -194,6 +194,12 @@ def validate_config(ws: WorkspaceState, config: dict[str, Any]) -> list[dict[str
     # Surfacing it here lets the existing "Fix validation errors first"
     # banner block the user before they even click Fit.
     normalized.extend(_workspace_split_errors(ws, config))
+    # Issue #394: regression metrics that the loaded target column makes
+    # mathematically impossible (MAPE on zero targets, RMSLE on negative
+    # targets, R² on a constant target). Returned as severity="warning"
+    # so the banner advises but does not block — the user can still fit
+    # if they accept that lizyml will skip those metrics mid-fold.
+    normalized.extend(_workspace_metric_compatibility_errors(ws, config))
     return normalized
 
 
@@ -231,6 +237,122 @@ def _workspace_split_errors(
             "suggested_fix": (f"Set Folds (split.n_splits) to {n_rows} or fewer."),
         }
     ]
+
+
+def _metric_entry_name(metric: Any) -> str | None:
+    """Return the metric name from a MetricEntry (str or {name: params}).
+
+    Mirrors the frontend's ``metricEntryName`` helper: a metric is either
+    a plain string ``"auc"`` or a single-key dict ``{"precision_at_k":
+    {"k": 20}}``. Anything else (None, multi-key dict, non-string key)
+    returns None so callers can defensively skip malformed entries
+    without raising.
+    """
+    if isinstance(metric, str):
+        return metric
+    if isinstance(metric, dict) and len(metric) == 1:
+        key = next(iter(metric.keys()))
+        if isinstance(key, str):
+            return key
+    return None
+
+
+def _workspace_metric_compatibility_errors(
+    ws: WorkspaceState, config: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Issue #394: warn before Fit when a configured regression metric
+    is incompatible with the loaded dataset's target column.
+
+    Each entry returns ``severity="warning"`` (not ``"error"``) so the
+    banner advises but does not gate Fit — the underlying lizyml fit
+    path may either skip the metric or surface a clearer mid-fold
+    error, but no data is destroyed by attempting it. The
+    ``suggested_fix`` names the metric to remove and, where applicable,
+    points at upstream lizyml 0.11.0's sMAPE / WAPE as zero-tolerant
+    alternatives.
+
+    Currently detected (regression task only):
+
+    * ``mape``  — undefined when ``y_true`` contains zeros
+                  (lizyml/metrics/regression.py raises mid-fit)
+    * ``rmsle`` — undefined when ``y_true`` contains negative values
+    * ``r2``    — degenerate (NaN / +∞) when the target is constant
+                  (variance == 0)
+
+    Short-circuits to an empty list when no data is loaded, when the
+    target column is missing or non-numeric, or when ``evaluation`` is
+    not a dict. Defensive on every layer because ``validate_config``
+    runs against arbitrary user input that the schema layer may also
+    have rejected.
+    """
+    if ws.dataframe is None:
+        return []
+    if not isinstance(config, dict):
+        return []
+    data = config.get("data")
+    target = data.get("target") if isinstance(data, dict) else None
+    if not isinstance(target, str) or target not in ws.dataframe.columns:
+        return []
+    evaluation = config.get("evaluation")
+    metrics = evaluation.get("metrics") if isinstance(evaluation, dict) else None
+    if not isinstance(metrics, list) or not metrics:
+        return []
+    target_series = ws.dataframe[target]
+    if not pd.api.types.is_numeric_dtype(target_series):
+        return []
+
+    metric_names: set[str] = set()
+    for entry in metrics:
+        name = _metric_entry_name(entry)
+        if name is not None:
+            metric_names.add(name)
+
+    errors: list[dict[str, Any]] = []
+    if "mape" in metric_names and bool((target_series == 0).any()):
+        errors.append(
+            {
+                "path": "evaluation.metrics",
+                "message": (
+                    f"MAPE is undefined when target column '{target}' contains zeros."
+                ),
+                "severity": "warning",
+                "suggested_fix": (
+                    "Remove 'mape' from evaluation.metrics — or replace it "
+                    "with 'smape' / 'wape' which tolerate zero targets "
+                    "(lizyml >= 0.11.0)."
+                ),
+            }
+        )
+    if "rmsle" in metric_names and bool((target_series < 0).any()):
+        errors.append(
+            {
+                "path": "evaluation.metrics",
+                "message": (
+                    f"RMSLE is undefined when target column '{target}' "
+                    f"contains negative values."
+                ),
+                "severity": "warning",
+                "suggested_fix": "Remove 'rmsle' from evaluation.metrics.",
+            }
+        )
+    if "r2" in metric_names:
+        # Constant target → variance == 0. Use std() to skip NaNs; pandas
+        # returns NaN when there is < 2 non-null observations, which we
+        # also treat as "cannot compute R²".
+        std = target_series.std(skipna=True)
+        if pd.isna(std) or float(std) == 0.0:
+            errors.append(
+                {
+                    "path": "evaluation.metrics",
+                    "message": (
+                        f"R² is undefined when target column '{target}' is "
+                        f"constant (variance == 0)."
+                    ),
+                    "severity": "warning",
+                    "suggested_fix": "Remove 'r2' from evaluation.metrics.",
+                }
+            )
+    return errors
 
 
 def load_config_from_file(

--- a/tests/contract/test_validate_metric_compatibility.py
+++ b/tests/contract/test_validate_metric_compatibility.py
@@ -1,0 +1,283 @@
+"""Validate API metric-compatibility contract (Issue #394 / PR-C2).
+
+The pre-PR-C2 ``validate_config`` accepted any combination of
+``evaluation.metrics`` because the Pydantic schema does not know about
+the loaded dataset's target shape. As a result, configurations like
+``mape`` on a target column that contains zeros would pass Validate,
+get accepted by ``POST /fit``, and fail mid-fold with a confusing
+``LizyMLError(UNSUPPORTED_METRIC)`` from the lizyml regression metric
+helper.
+
+PR-C2 surfaces these mismatches up-front as ``severity="warning"``
+entries on the validate envelope so the frontend can render a yellow
+banner with the per-metric ``suggested_fix`` instead of letting the
+fit run for several seconds and then fail. The shape mismatches we
+detect today (regression task only):
+
+* ``mape``  — undefined when any target value is 0
+* ``rmsle`` — undefined when any target value is < 0
+* ``r2``    — undefined when the target column is constant (variance 0)
+
+This file pins the contract: trigger conditions, severity assignment,
+``suggested_fix`` text shape, and the negative cases (no data, valid
+target, non-numeric target, malformed input).
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_regression_csv(
+    tmp_path: Path,
+    *,
+    target_values: list[float],
+    name: str = "train.csv",
+) -> str:
+    """Stage a 3-column CSV with the requested target values."""
+    csv_path = tmp_path / name
+    with csv_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["a", "b", "y"])
+        for i, val in enumerate(target_values):
+            writer.writerow([i, i + 1, val])
+    return str(csv_path)
+
+
+def _load_data(client: TestClient, csv_path: str) -> None:
+    res = client.post("/api/workspace/data/path", json={"path": csv_path})
+    assert res.status_code == 200, res.text
+
+
+def _regression_defaults(client: TestClient, target: str = "y") -> dict[str, Any]:
+    res = client.get(
+        f"/api/workspace/config/defaults?task=regression&target={target}",
+    )
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def _set_metrics(config: dict[str, Any], metric_names: list[str]) -> dict[str, Any]:
+    """Replace ``evaluation.metrics`` with a fresh list of plain names."""
+    config = dict(config)
+    evaluation = dict(config.get("evaluation", {}))
+    evaluation["metrics"] = list(metric_names)
+    config["evaluation"] = evaluation
+    return config
+
+
+def _validate(client: TestClient, config: dict[str, Any]) -> list[dict[str, Any]]:
+    res = client.post("/api/workspace/config/validate", json=config)
+    assert res.status_code == 200, res.text
+    return res.json()["errors"]
+
+
+def _metric_warnings(errors: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return entries the metric-compat validator owns."""
+    return [e for e in errors if e.get("path") == "evaluation.metrics"]
+
+
+# ---------------------------------------------------------------------------
+# Positive cases — each trigger surfaces exactly one warning
+# ---------------------------------------------------------------------------
+
+
+def test_mape_with_zero_target_emits_warning(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """A regression target containing 0 must flag ``mape`` as
+    incompatible. The suggested fix names sMAPE / WAPE as zero-tolerant
+    replacements (lizyml >= 0.11.0)."""
+    csv_path = _create_regression_csv(
+        tmp_path, target_values=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    )
+    _load_data(client, csv_path)
+    config = _set_metrics(_regression_defaults(client), ["mae", "mape"])
+    errors = _validate(client, config)
+
+    warnings = _metric_warnings(errors)
+    assert len(warnings) == 1, errors
+    err = warnings[0]
+    assert err["severity"] == "warning"
+    assert err["suggested_fix"] is not None
+    assert "mape" in err["message"].lower()
+    assert "smape" in err["suggested_fix"].lower()
+    assert "wape" in err["suggested_fix"].lower()
+
+
+def test_rmsle_with_negative_target_emits_warning(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """RMSLE is undefined for negative ``y_true`` (the inner ``log1p``
+    breaks). The validator must catch this before fit time."""
+    csv_path = _create_regression_csv(
+        tmp_path, target_values=[-1.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    )
+    _load_data(client, csv_path)
+    config = _set_metrics(_regression_defaults(client), ["mae", "rmsle"])
+    errors = _validate(client, config)
+
+    warnings = _metric_warnings(errors)
+    assert len(warnings) == 1, errors
+    err = warnings[0]
+    assert err["severity"] == "warning"
+    assert err["suggested_fix"] is not None
+    assert "rmsle" in err["message"].lower()
+    assert "rmsle" in err["suggested_fix"].lower()
+
+
+def test_r2_with_constant_target_emits_warning(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """R² is degenerate when the target has zero variance. Surface a
+    warning rather than letting the fold loop surface a NaN later."""
+    csv_path = _create_regression_csv(tmp_path, target_values=[5.0] * 10)
+    _load_data(client, csv_path)
+    config = _set_metrics(_regression_defaults(client), ["mae", "r2"])
+    errors = _validate(client, config)
+
+    warnings = _metric_warnings(errors)
+    assert len(warnings) == 1, errors
+    err = warnings[0]
+    assert err["severity"] == "warning"
+    assert err["suggested_fix"] is not None
+    assert "r2" in err["message"].lower() or "r²" in err["message"].lower()
+    assert "r2" in err["suggested_fix"].lower()
+
+
+def test_multiple_metric_issues_emit_one_warning_each(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """A single config with two bad metrics surfaces two warnings — one
+    per metric — so the user can resolve each independently."""
+    # Target contains both 0 (kills mape) and a negative value (kills
+    # rmsle); the rest are non-degenerate so std() != 0.
+    csv_path = _create_regression_csv(
+        tmp_path, target_values=[0.0, -1.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+    )
+    _load_data(client, csv_path)
+    config = _set_metrics(_regression_defaults(client), ["mae", "mape", "rmsle"])
+    errors = _validate(client, config)
+
+    warnings = _metric_warnings(errors)
+    paths = [e["path"] for e in warnings]
+    messages = [e["message"].lower() for e in warnings]
+    assert len(warnings) == 2, errors
+    assert paths.count("evaluation.metrics") == 2
+    assert any("mape" in m for m in messages)
+    assert any("rmsle" in m for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — quiet when there is nothing to flag
+# ---------------------------------------------------------------------------
+
+
+def test_no_warning_when_target_has_no_zero_or_negative(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Strictly-positive non-constant target keeps mape/rmsle/r2 valid."""
+    csv_path = _create_regression_csv(
+        tmp_path, target_values=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+    )
+    _load_data(client, csv_path)
+    config = _set_metrics(_regression_defaults(client), ["mae", "mape", "rmsle", "r2"])
+    errors = _validate(client, config)
+    assert _metric_warnings(errors) == []
+
+
+def test_no_warning_when_no_data_loaded(client: TestClient) -> None:
+    """The validator must short-circuit before reading the dataframe.
+
+    Without a loaded CSV the row-count and target-value preconditions
+    cannot be checked at all; the metric-compat validator stays quiet
+    so the user does not see warnings for a workspace that has no data
+    to disagree with.
+    """
+    # ``_regression_defaults`` calls /defaults which does not require
+    # data; we then validate a config that *would* trigger mape if data
+    # were loaded. No CSV ever reaches the workspace.
+    config = _set_metrics(_regression_defaults(client), ["mae", "mape"])
+    errors = _validate(client, config)
+    assert _metric_warnings(errors) == []
+
+
+def test_no_warning_for_metrics_not_in_the_compat_list(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Metrics outside the {mape, rmsle, r2} watchlist are ignored even
+    on a target that would trigger the watchlist members.
+
+    This guards against the validator getting clever and over-warning
+    for metrics it does not actually understand.
+    """
+    csv_path = _create_regression_csv(
+        tmp_path, target_values=[0.0, -1.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+    )
+    _load_data(client, csv_path)
+    config = _set_metrics(_regression_defaults(client), ["mae", "rmse", "huber"])
+    errors = _validate(client, config)
+    assert _metric_warnings(errors) == []
+
+
+def test_warning_does_not_block_validate_valid_flag(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Warnings advise but do not invalidate a config — the response's
+    ``valid`` flag still reflects whether *errors* exist."""
+    csv_path = _create_regression_csv(
+        tmp_path, target_values=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    )
+    _load_data(client, csv_path)
+    config = _set_metrics(_regression_defaults(client), ["mae", "mape"])
+    res = client.post("/api/workspace/config/validate", json=config)
+    assert res.status_code == 200, res.text
+    body = res.json()
+    # The schema-level body is fine; only a workspace-aware warning is
+    # raised. ``valid`` must therefore stay True so that frontend
+    # gating logic that filters on severity decides Fit eligibility,
+    # not the bare ``valid`` boolean.
+    assert body["valid"] is True
+    warnings = _metric_warnings(body["errors"])
+    assert len(warnings) == 1
+    assert warnings[0]["severity"] == "warning"
+
+
+# ---------------------------------------------------------------------------
+# Defensive cases — malformed metrics list / parameterised metric entries
+# ---------------------------------------------------------------------------
+
+
+def test_parameterised_metric_entry_is_recognised(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Metrics may arrive as ``{name: params}`` dicts (e.g.
+    ``precision_at_k``). The validator must extract the name without
+    raising even when the value is a dict, and still flag the watchlist
+    entries the user has selected.
+    """
+    csv_path = _create_regression_csv(
+        tmp_path, target_values=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    )
+    _load_data(client, csv_path)
+    config = _set_metrics(_regression_defaults(client), ["mae"])
+    # Inject a dict-form mape entry by hand; the schema accepts both
+    # plain strings and parameterised dicts.
+    config["evaluation"]["metrics"].append({"mape": {}})
+    errors = _validate(client, config)
+
+    warnings = _metric_warnings(errors)
+    assert len(warnings) == 1
+    assert "mape" in warnings[0]["message"].lower()


### PR DESCRIPTION
## Summary

Closes #394.

LizyStudio passed lizyml's regression metric defaults (`["huber", "mae", "mape"]`) through to fit unchanged, so a target column containing zeros would clear Validate, get accepted by `POST /fit`, and then fail mid-fold with `LizyMLError(UNSUPPORTED_METRIC)` from `MAPE.__call__`. Three regression metric / target shapes have this class of mismatch:

| Metric  | Trigger condition (target)                | Suggested fix                                                                            |
|---------|-------------------------------------------|------------------------------------------------------------------------------------------|
| `mape`  | any value == 0                            | Remove from `evaluation.metrics`; or replace with `smape` / `wape` (lizyml 0.11.0+).     |
| `rmsle` | any value < 0                             | Remove from `evaluation.metrics`.                                                        |
| `r2`    | target is constant (variance == 0)        | Remove from `evaluation.metrics`.                                                        |

## Changes

### Backend
- `_workspace_metric_compatibility_errors` in `src/lizystudio/services/workspace.py` — wired into `validate_config` after `_workspace_split_errors`. Returns `severity="warning"` entries; the MAPE suggestion calls out `smape` / `wape` as zero-tolerant alternatives shipped in lizyml 0.11.0.
- Validate / save gating now respects severity: `valid=false` and `saved=false` flip only on `severity="error"` entries. Pre-PR-B4 entries without a `severity` field default to `"error"`, keeping legacy semantics.

### Frontend
- `ConfigError` interface extended with optional `severity` and `suggested_fix`. `isBlockingError(err)` helper exported from `@/api/types`.
- `ConfigEditorBody` now renders a dual-banner: red destructive banner for blocking errors, yellow advisory banner for `severity="warning"` (with the `suggested_fix` rendered as a "Suggestion: …" second line).
- `useModelPanelData` gates `fitEnabled` and the "Fix validation errors first" tooltip on `blockingErrors.length` rather than total error count.

## Acceptance criteria

- [x] Validate emits `severity="warning"` entries for the three regression metric cases.
- [x] Each warning carries a `suggested_fix` string naming the metric to remove.
- [x] MAPE suggestion mentions `smape` / `wape` as alternatives.
- [x] Backend short-circuits when no data is loaded (no false warnings).
- [x] Backend ignores metrics outside the watchlist (no over-warning).
- [x] `valid` / `saved` flags ignore warnings — config persists, Fit stays enabled.
- [x] Frontend renders warnings in a separate yellow banner with `data-testid="config-warning-banner"`.
- [x] Pre-PR-B4 entries without `severity` continue to behave as blocking errors.
- [x] Parameterised metric entries (`{"mape": {}}`) are recognised.

## Test plan

- [x] `tests/contract/test_validate_metric_compatibility.py` — 9 new cases.
- [x] `frontend/src/components/workspace/ConfigEditorBody.test.tsx` — 6 new cases.
- [x] `frontend/src/hooks/useModelPanelData.test.ts` — 2 new cases (warning-only / mixed severity).
- [x] `uv run pytest -q` — 1335 passed, 10 skipped.
- [x] `pnpm test` — 1834 passed (one unrelated WSL2 + Node 18 pool worker timeout on `useMediaQuery.test.ts`; isolated rerun 4/4 PASS).
- [x] `npx tsc --noEmit` — clean.
- [x] `pnpm check` (biome) — clean.
- [x] `pnpm build` — green.
- [x] `uv run ruff check` / `format --check` / `mypy` on touched files — clean.
- [ ] CI on PR — pending.

## Out of scope

- Auto-fix CTA — Issue #394 marks this as optional. A follow-up PR can add a "Remove `mape`" button on each warning row that calls `PATCH /api/workspace/config` with an `unset` op.
- Adding new metrics (sMAPE / WAPE) — already shipped in lizyml 0.11.0 (see PR #398 / nbx-liz/LizyML#101).

## References

- Issue #394
- Companion: nbx-liz/LizyML#101 / nbx-liz/LizyML@5d1dd19 (sMAPE / WAPE in lizyml 0.11.0)
- Sibling PRs: #397 (PR-C1, SHAP fix, merged), #398 (lizyml 0.11.0 bump, merged)
- `src/lizystudio/services/workspace.py` (`_workspace_split_errors` precedent)
- `lizyml/metrics/regression.py:130-158` (MAPE zero guard)
- PR-B4 / R-3.4 (validate envelope `severity` + `suggested_fix` fields)
