### PR TITLE
test: edge-case + integration coverage for v0.4.1 severity envelope (#404, #405)

### DIFF
--- a/frontend/src/api/types.test.ts
+++ b/frontend/src/api/types.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import type { ConfigError } from "./types";
+import { isBlockingError } from "./types";
+
+// Issue #404 follow-up: lock the severity defaulting rule that the
+// PR-B4 envelope (P-0100) made canonical. Frontend code paths that
+// gate Fit / Tune / Save on validation entries must treat missing
+// ``severity`` as ``"error"`` for backward compatibility with older
+// backend builds; ``"warning"`` and ``"info"`` advise but do not block.
+describe("isBlockingError", () => {
+  it("treats a missing severity as error (legacy backend default)", () => {
+    const err: ConfigError = { path: "split.n_splits", message: "bad" };
+    expect(isBlockingError(err)).toBe(true);
+  });
+
+  it("blocks when severity is 'error'", () => {
+    const err: ConfigError = {
+      path: "split.n_splits",
+      message: "n_splits > n_rows",
+      severity: "error",
+    };
+    expect(isBlockingError(err)).toBe(true);
+  });
+
+  it("does not block when severity is 'warning'", () => {
+    const err: ConfigError = {
+      path: "evaluation.metrics",
+      message: "MAPE undefined when target contains zeros",
+      severity: "warning",
+      suggested_fix: "Use 'smape' or 'wape' instead (lizyml 0.11.0+).",
+    };
+    expect(isBlockingError(err)).toBe(false);
+  });
+
+  it("does not block when severity is 'info'", () => {
+    const err: ConfigError = {
+      path: "evaluation.metrics",
+      message: "Heads up — this metric is preview-only.",
+      severity: "info",
+    };
+    expect(isBlockingError(err)).toBe(false);
+  });
+});

--- a/frontend/src/components/workspace/ConfigEditorBody.integration.test.tsx
+++ b/frontend/src/components/workspace/ConfigEditorBody.integration.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * Integration test (Issue #405): validate-debounce → ConfigEditorBody
+ * warning banner.
+ *
+ * Unit-level coverage already exists on both ends:
+ *
+ * - {@link ../../hooks/useModelPanelData.test.ts} verifies that
+ *   handleConfigChange enqueues a debounced validate call.
+ * - {@link ./ConfigEditorBody.test.tsx} verifies that the banner
+ *   renders correctly when given an `errors` prop containing a
+ *   severity=warning entry.
+ *
+ * What was missing pre-#405: an end-to-end integration test proving
+ * that a warning returned by `validateConfig` actually flows through
+ * the hook's `setErrors` call (after the 500ms debounce) into a
+ * ConfigEditorBody render with the suggested_fix copy intact. A
+ * regression in either edge — severity dropped during cache hydration,
+ * suggested_fix lost on the wire, banner inadvertently hidden by a
+ * filter — would slip past the unit suites.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useEffect, useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useModelPanelData } from "@/hooks/useModelPanelData";
+import { ConfigEditorBody } from "./ConfigEditorBody";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("@/api/workspace", () => ({
+  fetchBackends: vi
+    .fn()
+    .mockResolvedValue([{ name: "lizyml", version: "0.1" }]),
+  fetchColumns: vi.fn().mockResolvedValue({
+    columns: [{ name: "y", suggested_excluded: false }],
+  }),
+  fetchConfig: vi.fn().mockResolvedValue({
+    task: "regression",
+    data: { target: "y" },
+    evaluation: { metrics: ["mae"] },
+  }),
+  fetchConfigSchema: vi.fn().mockResolvedValue({ type: "object" }),
+  fetchUiSchema: vi.fn().mockResolvedValue({}),
+  getConfigDownloadUrl: vi.fn().mockReturnValue("/api/config/download"),
+  updateConfig: vi
+    .fn()
+    .mockResolvedValue({ config: {}, errors: [], saved: true }),
+  uploadConfig: vi.fn().mockResolvedValue({ errors: [] }),
+  validateConfig: vi.fn().mockResolvedValue({ errors: [] }),
+}));
+
+import { validateConfig } from "@/api/workspace";
+
+vi.mock("./ConfigForm", () => ({
+  ConfigForm: () => <div data-testid="config-form-stub" />,
+}));
+vi.mock("./TuneTab", () => ({
+  TuneTab: () => <div data-testid="tune-tab-stub" />,
+}));
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+/**
+ * Bridge harness: drives useModelPanelData and renders
+ * ConfigEditorBody with the hook's `errors` output. Exposes
+ * handleConfigChange via a ref-bound trigger button so the test does
+ * not need to drive through a full ConfigForm render.
+ */
+function Harness({ nextConfig }: { nextConfig: Record<string, unknown> }) {
+  const data = useModelPanelData({ hasData: true, running: false });
+  const nextConfigRef = useRef(nextConfig);
+  useEffect(() => {
+    nextConfigRef.current = nextConfig;
+  }, [nextConfig]);
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="trigger-edit"
+        onClick={() => {
+          void data.handleConfigChange(nextConfigRef.current);
+        }}
+      />
+      <ConfigEditorBody
+        activeTab="tune"
+        hasData
+        running={false}
+        errors={data.errors}
+        schema={data.schema}
+        config={data.config}
+        onChange={data.handleConfigChange}
+        task="regression"
+        uiSchema={data.uiSchema}
+        columns={data.nonExcludedColumns}
+      />
+    </>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+describe("validate-debounce → ConfigEditorBody warning banner (Issue #405)", () => {
+  it("shows the warning banner with suggested_fix after the debounce window", async () => {
+    vi.mocked(validateConfig).mockResolvedValue({
+      errors: [
+        {
+          path: "evaluation.metrics",
+          message: "MAPE is undefined when target column 'y' contains zeros.",
+          severity: "warning",
+          suggested_fix:
+            "Remove 'mape' from evaluation.metrics — or replace it with 'smape' / 'wape' which tolerate zero targets (lizyml >= 0.11.0).",
+        },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+    } as any);
+
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <Harness
+          nextConfig={{
+            task: "regression",
+            data: { target: "y" },
+            evaluation: { metrics: ["mae", "mape"] },
+          }}
+        />
+      </Wrapper>,
+    );
+
+    // Wait for the trigger button to appear (initial render done).
+    const trigger = await screen.findByTestId("trigger-edit");
+
+    // Trigger an edit — the PUT /config mock returns saved=true with no
+    // errors, then the hook starts the 500ms debounced validate.
+    await act(async () => {
+      fireEvent.click(trigger);
+    });
+
+    // The hook's setErrors fires with the warning after the debounce
+    // window. We wait via real timers so React's scheduler, fetch
+    // microtasks, and the radix tooltip's RAF cycle all stay in their
+    // production-equivalent path. The default findBy timeout (1s) is
+    // plenty to bridge the 500ms VALIDATION_DEBOUNCE_MS.
+    const banner = await screen.findByTestId(
+      "config-warning-banner",
+      undefined,
+      { timeout: 2000 },
+    );
+    expect(banner).toBeInTheDocument();
+    // a11y: SR notification (non-blocking, not an alert)
+    expect(banner).toHaveAttribute("role", "status");
+    expect(validateConfig).toHaveBeenCalledTimes(1);
+    expect(validateConfig).toHaveBeenCalledWith({
+      task: "regression",
+      data: { target: "y" },
+      evaluation: { metrics: ["mae", "mape"] },
+    });
+    // Severity envelope made it through the wire: banner shows the
+    // suggested_fix beneath the message.
+    expect(banner.textContent).toContain("MAPE is undefined");
+    expect(banner.textContent).toContain("Suggestion:");
+    expect(banner.textContent).toContain("smape");
+    // No blocking-error banner — severity=warning must not surface as
+    // a destructive role="alert" overlay.
+    expect(screen.queryByTestId("config-error-banner")).toBeNull();
+  });
+
+  it("clears the banner when the next validate returns no warnings", async () => {
+    vi.mocked(validateConfig)
+      .mockResolvedValueOnce({
+        errors: [
+          {
+            path: "evaluation.metrics",
+            message: "MAPE undefined when target contains zeros.",
+            severity: "warning",
+            suggested_fix: "Use 'smape' instead.",
+          },
+        ],
+        // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+      } as any)
+      .mockResolvedValueOnce({
+        errors: [],
+        // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+      } as any);
+
+    const Wrapper = makeWrapper();
+    const { rerender } = render(
+      <Wrapper>
+        <Harness
+          nextConfig={{
+            task: "regression",
+            data: { target: "y" },
+            evaluation: { metrics: ["mae", "mape"] },
+          }}
+        />
+      </Wrapper>,
+    );
+    const trigger = await screen.findByTestId("trigger-edit");
+
+    // First edit — banner appears after the debounced validate fires
+    await act(async () => {
+      fireEvent.click(trigger);
+    });
+    expect(
+      await screen.findByTestId("config-warning-banner", undefined, {
+        timeout: 2000,
+      }),
+    ).toBeInTheDocument();
+
+    // Update the config the harness will send next, then click again.
+    rerender(
+      <Wrapper>
+        <Harness
+          nextConfig={{
+            task: "regression",
+            data: { target: "y" },
+            evaluation: { metrics: ["mae"] },
+          }}
+        />
+      </Wrapper>,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("trigger-edit"));
+    });
+    await waitFor(
+      () => {
+        expect(screen.queryByTestId("config-warning-banner")).toBeNull();
+      },
+      { timeout: 2000 },
+    );
+  });
+});

--- a/tests/contract/test_validate_metric_compatibility.py
+++ b/tests/contract/test_validate_metric_compatibility.py
@@ -281,3 +281,195 @@ def test_parameterised_metric_entry_is_recognised(
     warnings = _metric_warnings(errors)
     assert len(warnings) == 1
     assert "mape" in warnings[0]["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — Issue #404 follow-up
+#
+# These pin the helper's defensive behaviour against degenerate target
+# columns (all-NaN, ±inf), parametric input shapes (int64 vs float64,
+# duplicates, malformed dict entries) and out-of-shape ``evaluation``
+# fields. Together with the positive cases above they take the contract
+# coverage from 9 cases to 16, fully covering the PR-C2 + PR-D1 watchlist
+# logic so R-1 / R-3 work that touches the validate path inherits a
+# locked surface.
+# ---------------------------------------------------------------------------
+
+
+def test_target_all_nan_does_not_crash(client: TestClient, tmp_path: Path) -> None:
+    """All-NaN target degenerates std() to NaN. The R² guard
+    short-circuits on ``pd.isna(std)`` and emits the constant-target
+    warning; mape / rmsle stay quiet because comparisons against NaN
+    return False, not True. The validator must complete without
+    raising on a column pandas reads as a numeric column of NaNs."""
+    # An empty CSV cell is read by pandas as NaN; stage 10 such rows.
+    csv_path = tmp_path / "all_nan.csv"
+    with csv_path.open("w") as f:
+        f.write("a,b,y\n")
+        for i in range(10):
+            f.write(f"{i},{i + 1},\n")
+    _load_data(client, str(csv_path))
+
+    config = _set_metrics(_regression_defaults(client), ["mae", "mape", "rmsle", "r2"])
+    # Helper must not raise; whether r2 is flagged depends on whether
+    # pandas treats the empty target as numeric — both outcomes are
+    # acceptable as long as no exception escapes.
+    errors = _validate(client, config)
+    metric_paths = [e["path"] for e in _metric_warnings(errors)]
+    # mape / rmsle never fire on all-NaN (NaN comparisons are False)
+    for warn in _metric_warnings(errors):
+        assert "mape" not in warn["message"].lower()
+        assert "rmsle" not in warn["message"].lower()
+    # And the helper definitely completed — duplicate-path is fine
+    assert all(p == "evaluation.metrics" for p in metric_paths)
+
+
+def test_target_with_inf_does_not_crash(client: TestClient, tmp_path: Path) -> None:
+    """Inf and -inf in the target column are pandas-numeric (float64)
+    and must not break the helper. Specifically:
+
+    * ``mape`` does NOT fire on ``inf`` because ``inf == 0`` is False
+    * ``rmsle`` DOES fire on ``-inf`` because ``-inf < 0`` is True
+    * neither check raises a Python exception
+    """
+    csv_path = _create_regression_csv(
+        tmp_path,
+        target_values=[
+            float("inf"),
+            float("-inf"),
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+            5.0,
+            6.0,
+            7.0,
+            8.0,
+        ],
+    )
+    _load_data(client, csv_path)
+
+    config = _set_metrics(_regression_defaults(client), ["mape", "rmsle"])
+    errors = _validate(client, config)
+    warnings = _metric_warnings(errors)
+    messages = [w["message"].lower() for w in warnings]
+
+    # MAPE quiet — no exact zero in the target
+    assert not any("mape" in m for m in messages), warnings
+    # RMSLE fires — -inf qualifies as negative
+    assert any("rmsle" in m for m in messages), warnings
+
+
+def test_target_int64_and_float64_yield_consistent_warnings(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """The validator should not depend on whether pandas inferred the
+    target as int64 or float64. A target of ``[0, 1, 2, ...]`` (int64)
+    and ``[0.0, 1.0, 2.0, ...]`` (float64) must both flag MAPE and
+    neither one extra metric."""
+    int_path = _create_regression_csv(
+        tmp_path,
+        target_values=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],  # type: ignore[list-item]
+        name="int_target.csv",
+    )
+    _load_data(client, int_path)
+    config = _set_metrics(_regression_defaults(client), ["mape"])
+    int_warnings = _metric_warnings(_validate(client, config))
+
+    float_path = _create_regression_csv(
+        tmp_path,
+        target_values=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+        name="float_target.csv",
+    )
+    _load_data(client, float_path)
+    float_warnings = _metric_warnings(_validate(client, config))
+
+    assert len(int_warnings) == len(float_warnings) == 1
+    # Same metric flagged, identical suggested_fix text
+    assert int_warnings[0]["suggested_fix"] == float_warnings[0]["suggested_fix"]
+
+
+def test_duplicate_metric_names_emit_a_single_warning(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Backend dedup uses a set, so ``["mae", "mape", "mape"]`` must
+    surface exactly one MAPE warning. Frontends that copy-paste metric
+    chips can produce duplicates and we should not punish that with
+    duplicated banners."""
+    csv_path = _create_regression_csv(
+        tmp_path, target_values=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    )
+    _load_data(client, csv_path)
+    config = _set_metrics(_regression_defaults(client), ["mae", "mape", "mape"])
+    warnings = _metric_warnings(_validate(client, config))
+    assert len(warnings) == 1
+    assert "mape" in warnings[0]["message"].lower()
+
+
+def test_malformed_metric_entries_are_skipped(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """``_metric_entry_name`` returns None for empty dicts, multi-key
+    dicts, and dicts with non-string keys. Such entries must be silently
+    skipped — they may also be rejected by Pydantic, but that is not
+    this helper's responsibility. The contract here is purely that we
+    do not raise."""
+    csv_path = _create_regression_csv(
+        tmp_path, target_values=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    )
+    _load_data(client, csv_path)
+    config = _set_metrics(_regression_defaults(client), ["mae"])
+    # The Pydantic schema may reject these; we still want the helper to
+    # be defensive enough that a backend round-trip would not 500.
+    config["evaluation"]["metrics"].extend(
+        [
+            {},  # empty dict — no key
+            {"mape": {}, "rmsle": {}},  # multi-key dict — ambiguous
+        ]
+    )
+    res = client.post("/api/workspace/config/validate", json=config)
+    # Whatever Pydantic does, this must not 5xx.
+    assert res.status_code == 200, res.text
+    # The malformed entries are dropped; metric-compat watchlist sees
+    # only the plain-string ``mae``, which is not on the watchlist, so
+    # no metric warnings.
+    warnings = _metric_warnings(res.json()["errors"])
+    for w in warnings:
+        # If anything is flagged it must reference one of the watchlist
+        # names — we never invent a name from a malformed entry.
+        msg = w["message"].lower()
+        assert any(k in msg for k in ("mape", "rmsle", "r2"))
+
+
+def test_evaluation_field_non_dict_does_not_crash(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """``config["evaluation"]`` may arrive as a list, ``None``, or be
+    omitted entirely. Each shape must short-circuit to "no metric
+    warning" without raising — the Pydantic layer handles its own
+    rejection separately."""
+    csv_path = _create_regression_csv(
+        tmp_path, target_values=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    )
+    _load_data(client, csv_path)
+    base = _regression_defaults(client)
+
+    # 1) evaluation = []  -> not a dict -> no metric warning
+    list_config = dict(base)
+    list_config["evaluation"] = []
+    res_list = client.post("/api/workspace/config/validate", json=list_config)
+    assert res_list.status_code == 200, res_list.text
+    assert _metric_warnings(res_list.json()["errors"]) == []
+
+    # 2) evaluation = None
+    none_config = dict(base)
+    none_config["evaluation"] = None
+    res_none = client.post("/api/workspace/config/validate", json=none_config)
+    assert res_none.status_code == 200, res_none.text
+    assert _metric_warnings(res_none.json()["errors"]) == []
+
+    # 3) evaluation key absent entirely
+    missing_config = {k: v for k, v in base.items() if k != "evaluation"}
+    res_missing = client.post("/api/workspace/config/validate", json=missing_config)
+    assert res_missing.status_code == 200, res_missing.text
+    assert _metric_warnings(res_missing.json()["errors"]) == []


### PR DESCRIPTION
## Summary

Closes #404 (backend edge cases + frontend `isBlockingError`).
Closes #405 (validate-debounce -> warning banner integration).

Adds 12 new test cases (6 backend + 4 frontend types + 2 frontend integration) that lock the v0.4.1 severity envelope (P-0100) and metric-compat watchlist (P-0101) against shape regressions in R-1 / R-3 follow-up work. No production code changes.

## Backend (#404) — 6 cases

`tests/contract/test_validate_metric_compatibility.py` (9 -> 15 cases):

- `target_all_nan_does_not_crash` — `pd.Series` of `NaN` does not raise; `mape` / `rmsle` stay quiet because `NaN` comparisons are False.
- `target_with_inf_does_not_crash` — `[inf, -inf, ...]` verifies `mape` no warning (`inf != 0`) and `rmsle` warning (`-inf < 0`) without raising.
- `target_int64_and_float64_yield_consistent_warnings` — int target vs float target produce identical `suggested_fix` strings.
- `duplicate_metric_names_emit_a_single_warning` — `["mae","mape","mape"]` set-dedups to one warning.
- `malformed_metric_entries_are_skipped` — empty dicts, multi-key dicts pass through without 5xx.
- `evaluation_field_non_dict_does_not_crash` — `evaluation = []`, `None`, or absent short-circuits cleanly.

## Frontend types (#404) — 4 cases

`frontend/src/api/types.test.ts` (new file) on `isBlockingError`:

- missing severity defaults to `error` (legacy backend default).
- `severity="error"` blocks.
- `severity="warning"` does not block.
- `severity="info"` does not block.

## Frontend integration (#405) — 2 cases

`frontend/src/components/workspace/ConfigEditorBody.integration.test.tsx` (new file) — mounts `useModelPanelData` + `ConfigEditorBody` together with a mocked workspace API to verify the validate-debounce -> `setErrors` -> banner render path end-to-end:

- shows the warning banner with `suggested_fix` after the debounce window.
- clears the banner when the next validate returns no warnings.

Both cases assert `role="status"` (a11y), the `suggested_fix` copy is rendered as the second line, and that `severity=warning` never surfaces as a destructive `role="alert"` overlay. Uses real timers + 2000ms `findBy` timeout so React + radix + react-query all stay on their production path (fake timers caused afterEach to hang on RAF deps).

## Test plan

- [x] backend: `uv run pytest tests/contract/test_validate_metric_compatibility.py` — 15 passed
- [x] frontend types: `pnpm vitest run src/api/types.test.ts` — 4 passed
- [x] frontend integration: `pnpm vitest run src/components/workspace/ConfigEditorBody.integration.test.tsx` — 2 passed
- [x] `pnpm build` — green
- [x] `uv run ruff check .` + `uv run ruff format --check .` — clean
- [x] `pnpm exec biome check` — clean

## Refs

- HISTORY.md P-0100 (severity envelope formalization) — see PR #406
- HISTORY.md P-0101 (metric-compat watchlist) — see PR #406
- Issue #394, PR #399 (PR-C2), PR #400 (PR-D1)
- handoff: `docs/pre-v05-handoff-2026-05-05.md` §3.2 S-1 + §3.3 O-1
