### PR TITLE
docs(spec): record v0.4.1 severity envelope + metric-compat watchlist (P-0100, P-0101)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -2385,6 +2385,41 @@ Workspace の `workspace_result` は完了時に自動更新される。
 
 **Active-job lock (P-0089 / Issue #279):** ジョブが running 中は `PUT /api/workspace/config` / `PATCH /api/workspace/config` が `WORKSPACE_LOCKED` (409) を返す。詳細は §3.4。
 
+#### Validate response envelope (P-0100 / P-0101 / Issue #394)
+
+`POST /api/workspace/config/validate` / `PUT /api/workspace/config` / `POST /api/workspace/upload` の `errors[]` 各要素は以下の envelope を返す:
+
+```json
+{
+  "valid": false,
+  "errors": [
+    {
+      "loc": "evaluation.metrics",
+      "msg": "MAPE is undefined when target contains zeros (3 rows). Use 'smape' or 'wape' instead (lizyml 0.11.0+).",
+      "severity": "warning",
+      "suggested_fix": "Use 'smape' or 'wape' instead (lizyml 0.11.0+)"
+    }
+  ]
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `severity` | `"error" \| "warning" \| "info"` (default `"error"`) | block 判定に使う。`"error"` のみ `valid=false` / `saved=false` を flip。`"warning"` / `"info"` は advisory のみ |
+| `suggested_fix` | `str \| null` (default `null`) | 警告に対する具体的な置換アクション。Frontend では yellow banner の二行目に表示 |
+
+**Block 判定ルール (P-0100):** `_blocking_errors([entry, ...])` ヘルパが Service / API 層共通で `severity == "error"` のみを抽出し、`POST /fit` / `POST /tune` / `PUT /config` / `POST /upload` の 4xx 判定に使う。`severity` 未設定の旧 ValidationError は backward-compat のため `"error"` 扱い。
+
+**Metric-compat watchlist (P-0101):** `task=regression` のとき以下の組み合わせは `severity="warning"` で auto-disable される:
+
+| Metric | Trigger | suggested_fix |
+|---|---|---|
+| `mape` | target に 0 が 1 件以上 | `"Use 'smape' or 'wape' instead (lizyml 0.11.0+)"` |
+| `rmsle` | target に負値が 1 件以上 | `"Remove 'rmsle' from evaluation.metrics"` |
+| `r2` | target が定数 (`nunique() == 1`) | `"Remove 'r2' from evaluation.metrics"` |
+
+警告だが block しないため、ユーザは無視して fit を実行できる（実行時に該当 metric は nan を返す可能性）。後続バックエンドが増えたときの抽象化は Issue #403 で予定。
+
 ### 5.3 Jobs API
 
 永続化されたジョブを管理する。

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3184,4 +3184,122 @@ frontend で virtualization / top-N を入れても、転送する payload 自�
 
 - 2026-05-05 **Proposed** — PR-B3 で実装。auto mode で Phase B 実装中、Change Gate scope は `load_dataframe` の失敗タイミング精緻化のみ。**ユーザ承認済** (Phase B 全体着手承認)
 
+### P-0099: (採番予約) v0.5 R-1 状態整合性 invariants + `paused` job state（Change Gate）
+
+- **Status:** 🟡 採番予約のみ。Day 4 で本文起票予定
+- **Scope:** v0.5 R-1.1〜R-1.4 で導入する job state machine 不変条件の宣言、および R-1.4 (#360) で必要となる `paused` 状態の Change Gate
+- **Reference:** `docs/pre-v05-handoff-2026-05-05.md` §3.1 M-2
+
+### P-0100: severity envelope の正式化（PR-B4 → PR-C2/PR-D1, Issue #394）
+
+- **Date:** 2026-05-05 起票 / 同日 Decision
+- **Related:** PR #399 (PR-C2 feat/validate-metric-compat-394), PR #400 (PR-D1 fix/fit-tune-severity-filter-394), Issue #394, P-0097 (Wide DataFrame), CHANGELOG v0.4.1
+
+#### Motivation
+
+PR-B4 で `ValidationError` payload に `severity: Literal["error", "warning", "info"]` と `suggested_fix: str | None` が導入されたが、Pydantic Literal の正式宣言と「どこで `severity` を見るか」のセマンティクスが HISTORY 未記録のまま v0.4.1 リリースに乗った。PR-C2 と PR-D1 で raise sites が確定したため、後続 R-1 / R-3 が同 envelope を使い続ける前提として正式化する。
+
+#### Purpose
+
+- `severity="error"` 以外は `valid=true` / `saved=true` を維持し block しない
+- `severity` 未設定の旧 ValidationError は `"error"` として扱い backward compatible
+- `_blocking_errors` 共通ヘルパで「block 判定 = `severity != "warning|info"`」を一箇所に集約
+- `suggested_fix` は警告を「具体的な置換アクション」に紐付ける recovery hint slot として API 仕様に組み込む
+
+#### Impact
+
+- Public API: `POST /api/workspace/config/validate` / `PUT /api/workspace/config` / `POST /api/workspace/upload` の `errors[]` 各要素に `severity` (default `"error"`) と `suggested_fix` (default `null`) が必須キーとして登場
+- `POST /api/workspace/fit` / `POST /api/workspace/tune` は warning-only config (= severity != "error") を 422 で返さなくなる（PR-D1 #400 で修正）
+- Frontend: yellow warning banner が ConfigForm 上部に追加 (ConfigEditorBody.tsx)、blocking と非 blocking を視覚分離
+- 既存 ValidationError 使用箇所はキー追加のみで挙動不変
+
+#### Compatibility
+
+- 旧 ValidationError (severity 未設定) は default `"error"` で従来挙動を維持
+- Frontend `isBlockingError(entry)` ヘルパが `entry.severity ?? "error"` で wrap
+- `_blocking_errors([entry, ...])` ヘルパが Service / API 層共通で severity フィルタ
+- 全フィールド optional 追加 → JSON Schema 後方互換
+
+#### Acceptance criteria
+
+- [x] `tests/contract/test_validate_severity_and_suggested_fix.py` で envelope shape を契約化
+- [x] `tests/contract/test_fit_tune_severity_filter.py` で fit/tune が warning-only config を受け入れることを 7 cases pin（PR-D1 #400）
+- [x] `frontend/src/api/types.ts` に `isBlockingError` ヘルパ + 単体テストへの落とし込みは S-1 / O-1 で追加（#404 / #405）
+- [x] CHANGELOG v0.4.1 で公開挙動を記述
+
+#### Alternatives considered
+
+- **(a) 別フィールド `level: "fatal" | "warn"` を使う**: 拒否。`severity` がすでに WCAG / RFC 用語と整合、Toast / aria-live にもそのまま流用可能
+- **(b) HTTP status を 422 / 200 で分離**: 拒否。同一エンドポイントの一覧に warning と error が混在するケースで status を分けると複雑化、UI が両方をマージできない
+- **(c) suggested_fix を別 endpoint に切り出す**: 拒否。round-trip が増え UX 悪化
+
+→ 採用は **(d) 同 envelope で severity + suggested_fix を inline**。
+
+#### Decision
+
+- 2026-05-05 **Decided (post-hoc)** — PR-C2 / PR-D1 で実装済、本 Decision 記録は v0.4.1 リリース後の reconciliation。後続 R-1 / R-3 / R-3.4.2 (Diagnostic export) はこの envelope を前提に拡張する
+
+### P-0101: metric-compat watchlist による uncomputable metric の auto-disable（PR-C2, Issue #394）
+
+- **Date:** 2026-05-05 起票 / 同日 Decision
+- **Related:** PR #399 (PR-C2 feat/validate-metric-compat-394), PR #400 (PR-D1), Issue #394, P-0100 (severity envelope), CHANGELOG v0.4.1, LizyML 0.11.0 (sMAPE / WAPE)
+
+#### Motivation
+
+`mape` / `rmsle` / `r2` は target 列の値域が条件を満たさないと数学的に計算できない:
+
+- `mape`: target に 0 が含まれると ZeroDivisionError 相当
+- `rmsle`: target に負値が含まれると `log(1+x)` で nan
+- `r2`: target が定数だと分散 0 で nan
+
+ユーザがこれらを Tuning 設定の `evaluation.metrics` に入れたまま fit すると、結果として nan / 例外で失敗するか、ジョブ完走後に metric が表示されない。事前に `validate` レイヤで「この target だと計算不能なので外しますね」と返したい。
+
+#### Purpose
+
+- Service 層の `_workspace_metric_compatibility_errors(config, df)` で target 列を inspect し、watchlist 該当 metric があれば `severity="warning"` の ValidationError を返す
+- `suggested_fix` で具体的な置換 metric 名を返す (例: `mape` 該当時は LizyML 0.11.0 で追加された `smape` / `wape` を提案)
+- `task=regression` のときだけ作動（binary / multiclass は対象外、HIGH-1 として PR-D1 で task ガード追加）
+- 検出ルールはこの Decision で固定し、後続バックエンドが増えたときは [Issue #403](https://github.com/nbx-liz/LizyStudio/issues/403) で BackendAdapter 抽象化
+
+#### Impact
+
+- 新 helper: `_workspace_metric_compatibility_errors(config, df) -> list[ValidationError]`
+- 呼び出しタイミング: `POST /api/workspace/config/validate` / `PUT /api/workspace/config` / `POST /api/workspace/upload`
+- Frontend 影響: yellow banner に `suggested_fix` を二行目で表示 (P-0100 で導入された envelope を流用)
+- 検出は **non-blocking** (severity=warning)。ユーザはそのまま fit を実行可能だが、metric は実行時に nan を返す可能性
+
+#### Watchlist 仕様
+
+| Metric | Trigger | suggested_fix |
+|---|---|---|
+| `mape` | target に 0 が 1 件以上 | "Use `smape` or `wape` instead (lizyml 0.11.0+)" |
+| `rmsle` | target に負値が 1 件以上 | "Remove `rmsle` from evaluation.metrics" |
+| `r2` | target の `nunique() == 1` (定数) | "Remove `r2` from evaluation.metrics" |
+
+#### Compatibility
+
+- watchlist は backward-compat: 警告だが block しない、既存 fit の挙動は不変
+- 旧バックエンド (lizyml 0.10.x) で sMAPE / WAPE が無くても suggested_fix は文字列のみ → クライアントは盲目に表示するだけで壊れない
+- task != "regression" のときは作動しない (binary classification で `r2` を入れるとそもそも metric registry でエラーになる別経路)
+
+#### Acceptance criteria
+
+- [x] `src/lizystudio/services/workspace.py` で `_workspace_metric_compatibility_errors` 実装
+- [x] PR #399 で 3 endpoints (`validate` / `PUT /config` / `upload`) に組み込み
+- [x] PR #400 で `task=regression` ガード + fit/tune raise sites の severity フィルタ
+- [x] `tests/contract/test_validate_metric_compatibility.py` で 9 cases (今後 #404 で 7 cases 追加して 16 cases へ)
+- [x] CHANGELOG v0.4.1 で公開挙動を記述
+
+#### Alternatives considered
+
+- **(a) Backend 任せ (fit 実行時に nan を返す)**: 拒否。ユーザが trial を浪費した後に気づく、UX 悪化
+- **(b) Hard error (severity="error" で block)**: 拒否。数学的不能でも MAPE を許容したい上級ユーザもいる、過剰な強制
+- **(c) BackendAdapter abstract method として最初から抽象化**: defer。第二 backend が見えるまで抽象化は YAGNI、Issue #403 として後送り
+
+→ 採用は **(d) Service 層 helper + watchlist 定義 + non-blocking warning**。Adapter 抽象化は #403 で別途。
+
+#### Decision
+
+- 2026-05-05 **Decided (post-hoc)** — PR-C2 / PR-D1 で実装済、本 Decision 記録は v0.4.1 リリース後の reconciliation。Issue #403 で BackendAdapter 抽象化、#404 で異常系 7 cases 追加が follow-up
+
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 - このファイルは **横串インデックス** であり、詳細はリンク先で確認すること。
 - 着手する際は HISTORY に Proposal を起票（変更ゲート対象の場合）→ PLAN にフェーズ追加 → 実装、の順で進める。
 
-最終更新: 2026-05-01（直近 PR #329-#335 反映完了：P-0093 / #328 / cleanup / Tier 3 docs / P-0094 Proposal+impl / BLUEPRINT audit）
+最終更新: 2026-05-05（v0.4.1 リリース反映：CHANGELOG / HISTORY P-0095..P-0098 / Open Issues #403..#405 / v0.5 R-1 Next Action）
 
 ---
 
@@ -103,6 +103,16 @@
 
 | 完了日 | ID | タイトル | 主要 PR |
 |---|---|---|---|
+| 2026-05-05 | **v0.4.1 release** | Validate clarity patch — severity envelope + auto-disable uncomputable metrics + lizyml 0.11.0 (sMAPE/WAPE) | #397 / #398 / #399 / #400 / #401 / #402 (release merge) |
+| 2026-05-05 | PR-D1 (#400) | fit/tune raise sites filter on `severity="error"`; warning-only configs no longer 422 | #400 |
+| 2026-05-05 | PR-C2 (#399) | `_workspace_metric_compatibility_errors` auto-disables `mape`/`rmsle`/`r2` via severity=warning + suggested_fix | #399 |
+| 2026-05-05 | LizyML 0.11.0 bump | adopt sMAPE / WAPE (zero-tolerant MAPE alternatives) | #398 |
+| 2026-05-05 | PR-C1 (#397) | hide redundant SHAP Summary tab in Workspace Plot panel | #397 |
+| 2026-05-05 | **v0.4.0 release** | Wide DataFrame — data/preview & importance payload caps, chunked CSV fail-fast | (multiple, #395 release merge) |
+| 2026-05-05 | P-0098 | `load_dataframe` chunk-based fail-fast memory guard (PR-B3) | (in v0.4.0) |
+| 2026-05-05 | P-0097 | Wide DataFrame data/preview + importance payload caps (#361 / R-5.1) | (in v0.4.0) |
+| 2026-05-04 | P-0096 | 業務利用 (business-use) 定義の確定と v0.4 Exit Criteria への反映 | (docs) |
+| 2026-05-03 | P-0095 | Backend fit→load round-trip integration test as required CI gate (#346 Phase C) | #348..#354 |
 | 2026-05-01 | BLUEPRINT audit | P-0086..P-0094 の Decisions を BLUEPRINT.md §3.3/§3.4/§5.2/§5.5/§6.1/§8.1 に反映 | #335 |
 | 2026-05-01 | P-0094 (impl) | pytest-benchmark perf baseline (`tests/bench/` + nightly job) | #334 |
 | 2026-05-01 | P-0094 (proposal) | pytest-benchmark introduction Proposal-only | #333 |
@@ -123,6 +133,14 @@
 ---
 
 ## 3. アクティブ：仕様変更を伴う Proposal
+
+### 3.-1 v0.5 R-1 invariants Proposal（採番予約：P-0099, P-0100, P-0101）
+
+- **状態**: 🟡 未起票（v0.5 R-1 着手直前に書く。`docs/pre-v05-handoff-2026-05-05.md` §3.1 M-2 / M-3 参照）
+- **P-0099**: Job state machine invariants + `paused` state（R-1 全体の Change Gate）
+- **P-0100**: severity envelope formalization (PR-B4) — Pydantic Literal 化、`_blocking_errors` セマンティクス（PR-D1 #400 で確立、未記録）
+- **P-0101**: metric-compat watchlist — `_workspace_metric_compatibility_errors` の検出ルール（PR-C2 #399 / PR-D1 #400 で確立、未記録）
+- **次回採番**: P-0102 以降
 
 ### 3.0 P-0094 (済)：pytest-benchmark performance baseline（Issue #27 (a)）
 
@@ -228,11 +246,16 @@
 
 ## 5. アクティブ：Open Issues
 
-直近 4 件（#327 / #328 / #298 / #304）はすべて closed 済み。Tier 4 戦略課題のみ残存。
+v0.4.1 リリース後の Open Issue は 5 件。
 
 | Issue | タイトル | priority | 推奨アクション |
 |---|---|---|---|
-| **#27** | [Testing] Add load and concurrency tests | medium / tier-4 | (a) `pytest-benchmark` 100k-row microbench を tier-3 で先行マージ可 / (b) 並行 fit stress harness は tier-4 |
+| **#360** | feat(tune): long-run resumability (24h+, all termination paths) | tier-4 / high | **v0.5 core (R-1.4, 3 週間)**。LizyML 上流対応待ち（M-1 で起票予定） |
+| **#384** | [Testing] #28 follow-up — Server Restart Recovery (blocked on #360) | tier-3 / medium | **R-1.5b (v0.5)** — #360 解消後 |
+| **#403** | refactor(backend): move metric-compat watchlist behind BackendAdapter abstraction (HIGH-2) | tier-3 / medium | **v0.6 defer 推奨** — 第 2 backend が見えてから |
+| **#404** | test: add edge-case coverage for `_workspace_metric_compatibility_errors` | tier-2 / medium | **S-1 (Day 3 着手)** — 7 cases (NaN/inf/dtype/dedup/malformed) |
+| **#405** | test(frontend): integration coverage for validate-debounce → warning banner | tier-3 / medium | **O-1 (並行可)** — frontend 単独 |
+| **#27** | [Testing] Add load and concurrency tests | medium / tier-4 | (a) `pytest-benchmark` baseline は P-0094 で完了。(b) 並行 fit stress harness は実機要件あり |
 | **#28** | [Testing] Add offline/resume resilience tests | medium / tier-4 | `current_job_id` ライフサイクル契約決定が前提。post-completion deep-link は #143 でカバー済み、during-run reload が gap |
 | **#125** | chore(frontend): migrate Tailwind CSS v3 → v4 | medium / tier-4 | Owner status: `Button` で spike → 専用 sprint。即着手は推奨しない |
 
@@ -242,36 +265,63 @@
 
 | 対象 | 最終更新 | リスク | 対応 |
 |---|---|---|---|
-| `BLUEPRINT.md` | ✅ 2026-05-01 reconciled | — | P-0086 / P-0088 / P-0089 / P-0093 / `JOB_CONFLICT` / `preflight_checkpoint_dir` / P-0094 perf bench の drift を反映済み |
+| `BLUEPRINT.md` | 🟡 2026-05-01 (P-0094 まで反映) | 中 | P-0095..P-0098 と v0.4.1 severity envelope（PR-B4 / PR-C2 / PR-D1）が未反映。**M-4 (Day 2) で §5 (API) に severity / suggested_fix を追記** |
+| `HISTORY.md` Decision 記録 | 🟡 2026-05-04 P-0098 まで | 中 | v0.4.1 で導入された severity envelope / metric-compat watchlist が Decision 未記録。**M-3 (Day 2) で P-0100 / P-0101 を起票** |
+| `PLAN.md` v3-N | 🟡 2026-05-01 v3-15 まで | 中 | v0.4.0 / v0.4.1 phase が未確定、v0.5 R-1〜R-2 phase が未追加。**M-5 (Day 4) で v3-16 以降を追加** |
 | `docs/architecture.md` / `api.md` / `adapter-guide.md` | ✅ 2026-05-01 reconciled | — | 棚卸し完了。`tests/contract/test_adapter_guide_method_names.py` で adapter-guide.md ↔ Protocol の drift を gating |
-| `PLAN.md` v3-13/14/15 | ✅ 反映済み（2026-04-30, 2026-05-01） | — | — |
-| `HISTORY.md` P-0092 follow-ups | ✅ 反映済み（2026-04-30、PR #303 周辺で追記） | — | — |
-| `MEMORY.md` 古いノート | ✅ 直近セッションで更新（`project_coupling_refactor_progress` 等は post-#271 / P-0092 完了以降に上書き済み） | — | — |
+| `docs/architecture-as-implemented.md` | 🟡 2026-04-17 | 中 | severity filter / `_blocking_errors` の hop 図が未更新。**S-4 (Day 3) で更新** |
+| `docs/v0.4-business-readiness-plan.md` | 🟡 2026-04 | 低 | R-3.4 (Validate API) は v0.4.0 / v0.4.1 で完了。**S-3 (Day 1 午後) でレビュー → header に shipped 記載** |
+| `MEMORY.md` 古いノート | ✅ 直近セッションで更新 | — | `project_v041_shipped` / `project_pre_v05_work_plan` 反映済み |
 | `analysis/` 削除済み | 2026-04 期間 | `python-analyst` ↔ `lizystudio-analyst` パイプライン成果物の置き場が無い | 🟡 意図的削除か要確認、別 issue 検討 |
 
 ---
 
 ## 7. 推奨 Next Action（ROI 順 / 1 PR 単位）
 
-> 旧 Tier 0 / Tier 1 / Tier 2 のアイテムは 2026-04-30〜2026-05-01 に解消済み（B-4/B-5/B-6/B-2 → PR #312-#315、B-1 → PR #316、Phase C generator + wave 1〜8 → PR #317-#325、B-8 → PR #318、#327/#328 → PR #329/#330）。残るは Tier 3 戦略課題と Tier 4 長期計画。
+> v0.4.1 リリース完了 (2026-05-05)。詳細な v0.5 着手前の作業内訳は `docs/pre-v05-handoff-2026-05-05.md` 参照（MUST 6 + SHOULD 4 + OPTIONAL 3 = 13 件、計 4-7 日）。
 
-### Tier 3：戦略課題
+### Tier 1：v0.5 着手前必須（MUST、4-6 日）
 
-1. **P-0094 implementation**: pytest-benchmark microbench — Proposal accept 後の実装 PR（`feat/pytest-benchmark-baseline-p0094` で着手予定）
-2. **P-0095 として P-0087 Phase 3 を Proposal 化**（`cv_strategy_fields` の Pydantic 自動派生）— lizyml 側で構造化フィールドメタデータ export が前提のためリポジトリ間調整必要
-3. **#28** offline/resume resilience tests — `current_job_id` ライフサイクル契約決定が前提
+1. **M-1**: LizyML 側に Optuna persistent storage Issue を起票（`/home/rem/repos/LizyML`、cross-repo）— v0.5 R-1.4 (#360) のクリティカルパス
+2. **M-2**: HISTORY.md P-0099 起票（R-1 invariants + `paused` state Change Gate）
+3. **M-3**: HISTORY.md P-0100 / P-0101 起票（severity envelope / metric-compat watchlist Decision）
+4. **M-4**: BLUEPRINT.md §5 (API) に severity / suggested_fix を反映
+5. **M-5**: PLAN.md v3-N (R-1 〜 R-2) phase 追加 + v0.4.0 / v0.4.1 phase 確定
+6. **M-6**: handoff docs cleanup（5 ファイル削除） — 一部完了（3 ファイル削除済、本 ROADMAP 更新後 `pre-v05-handoff-2026-05-05.md` 削除予定）
 
-### Tier 4：要長期計画
+### Tier 2：高 ROI 準備（SHOULD、1-2 日）
 
-5. **#27 (b)** 並行 fit stress harness — 実機マシン要件あり
-6. **#125** Tailwind v4 — Button で spike → 専用 sprint
-7. ML Backend 2nd 実装による Adapter 抽象検証 — 候補 backend 選定が未決
+7. **S-1**: #404 異常系テスト 7 cases 追加（`tests/contract/test_validate_metric_compatibility.py` + `frontend/src/api/types.test.ts`）
+8. **S-2**: 本 ROADMAP の post-v0.4.1 reconciliation — 進行中（本コミット）
+9. **S-3**: `docs/v0.4-business-readiness-plan.md` レビュー + shipped 状態確定
+10. **S-4**: `docs/architecture-as-implemented.md` 更新（severity filter / `_blocking_errors` hop 図）
+
+### Tier 3：v0.5 と並行可（OPTIONAL、3-5 日）
+
+11. **O-1**: #405 integration test (validate-debounce → warning banner) — frontend 単独
+12. **O-2**: #403 BackendAdapter metric-compat refactor — 第 2 backend が見えるまで defer 推奨
+13. **O-3**: P-0087 Phase 3 (`cv_strategy_fields` 自動派生) — LizyML 構造化 export 待ち、defer 推奨
+
+### Tier 4：v0.5 core（着手後 8-12 週間）
+
+- **#360** Tune long-run resumability (R-1.4, 3 週間) — M-1 上流対応待ち
+- **#384** Server Restart Recovery (R-1.5b, 1 週間) — #360 解消後
+- **#358** BlockedGroup race (R-1.2)
+- **#359** job-num drift (R-1.5)
+- WS 再接続 / ブラウザリロード復元 (R-2)
+
+### Tier 5：要長期計画（v0.6 以降）
+
+- **#27 (b)** 並行 fit stress harness — 実機マシン要件あり
+- **#125** Tailwind v4 — Button で spike → 専用 sprint
+- ML Backend 2nd 実装による Adapter 抽象検証 — 候補 backend 選定が未決
 
 ---
 
 ## 8. 運用メモ
 
-- 新規 Proposal を起票するときは **P-0095 から採番**（P-0094 = pytest-benchmark Proposal 起票は 2026-05-01 に消化）。`H-XXXX` 採番は終了。
+- 新規 Proposal を起票するときは **P-0099 から採番**（P-0098 = `load_dataframe` chunked CSV、2026-05-04 で消化済）。`H-XXXX` 採番は終了。
+- v0.5 R-1 着手時は P-0099 (invariants + `paused` state)、v0.4.1 機能の Decision 記録は P-0100 / P-0101 を予約済み。
 - E2E 単独追加（仕様変更なし）は HISTORY 起票不要、本 ROADMAP の §3 を更新するだけで OK。
 - 本 ROADMAP はステータス変更時に都度更新。タスク完了時は §1 へ移動、新規着手時は §2/§3/§4 へ追加する。
 - 古い ID（B-N coupling、A.M Phase A など）は履歴参照のためそのまま残す。検索性のため改名はしない。

--- a/docs/architecture-as-implemented.md
+++ b/docs/architecture-as-implemented.md
@@ -258,6 +258,44 @@ stateDiagram-v2
 
 ---
 
+## 5.4 Validate envelope flow (P-0100 / P-0101, v0.4.1 で確立)
+
+`POST /api/workspace/config/validate` / `PUT /api/workspace/config` / `POST /api/workspace/upload` の `errors[]` 各要素は `severity: Literal["error", "warning", "info"]`（default `"error"`）と `suggested_fix: str | None` を持つ envelope を返す。
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant C as Client (React)
+  participant R as api/workspace.py
+  participant SVC as services/workspace.py
+  participant ADP as BackendAdapter
+
+  C->>R: POST /api/workspace/config/validate {config}
+  R->>ADP: validate_config(cfg)
+  ADP-->>R: list[ValidationError]   # severity defaults to "error"
+  R->>SVC: _workspace_metric_compatibility_errors(cfg, df)
+  SVC-->>R: list[ValidationError]   # severity="warning" + suggested_fix
+  R->>R: errors = adapter_errors + watchlist_errors
+  R->>R: valid = len(_blocking_errors(errors)) == 0
+  R-->>C: {valid, errors[]}
+
+  Note over R,SVC: _blocking_errors filters severity=="error"<br/>fit/tune 4 raise sites use the same helper (PR-D1 #400)
+```
+
+Block 判定の hop:
+
+| 呼び出し元 | 判定ヘルパ | block する severity |
+|---|---|---|
+| `POST /workspace/config/validate` | `valid = len(_blocking_errors(errors)) == 0` | `"error"` |
+| `PUT /workspace/config` | `saved = len(_blocking_errors(errors)) == 0`、422 raise | `"error"` |
+| `POST /workspace/upload` | 同上 | `"error"` |
+| `POST /workspace/fit` `/tune` | 4 raise sites が `_blocking_errors` 経由（PR-D1 #400） | `"error"` |
+| Frontend `isBlockingError(entry)` | `(entry.severity ?? "error") === "error"` | `"error"` |
+
+Frontend は `useModelPanelData` で `errors[]` を `blockingErrors` / `warningEntries` の 2 グループに分割し、ConfigEditorBody が red banner（block）と yellow banner（advisory + suggested_fix）を二段重ねで描画する。
+
+---
+
 ## 6. "fit" Request End-to-End Flow
 
 ```mermaid

--- a/docs/v0.4-business-readiness-plan.md
+++ b/docs/v0.4-business-readiness-plan.md
@@ -1,9 +1,10 @@
 # v0.4 Business-Readiness Plan
 
-> **Status**: DRAFT v0.1 (2026-05-03 起票)
+> **Status**: PARTIAL — R-3.4 / R-5 shipped in v0.4.0 / v0.4.1 (2026-05-05). R-1 / R-2 / R-3 (残) / R-4 deferred to v0.5+.
 > **基底**: [`docs/business-use-definition.md`](business-use-definition.md) v0.2 CONFIRMED
 > **目的**: v0.4 を「業務利用可能」レベルにするための Phase 別実装計画。確定された定義に基づき、必要十分な作業項目を列挙する。
-> **承認**: 本計画を Tier 4 (アクティブな個別計画) として固定するため、`HISTORY.md` に Proposal P-0096 を起票して Change Gate を通す。
+> **承認**: HISTORY.md P-0096 (業務利用定義の確定、2026-05-04 merged) で Tier 4 として固定済。
+> **当初版**: DRAFT v0.1 (2026-05-03 起票) → v0.2 (2026-05-05、§10 改訂履歴参照)
 
 ---
 
@@ -25,16 +26,18 @@
 
 ## 1. Phase 構成と工数感
 
-| Phase | 内容 | 工数 |
-|---|---|---|
-| R-1 | 状態整合性の徹底 + **Tune resume** | 6 週間 |
-| R-2 | セッション復元 (WS reconnect, browser reload) | 2 週間 |
-| R-3 | エラー復旧 (typed errors, recovery hints) | 3 週間 |
-| R-4 | 互換性ロック (format_version, Pickle compat) | 2 週間 |
-| **R-5** | **Wide DataFrame + Large CSV scaling** (新設) | 3 週間 |
-| **合計** | | **約 16 週間 (4 ヶ月)** |
+| Phase | 内容 | 工数 | ステータス |
+|---|---|---|---|
+| R-1 | 状態整合性の徹底 + **Tune resume** | 6 週間 | 🟡 v0.5 着手予定 |
+| R-2 | セッション復元 (WS reconnect, browser reload) | 2 週間 | 🟡 v0.5 着手予定 |
+| R-3 | エラー復旧 (typed errors, recovery hints) | 3 週間 | 🟢 R-3.4 のみ完了 (v0.4.0 / v0.4.1)、R-3.1〜R-3.3 は v0.6+ 送り |
+| R-4 | 互換性ロック (format_version, Pickle compat) | 2 週間 | 🟡 v0.5 着手予定 |
+| **R-5** | **Wide DataFrame + Large CSV scaling** (新設) | 3 週間 | ✅ **完了 (v0.4.0 / v0.4.1, 2026-05-05)** |
+| **合計** | | **約 16 週間 (4 ヶ月)** | — |
 
 スケジュールは「ソロ作業」を前提とした見積。チームで取り組む場合は短縮可能。
+
+> **2026-05-05 時点の進捗**: R-5 (Wide DataFrame + Large CSV) と R-3.4 (Validate API + suggested_fix) は v0.4.0 / v0.4.1 リリースで完了。残り R-1 / R-2 / R-4 は **v0.5 のスコープ**として `docs/pre-v05-handoff-2026-05-05.md` で着手計画を引き継ぐ。R-1.4 (Tune resume) は LizyML #105 (Optuna persistent storage) のクリティカルパス上にある。
 
 ---
 
@@ -131,10 +134,12 @@
 
 ### R-3.4 Validate API 強化 + Diagnostic export (0.5週間)
 
-| ID | 項目 | 受け入れ基準 |
-|---|---|---|
-| R-3.4.1 | Fit 起動前の `config/validate` 強化 | target存在、CV 適合性、一意制約まで検証 |
-| R-3.4.2 | `lizystudio diagnose` CLI / `/api/diagnostics/bundle` | 個人情報 redact 済の zip ダウンロード |
+> **Status**: 🟢 R-3.4.1 部分完了 (v0.4.1)。R-3.4.2 (CLI diagnose) は v0.6+ 送り。
+
+| ID | 項目 | 受け入れ基準 | ステータス |
+|---|---|---|---|
+| R-3.4.1 | Fit 起動前の `config/validate` 強化 | target存在、CV 適合性、一意制約まで検証 | ✅ v0.4.1 (severity envelope + metric-compat watchlist + suggested_fix; PR #399 / #400) |
+| R-3.4.2 | `lizystudio diagnose` CLI / `/api/diagnostics/bundle` | 個人情報 redact 済の zip ダウンロード | 🔴 v0.6+ deferred |
 
 ---
 
@@ -157,6 +162,8 @@
 ---
 
 ## 6. Phase R-5 — Wide DataFrame + Large CSV (3週間, 新設)
+
+> **Status**: ✅ **完了 (v0.4.0 / v0.4.1, 2026-05-05)** — R-5.1 / R-5.2 ともに shipped。Issue #361 close 済。HISTORY.md P-0097 / P-0098 で Decision 確定。
 
 業務利用上限 **1000万行 × 1万列 × 100GB** に対して、UI と性能を担保する。**BYO RAM 戦略**で実装は単純化 (チャンク・サンプリング不要)。
 
@@ -201,7 +208,18 @@
 
 ## 8. v0.5 へ送るもの (Out of v0.4 scope)
 
-`business-use-definition.md` v0.2 で確認したが v0.4 では着手しない:
+### 8.1 v0.5 で実施 (本計画から繰越)
+
+| Phase | 内容 | 工数 | 依存 |
+|---|---|---|---|
+| R-1 | 状態整合性 + Tune resume (R-1.1〜R-1.5) | 6 週間 | LizyML #105 (Optuna persistent storage) |
+| R-2 | セッション復元 (WS reconnect, browser reload) | 2 週間 | R-1 完了 |
+| R-4 | 互換性ロック (format_version, Pickle compat) | 2 週間 | — |
+| R-3 残 | R-3.1〜R-3.3 (typed errors / recovery hints / plot symmetric audit) | 2-3 週間 | — |
+
+### 8.2 v0.6+ 送り (戦略タスク)
+
+`business-use-definition.md` v0.2 で確認したが v0.4 / v0.5 では着手しない:
 
 - 商用サポート (§14, Q7) — 提供しない
 - マルチユーザ並行制御 (§7) — 1 名利用のため不要
@@ -209,20 +227,23 @@
 - LLM 統合 — 要件が明確化された時点で起票
 - PyTorch backend — lizyml 側対応後に v0.5 以降で起票
 - 監査ログ・認証層 (§10) — Out of scope (ユーザ環境側で対応)
+- R-3.4.2 `lizystudio diagnose` CLI — v0.6+ 送り (R-3.4.1 は v0.4.1 で完了)
 
-v0.5 では性能 SLO 監視 (Bench harness 自動化)、運用 runbook、 backup/restore CLI、Docker 公式 image を整備する。
+v0.6 では性能 SLO 監視 (Bench harness 自動化)、運用 runbook、backup/restore CLI、Docker 公式 image を整備する。
 
 ---
 
 ## 9. 次のアクション
 
-| 順序 | アクション | 担当 |
-|---|---|---|
-| 1 | `HISTORY.md` に Proposal P-0096 (業務利用定義の確定) を起票 | dev |
-| 2 | `PLAN.md` に v0.4-N セクションを追加し本計画を反映 | dev |
-| 3 | `ROADMAP.md` を更新 (Tier 2 INDEX に本計画と Issue #360/#361 を登録) | dev |
-| 4 | Phase R-1 から着手 (6週間) | dev |
-| 5 | 各 Phase 完了時に Exit Criteria を確認、PR 単位でマージ | dev |
+> **2026-05-05 状態**: Step 1〜3 は完了。Step 4 (Phase R-1) は v0.5 着手前に 13 件の準備タスクを `docs/pre-v05-handoff-2026-05-05.md` で実施してから着手する。
+
+| 順序 | アクション | 担当 | ステータス |
+|---|---|---|---|
+| 1 | `HISTORY.md` に Proposal P-0096 (業務利用定義の確定) を起票 | dev | ✅ 完了 (2026-05-04) |
+| 2 | `PLAN.md` に v3-N セクションを追加し本計画を反映 | dev | 🟡 v3-15 まで反映、R-1 以降は M-5 で追加予定 |
+| 3 | `ROADMAP.md` を更新 (Tier 2 INDEX に本計画と Issue #360/#361 を登録) | dev | ✅ 完了 (2026-05-05、本セッション S-2) |
+| 4 | Phase R-1 から着手 (6週間) | dev | 🟡 v0.5 着手 — `pre-v05-handoff-2026-05-05.md` の MUST 6 件完了後 |
+| 5 | 各 Phase 完了時に Exit Criteria を確認、PR 単位でマージ | dev | — |
 
 ---
 
@@ -231,3 +252,4 @@ v0.5 では性能 SLO 監視 (Bench harness 自動化)、運用 runbook、 backu
 | 版 | 日付 | 内容 |
 |---|---|---|
 | v0.1 | 2026-05-03 | 初版。`business-use-definition.md` v0.2 に基づき Phase R-1〜R-5 を確定 |
+| v0.2 | 2026-05-05 | v0.4.0 / v0.4.1 リリース反映。R-5 / R-3.4.1 を完了マーク、R-3.4.2 / R-3.1〜R-3.3 を v0.6+ 送り、R-1 / R-2 / R-4 は v0.5 へ繰越し。Status を PARTIAL に更新 |


### PR DESCRIPTION
## Summary

Records v0.4.1 design Decisions that were merged-and-shipped without HISTORY entries, and reconciles all Tier 2/3/4 docs with the v0.4.1 release state. This is a **post-hoc spec reconciliation** PR — no code changes, no behaviour changes. Memory `feedback_no_docs_only_pr` exception: HISTORY/BLUEPRINT updates are spec-doc Decisions tied to PR #399 / #400 implementation.

## Why now

`docs/pre-v05-handoff-2026-05-05.md` flagged 4 spec-doc drifts after v0.4.1 ship:
- HISTORY.md: severity envelope (PR-B4) and metric-compat watchlist (PR-C2) had no Decision record
- BLUEPRINT.md §5: validate response envelope (`severity` + `suggested_fix`) was un-specified
- ROADMAP.md: v0.4.0 / v0.4.1 releases not on the "recent shipped" table, P-0095..P-0098 missing
- v0.4-business-readiness-plan: still marked DRAFT v0.1, R-5 / R-3.4.1 actually shipped

R-1 work (state-machine invariants for v0.5) will plug into the same severity envelope, so locking the spec now prevents drift during the bigger refactor.

## Changes

### HISTORY.md (Tier 1 spec)

- **P-0099 (reservation only)** — slot for R-1 invariants + `paused` state Change Gate, body to be written before v0.5 R-1 kickoff (see `pre-v05-handoff` §3.1 M-2)
- **P-0100 (Decided post-hoc)** — severity envelope formalization. Locks `severity: Literal["error","warning","info"]` (default `"error"`) + `suggested_fix: str | None`, `_blocking_errors` filter semantics (severity == "error"), and the 4 fit/tune raise sites fix from PR-D1
- **P-0101 (Decided post-hoc)** — metric-compat watchlist. Locks the watchlist table (`mape` zeros / `rmsle` negatives / `r2` constant), `task=regression` guard, suggested_fix copy, and defers BackendAdapter abstraction to Issue #403

### BLUEPRINT.md §5.2 (Tier 1 spec)

- New "Validate response envelope" subsection under Workspace API → Config — JSON shape, severity table, `_blocking_errors` rule, full watchlist trigger table

### docs/architecture-as-implemented.md §5.4 (Tier 3)

- New mermaid sequence diagram showing the validate hop: adapter errors + watchlist errors → `_blocking_errors` filter → response
- Hop table: which call sites use which helper, with frontend `isBlockingError` mapping

### docs/ROADMAP.md (Tier 2 INDEX)

- §2 recent-shipped table — added v0.4.1 (5 PRs + release merge), v0.4.0 (Wide DataFrame), P-0095 / P-0096 / P-0097 / P-0098
- §3.-1 — Proposal reservation slot for P-0099 / P-0100 / P-0101
- §5 — added open issues #360 / #384 / #403 / #404 / #405 with recommended action
- §6 — drift table updated (BLUEPRINT / HISTORY / PLAN now flagged 🟡 with M-2..M-5 follow-ups)
- §7 — Next Action restructured into Tier 1..5 (MUST / SHOULD / OPTIONAL / v0.5 core / long-term)

### docs/v0.4-business-readiness-plan.md v0.2 (Tier 4 plan)

- Status: DRAFT v0.1 → **PARTIAL** (R-3.4.1 + R-5 shipped, R-1/R-2/R-4 deferred to v0.5)
- §1 phase table: each row gets a status column with shipped / deferred markers
- §3.4 R-3.4: split R-3.4.1 (shipped v0.4.1) vs R-3.4.2 (v0.6+ deferred)
- §6 R-5: marked shipped 2026-05-05
- §8: split into "v0.5 carry-over" (R-1/R-2/R-4 + remaining R-3) and "v0.6+ deferred" tables
- §9 next-actions: marks Step 1/3 done, Step 4 (R-1) blocked on `pre-v05-handoff` MUST 6 items
- §10 revision history: appended v0.2 row

### Working tree (not in commit)

- Removed 3 stale handoff docs (untracked): `gui-verification-handoff-2026-05-04.md`, `phase-b-handoff-2026-05-04.md`, `post-v040-handoff-2026-05-05.md`
- `pre-v05-handoff-2026-05-05.md` retained as untracked until Day 4 work completes

## Cross-repo

[LizyML#105](https://github.com/nbx-liz/LizyML/issues/105) opened in same session — Optuna persistent storage for tune resumability (M-1 in handoff). Critical path for #360 / v0.5 R-1.4. Not part of this PR.

## Test plan

- [x] No code changes — pre-commit ruff / format / biome all skipped (no source files staged)
- [x] HISTORY P-0100 / P-0101 reference real PRs that merged 2026-05-05 (#399 / #400)
- [x] BLUEPRINT envelope spec matches `tests/contract/test_validate_severity_and_suggested_fix.py` and `tests/contract/test_fit_tune_severity_filter.py` assertions (verified by grep)
- [x] ROADMAP §6 drift markers point at the M-X / S-X follow-up that will resolve them

## Refs

- Issue #394 (envelope source bug)
- PR #399 (PR-C2 metric-compat watchlist impl)
- PR #400 (PR-D1 severity filter for fit/tune)
- `docs/pre-v05-handoff-2026-05-05.md` §3.1 M-3 / M-4 + §3.2 S-2 / S-3 / S-4
