### PR TITLE
docs(history,plan): P-0099 R-1 invariants + paused state Change Gate (v0.5 prep)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3184,11 +3184,96 @@ frontend で virtualization / top-N を入れても、転送する payload 自�
 
 - 2026-05-05 **Proposed** — PR-B3 で実装。auto mode で Phase B 実装中、Change Gate scope は `load_dataframe` の失敗タイミング精緻化のみ。**ユーザ承認済** (Phase B 全体着手承認)
 
-### P-0099: (採番予約) v0.5 R-1 状態整合性 invariants + `paused` job state（Change Gate）
+### P-0099: v0.5 R-1 状態整合性 invariants + `paused` job state（Change Gate）
 
-- **Status:** 🟡 採番予約のみ。Day 4 で本文起票予定
-- **Scope:** v0.5 R-1.1〜R-1.4 で導入する job state machine 不変条件の宣言、および R-1.4 (#360) で必要となる `paused` 状態の Change Gate
-- **Reference:** `docs/pre-v05-handoff-2026-05-05.md` §3.1 M-2
+- **Date:** 2026-05-06 起票
+- **Related:** Issue #360 (Tune long-run resumability), Issue #358 (BlockedGroup race), Issue #359 (job-num drift), Issue #384 (Server Restart Recovery), LizyML #105 (Optuna persistent storage), `docs/v0.4-business-readiness-plan.md` §2 (R-1), `~/.claude/rules/common/invariants-first.md`
+
+#### Motivation
+
+v0.4 リリースまでの slot release / cancel race 系列バグ (P-0086〜P-0089 周辺) はいずれも「不変条件が事前に文章化されていない」ことが根本原因だった (memory `feedback_count_budget_assertions` の lesson 系列)。v0.5 で R-1.4 (Tune long-run resumability, 24h+) を実装すると job state machine が **`paused` 状態を新たに持つ** ため、現状の slot release / cancel / subprocess crash の各経路に新しい遷移が増える。先に invariants を declare → invariant test を RED phase で書く → 実装、の順を強制する。
+
+CLAUDE.md §2 Change Gate 対象（state machine 変更 / 並行性・所有権の設計 / shared state の不変条件）にすべて該当するため Proposal-first で承認を取る。
+
+#### Purpose
+
+- v0.5 R-1.1〜R-1.4 全体の不変条件を **R-1.x 着手前に invariant test として encode** し、リファクタ中に regression を「Test failed」で即座に発見できるようにする
+- `paused` 状態を job lifecycle に追加（`pending → running → paused → running → succeeded|failed|cancelled` の遷移を許可、illegal transitions は assert で reject）
+- `meta.json` の atomic write (tmpfile + fsync + rename) を invariant 化し、subprocess crash 中のファイル破損を構造的に防ぐ
+- 上記すべてを各 R-1.x phase の Acceptance criteria に紐付ける
+
+#### Invariants
+
+以下を v0.5 R-1 期間中の **不変条件** として宣言する。各 INV-N は対応する invariant test を `tests/regression/` または `tests/e2e/` に持ち、code には possible なら `assert` / runtime guard / branded type で encode する。
+
+- **INV-1**: `active_job_id` holds at most one running-or-paused job at any time — released on **completion OR cancel OR exception OR SIGKILL OR WebSocket disconnect OR browser close** (6 termination paths). 違反シナリオ: terminal write 後に release が漏れる、subprocess crash で release callback が呼ばれない
+- **INV-2**: `meta.json` is written atomically (tmpfile + fsync + rename) — `kill -9` mid-write でも整合性が破れない。違反シナリオ: 親プロセスが部分書き込み中に強制終了 → 子の load_job が JSON parse error
+- **INV-3**: state machine transitions は明示宣言、illegal transitions は assert で reject。許可される遷移は以下のみ:
+  - `[*] → pending`（POST /fit / /tune）
+  - `pending → running` (worker thread が claim_active)
+  - `pending → cancelled` (DELETE / cancel before start)
+  - `running → succeeded` (terminal write OK)
+  - `running → failed` (exception or subprocess died)
+  - `running → cancelled` (cancel signal observed mid-run)
+  - **`running → paused`** (Tune trial 完了時に user pause OR scheduled checkpoint, R-1.4 で導入)
+  - **`paused → running`** (Resume button or auto-resume on restart)
+  - **`paused → cancelled`** (cancel during paused state)
+  - **`paused → failed`** (storage corruption detected on resume)
+- **INV-4**: `paused` 状態の job は **trial-level checkpoint + `meta.json` から完全復元可能** — Optuna study を re-attach して trial.number / best_value / trial.state が一致する。違反シナリオ: journal file が corrupted で resume 不能、勝手に新 trial が走る
+- **INV-5**: cancel observation is monotonic — `is_cancel_requested(job_id)` が一度 True を返したら、その後 (job 完了まで) 連続 True を返す。違反シナリオ: race で `clear_cancel` が早く走り、worker が「キャンセルされてない」と判断して terminal write を上書き
+- **INV-6**: subprocess crash recovery — 子 process が `SIGKILL` で死ぬと、親 watchdog が **bounded time window 以内** に `failed (reason="subprocess died")` で terminal write + slot release。違反シナリオ: 子が消えても active_slot がぶら下がり続けて次の job を block
+- **INV-7**: WebSocket disconnect は active slot を release **しない** — 進行中 job は subscriber 数に依らず completion または terminal failure まで走る。違反シナリオ: ブラウザを閉じたら fit が止まる、reload で resume できない
+
+#### Impact
+
+**Public API (Change Gate scope):**
+- `meta.json` schema に `"paused"` を追加。`status: Literal["pending","running","succeeded","failed","cancelled","paused"]`
+- `format_version` を `1` → `2` (P-0095 round-trip CI gate に組み込み)
+- `POST /api/jobs/{job_id}/pause` (新規, R-1.4): running Tune を paused に遷移
+- `POST /api/jobs/{job_id}/resume` 既存と統合: paused state を resume するロジックを既存の retune-resume 経路と並行サポート (H-0062 Phase B 拡張)
+- WebSocket message に `{"type":"paused", "trial_number": N, "checkpoint_path": "..."}` を追加
+- Frontend: Jobs UI に "Pause" / "Resume" ボタン (paused 状態のみ表示)
+
+**Internal (no API change):**
+- `services/jobs.py:JobStore` に `pause(job_id)` / `unpause(job_id)` 追加
+- `services/training.py` の Tune loop で trial 完了 callback に "should_pause" check を挿入
+- `backends/lizyml/lifecycle_mixin.py` で Optuna study の `storage` パラメタを passthrough (LizyML #105 待ち)
+
+#### Compatibility
+
+- v0.4 までで作成した `meta.json` (format_version=1) は `paused` フィールドを持たない → migration で `paused: false` を default に挿入。read-only で読める
+- POST /api/jobs/{job_id}/pause は新規追加なのでクライアント側で 404 をハンドルする legacy path は不要
+- WebSocket `paused` メッセージは未知タイプとして無視されるよう既存 client の switch に default branch を追加 (R-2.1 で別途扱う)
+- LizyML 0.11.x で `storage=` パラメタが無いため、LizyML #105 が merged するまでは `paused` 経路を feature flag (`LIZYSTUDIO_TUNE_RESUME_ENABLED=0`) で off にする
+
+#### Acceptance criteria
+
+R-1.1〜R-1.5b の各 phase に invariant test を割り当てる。本 Proposal の DoD は「invariant declaration が PLAN.md の各 phase に reflectee されている」こと。実装は phase 単位で行う。
+
+- [ ] PLAN.md v3-17 (R-1.1) に **INV-1 / INV-5** の invariant test を Acceptance criteria として明記
+- [ ] PLAN.md v3-18 (R-1.2) に **INV-5** + #358 の regression test を明記
+- [ ] PLAN.md v3-19 (R-1.3) に **INV-2 / INV-6** の invariant test を明記
+- [ ] PLAN.md v3-20 (R-1.4) に **INV-3 / INV-4** の invariant test + LizyML #105 dependency を明記
+- [ ] PLAN.md v3-21 (R-1.5) に Issue #359 (job-num drift) の regression test を明記
+- [ ] PLAN.md v3-22 (R-1.5b) に **INV-7** + Issue #384 の regression test を明記
+- [ ] BLUEPRINT.md §3.4 (Job lifecycle) に上記 INV-1〜INV-7 を明記
+- [ ] CHANGELOG.md (v0.5.0 release notes drafting 時) に `paused` 状態追加を Breaking 寸前 (Added) で記述
+- [ ] Issues #358 / #359 / #360 / #384 を本 Proposal の child Issue として label
+
+#### Alternatives considered
+
+- **(a) Invariant 宣言なし、phase 別に都度 PR 単位で書く**: 拒否。slot release 系の regression 5回連発の実績 (memory `feedback_symmetry_audit_on_fixes`) は事前 invariant declaration 不在が原因
+- **(b) `paused` の代わりに既存 `running` のサブステートとして表現**: 拒否。状態遷移が暗黙化され client / DB / WS 全層で「実は走っていない running」が解釈の余地として残る
+- **(c) Optuna 永続化を LizyStudio 側で wrap (LizyML #105 を待たない)**: 拒否。`Tuner.tune()` を bypass すると round_number / prior_trials / expanded_dims tracking (LizyML H-0068) を re-implement する必要、保守コストで割に合わない
+- **(d) format_version を bump せず paused を後付け**: 拒否。P-0095 の round-trip CI gate が format_version を読むので migration matrix に明示的に乗せる方が安全
+
+→ 採用は **(e) Invariants 7 件を Proposal で declare、phase 単位で invariant test を RED phase に強制、`paused` を state machine の正規 1st-class member にする**。
+
+#### Decision
+
+- 2026-05-06 **Proposed** — v0.5 R-1.1 着手前に user 承認を取り、PLAN.md に v3-17〜v3-22 を追加した時点で **Approved**。実装は phase 単位、各 phase の PR が invariant test を含む
+
+
 
 ### P-0100: severity envelope の正式化（PR-B4 → PR-C2/PR-D1, Issue #394）
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1233,8 +1233,280 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 
 ---
 
-## 採番ガイダンス（v3-17 以降）
+## Phase v3-17: v0.5 R-1.1 — Slot release invariant 6 経路検証（P-0099 INV-1 / INV-5）
 
-- 新規 Proposal は **P-0095** 以降を起票（P-0094 = 2026-05-01 pytest-benchmark）。
-- 仕様変更を伴う作業は HISTORY.md に Proposal → 本 PLAN.md にフェーズ追加（`v3-17`...）の順で進める。
+**期間:** v0.5 着手後 1 週間（LizyML #105 と独立）
+
+**対象 Proposal:** P-0099
+
+**Entry criteria:**
+- HISTORY.md P-0099 が **Approved**（user 承認）
+- Issues #358 / #359 / #360 / #384 に P-0099 の child label が貼られている
+
+**動機:** v0.4 までで slot release 系 regression が 5 連続発生（P-0086〜P-0091 周辺）した根本原因は不変条件の事前文書化不在。v0.5 R-1.4 で `paused` 状態を追加する前に、6 経路（normal / cancel / exception / SIGKILL / WebSocket切断 / browser閉じる）すべてで `active_job_id` が release されることを invariant test で固定する。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-17a | INV-1 / INV-5 の invariant test を `tests/regression/test_inv_slot_release.py` に書く（RED phase） | 🟡 | — |
+| v3-17b | 既存 release 経路の audit + 抜け落ちを修正（GREEN phase） | 🟡 | — |
+| v3-17c | Playwright で WS切断 / browser閉じる経路を E2E 化 | 🟡 | — |
+
+**DoD:**
+- [ ] `tests/regression/test_inv_slot_release.py` で 6 経路すべてが green、各 path に `assert active_job_id is None` がある
+- [ ] `tests/regression/test_inv_cancel_monotonic.py` で `is_cancel_requested` の monotonic 性が確認される（INV-5）
+- [ ] Playwright `tests/e2e/slot-release-paths.spec.ts` で WS切断 + browser閉じるの 2 経路を実機 verification
+- [ ] `services/jobs.py:JobStore` に `assert _active_job_id is None or _active_job_id == job_id` 等の runtime guard が encode 済
+
+**Exit criteria:** 上記 DoD すべて green。次は v3-18。
+
+---
+
+## Phase v3-18: v0.5 R-1.2 — Cancel race の修復（P-0099 INV-5 / Issue #358）
+
+**期間:** v3-17 完了後 1 週間
+
+**対象 Proposal:** P-0099, Issue #358 (BlockedGroup race)
+
+**動機:** Cancel + 完了通知の競合で「キャンセル押下後の `cancelled` 状態が completion で上書きされる」regression を構造的に閉じる。memory `feedback_count_budget_assertions` の lesson を踏まえ、count-based assertion で証明する。
+
+**Entry criteria:** v3-17 完了。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-18a | Issue #358 の reproducer を `tests/regression/test_reg_358_blocked_group_cancel_race.py` に固定 | 🟡 | — |
+| v3-18b | cancel + terminal write の race を count-based assertion で test | 🟡 | — |
+| v3-18c | services/training.py で cancel observation を pre-terminal-write に固定 | 🟡 | — |
+
+**DoD:**
+- [ ] Issue #358 が close 済（reproducer green）
+- [ ] count-based assertion: 100 並行 cancel-during-completion で `cancelled` 状態が常に observable 1 件以上
+- [ ] INV-5 の monotonic 性が cancel race のすべての interleaving で破れない
+
+---
+
+## Phase v3-19: v0.5 R-1.3 — Subprocess crash 復旧 + atomic meta.json（P-0099 INV-2 / INV-6）
+
+**期間:** v3-18 完了後 1 週間
+
+**対象 Proposal:** P-0099
+
+**動機:** OpenMP detection で subprocess に行く経路は kill -9 で死ぬと親が状態を見失う既知のリスク。`meta.json` の atomic write も子プロセスが mid-write で死ぬと file が壊れる。R-1.4 (Tune resume) で trial-level checkpoint を書く前に、書き込み一貫性を保証する。
+
+**Entry criteria:** v3-18 完了。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-19a | `services/jobs.py:_write_meta_atomic` で tmpfile + fsync + rename を実装 | 🟡 | — |
+| v3-19b | `tests/regression/test_inv_meta_json_atomic.py` で kill -9 mid-write の simulate test (INV-2) | 🟡 | — |
+| v3-19c | subprocess crash watchdog を `services/training.py` に追加（INV-6） | 🟡 | — |
+| v3-19d | `tests/regression/test_inv_subprocess_crash_recovery.py` で kill -9 → bounded time → failed terminal の test | 🟡 | — |
+
+**DoD:**
+- [ ] INV-2 / INV-6 の invariant test green
+- [ ] `meta.json` write 経路すべてが `_write_meta_atomic` 経由（grep で hand-rolled `open(...,"w")` がない）
+- [ ] watchdog が `polling interval <= 5s` で subprocess の生存確認、死亡検知から terminal write までが <= 10s
+
+---
+
+## Phase v3-20: v0.5 R-1.4 — Tune long-run resumability（P-0099 INV-3 / INV-4 / Issue #360）
+
+**期間:** v3-19 完了後 3 週間。**LizyML #105 (Optuna persistent storage) merged が前提。**
+
+**対象 Proposal:** P-0099 + Issue #360
+
+**動機:** v0.4 で識別された最大の業務リスク (`docs/v0.4-business-readiness-plan.md` §0)。24h+ Tune 中に SIGKILL / network 切断 / browser リロードで進捗が完全消失する問題を構造的に解消する。
+
+**Entry criteria:**
+- v3-19 完了
+- LizyML #105 merged + LizyStudio 側 `pyproject.toml` で対応 minor version へ bump
+- `LIZYSTUDIO_TUNE_RESUME_ENABLED=1` を default に切り替え可能
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-20a | `meta.json` schema に `status="paused"` 追加 + format_version 1 → 2 migration（INV-3） | 🟡 | — |
+| v3-20b | `backends/lizyml/lifecycle_mixin.py` で `tune(storage=...)` passthrough | 🟡 | — |
+| v3-20c | `services/jobs.py` に `pause(job_id)` / `unpause(job_id)`、API `POST /api/jobs/{job_id}/pause` 追加 | 🟡 | — |
+| v3-20d | WebSocket message に `paused` type 追加 + frontend ハンドリング | 🟡 | — |
+| v3-20e | Frontend Jobs UI に Pause / Resume ボタン（paused 状態のみ表示） | 🟡 | — |
+| v3-20f | `tests/regression/test_inv_paused_roundtrip.py` で trial-level checkpoint round-trip (INV-4) | 🟡 | — |
+| v3-20g | Playwright `tests/e2e/tune-resume.spec.ts` で 24h 模擬 (時間圧縮 mock) の resume シナリオ | 🟡 | — |
+
+**DoD:**
+- [ ] INV-3 / INV-4 の invariant test green
+- [ ] Issue #360 が close 済
+- [ ] format_version=2 への migration が P-0095 round-trip CI gate に組み込まれている
+- [ ] CHANGELOG (v0.5 draft) に `paused` 状態が Added で記載
+- [ ] `LIZYSTUDIO_TUNE_RESUME_ENABLED` を `1` で default 化、feature flag 経由で off にも切替可
+
+---
+
+## Phase v3-21: v0.5 R-1.5 — Issue #359 job-num drift 解消
+
+**期間:** v3-20 と並行可（state machine 変更を含まない）、0.5 週間
+
+**対象:** Issue #359
+
+**動機:** `job_num` を frontend 側で計算せず API レスポンスに含めることで、削除や cancel 後の番号 drift を解消。
+
+**Entry criteria:** v3-17 完了（slot release が安定したら着手可）。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-21a | `meta.json` に不変 `job_num: int` を保存（format_version=2 と同 PR が望ましい） | 🟡 | — |
+| v3-21b | API `GET /api/jobs` / `GET /api/jobs/{id}` レスポンスに `job_num` 追加（openapi-typescript 再生成） | 🟡 | — |
+| v3-21c | Frontend で `job_num` を index 計算から API レスポンス参照に切替 | 🟡 | — |
+
+**DoD:**
+- [ ] Issue #359 が close 済
+- [ ] `tests/regression/test_reg_359_job_num_stable.py` で削除 + 新規作成サイクル後の番号 stability 確認
+
+---
+
+## Phase v3-22: v0.5 R-1.5b — Server Restart Recovery（P-0099 INV-7 / Issue #384）
+
+**期間:** v3-20 完了後 1 週間
+
+**対象:** P-0099 + Issue #384 (#360 ブロック解除後)
+
+**動機:** サーバ再起動後に running / paused job が UI に正しく復元されること。LizyML #105 + R-1.4 が完了している前提で、再起動シナリオを E2E 化する。
+
+**Entry criteria:** v3-20 完了 (#360 解消)。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-22a | server lifespan startup で paused jobs を `meta.json` から再 attach | 🟡 | — |
+| v3-22b | `tests/regression/test_inv_ws_disconnect_does_not_release.py` で INV-7 検証 | 🟡 | — |
+| v3-22c | Playwright `tests/e2e/server-restart-recovery.spec.ts` で実 restart シナリオ | 🟡 | — |
+
+**DoD:**
+- [ ] Issue #384 が close 済
+- [ ] INV-7 の invariant test green
+
+---
+
+## Phase v3-23: v0.5 R-2.1 — WebSocket 再接続戦略
+
+**期間:** v3-22 完了後 1 週間
+
+**対象:** `docs/v0.4-business-readiness-plan.md` §3.1
+
+**動機:** Long-run Tune (24h) でネットワーク断絶からの復帰を確実にする。exponential backoff、最大 reconnect interval 5min。
+
+**Entry criteria:** v3-22 完了。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-23a | Frontend `useJobProgress` hook の reconnect ロジックを exponential backoff 化 | 🟡 | — |
+| v3-23b | Backend WebSocket handler で resume token を発行 → reconnect で missed messages を replay | 🟡 | — |
+| v3-23c | Playwright で 10s 切断 → 復帰の progress 続行 verification | 🟡 | — |
+
+**DoD:**
+- [ ] 10s 切断後 progress 続行、最終 status 一致
+- [ ] 5min 切断後でも reconnect 試行は継続、復帰時に missed messages 受信
+
+---
+
+## Phase v3-24: v0.5 R-2.2 — ブラウザリロード状態復元
+
+**期間:** v3-23 完了後 1 週間
+
+**対象:** `docs/v0.4-business-readiness-plan.md` §3.2
+
+**動機:** リロード時に data + config + 進行中 job がそのまま見える状態を実現。1 名利用前提なので multi-tab 衝突制御は scope 外。
+
+**Entry criteria:** v3-23 完了。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-24a | Frontend で workspace state を localStorage / IndexedDB に persist（or 既存 GET /status を活用） | 🟡 | — |
+| v3-24b | `beforeunload` で form ダーティ警告（dirty config を保存しないとロストする旨） | 🟡 | — |
+| v3-24c | Playwright で reload 後の data + config + running job 復元を Visual diff verification | 🟡 | — |
+
+**DoD:**
+- [ ] reload 後 30s 以内に form / data / progress が前と同じ状態
+- [ ] dirty config がある状態で reload 試行 → confirm ダイアログ表示
+
+---
+
+## Phase v3-25: v0.5 R-4.1 — format_version migration matrix CI gate
+
+**期間:** v3-20 完了後（並行可）、1 週間
+
+**対象:** P-0095 拡張 + `docs/v0.4-business-readiness-plan.md` §5.1
+
+**動機:** R-1.4 で format_version を 1→2 に bump する。過去 workspace を新 CLI が壊さない保証を CI で gating する。
+
+**Entry criteria:** v3-20 完了 (format_version=2 が定義済)。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-25a | `tests/regression/test_format_version_migration_matrix.py` で v0 → v1 → v2 の round-trip | 🟡 | — |
+| v3-25b | CI workflow で過去 fixture (v0 / v1) を fetch + load + 新 release で save → load → 同値 assertion | 🟡 | — |
+| v3-25c | 古い format_version を read-only で開く保護 (CLI の write モードで明示的にエラー) | 🟡 | — |
+
+**DoD:**
+- [ ] CI で migration matrix が gating
+- [ ] 古い workspace を新 CLI で開いても `LIZYSTUDIO_ALLOW_LEGACY_READ=1` 無しに data destruction が起きない
+
+---
+
+## Phase v3-26: v0.5 R-4.2 — Pickle compatibility test（P-0095 拡張）
+
+**期間:** v3-25 と並行可、1 週間
+
+**対象:** `docs/v0.4-business-readiness-plan.md` §5.2
+
+**動機:** lizyml minor バンプ時に Pickle 互換切れが起きると過去のモデルが load できなくなる。Nightly CI で過去 N=3 minor version の互換性を確認する。
+
+**Entry criteria:** v3-25 完了。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-26a | `.github/workflows/nightly.yml` に pickle compat job 追加 | 🟡 | — |
+| v3-26b | `tests/bench/test_bench_pickle_compat.py` で過去 lizyml 版で fit → 現行で load の round-trip | 🟡 | — |
+| v3-26c | `cloudpickle` 互換切れ検出時の明示エラー (`PICKLE_INCOMPATIBLE`) | 🟡 | — |
+
+**DoD:**
+- [ ] Nightly CI で過去 3 minor version すべて green
+- [ ] 互換切れ時のエラーメッセージが recovery_hint と suggested_fix を含む（P-0100 envelope を再利用）
+
+---
+
+## v0.5 Exit Criteria
+
+`docs/v0.4-business-readiness-plan.md` §7 を本 v3-17〜v3-26 で消化する。すべての DoD が green、かつ:
+
+- [ ] 24h Tune が SIGKILL / network 切断 / browser リロードで再開可能（INV-3 / INV-4）
+- [ ] ブラウザリロード後に data + config + 進行中 job が完全復元（v3-24）
+- [ ] format_version migration matrix が CI で gating（v3-25）
+- [ ] Slot release が 6 経路全てで test カバー済（INV-1）
+- [ ] 業務利用 KPI (`docs/business-use-definition.md` v0.2 §16) 達成
+
+---
+
+## 採番ガイダンス（v3-27 以降）
+
+- 新規 Proposal は **P-0102** 以降を起票（P-0101 = 2026-05-05 metric-compat watchlist Decision、P-0099 = 2026-05-06 R-1 invariants）。
+- 仕様変更を伴う作業は HISTORY.md に Proposal → 本 PLAN.md にフェーズ追加（`v3-27`...）の順で進める。
 - 詳細な未着手バックログは `docs/ROADMAP.md` を参照。
+- v0.6+ 候補: 第 2 backend (Issue #403)、Tailwind v4 (#125)、P-0087 Phase 3、LLM 統合、PyTorch backend、監査ログ・認証。


### PR DESCRIPTION
## Summary

Change Gate per `CLAUDE.md` section 2 — state-machine extension + declared invariants for the v0.5 R-1 reliability sprint. **Spec-only PR** (HISTORY + PLAN). Implementation lands phase-by-phase as v3-17 through v3-26 over the next 8-12 weeks.

This unblocks v0.5 R-1.1 kickoff once the user approves the Decision row in HISTORY.md.

## Why a Change Gate

`paused` is a new 1st-class state in the job state machine, and `meta.json` `format_version` bumps 1 -> 2. Both fall under the gate-required list in `~/.claude/rules/project/change-gate.md`:

- state machine changes (paused transitions)
- concurrency / ownership design (active_slot, cancel monotonicity)
- invariants over shared state (the 7 INV-N rules below)
- storage format version

Per `~/.claude/rules/common/invariants-first.md`, invariants must be declared before implementation and the RED-phase test must encode each one. This PR delivers the declarations; v3-17..v3-26 PRs each ship the invariant tests + the implementation that satisfies them.

## What changes

### HISTORY.md P-0099

Replaces the reservation slot landed in PR #406 with the full Proposal body. Declares **7 invariants**:

- **INV-1**: `active_job_id` holds at most one running-or-paused job; released on completion / cancel / exception / SIGKILL / WS disconnect / browser close (6 paths).
- **INV-2**: `meta.json` is written atomically (tmpfile + fsync + rename) — kill -9 mid-write must not corrupt the file.
- **INV-3**: state machine transitions are explicitly enumerated; illegal transitions are asserted to fail. `paused` is added as a 1st-class member with transitions running ↔ paused, paused → cancelled / failed.
- **INV-4**: a `paused` job is fully restorable from disk — trial-level checkpoint + meta.json round-trip yields identical Optuna study state.
- **INV-5**: cancel observation is monotonic — once `is_cancel_requested(job_id)` returns True, all subsequent reads return True until job completion.
- **INV-6**: subprocess crash recovery — child kill -9 transitions parent's view of the job to `failed (subprocess died)` within a bounded time window.
- **INV-7**: WebSocket disconnect does NOT release the active slot; running jobs continue to completion or terminal failure regardless of subscriber presence.

Public API impact:
- `meta.json.status: Literal["pending","running","succeeded","failed","cancelled","paused"]`
- `format_version` 1 -> 2 (slotted into the P-0095 round-trip CI gate)
- `POST /api/jobs/{job_id}/pause` (new)
- `POST /api/jobs/{job_id}/resume` extended to handle paused state alongside H-0062 retune-resume
- WebSocket message `{"type":"paused", "trial_number": N, "checkpoint_path": "..."}`
- Frontend Pause / Resume buttons in Jobs UI

Backward compatibility: legacy `meta.json` (format_version=1) reads cleanly with `paused: false` default; the `paused` WS message is unknown to existing clients and gets ignored by the default switch branch. LizyML upstream (#105) ships `storage=` passthrough first; until then `LIZYSTUDIO_TUNE_RESUME_ENABLED=0` keeps the resume path off.

### PLAN.md v3-17 through v3-26

Ten new phases with explicit Entry / Exit criteria, sub-phase breakdown, and DoD pointing at the INV-N invariant tests:

| Phase | Topic | Weeks | Issue / Proposal | Invariants |
|---|---|---|---|---|
| v3-17 | Slot release 6 paths | 1 | P-0099 | INV-1 / INV-5 |
| v3-18 | Cancel race fix | 1 | #358 | INV-5 |
| v3-19 | Subprocess crash + atomic meta.json | 1 | P-0099 | INV-2 / INV-6 |
| v3-20 | Tune long-run resumability | 3 | #360 + LizyML #105 | INV-3 / INV-4 |
| v3-21 | job-num drift | 0.5 | #359 | — |
| v3-22 | Server Restart Recovery | 1 | #384 | INV-7 |
| v3-23 | WebSocket reconnection | 1 | R-2.1 | — |
| v3-24 | Browser reload restore | 1 | R-2.2 | — |
| v3-25 | format_version migration matrix CI gate | 1 | R-4.1 + P-0095 | — |
| v3-26 | Pickle compatibility test | 1 | R-4.2 + P-0095 | — |

v0.5 Exit Criteria carried over from `docs/v0.4-business-readiness-plan.md` section 7. v3-21 (job-num drift) and v3-25 (format_version matrix) are flagged as parallel-safe with v3-20.

### Numbering guidance

Next Proposal: **P-0102**. Next PLAN phase: **v3-27**.

## Test plan

Spec-only PR — no automated tests. Manual verification:

- [x] HISTORY P-0099 references real Issues (#358 / #359 / #360 / #384) and the upstream LizyML #105 issue
- [x] PLAN v3-17..v3-26 sub-phase tests reference the correct INV-N declared in HISTORY
- [x] Numbering: next Proposal P-0102 matches HISTORY (P-0101 was the last Decided in #406), next phase v3-27 matches PLAN (v3-26 is the last new phase)
- [x] LizyML #105 dependency is wired at v3-20 Entry criteria, not earlier (so v3-17..v3-19 stay LizyML-independent)
- [x] format_version migration matrix (v3-25) follows v3-20 (which introduces v=2)

## Refs

- Issue #358 (BlockedGroup race) — to be closed by v3-18
- Issue #359 (job-num drift) — to be closed by v3-21
- Issue #360 (Tune long-run resumability) — to be closed by v3-20
- Issue #384 (Server Restart Recovery) — to be closed by v3-22
- LizyML #105 (Optuna persistent storage) — upstream dependency for v3-20
- HISTORY P-0095 (fit→load round-trip CI gate) — extended by v3-25 / v3-26
- `docs/v0.4-business-readiness-plan.md` v0.2 (sections 2 / 3 / 5)
- handoff: `docs/pre-v05-handoff-2026-05-05.md` section 3.1 M-2 / M-5
