### PR TITLE
release: v0.4.2 — v0.5 prep + spec reconciliation

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -2385,6 +2385,41 @@ Workspace の `workspace_result` は完了時に自動更新される。
 
 **Active-job lock (P-0089 / Issue #279):** ジョブが running 中は `PUT /api/workspace/config` / `PATCH /api/workspace/config` が `WORKSPACE_LOCKED` (409) を返す。詳細は §3.4。
 
+#### Validate response envelope (P-0100 / P-0101 / Issue #394)
+
+`POST /api/workspace/config/validate` / `PUT /api/workspace/config` / `POST /api/workspace/upload` の `errors[]` 各要素は以下の envelope を返す:
+
+```json
+{
+  "valid": false,
+  "errors": [
+    {
+      "loc": "evaluation.metrics",
+      "msg": "MAPE is undefined when target contains zeros (3 rows). Use 'smape' or 'wape' instead (lizyml 0.11.0+).",
+      "severity": "warning",
+      "suggested_fix": "Use 'smape' or 'wape' instead (lizyml 0.11.0+)"
+    }
+  ]
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `severity` | `"error" \| "warning" \| "info"` (default `"error"`) | block 判定に使う。`"error"` のみ `valid=false` / `saved=false` を flip。`"warning"` / `"info"` は advisory のみ |
+| `suggested_fix` | `str \| null` (default `null`) | 警告に対する具体的な置換アクション。Frontend では yellow banner の二行目に表示 |
+
+**Block 判定ルール (P-0100):** `_blocking_errors([entry, ...])` ヘルパが Service / API 層共通で `severity == "error"` のみを抽出し、`POST /fit` / `POST /tune` / `PUT /config` / `POST /upload` の 4xx 判定に使う。`severity` 未設定の旧 ValidationError は backward-compat のため `"error"` 扱い。
+
+**Metric-compat watchlist (P-0101):** `task=regression` のとき以下の組み合わせは `severity="warning"` で auto-disable される:
+
+| Metric | Trigger | suggested_fix |
+|---|---|---|
+| `mape` | target に 0 が 1 件以上 | `"Use 'smape' or 'wape' instead (lizyml 0.11.0+)"` |
+| `rmsle` | target に負値が 1 件以上 | `"Remove 'rmsle' from evaluation.metrics"` |
+| `r2` | target が定数 (`nunique() == 1`) | `"Remove 'r2' from evaluation.metrics"` |
+
+警告だが block しないため、ユーザは無視して fit を実行できる（実行時に該当 metric は nan を返す可能性）。後続バックエンドが増えたときの抽象化は Issue #403 で予定。
+
 ### 5.3 Jobs API
 
 永続化されたジョブを管理する。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,78 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-05-06
+
+The **v0.5 prep** maintenance release. **No user-facing behaviour
+changes** — the on-disk job format, REST API surface, and frontend UX
+are byte-for-byte identical to v0.4.1. This release exists so
+downstream consumers can pin against a stable artifact while the v0.5
+R-1 reliability sprint lands phase by phase over the coming weeks.
+
+Bundles:
+
+1. Post-v0.4.1 spec reconciliation — locks the severity envelope
+   introduced by PR-B4 / PR-C2 / PR-D1 as a documented Decision.
+2. Edge-case + integration test coverage for the metric-compat
+   watchlist and the validate-debounce → warning banner render path.
+3. The v0.5 R-1 Change Gate Proposal (P-0099) declaring the seven
+   invariants and the new `paused` job state that v3-17 through v3-26
+   will encode as invariant tests before implementation.
+
+### Documentation
+
+- **HISTORY P-0100** — formalises the `severity` envelope (PR-B4)
+  post-hoc: `severity: Literal["error","warning","info"]`, default
+  `"error"` for backward compatibility with pre-PR-B4 backends, and
+  the `_blocking_errors` filter semantics that PR-D1 (#400) wired into
+  all four `/fit` and `/tune` raise sites.
+- **HISTORY P-0101** — documents the metric-compat watchlist
+  (`mape` / `rmsle` / `r2`) and the `task=regression` guard introduced
+  by PR-C2 (#399) and PR-D1 (#400).
+- **HISTORY P-0099** — declares the seven invariants (INV-1 through
+  INV-7) and the new `paused` job state that the v0.5 R-1 sprint will
+  encode as invariant tests before implementation. **Proposal-only
+  Change Gate; no runtime change in this release.**
+- **BLUEPRINT §5.2** — Validate response envelope spec (severity
+  Literal, `suggested_fix` nullability, watchlist trigger table,
+  `_blocking_errors` semantics, frontend `isBlockingError` mapping).
+- **PLAN.md** — adds 10 new phases (`v3-17` through `v3-26`) covering
+  R-1.1 through R-4.2 with explicit Entry / Exit criteria and DoD
+  pointing at the corresponding INV-N invariant tests.
+- `docs/v0.4-business-readiness-plan.md` v0.2 — status PARTIAL; R-3.4.1
+  and R-5 marked shipped; R-1 / R-2 / R-4 carried over to v0.5.
+- `docs/architecture-as-implemented.md` §5.4 — Validate envelope hop
+  diagram + frontend `isBlockingError` mapping.
+- `docs/ROADMAP.md` post-v0.4.1 reconciliation (recent shipped, open
+  issues, v0.5 R-1 Next Actions, drift flags for PLAN / BLUEPRINT
+  follow-ups already addressed by this release).
+
+### Tests
+
+- 6 new backend cases on `tests/contract/test_validate_metric_compatibility.py`
+  (9 → 15) covering all-NaN target, ±inf target, int64 vs float64
+  consistency, duplicate metric dedup, malformed metric entries, and
+  non-dict `evaluation` field defensive handling (#404).
+- 4 new frontend cases on `frontend/src/api/types.test.ts` locking the
+  `isBlockingError` severity-default rule (#404).
+- 2 new frontend integration cases on
+  `frontend/src/components/workspace/ConfigEditorBody.integration.test.tsx`
+  exercising the validate-debounce → `setErrors` → warning banner render
+  path end-to-end with a mocked workspace API (#405).
+
+### Cross-repo
+
+- [`LizyML #105`](https://github.com/nbx-liz/LizyML/issues/105) filed —
+  Optuna persistent storage (`JournalStorage`) for resumable tuning.
+  Critical path for v0.5 R-1.4 (`#360`); LizyStudio v3-20 cannot start
+  until this lands upstream.
+
+### Internal follow-ups (no user impact)
+
+- `#403` (BackendAdapter metric-compat refactor) — deferred to v0.6
+  alongside the second `BackendAdapter` implementation. Watchlist
+  behaviour stays locked by the contract suite.
+
 ## [0.4.1] - 2026-05-05
 
 The **Validate clarity** patch release. Bundles three follow-ups to the

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3184,11 +3184,96 @@ frontend で virtualization / top-N を入れても、転送する payload 自�
 
 - 2026-05-05 **Proposed** — PR-B3 で実装。auto mode で Phase B 実装中、Change Gate scope は `load_dataframe` の失敗タイミング精緻化のみ。**ユーザ承認済** (Phase B 全体着手承認)
 
-### P-0099: (採番予約) v0.5 R-1 状態整合性 invariants + `paused` job state（Change Gate）
+### P-0099: v0.5 R-1 状態整合性 invariants + `paused` job state（Change Gate）
 
-- **Status:** 🟡 採番予約のみ。Day 4 で本文起票予定
-- **Scope:** v0.5 R-1.1〜R-1.4 で導入する job state machine 不変条件の宣言、および R-1.4 (#360) で必要となる `paused` 状態の Change Gate
-- **Reference:** `docs/pre-v05-handoff-2026-05-05.md` §3.1 M-2
+- **Date:** 2026-05-06 起票
+- **Related:** Issue #360 (Tune long-run resumability), Issue #358 (BlockedGroup race), Issue #359 (job-num drift), Issue #384 (Server Restart Recovery), LizyML #105 (Optuna persistent storage), `docs/v0.4-business-readiness-plan.md` §2 (R-1), `~/.claude/rules/common/invariants-first.md`
+
+#### Motivation
+
+v0.4 リリースまでの slot release / cancel race 系列バグ (P-0086〜P-0089 周辺) はいずれも「不変条件が事前に文章化されていない」ことが根本原因だった (memory `feedback_count_budget_assertions` の lesson 系列)。v0.5 で R-1.4 (Tune long-run resumability, 24h+) を実装すると job state machine が **`paused` 状態を新たに持つ** ため、現状の slot release / cancel / subprocess crash の各経路に新しい遷移が増える。先に invariants を declare → invariant test を RED phase で書く → 実装、の順を強制する。
+
+CLAUDE.md §2 Change Gate 対象（state machine 変更 / 並行性・所有権の設計 / shared state の不変条件）にすべて該当するため Proposal-first で承認を取る。
+
+#### Purpose
+
+- v0.5 R-1.1〜R-1.4 全体の不変条件を **R-1.x 着手前に invariant test として encode** し、リファクタ中に regression を「Test failed」で即座に発見できるようにする
+- `paused` 状態を job lifecycle に追加（`pending → running → paused → running → succeeded|failed|cancelled` の遷移を許可、illegal transitions は assert で reject）
+- `meta.json` の atomic write (tmpfile + fsync + rename) を invariant 化し、subprocess crash 中のファイル破損を構造的に防ぐ
+- 上記すべてを各 R-1.x phase の Acceptance criteria に紐付ける
+
+#### Invariants
+
+以下を v0.5 R-1 期間中の **不変条件** として宣言する。各 INV-N は対応する invariant test を `tests/regression/` または `tests/e2e/` に持ち、code には possible なら `assert` / runtime guard / branded type で encode する。
+
+- **INV-1**: `active_job_id` holds at most one running-or-paused job at any time — released on **completion OR cancel OR exception OR SIGKILL OR WebSocket disconnect OR browser close** (6 termination paths). 違反シナリオ: terminal write 後に release が漏れる、subprocess crash で release callback が呼ばれない
+- **INV-2**: `meta.json` is written atomically (tmpfile + fsync + rename) — `kill -9` mid-write でも整合性が破れない。違反シナリオ: 親プロセスが部分書き込み中に強制終了 → 子の load_job が JSON parse error
+- **INV-3**: state machine transitions は明示宣言、illegal transitions は assert で reject。許可される遷移は以下のみ:
+  - `[*] → pending`（POST /fit / /tune）
+  - `pending → running` (worker thread が claim_active)
+  - `pending → cancelled` (DELETE / cancel before start)
+  - `running → succeeded` (terminal write OK)
+  - `running → failed` (exception or subprocess died)
+  - `running → cancelled` (cancel signal observed mid-run)
+  - **`running → paused`** (Tune trial 完了時に user pause OR scheduled checkpoint, R-1.4 で導入)
+  - **`paused → running`** (Resume button or auto-resume on restart)
+  - **`paused → cancelled`** (cancel during paused state)
+  - **`paused → failed`** (storage corruption detected on resume)
+- **INV-4**: `paused` 状態の job は **trial-level checkpoint + `meta.json` から完全復元可能** — Optuna study を re-attach して trial.number / best_value / trial.state が一致する。違反シナリオ: journal file が corrupted で resume 不能、勝手に新 trial が走る
+- **INV-5**: cancel observation is monotonic — `is_cancel_requested(job_id)` が一度 True を返したら、その後 (job 完了まで) 連続 True を返す。違反シナリオ: race で `clear_cancel` が早く走り、worker が「キャンセルされてない」と判断して terminal write を上書き
+- **INV-6**: subprocess crash recovery — 子 process が `SIGKILL` で死ぬと、親 watchdog が **bounded time window 以内** に `failed (reason="subprocess died")` で terminal write + slot release。違反シナリオ: 子が消えても active_slot がぶら下がり続けて次の job を block
+- **INV-7**: WebSocket disconnect は active slot を release **しない** — 進行中 job は subscriber 数に依らず completion または terminal failure まで走る。違反シナリオ: ブラウザを閉じたら fit が止まる、reload で resume できない
+
+#### Impact
+
+**Public API (Change Gate scope):**
+- `meta.json` schema に `"paused"` を追加。`status: Literal["pending","running","succeeded","failed","cancelled","paused"]`
+- `format_version` を `1` → `2` (P-0095 round-trip CI gate に組み込み)
+- `POST /api/jobs/{job_id}/pause` (新規, R-1.4): running Tune を paused に遷移
+- `POST /api/jobs/{job_id}/resume` 既存と統合: paused state を resume するロジックを既存の retune-resume 経路と並行サポート (H-0062 Phase B 拡張)
+- WebSocket message に `{"type":"paused", "trial_number": N, "checkpoint_path": "..."}` を追加
+- Frontend: Jobs UI に "Pause" / "Resume" ボタン (paused 状態のみ表示)
+
+**Internal (no API change):**
+- `services/jobs.py:JobStore` に `pause(job_id)` / `unpause(job_id)` 追加
+- `services/training.py` の Tune loop で trial 完了 callback に "should_pause" check を挿入
+- `backends/lizyml/lifecycle_mixin.py` で Optuna study の `storage` パラメタを passthrough (LizyML #105 待ち)
+
+#### Compatibility
+
+- v0.4 までで作成した `meta.json` (format_version=1) は `paused` フィールドを持たない → migration で `paused: false` を default に挿入。read-only で読める
+- POST /api/jobs/{job_id}/pause は新規追加なのでクライアント側で 404 をハンドルする legacy path は不要
+- WebSocket `paused` メッセージは未知タイプとして無視されるよう既存 client の switch に default branch を追加 (R-2.1 で別途扱う)
+- LizyML 0.11.x で `storage=` パラメタが無いため、LizyML #105 が merged するまでは `paused` 経路を feature flag (`LIZYSTUDIO_TUNE_RESUME_ENABLED=0`) で off にする
+
+#### Acceptance criteria
+
+R-1.1〜R-1.5b の各 phase に invariant test を割り当てる。本 Proposal の DoD は「invariant declaration が PLAN.md の各 phase に reflectee されている」こと。実装は phase 単位で行う。
+
+- [ ] PLAN.md v3-17 (R-1.1) に **INV-1 / INV-5** の invariant test を Acceptance criteria として明記
+- [ ] PLAN.md v3-18 (R-1.2) に **INV-5** + #358 の regression test を明記
+- [ ] PLAN.md v3-19 (R-1.3) に **INV-2 / INV-6** の invariant test を明記
+- [ ] PLAN.md v3-20 (R-1.4) に **INV-3 / INV-4** の invariant test + LizyML #105 dependency を明記
+- [ ] PLAN.md v3-21 (R-1.5) に Issue #359 (job-num drift) の regression test を明記
+- [ ] PLAN.md v3-22 (R-1.5b) に **INV-7** + Issue #384 の regression test を明記
+- [ ] BLUEPRINT.md §3.4 (Job lifecycle) に上記 INV-1〜INV-7 を明記
+- [ ] CHANGELOG.md (v0.5.0 release notes drafting 時) に `paused` 状態追加を Breaking 寸前 (Added) で記述
+- [ ] Issues #358 / #359 / #360 / #384 を本 Proposal の child Issue として label
+
+#### Alternatives considered
+
+- **(a) Invariant 宣言なし、phase 別に都度 PR 単位で書く**: 拒否。slot release 系の regression 5回連発の実績 (memory `feedback_symmetry_audit_on_fixes`) は事前 invariant declaration 不在が原因
+- **(b) `paused` の代わりに既存 `running` のサブステートとして表現**: 拒否。状態遷移が暗黙化され client / DB / WS 全層で「実は走っていない running」が解釈の余地として残る
+- **(c) Optuna 永続化を LizyStudio 側で wrap (LizyML #105 を待たない)**: 拒否。`Tuner.tune()` を bypass すると round_number / prior_trials / expanded_dims tracking (LizyML H-0068) を re-implement する必要、保守コストで割に合わない
+- **(d) format_version を bump せず paused を後付け**: 拒否。P-0095 の round-trip CI gate が format_version を読むので migration matrix に明示的に乗せる方が安全
+
+→ 採用は **(e) Invariants 7 件を Proposal で declare、phase 単位で invariant test を RED phase に強制、`paused` を state machine の正規 1st-class member にする**。
+
+#### Decision
+
+- 2026-05-06 **Proposed** — v0.5 R-1.1 着手前に user 承認を取り、PLAN.md に v3-17〜v3-22 を追加した時点で **Approved**。実装は phase 単位、各 phase の PR が invariant test を含む
+
+
 
 ### P-0100: severity envelope の正式化（PR-B4 → PR-C2/PR-D1, Issue #394）
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3184,4 +3184,122 @@ frontend で virtualization / top-N を入れても、転送する payload 自�
 
 - 2026-05-05 **Proposed** — PR-B3 で実装。auto mode で Phase B 実装中、Change Gate scope は `load_dataframe` の失敗タイミング精緻化のみ。**ユーザ承認済** (Phase B 全体着手承認)
 
+### P-0099: (採番予約) v0.5 R-1 状態整合性 invariants + `paused` job state（Change Gate）
+
+- **Status:** 🟡 採番予約のみ。Day 4 で本文起票予定
+- **Scope:** v0.5 R-1.1〜R-1.4 で導入する job state machine 不変条件の宣言、および R-1.4 (#360) で必要となる `paused` 状態の Change Gate
+- **Reference:** `docs/pre-v05-handoff-2026-05-05.md` §3.1 M-2
+
+### P-0100: severity envelope の正式化（PR-B4 → PR-C2/PR-D1, Issue #394）
+
+- **Date:** 2026-05-05 起票 / 同日 Decision
+- **Related:** PR #399 (PR-C2 feat/validate-metric-compat-394), PR #400 (PR-D1 fix/fit-tune-severity-filter-394), Issue #394, P-0097 (Wide DataFrame), CHANGELOG v0.4.1
+
+#### Motivation
+
+PR-B4 で `ValidationError` payload に `severity: Literal["error", "warning", "info"]` と `suggested_fix: str | None` が導入されたが、Pydantic Literal の正式宣言と「どこで `severity` を見るか」のセマンティクスが HISTORY 未記録のまま v0.4.1 リリースに乗った。PR-C2 と PR-D1 で raise sites が確定したため、後続 R-1 / R-3 が同 envelope を使い続ける前提として正式化する。
+
+#### Purpose
+
+- `severity="error"` 以外は `valid=true` / `saved=true` を維持し block しない
+- `severity` 未設定の旧 ValidationError は `"error"` として扱い backward compatible
+- `_blocking_errors` 共通ヘルパで「block 判定 = `severity != "warning|info"`」を一箇所に集約
+- `suggested_fix` は警告を「具体的な置換アクション」に紐付ける recovery hint slot として API 仕様に組み込む
+
+#### Impact
+
+- Public API: `POST /api/workspace/config/validate` / `PUT /api/workspace/config` / `POST /api/workspace/upload` の `errors[]` 各要素に `severity` (default `"error"`) と `suggested_fix` (default `null`) が必須キーとして登場
+- `POST /api/workspace/fit` / `POST /api/workspace/tune` は warning-only config (= severity != "error") を 422 で返さなくなる（PR-D1 #400 で修正）
+- Frontend: yellow warning banner が ConfigForm 上部に追加 (ConfigEditorBody.tsx)、blocking と非 blocking を視覚分離
+- 既存 ValidationError 使用箇所はキー追加のみで挙動不変
+
+#### Compatibility
+
+- 旧 ValidationError (severity 未設定) は default `"error"` で従来挙動を維持
+- Frontend `isBlockingError(entry)` ヘルパが `entry.severity ?? "error"` で wrap
+- `_blocking_errors([entry, ...])` ヘルパが Service / API 層共通で severity フィルタ
+- 全フィールド optional 追加 → JSON Schema 後方互換
+
+#### Acceptance criteria
+
+- [x] `tests/contract/test_validate_severity_and_suggested_fix.py` で envelope shape を契約化
+- [x] `tests/contract/test_fit_tune_severity_filter.py` で fit/tune が warning-only config を受け入れることを 7 cases pin（PR-D1 #400）
+- [x] `frontend/src/api/types.ts` に `isBlockingError` ヘルパ + 単体テストへの落とし込みは S-1 / O-1 で追加（#404 / #405）
+- [x] CHANGELOG v0.4.1 で公開挙動を記述
+
+#### Alternatives considered
+
+- **(a) 別フィールド `level: "fatal" | "warn"` を使う**: 拒否。`severity` がすでに WCAG / RFC 用語と整合、Toast / aria-live にもそのまま流用可能
+- **(b) HTTP status を 422 / 200 で分離**: 拒否。同一エンドポイントの一覧に warning と error が混在するケースで status を分けると複雑化、UI が両方をマージできない
+- **(c) suggested_fix を別 endpoint に切り出す**: 拒否。round-trip が増え UX 悪化
+
+→ 採用は **(d) 同 envelope で severity + suggested_fix を inline**。
+
+#### Decision
+
+- 2026-05-05 **Decided (post-hoc)** — PR-C2 / PR-D1 で実装済、本 Decision 記録は v0.4.1 リリース後の reconciliation。後続 R-1 / R-3 / R-3.4.2 (Diagnostic export) はこの envelope を前提に拡張する
+
+### P-0101: metric-compat watchlist による uncomputable metric の auto-disable（PR-C2, Issue #394）
+
+- **Date:** 2026-05-05 起票 / 同日 Decision
+- **Related:** PR #399 (PR-C2 feat/validate-metric-compat-394), PR #400 (PR-D1), Issue #394, P-0100 (severity envelope), CHANGELOG v0.4.1, LizyML 0.11.0 (sMAPE / WAPE)
+
+#### Motivation
+
+`mape` / `rmsle` / `r2` は target 列の値域が条件を満たさないと数学的に計算できない:
+
+- `mape`: target に 0 が含まれると ZeroDivisionError 相当
+- `rmsle`: target に負値が含まれると `log(1+x)` で nan
+- `r2`: target が定数だと分散 0 で nan
+
+ユーザがこれらを Tuning 設定の `evaluation.metrics` に入れたまま fit すると、結果として nan / 例外で失敗するか、ジョブ完走後に metric が表示されない。事前に `validate` レイヤで「この target だと計算不能なので外しますね」と返したい。
+
+#### Purpose
+
+- Service 層の `_workspace_metric_compatibility_errors(config, df)` で target 列を inspect し、watchlist 該当 metric があれば `severity="warning"` の ValidationError を返す
+- `suggested_fix` で具体的な置換 metric 名を返す (例: `mape` 該当時は LizyML 0.11.0 で追加された `smape` / `wape` を提案)
+- `task=regression` のときだけ作動（binary / multiclass は対象外、HIGH-1 として PR-D1 で task ガード追加）
+- 検出ルールはこの Decision で固定し、後続バックエンドが増えたときは [Issue #403](https://github.com/nbx-liz/LizyStudio/issues/403) で BackendAdapter 抽象化
+
+#### Impact
+
+- 新 helper: `_workspace_metric_compatibility_errors(config, df) -> list[ValidationError]`
+- 呼び出しタイミング: `POST /api/workspace/config/validate` / `PUT /api/workspace/config` / `POST /api/workspace/upload`
+- Frontend 影響: yellow banner に `suggested_fix` を二行目で表示 (P-0100 で導入された envelope を流用)
+- 検出は **non-blocking** (severity=warning)。ユーザはそのまま fit を実行可能だが、metric は実行時に nan を返す可能性
+
+#### Watchlist 仕様
+
+| Metric | Trigger | suggested_fix |
+|---|---|---|
+| `mape` | target に 0 が 1 件以上 | "Use `smape` or `wape` instead (lizyml 0.11.0+)" |
+| `rmsle` | target に負値が 1 件以上 | "Remove `rmsle` from evaluation.metrics" |
+| `r2` | target の `nunique() == 1` (定数) | "Remove `r2` from evaluation.metrics" |
+
+#### Compatibility
+
+- watchlist は backward-compat: 警告だが block しない、既存 fit の挙動は不変
+- 旧バックエンド (lizyml 0.10.x) で sMAPE / WAPE が無くても suggested_fix は文字列のみ → クライアントは盲目に表示するだけで壊れない
+- task != "regression" のときは作動しない (binary classification で `r2` を入れるとそもそも metric registry でエラーになる別経路)
+
+#### Acceptance criteria
+
+- [x] `src/lizystudio/services/workspace.py` で `_workspace_metric_compatibility_errors` 実装
+- [x] PR #399 で 3 endpoints (`validate` / `PUT /config` / `upload`) に組み込み
+- [x] PR #400 で `task=regression` ガード + fit/tune raise sites の severity フィルタ
+- [x] `tests/contract/test_validate_metric_compatibility.py` で 9 cases (今後 #404 で 7 cases 追加して 16 cases へ)
+- [x] CHANGELOG v0.4.1 で公開挙動を記述
+
+#### Alternatives considered
+
+- **(a) Backend 任せ (fit 実行時に nan を返す)**: 拒否。ユーザが trial を浪費した後に気づく、UX 悪化
+- **(b) Hard error (severity="error" で block)**: 拒否。数学的不能でも MAPE を許容したい上級ユーザもいる、過剰な強制
+- **(c) BackendAdapter abstract method として最初から抽象化**: defer。第二 backend が見えるまで抽象化は YAGNI、Issue #403 として後送り
+
+→ 採用は **(d) Service 層 helper + watchlist 定義 + non-blocking warning**。Adapter 抽象化は #403 で別途。
+
+#### Decision
+
+- 2026-05-05 **Decided (post-hoc)** — PR-C2 / PR-D1 で実装済、本 Decision 記録は v0.4.1 リリース後の reconciliation。Issue #403 で BackendAdapter 抽象化、#404 で異常系 7 cases 追加が follow-up
+
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1233,8 +1233,280 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 
 ---
 
-## 採番ガイダンス（v3-17 以降）
+## Phase v3-17: v0.5 R-1.1 — Slot release invariant 6 経路検証（P-0099 INV-1 / INV-5）
 
-- 新規 Proposal は **P-0095** 以降を起票（P-0094 = 2026-05-01 pytest-benchmark）。
-- 仕様変更を伴う作業は HISTORY.md に Proposal → 本 PLAN.md にフェーズ追加（`v3-17`...）の順で進める。
+**期間:** v0.5 着手後 1 週間（LizyML #105 と独立）
+
+**対象 Proposal:** P-0099
+
+**Entry criteria:**
+- HISTORY.md P-0099 が **Approved**（user 承認）
+- Issues #358 / #359 / #360 / #384 に P-0099 の child label が貼られている
+
+**動機:** v0.4 までで slot release 系 regression が 5 連続発生（P-0086〜P-0091 周辺）した根本原因は不変条件の事前文書化不在。v0.5 R-1.4 で `paused` 状態を追加する前に、6 経路（normal / cancel / exception / SIGKILL / WebSocket切断 / browser閉じる）すべてで `active_job_id` が release されることを invariant test で固定する。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-17a | INV-1 / INV-5 の invariant test を `tests/regression/test_inv_slot_release.py` に書く（RED phase） | 🟡 | — |
+| v3-17b | 既存 release 経路の audit + 抜け落ちを修正（GREEN phase） | 🟡 | — |
+| v3-17c | Playwright で WS切断 / browser閉じる経路を E2E 化 | 🟡 | — |
+
+**DoD:**
+- [ ] `tests/regression/test_inv_slot_release.py` で 6 経路すべてが green、各 path に `assert active_job_id is None` がある
+- [ ] `tests/regression/test_inv_cancel_monotonic.py` で `is_cancel_requested` の monotonic 性が確認される（INV-5）
+- [ ] Playwright `tests/e2e/slot-release-paths.spec.ts` で WS切断 + browser閉じるの 2 経路を実機 verification
+- [ ] `services/jobs.py:JobStore` に `assert _active_job_id is None or _active_job_id == job_id` 等の runtime guard が encode 済
+
+**Exit criteria:** 上記 DoD すべて green。次は v3-18。
+
+---
+
+## Phase v3-18: v0.5 R-1.2 — Cancel race の修復（P-0099 INV-5 / Issue #358）
+
+**期間:** v3-17 完了後 1 週間
+
+**対象 Proposal:** P-0099, Issue #358 (BlockedGroup race)
+
+**動機:** Cancel + 完了通知の競合で「キャンセル押下後の `cancelled` 状態が completion で上書きされる」regression を構造的に閉じる。memory `feedback_count_budget_assertions` の lesson を踏まえ、count-based assertion で証明する。
+
+**Entry criteria:** v3-17 完了。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-18a | Issue #358 の reproducer を `tests/regression/test_reg_358_blocked_group_cancel_race.py` に固定 | 🟡 | — |
+| v3-18b | cancel + terminal write の race を count-based assertion で test | 🟡 | — |
+| v3-18c | services/training.py で cancel observation を pre-terminal-write に固定 | 🟡 | — |
+
+**DoD:**
+- [ ] Issue #358 が close 済（reproducer green）
+- [ ] count-based assertion: 100 並行 cancel-during-completion で `cancelled` 状態が常に observable 1 件以上
+- [ ] INV-5 の monotonic 性が cancel race のすべての interleaving で破れない
+
+---
+
+## Phase v3-19: v0.5 R-1.3 — Subprocess crash 復旧 + atomic meta.json（P-0099 INV-2 / INV-6）
+
+**期間:** v3-18 完了後 1 週間
+
+**対象 Proposal:** P-0099
+
+**動機:** OpenMP detection で subprocess に行く経路は kill -9 で死ぬと親が状態を見失う既知のリスク。`meta.json` の atomic write も子プロセスが mid-write で死ぬと file が壊れる。R-1.4 (Tune resume) で trial-level checkpoint を書く前に、書き込み一貫性を保証する。
+
+**Entry criteria:** v3-18 完了。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-19a | `services/jobs.py:_write_meta_atomic` で tmpfile + fsync + rename を実装 | 🟡 | — |
+| v3-19b | `tests/regression/test_inv_meta_json_atomic.py` で kill -9 mid-write の simulate test (INV-2) | 🟡 | — |
+| v3-19c | subprocess crash watchdog を `services/training.py` に追加（INV-6） | 🟡 | — |
+| v3-19d | `tests/regression/test_inv_subprocess_crash_recovery.py` で kill -9 → bounded time → failed terminal の test | 🟡 | — |
+
+**DoD:**
+- [ ] INV-2 / INV-6 の invariant test green
+- [ ] `meta.json` write 経路すべてが `_write_meta_atomic` 経由（grep で hand-rolled `open(...,"w")` がない）
+- [ ] watchdog が `polling interval <= 5s` で subprocess の生存確認、死亡検知から terminal write までが <= 10s
+
+---
+
+## Phase v3-20: v0.5 R-1.4 — Tune long-run resumability（P-0099 INV-3 / INV-4 / Issue #360）
+
+**期間:** v3-19 完了後 3 週間。**LizyML #105 (Optuna persistent storage) merged が前提。**
+
+**対象 Proposal:** P-0099 + Issue #360
+
+**動機:** v0.4 で識別された最大の業務リスク (`docs/v0.4-business-readiness-plan.md` §0)。24h+ Tune 中に SIGKILL / network 切断 / browser リロードで進捗が完全消失する問題を構造的に解消する。
+
+**Entry criteria:**
+- v3-19 完了
+- LizyML #105 merged + LizyStudio 側 `pyproject.toml` で対応 minor version へ bump
+- `LIZYSTUDIO_TUNE_RESUME_ENABLED=1` を default に切り替え可能
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-20a | `meta.json` schema に `status="paused"` 追加 + format_version 1 → 2 migration（INV-3） | 🟡 | — |
+| v3-20b | `backends/lizyml/lifecycle_mixin.py` で `tune(storage=...)` passthrough | 🟡 | — |
+| v3-20c | `services/jobs.py` に `pause(job_id)` / `unpause(job_id)`、API `POST /api/jobs/{job_id}/pause` 追加 | 🟡 | — |
+| v3-20d | WebSocket message に `paused` type 追加 + frontend ハンドリング | 🟡 | — |
+| v3-20e | Frontend Jobs UI に Pause / Resume ボタン（paused 状態のみ表示） | 🟡 | — |
+| v3-20f | `tests/regression/test_inv_paused_roundtrip.py` で trial-level checkpoint round-trip (INV-4) | 🟡 | — |
+| v3-20g | Playwright `tests/e2e/tune-resume.spec.ts` で 24h 模擬 (時間圧縮 mock) の resume シナリオ | 🟡 | — |
+
+**DoD:**
+- [ ] INV-3 / INV-4 の invariant test green
+- [ ] Issue #360 が close 済
+- [ ] format_version=2 への migration が P-0095 round-trip CI gate に組み込まれている
+- [ ] CHANGELOG (v0.5 draft) に `paused` 状態が Added で記載
+- [ ] `LIZYSTUDIO_TUNE_RESUME_ENABLED` を `1` で default 化、feature flag 経由で off にも切替可
+
+---
+
+## Phase v3-21: v0.5 R-1.5 — Issue #359 job-num drift 解消
+
+**期間:** v3-20 と並行可（state machine 変更を含まない）、0.5 週間
+
+**対象:** Issue #359
+
+**動機:** `job_num` を frontend 側で計算せず API レスポンスに含めることで、削除や cancel 後の番号 drift を解消。
+
+**Entry criteria:** v3-17 完了（slot release が安定したら着手可）。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-21a | `meta.json` に不変 `job_num: int` を保存（format_version=2 と同 PR が望ましい） | 🟡 | — |
+| v3-21b | API `GET /api/jobs` / `GET /api/jobs/{id}` レスポンスに `job_num` 追加（openapi-typescript 再生成） | 🟡 | — |
+| v3-21c | Frontend で `job_num` を index 計算から API レスポンス参照に切替 | 🟡 | — |
+
+**DoD:**
+- [ ] Issue #359 が close 済
+- [ ] `tests/regression/test_reg_359_job_num_stable.py` で削除 + 新規作成サイクル後の番号 stability 確認
+
+---
+
+## Phase v3-22: v0.5 R-1.5b — Server Restart Recovery（P-0099 INV-7 / Issue #384）
+
+**期間:** v3-20 完了後 1 週間
+
+**対象:** P-0099 + Issue #384 (#360 ブロック解除後)
+
+**動機:** サーバ再起動後に running / paused job が UI に正しく復元されること。LizyML #105 + R-1.4 が完了している前提で、再起動シナリオを E2E 化する。
+
+**Entry criteria:** v3-20 完了 (#360 解消)。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-22a | server lifespan startup で paused jobs を `meta.json` から再 attach | 🟡 | — |
+| v3-22b | `tests/regression/test_inv_ws_disconnect_does_not_release.py` で INV-7 検証 | 🟡 | — |
+| v3-22c | Playwright `tests/e2e/server-restart-recovery.spec.ts` で実 restart シナリオ | 🟡 | — |
+
+**DoD:**
+- [ ] Issue #384 が close 済
+- [ ] INV-7 の invariant test green
+
+---
+
+## Phase v3-23: v0.5 R-2.1 — WebSocket 再接続戦略
+
+**期間:** v3-22 完了後 1 週間
+
+**対象:** `docs/v0.4-business-readiness-plan.md` §3.1
+
+**動機:** Long-run Tune (24h) でネットワーク断絶からの復帰を確実にする。exponential backoff、最大 reconnect interval 5min。
+
+**Entry criteria:** v3-22 完了。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-23a | Frontend `useJobProgress` hook の reconnect ロジックを exponential backoff 化 | 🟡 | — |
+| v3-23b | Backend WebSocket handler で resume token を発行 → reconnect で missed messages を replay | 🟡 | — |
+| v3-23c | Playwright で 10s 切断 → 復帰の progress 続行 verification | 🟡 | — |
+
+**DoD:**
+- [ ] 10s 切断後 progress 続行、最終 status 一致
+- [ ] 5min 切断後でも reconnect 試行は継続、復帰時に missed messages 受信
+
+---
+
+## Phase v3-24: v0.5 R-2.2 — ブラウザリロード状態復元
+
+**期間:** v3-23 完了後 1 週間
+
+**対象:** `docs/v0.4-business-readiness-plan.md` §3.2
+
+**動機:** リロード時に data + config + 進行中 job がそのまま見える状態を実現。1 名利用前提なので multi-tab 衝突制御は scope 外。
+
+**Entry criteria:** v3-23 完了。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-24a | Frontend で workspace state を localStorage / IndexedDB に persist（or 既存 GET /status を活用） | 🟡 | — |
+| v3-24b | `beforeunload` で form ダーティ警告（dirty config を保存しないとロストする旨） | 🟡 | — |
+| v3-24c | Playwright で reload 後の data + config + running job 復元を Visual diff verification | 🟡 | — |
+
+**DoD:**
+- [ ] reload 後 30s 以内に form / data / progress が前と同じ状態
+- [ ] dirty config がある状態で reload 試行 → confirm ダイアログ表示
+
+---
+
+## Phase v3-25: v0.5 R-4.1 — format_version migration matrix CI gate
+
+**期間:** v3-20 完了後（並行可）、1 週間
+
+**対象:** P-0095 拡張 + `docs/v0.4-business-readiness-plan.md` §5.1
+
+**動機:** R-1.4 で format_version を 1→2 に bump する。過去 workspace を新 CLI が壊さない保証を CI で gating する。
+
+**Entry criteria:** v3-20 完了 (format_version=2 が定義済)。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-25a | `tests/regression/test_format_version_migration_matrix.py` で v0 → v1 → v2 の round-trip | 🟡 | — |
+| v3-25b | CI workflow で過去 fixture (v0 / v1) を fetch + load + 新 release で save → load → 同値 assertion | 🟡 | — |
+| v3-25c | 古い format_version を read-only で開く保護 (CLI の write モードで明示的にエラー) | 🟡 | — |
+
+**DoD:**
+- [ ] CI で migration matrix が gating
+- [ ] 古い workspace を新 CLI で開いても `LIZYSTUDIO_ALLOW_LEGACY_READ=1` 無しに data destruction が起きない
+
+---
+
+## Phase v3-26: v0.5 R-4.2 — Pickle compatibility test（P-0095 拡張）
+
+**期間:** v3-25 と並行可、1 週間
+
+**対象:** `docs/v0.4-business-readiness-plan.md` §5.2
+
+**動機:** lizyml minor バンプ時に Pickle 互換切れが起きると過去のモデルが load できなくなる。Nightly CI で過去 N=3 minor version の互換性を確認する。
+
+**Entry criteria:** v3-25 完了。
+
+**サブフェーズ:**
+
+| サブフェーズ | 内容 | 状態 | PR |
+|---|---|---|---|
+| v3-26a | `.github/workflows/nightly.yml` に pickle compat job 追加 | 🟡 | — |
+| v3-26b | `tests/bench/test_bench_pickle_compat.py` で過去 lizyml 版で fit → 現行で load の round-trip | 🟡 | — |
+| v3-26c | `cloudpickle` 互換切れ検出時の明示エラー (`PICKLE_INCOMPATIBLE`) | 🟡 | — |
+
+**DoD:**
+- [ ] Nightly CI で過去 3 minor version すべて green
+- [ ] 互換切れ時のエラーメッセージが recovery_hint と suggested_fix を含む（P-0100 envelope を再利用）
+
+---
+
+## v0.5 Exit Criteria
+
+`docs/v0.4-business-readiness-plan.md` §7 を本 v3-17〜v3-26 で消化する。すべての DoD が green、かつ:
+
+- [ ] 24h Tune が SIGKILL / network 切断 / browser リロードで再開可能（INV-3 / INV-4）
+- [ ] ブラウザリロード後に data + config + 進行中 job が完全復元（v3-24）
+- [ ] format_version migration matrix が CI で gating（v3-25）
+- [ ] Slot release が 6 経路全てで test カバー済（INV-1）
+- [ ] 業務利用 KPI (`docs/business-use-definition.md` v0.2 §16) 達成
+
+---
+
+## 採番ガイダンス（v3-27 以降）
+
+- 新規 Proposal は **P-0102** 以降を起票（P-0101 = 2026-05-05 metric-compat watchlist Decision、P-0099 = 2026-05-06 R-1 invariants）。
+- 仕様変更を伴う作業は HISTORY.md に Proposal → 本 PLAN.md にフェーズ追加（`v3-27`...）の順で進める。
 - 詳細な未着手バックログは `docs/ROADMAP.md` を参照。
+- v0.6+ 候補: 第 2 backend (Issue #403)、Tailwind v4 (#125)、P-0087 Phase 3、LLM 統合、PyTorch backend、監査ログ・認証。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 - このファイルは **横串インデックス** であり、詳細はリンク先で確認すること。
 - 着手する際は HISTORY に Proposal を起票（変更ゲート対象の場合）→ PLAN にフェーズ追加 → 実装、の順で進める。
 
-最終更新: 2026-05-01（直近 PR #329-#335 反映完了：P-0093 / #328 / cleanup / Tier 3 docs / P-0094 Proposal+impl / BLUEPRINT audit）
+最終更新: 2026-05-05（v0.4.1 リリース反映：CHANGELOG / HISTORY P-0095..P-0098 / Open Issues #403..#405 / v0.5 R-1 Next Action）
 
 ---
 
@@ -103,6 +103,16 @@
 
 | 完了日 | ID | タイトル | 主要 PR |
 |---|---|---|---|
+| 2026-05-05 | **v0.4.1 release** | Validate clarity patch — severity envelope + auto-disable uncomputable metrics + lizyml 0.11.0 (sMAPE/WAPE) | #397 / #398 / #399 / #400 / #401 / #402 (release merge) |
+| 2026-05-05 | PR-D1 (#400) | fit/tune raise sites filter on `severity="error"`; warning-only configs no longer 422 | #400 |
+| 2026-05-05 | PR-C2 (#399) | `_workspace_metric_compatibility_errors` auto-disables `mape`/`rmsle`/`r2` via severity=warning + suggested_fix | #399 |
+| 2026-05-05 | LizyML 0.11.0 bump | adopt sMAPE / WAPE (zero-tolerant MAPE alternatives) | #398 |
+| 2026-05-05 | PR-C1 (#397) | hide redundant SHAP Summary tab in Workspace Plot panel | #397 |
+| 2026-05-05 | **v0.4.0 release** | Wide DataFrame — data/preview & importance payload caps, chunked CSV fail-fast | (multiple, #395 release merge) |
+| 2026-05-05 | P-0098 | `load_dataframe` chunk-based fail-fast memory guard (PR-B3) | (in v0.4.0) |
+| 2026-05-05 | P-0097 | Wide DataFrame data/preview + importance payload caps (#361 / R-5.1) | (in v0.4.0) |
+| 2026-05-04 | P-0096 | 業務利用 (business-use) 定義の確定と v0.4 Exit Criteria への反映 | (docs) |
+| 2026-05-03 | P-0095 | Backend fit→load round-trip integration test as required CI gate (#346 Phase C) | #348..#354 |
 | 2026-05-01 | BLUEPRINT audit | P-0086..P-0094 の Decisions を BLUEPRINT.md §3.3/§3.4/§5.2/§5.5/§6.1/§8.1 に反映 | #335 |
 | 2026-05-01 | P-0094 (impl) | pytest-benchmark perf baseline (`tests/bench/` + nightly job) | #334 |
 | 2026-05-01 | P-0094 (proposal) | pytest-benchmark introduction Proposal-only | #333 |
@@ -123,6 +133,14 @@
 ---
 
 ## 3. アクティブ：仕様変更を伴う Proposal
+
+### 3.-1 v0.5 R-1 invariants Proposal（採番予約：P-0099, P-0100, P-0101）
+
+- **状態**: 🟡 未起票（v0.5 R-1 着手直前に書く。`docs/pre-v05-handoff-2026-05-05.md` §3.1 M-2 / M-3 参照）
+- **P-0099**: Job state machine invariants + `paused` state（R-1 全体の Change Gate）
+- **P-0100**: severity envelope formalization (PR-B4) — Pydantic Literal 化、`_blocking_errors` セマンティクス（PR-D1 #400 で確立、未記録）
+- **P-0101**: metric-compat watchlist — `_workspace_metric_compatibility_errors` の検出ルール（PR-C2 #399 / PR-D1 #400 で確立、未記録）
+- **次回採番**: P-0102 以降
 
 ### 3.0 P-0094 (済)：pytest-benchmark performance baseline（Issue #27 (a)）
 
@@ -228,11 +246,16 @@
 
 ## 5. アクティブ：Open Issues
 
-直近 4 件（#327 / #328 / #298 / #304）はすべて closed 済み。Tier 4 戦略課題のみ残存。
+v0.4.1 リリース後の Open Issue は 5 件。
 
 | Issue | タイトル | priority | 推奨アクション |
 |---|---|---|---|
-| **#27** | [Testing] Add load and concurrency tests | medium / tier-4 | (a) `pytest-benchmark` 100k-row microbench を tier-3 で先行マージ可 / (b) 並行 fit stress harness は tier-4 |
+| **#360** | feat(tune): long-run resumability (24h+, all termination paths) | tier-4 / high | **v0.5 core (R-1.4, 3 週間)**。LizyML 上流対応待ち（M-1 で起票予定） |
+| **#384** | [Testing] #28 follow-up — Server Restart Recovery (blocked on #360) | tier-3 / medium | **R-1.5b (v0.5)** — #360 解消後 |
+| **#403** | refactor(backend): move metric-compat watchlist behind BackendAdapter abstraction (HIGH-2) | tier-3 / medium | **v0.6 defer 推奨** — 第 2 backend が見えてから |
+| **#404** | test: add edge-case coverage for `_workspace_metric_compatibility_errors` | tier-2 / medium | **S-1 (Day 3 着手)** — 7 cases (NaN/inf/dtype/dedup/malformed) |
+| **#405** | test(frontend): integration coverage for validate-debounce → warning banner | tier-3 / medium | **O-1 (並行可)** — frontend 単独 |
+| **#27** | [Testing] Add load and concurrency tests | medium / tier-4 | (a) `pytest-benchmark` baseline は P-0094 で完了。(b) 並行 fit stress harness は実機要件あり |
 | **#28** | [Testing] Add offline/resume resilience tests | medium / tier-4 | `current_job_id` ライフサイクル契約決定が前提。post-completion deep-link は #143 でカバー済み、during-run reload が gap |
 | **#125** | chore(frontend): migrate Tailwind CSS v3 → v4 | medium / tier-4 | Owner status: `Button` で spike → 専用 sprint。即着手は推奨しない |
 
@@ -242,36 +265,63 @@
 
 | 対象 | 最終更新 | リスク | 対応 |
 |---|---|---|---|
-| `BLUEPRINT.md` | ✅ 2026-05-01 reconciled | — | P-0086 / P-0088 / P-0089 / P-0093 / `JOB_CONFLICT` / `preflight_checkpoint_dir` / P-0094 perf bench の drift を反映済み |
+| `BLUEPRINT.md` | 🟡 2026-05-01 (P-0094 まで反映) | 中 | P-0095..P-0098 と v0.4.1 severity envelope（PR-B4 / PR-C2 / PR-D1）が未反映。**M-4 (Day 2) で §5 (API) に severity / suggested_fix を追記** |
+| `HISTORY.md` Decision 記録 | 🟡 2026-05-04 P-0098 まで | 中 | v0.4.1 で導入された severity envelope / metric-compat watchlist が Decision 未記録。**M-3 (Day 2) で P-0100 / P-0101 を起票** |
+| `PLAN.md` v3-N | 🟡 2026-05-01 v3-15 まで | 中 | v0.4.0 / v0.4.1 phase が未確定、v0.5 R-1〜R-2 phase が未追加。**M-5 (Day 4) で v3-16 以降を追加** |
 | `docs/architecture.md` / `api.md` / `adapter-guide.md` | ✅ 2026-05-01 reconciled | — | 棚卸し完了。`tests/contract/test_adapter_guide_method_names.py` で adapter-guide.md ↔ Protocol の drift を gating |
-| `PLAN.md` v3-13/14/15 | ✅ 反映済み（2026-04-30, 2026-05-01） | — | — |
-| `HISTORY.md` P-0092 follow-ups | ✅ 反映済み（2026-04-30、PR #303 周辺で追記） | — | — |
-| `MEMORY.md` 古いノート | ✅ 直近セッションで更新（`project_coupling_refactor_progress` 等は post-#271 / P-0092 完了以降に上書き済み） | — | — |
+| `docs/architecture-as-implemented.md` | 🟡 2026-04-17 | 中 | severity filter / `_blocking_errors` の hop 図が未更新。**S-4 (Day 3) で更新** |
+| `docs/v0.4-business-readiness-plan.md` | 🟡 2026-04 | 低 | R-3.4 (Validate API) は v0.4.0 / v0.4.1 で完了。**S-3 (Day 1 午後) でレビュー → header に shipped 記載** |
+| `MEMORY.md` 古いノート | ✅ 直近セッションで更新 | — | `project_v041_shipped` / `project_pre_v05_work_plan` 反映済み |
 | `analysis/` 削除済み | 2026-04 期間 | `python-analyst` ↔ `lizystudio-analyst` パイプライン成果物の置き場が無い | 🟡 意図的削除か要確認、別 issue 検討 |
 
 ---
 
 ## 7. 推奨 Next Action（ROI 順 / 1 PR 単位）
 
-> 旧 Tier 0 / Tier 1 / Tier 2 のアイテムは 2026-04-30〜2026-05-01 に解消済み（B-4/B-5/B-6/B-2 → PR #312-#315、B-1 → PR #316、Phase C generator + wave 1〜8 → PR #317-#325、B-8 → PR #318、#327/#328 → PR #329/#330）。残るは Tier 3 戦略課題と Tier 4 長期計画。
+> v0.4.1 リリース完了 (2026-05-05)。詳細な v0.5 着手前の作業内訳は `docs/pre-v05-handoff-2026-05-05.md` 参照（MUST 6 + SHOULD 4 + OPTIONAL 3 = 13 件、計 4-7 日）。
 
-### Tier 3：戦略課題
+### Tier 1：v0.5 着手前必須（MUST、4-6 日）
 
-1. **P-0094 implementation**: pytest-benchmark microbench — Proposal accept 後の実装 PR（`feat/pytest-benchmark-baseline-p0094` で着手予定）
-2. **P-0095 として P-0087 Phase 3 を Proposal 化**（`cv_strategy_fields` の Pydantic 自動派生）— lizyml 側で構造化フィールドメタデータ export が前提のためリポジトリ間調整必要
-3. **#28** offline/resume resilience tests — `current_job_id` ライフサイクル契約決定が前提
+1. **M-1**: LizyML 側に Optuna persistent storage Issue を起票（`/home/rem/repos/LizyML`、cross-repo）— v0.5 R-1.4 (#360) のクリティカルパス
+2. **M-2**: HISTORY.md P-0099 起票（R-1 invariants + `paused` state Change Gate）
+3. **M-3**: HISTORY.md P-0100 / P-0101 起票（severity envelope / metric-compat watchlist Decision）
+4. **M-4**: BLUEPRINT.md §5 (API) に severity / suggested_fix を反映
+5. **M-5**: PLAN.md v3-N (R-1 〜 R-2) phase 追加 + v0.4.0 / v0.4.1 phase 確定
+6. **M-6**: handoff docs cleanup（5 ファイル削除） — 一部完了（3 ファイル削除済、本 ROADMAP 更新後 `pre-v05-handoff-2026-05-05.md` 削除予定）
 
-### Tier 4：要長期計画
+### Tier 2：高 ROI 準備（SHOULD、1-2 日）
 
-5. **#27 (b)** 並行 fit stress harness — 実機マシン要件あり
-6. **#125** Tailwind v4 — Button で spike → 専用 sprint
-7. ML Backend 2nd 実装による Adapter 抽象検証 — 候補 backend 選定が未決
+7. **S-1**: #404 異常系テスト 7 cases 追加（`tests/contract/test_validate_metric_compatibility.py` + `frontend/src/api/types.test.ts`）
+8. **S-2**: 本 ROADMAP の post-v0.4.1 reconciliation — 進行中（本コミット）
+9. **S-3**: `docs/v0.4-business-readiness-plan.md` レビュー + shipped 状態確定
+10. **S-4**: `docs/architecture-as-implemented.md` 更新（severity filter / `_blocking_errors` hop 図）
+
+### Tier 3：v0.5 と並行可（OPTIONAL、3-5 日）
+
+11. **O-1**: #405 integration test (validate-debounce → warning banner) — frontend 単独
+12. **O-2**: #403 BackendAdapter metric-compat refactor — 第 2 backend が見えるまで defer 推奨
+13. **O-3**: P-0087 Phase 3 (`cv_strategy_fields` 自動派生) — LizyML 構造化 export 待ち、defer 推奨
+
+### Tier 4：v0.5 core（着手後 8-12 週間）
+
+- **#360** Tune long-run resumability (R-1.4, 3 週間) — M-1 上流対応待ち
+- **#384** Server Restart Recovery (R-1.5b, 1 週間) — #360 解消後
+- **#358** BlockedGroup race (R-1.2)
+- **#359** job-num drift (R-1.5)
+- WS 再接続 / ブラウザリロード復元 (R-2)
+
+### Tier 5：要長期計画（v0.6 以降）
+
+- **#27 (b)** 並行 fit stress harness — 実機マシン要件あり
+- **#125** Tailwind v4 — Button で spike → 専用 sprint
+- ML Backend 2nd 実装による Adapter 抽象検証 — 候補 backend 選定が未決
 
 ---
 
 ## 8. 運用メモ
 
-- 新規 Proposal を起票するときは **P-0095 から採番**（P-0094 = pytest-benchmark Proposal 起票は 2026-05-01 に消化）。`H-XXXX` 採番は終了。
+- 新規 Proposal を起票するときは **P-0099 から採番**（P-0098 = `load_dataframe` chunked CSV、2026-05-04 で消化済）。`H-XXXX` 採番は終了。
+- v0.5 R-1 着手時は P-0099 (invariants + `paused` state)、v0.4.1 機能の Decision 記録は P-0100 / P-0101 を予約済み。
 - E2E 単独追加（仕様変更なし）は HISTORY 起票不要、本 ROADMAP の §3 を更新するだけで OK。
 - 本 ROADMAP はステータス変更時に都度更新。タスク完了時は §1 へ移動、新規着手時は §2/§3/§4 へ追加する。
 - 古い ID（B-N coupling、A.M Phase A など）は履歴参照のためそのまま残す。検索性のため改名はしない。

--- a/docs/architecture-as-implemented.md
+++ b/docs/architecture-as-implemented.md
@@ -258,6 +258,44 @@ stateDiagram-v2
 
 ---
 
+## 5.4 Validate envelope flow (P-0100 / P-0101, v0.4.1 で確立)
+
+`POST /api/workspace/config/validate` / `PUT /api/workspace/config` / `POST /api/workspace/upload` の `errors[]` 各要素は `severity: Literal["error", "warning", "info"]`（default `"error"`）と `suggested_fix: str | None` を持つ envelope を返す。
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant C as Client (React)
+  participant R as api/workspace.py
+  participant SVC as services/workspace.py
+  participant ADP as BackendAdapter
+
+  C->>R: POST /api/workspace/config/validate {config}
+  R->>ADP: validate_config(cfg)
+  ADP-->>R: list[ValidationError]   # severity defaults to "error"
+  R->>SVC: _workspace_metric_compatibility_errors(cfg, df)
+  SVC-->>R: list[ValidationError]   # severity="warning" + suggested_fix
+  R->>R: errors = adapter_errors + watchlist_errors
+  R->>R: valid = len(_blocking_errors(errors)) == 0
+  R-->>C: {valid, errors[]}
+
+  Note over R,SVC: _blocking_errors filters severity=="error"<br/>fit/tune 4 raise sites use the same helper (PR-D1 #400)
+```
+
+Block 判定の hop:
+
+| 呼び出し元 | 判定ヘルパ | block する severity |
+|---|---|---|
+| `POST /workspace/config/validate` | `valid = len(_blocking_errors(errors)) == 0` | `"error"` |
+| `PUT /workspace/config` | `saved = len(_blocking_errors(errors)) == 0`、422 raise | `"error"` |
+| `POST /workspace/upload` | 同上 | `"error"` |
+| `POST /workspace/fit` `/tune` | 4 raise sites が `_blocking_errors` 経由（PR-D1 #400） | `"error"` |
+| Frontend `isBlockingError(entry)` | `(entry.severity ?? "error") === "error"` | `"error"` |
+
+Frontend は `useModelPanelData` で `errors[]` を `blockingErrors` / `warningEntries` の 2 グループに分割し、ConfigEditorBody が red banner（block）と yellow banner（advisory + suggested_fix）を二段重ねで描画する。
+
+---
+
 ## 6. "fit" Request End-to-End Flow
 
 ```mermaid

--- a/docs/v0.4-business-readiness-plan.md
+++ b/docs/v0.4-business-readiness-plan.md
@@ -1,9 +1,10 @@
 # v0.4 Business-Readiness Plan
 
-> **Status**: DRAFT v0.1 (2026-05-03 起票)
+> **Status**: PARTIAL — R-3.4 / R-5 shipped in v0.4.0 / v0.4.1 (2026-05-05). R-1 / R-2 / R-3 (残) / R-4 deferred to v0.5+.
 > **基底**: [`docs/business-use-definition.md`](business-use-definition.md) v0.2 CONFIRMED
 > **目的**: v0.4 を「業務利用可能」レベルにするための Phase 別実装計画。確定された定義に基づき、必要十分な作業項目を列挙する。
-> **承認**: 本計画を Tier 4 (アクティブな個別計画) として固定するため、`HISTORY.md` に Proposal P-0096 を起票して Change Gate を通す。
+> **承認**: HISTORY.md P-0096 (業務利用定義の確定、2026-05-04 merged) で Tier 4 として固定済。
+> **当初版**: DRAFT v0.1 (2026-05-03 起票) → v0.2 (2026-05-05、§10 改訂履歴参照)
 
 ---
 
@@ -25,16 +26,18 @@
 
 ## 1. Phase 構成と工数感
 
-| Phase | 内容 | 工数 |
-|---|---|---|
-| R-1 | 状態整合性の徹底 + **Tune resume** | 6 週間 |
-| R-2 | セッション復元 (WS reconnect, browser reload) | 2 週間 |
-| R-3 | エラー復旧 (typed errors, recovery hints) | 3 週間 |
-| R-4 | 互換性ロック (format_version, Pickle compat) | 2 週間 |
-| **R-5** | **Wide DataFrame + Large CSV scaling** (新設) | 3 週間 |
-| **合計** | | **約 16 週間 (4 ヶ月)** |
+| Phase | 内容 | 工数 | ステータス |
+|---|---|---|---|
+| R-1 | 状態整合性の徹底 + **Tune resume** | 6 週間 | 🟡 v0.5 着手予定 |
+| R-2 | セッション復元 (WS reconnect, browser reload) | 2 週間 | 🟡 v0.5 着手予定 |
+| R-3 | エラー復旧 (typed errors, recovery hints) | 3 週間 | 🟢 R-3.4 のみ完了 (v0.4.0 / v0.4.1)、R-3.1〜R-3.3 は v0.6+ 送り |
+| R-4 | 互換性ロック (format_version, Pickle compat) | 2 週間 | 🟡 v0.5 着手予定 |
+| **R-5** | **Wide DataFrame + Large CSV scaling** (新設) | 3 週間 | ✅ **完了 (v0.4.0 / v0.4.1, 2026-05-05)** |
+| **合計** | | **約 16 週間 (4 ヶ月)** | — |
 
 スケジュールは「ソロ作業」を前提とした見積。チームで取り組む場合は短縮可能。
+
+> **2026-05-05 時点の進捗**: R-5 (Wide DataFrame + Large CSV) と R-3.4 (Validate API + suggested_fix) は v0.4.0 / v0.4.1 リリースで完了。残り R-1 / R-2 / R-4 は **v0.5 のスコープ**として `docs/pre-v05-handoff-2026-05-05.md` で着手計画を引き継ぐ。R-1.4 (Tune resume) は LizyML #105 (Optuna persistent storage) のクリティカルパス上にある。
 
 ---
 
@@ -131,10 +134,12 @@
 
 ### R-3.4 Validate API 強化 + Diagnostic export (0.5週間)
 
-| ID | 項目 | 受け入れ基準 |
-|---|---|---|
-| R-3.4.1 | Fit 起動前の `config/validate` 強化 | target存在、CV 適合性、一意制約まで検証 |
-| R-3.4.2 | `lizystudio diagnose` CLI / `/api/diagnostics/bundle` | 個人情報 redact 済の zip ダウンロード |
+> **Status**: 🟢 R-3.4.1 部分完了 (v0.4.1)。R-3.4.2 (CLI diagnose) は v0.6+ 送り。
+
+| ID | 項目 | 受け入れ基準 | ステータス |
+|---|---|---|---|
+| R-3.4.1 | Fit 起動前の `config/validate` 強化 | target存在、CV 適合性、一意制約まで検証 | ✅ v0.4.1 (severity envelope + metric-compat watchlist + suggested_fix; PR #399 / #400) |
+| R-3.4.2 | `lizystudio diagnose` CLI / `/api/diagnostics/bundle` | 個人情報 redact 済の zip ダウンロード | 🔴 v0.6+ deferred |
 
 ---
 
@@ -157,6 +162,8 @@
 ---
 
 ## 6. Phase R-5 — Wide DataFrame + Large CSV (3週間, 新設)
+
+> **Status**: ✅ **完了 (v0.4.0 / v0.4.1, 2026-05-05)** — R-5.1 / R-5.2 ともに shipped。Issue #361 close 済。HISTORY.md P-0097 / P-0098 で Decision 確定。
 
 業務利用上限 **1000万行 × 1万列 × 100GB** に対して、UI と性能を担保する。**BYO RAM 戦略**で実装は単純化 (チャンク・サンプリング不要)。
 
@@ -201,7 +208,18 @@
 
 ## 8. v0.5 へ送るもの (Out of v0.4 scope)
 
-`business-use-definition.md` v0.2 で確認したが v0.4 では着手しない:
+### 8.1 v0.5 で実施 (本計画から繰越)
+
+| Phase | 内容 | 工数 | 依存 |
+|---|---|---|---|
+| R-1 | 状態整合性 + Tune resume (R-1.1〜R-1.5) | 6 週間 | LizyML #105 (Optuna persistent storage) |
+| R-2 | セッション復元 (WS reconnect, browser reload) | 2 週間 | R-1 完了 |
+| R-4 | 互換性ロック (format_version, Pickle compat) | 2 週間 | — |
+| R-3 残 | R-3.1〜R-3.3 (typed errors / recovery hints / plot symmetric audit) | 2-3 週間 | — |
+
+### 8.2 v0.6+ 送り (戦略タスク)
+
+`business-use-definition.md` v0.2 で確認したが v0.4 / v0.5 では着手しない:
 
 - 商用サポート (§14, Q7) — 提供しない
 - マルチユーザ並行制御 (§7) — 1 名利用のため不要
@@ -209,20 +227,23 @@
 - LLM 統合 — 要件が明確化された時点で起票
 - PyTorch backend — lizyml 側対応後に v0.5 以降で起票
 - 監査ログ・認証層 (§10) — Out of scope (ユーザ環境側で対応)
+- R-3.4.2 `lizystudio diagnose` CLI — v0.6+ 送り (R-3.4.1 は v0.4.1 で完了)
 
-v0.5 では性能 SLO 監視 (Bench harness 自動化)、運用 runbook、 backup/restore CLI、Docker 公式 image を整備する。
+v0.6 では性能 SLO 監視 (Bench harness 自動化)、運用 runbook、backup/restore CLI、Docker 公式 image を整備する。
 
 ---
 
 ## 9. 次のアクション
 
-| 順序 | アクション | 担当 |
-|---|---|---|
-| 1 | `HISTORY.md` に Proposal P-0096 (業務利用定義の確定) を起票 | dev |
-| 2 | `PLAN.md` に v0.4-N セクションを追加し本計画を反映 | dev |
-| 3 | `ROADMAP.md` を更新 (Tier 2 INDEX に本計画と Issue #360/#361 を登録) | dev |
-| 4 | Phase R-1 から着手 (6週間) | dev |
-| 5 | 各 Phase 完了時に Exit Criteria を確認、PR 単位でマージ | dev |
+> **2026-05-05 状態**: Step 1〜3 は完了。Step 4 (Phase R-1) は v0.5 着手前に 13 件の準備タスクを `docs/pre-v05-handoff-2026-05-05.md` で実施してから着手する。
+
+| 順序 | アクション | 担当 | ステータス |
+|---|---|---|---|
+| 1 | `HISTORY.md` に Proposal P-0096 (業務利用定義の確定) を起票 | dev | ✅ 完了 (2026-05-04) |
+| 2 | `PLAN.md` に v3-N セクションを追加し本計画を反映 | dev | 🟡 v3-15 まで反映、R-1 以降は M-5 で追加予定 |
+| 3 | `ROADMAP.md` を更新 (Tier 2 INDEX に本計画と Issue #360/#361 を登録) | dev | ✅ 完了 (2026-05-05、本セッション S-2) |
+| 4 | Phase R-1 から着手 (6週間) | dev | 🟡 v0.5 着手 — `pre-v05-handoff-2026-05-05.md` の MUST 6 件完了後 |
+| 5 | 各 Phase 完了時に Exit Criteria を確認、PR 単位でマージ | dev | — |
 
 ---
 
@@ -231,3 +252,4 @@ v0.5 では性能 SLO 監視 (Bench harness 自動化)、運用 runbook、 backu
 | 版 | 日付 | 内容 |
 |---|---|---|
 | v0.1 | 2026-05-03 | 初版。`business-use-definition.md` v0.2 に基づき Phase R-1〜R-5 を確定 |
+| v0.2 | 2026-05-05 | v0.4.0 / v0.4.1 リリース反映。R-5 / R-3.4.1 を完了マーク、R-3.4.2 / R-3.1〜R-3.3 を v0.6+ 送り、R-1 / R-2 / R-4 は v0.5 へ繰越し。Status を PARTIAL に更新 |

--- a/frontend/src/api/types.test.ts
+++ b/frontend/src/api/types.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import type { ConfigError } from "./types";
+import { isBlockingError } from "./types";
+
+// Issue #404 follow-up: lock the severity defaulting rule that the
+// PR-B4 envelope (P-0100) made canonical. Frontend code paths that
+// gate Fit / Tune / Save on validation entries must treat missing
+// ``severity`` as ``"error"`` for backward compatibility with older
+// backend builds; ``"warning"`` and ``"info"`` advise but do not block.
+describe("isBlockingError", () => {
+  it("treats a missing severity as error (legacy backend default)", () => {
+    const err: ConfigError = { path: "split.n_splits", message: "bad" };
+    expect(isBlockingError(err)).toBe(true);
+  });
+
+  it("blocks when severity is 'error'", () => {
+    const err: ConfigError = {
+      path: "split.n_splits",
+      message: "n_splits > n_rows",
+      severity: "error",
+    };
+    expect(isBlockingError(err)).toBe(true);
+  });
+
+  it("does not block when severity is 'warning'", () => {
+    const err: ConfigError = {
+      path: "evaluation.metrics",
+      message: "MAPE undefined when target contains zeros",
+      severity: "warning",
+      suggested_fix: "Use 'smape' or 'wape' instead (lizyml 0.11.0+).",
+    };
+    expect(isBlockingError(err)).toBe(false);
+  });
+
+  it("does not block when severity is 'info'", () => {
+    const err: ConfigError = {
+      path: "evaluation.metrics",
+      message: "Heads up — this metric is preview-only.",
+      severity: "info",
+    };
+    expect(isBlockingError(err)).toBe(false);
+  });
+});

--- a/frontend/src/components/workspace/ConfigEditorBody.integration.test.tsx
+++ b/frontend/src/components/workspace/ConfigEditorBody.integration.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * Integration test (Issue #405): validate-debounce → ConfigEditorBody
+ * warning banner.
+ *
+ * Unit-level coverage already exists on both ends:
+ *
+ * - {@link ../../hooks/useModelPanelData.test.ts} verifies that
+ *   handleConfigChange enqueues a debounced validate call.
+ * - {@link ./ConfigEditorBody.test.tsx} verifies that the banner
+ *   renders correctly when given an `errors` prop containing a
+ *   severity=warning entry.
+ *
+ * What was missing pre-#405: an end-to-end integration test proving
+ * that a warning returned by `validateConfig` actually flows through
+ * the hook's `setErrors` call (after the 500ms debounce) into a
+ * ConfigEditorBody render with the suggested_fix copy intact. A
+ * regression in either edge — severity dropped during cache hydration,
+ * suggested_fix lost on the wire, banner inadvertently hidden by a
+ * filter — would slip past the unit suites.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useEffect, useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useModelPanelData } from "@/hooks/useModelPanelData";
+import { ConfigEditorBody } from "./ConfigEditorBody";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("@/api/workspace", () => ({
+  fetchBackends: vi
+    .fn()
+    .mockResolvedValue([{ name: "lizyml", version: "0.1" }]),
+  fetchColumns: vi.fn().mockResolvedValue({
+    columns: [{ name: "y", suggested_excluded: false }],
+  }),
+  fetchConfig: vi.fn().mockResolvedValue({
+    task: "regression",
+    data: { target: "y" },
+    evaluation: { metrics: ["mae"] },
+  }),
+  fetchConfigSchema: vi.fn().mockResolvedValue({ type: "object" }),
+  fetchUiSchema: vi.fn().mockResolvedValue({}),
+  getConfigDownloadUrl: vi.fn().mockReturnValue("/api/config/download"),
+  updateConfig: vi
+    .fn()
+    .mockResolvedValue({ config: {}, errors: [], saved: true }),
+  uploadConfig: vi.fn().mockResolvedValue({ errors: [] }),
+  validateConfig: vi.fn().mockResolvedValue({ errors: [] }),
+}));
+
+import { validateConfig } from "@/api/workspace";
+
+vi.mock("./ConfigForm", () => ({
+  ConfigForm: () => <div data-testid="config-form-stub" />,
+}));
+vi.mock("./TuneTab", () => ({
+  TuneTab: () => <div data-testid="tune-tab-stub" />,
+}));
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+/**
+ * Bridge harness: drives useModelPanelData and renders
+ * ConfigEditorBody with the hook's `errors` output. Exposes
+ * handleConfigChange via a ref-bound trigger button so the test does
+ * not need to drive through a full ConfigForm render.
+ */
+function Harness({ nextConfig }: { nextConfig: Record<string, unknown> }) {
+  const data = useModelPanelData({ hasData: true, running: false });
+  const nextConfigRef = useRef(nextConfig);
+  useEffect(() => {
+    nextConfigRef.current = nextConfig;
+  }, [nextConfig]);
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="trigger-edit"
+        onClick={() => {
+          void data.handleConfigChange(nextConfigRef.current);
+        }}
+      />
+      <ConfigEditorBody
+        activeTab="tune"
+        hasData
+        running={false}
+        errors={data.errors}
+        schema={data.schema}
+        config={data.config}
+        onChange={data.handleConfigChange}
+        task="regression"
+        uiSchema={data.uiSchema}
+        columns={data.nonExcludedColumns}
+      />
+    </>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+describe("validate-debounce → ConfigEditorBody warning banner (Issue #405)", () => {
+  it("shows the warning banner with suggested_fix after the debounce window", async () => {
+    vi.mocked(validateConfig).mockResolvedValue({
+      errors: [
+        {
+          path: "evaluation.metrics",
+          message: "MAPE is undefined when target column 'y' contains zeros.",
+          severity: "warning",
+          suggested_fix:
+            "Remove 'mape' from evaluation.metrics — or replace it with 'smape' / 'wape' which tolerate zero targets (lizyml >= 0.11.0).",
+        },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+    } as any);
+
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <Harness
+          nextConfig={{
+            task: "regression",
+            data: { target: "y" },
+            evaluation: { metrics: ["mae", "mape"] },
+          }}
+        />
+      </Wrapper>,
+    );
+
+    // Wait for the trigger button to appear (initial render done).
+    const trigger = await screen.findByTestId("trigger-edit");
+
+    // Trigger an edit — the PUT /config mock returns saved=true with no
+    // errors, then the hook starts the 500ms debounced validate.
+    await act(async () => {
+      fireEvent.click(trigger);
+    });
+
+    // The hook's setErrors fires with the warning after the debounce
+    // window. We wait via real timers so React's scheduler, fetch
+    // microtasks, and the radix tooltip's RAF cycle all stay in their
+    // production-equivalent path. The default findBy timeout (1s) is
+    // plenty to bridge the 500ms VALIDATION_DEBOUNCE_MS.
+    const banner = await screen.findByTestId(
+      "config-warning-banner",
+      undefined,
+      { timeout: 2000 },
+    );
+    expect(banner).toBeInTheDocument();
+    // a11y: SR notification (non-blocking, not an alert)
+    expect(banner).toHaveAttribute("role", "status");
+    expect(validateConfig).toHaveBeenCalledTimes(1);
+    expect(validateConfig).toHaveBeenCalledWith({
+      task: "regression",
+      data: { target: "y" },
+      evaluation: { metrics: ["mae", "mape"] },
+    });
+    // Severity envelope made it through the wire: banner shows the
+    // suggested_fix beneath the message.
+    expect(banner.textContent).toContain("MAPE is undefined");
+    expect(banner.textContent).toContain("Suggestion:");
+    expect(banner.textContent).toContain("smape");
+    // No blocking-error banner — severity=warning must not surface as
+    // a destructive role="alert" overlay.
+    expect(screen.queryByTestId("config-error-banner")).toBeNull();
+  });
+
+  it("clears the banner when the next validate returns no warnings", async () => {
+    vi.mocked(validateConfig)
+      .mockResolvedValueOnce({
+        errors: [
+          {
+            path: "evaluation.metrics",
+            message: "MAPE undefined when target contains zeros.",
+            severity: "warning",
+            suggested_fix: "Use 'smape' instead.",
+          },
+        ],
+        // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+      } as any)
+      .mockResolvedValueOnce({
+        errors: [],
+        // biome-ignore lint/suspicious/noExplicitAny: test fixture shape
+      } as any);
+
+    const Wrapper = makeWrapper();
+    const { rerender } = render(
+      <Wrapper>
+        <Harness
+          nextConfig={{
+            task: "regression",
+            data: { target: "y" },
+            evaluation: { metrics: ["mae", "mape"] },
+          }}
+        />
+      </Wrapper>,
+    );
+    const trigger = await screen.findByTestId("trigger-edit");
+
+    // First edit — banner appears after the debounced validate fires
+    await act(async () => {
+      fireEvent.click(trigger);
+    });
+    expect(
+      await screen.findByTestId("config-warning-banner", undefined, {
+        timeout: 2000,
+      }),
+    ).toBeInTheDocument();
+
+    // Update the config the harness will send next, then click again.
+    rerender(
+      <Wrapper>
+        <Harness
+          nextConfig={{
+            task: "regression",
+            data: { target: "y" },
+            evaluation: { metrics: ["mae"] },
+          }}
+        />
+      </Wrapper>,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("trigger-edit"));
+    });
+    await waitFor(
+      () => {
+        expect(screen.queryByTestId("config-warning-banner")).toBeNull();
+      },
+      { timeout: 2000 },
+    );
+  });
+});

--- a/tests/contract/test_validate_metric_compatibility.py
+++ b/tests/contract/test_validate_metric_compatibility.py
@@ -281,3 +281,195 @@ def test_parameterised_metric_entry_is_recognised(
     warnings = _metric_warnings(errors)
     assert len(warnings) == 1
     assert "mape" in warnings[0]["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — Issue #404 follow-up
+#
+# These pin the helper's defensive behaviour against degenerate target
+# columns (all-NaN, ±inf), parametric input shapes (int64 vs float64,
+# duplicates, malformed dict entries) and out-of-shape ``evaluation``
+# fields. Together with the positive cases above they take the contract
+# coverage from 9 cases to 16, fully covering the PR-C2 + PR-D1 watchlist
+# logic so R-1 / R-3 work that touches the validate path inherits a
+# locked surface.
+# ---------------------------------------------------------------------------
+
+
+def test_target_all_nan_does_not_crash(client: TestClient, tmp_path: Path) -> None:
+    """All-NaN target degenerates std() to NaN. The R² guard
+    short-circuits on ``pd.isna(std)`` and emits the constant-target
+    warning; mape / rmsle stay quiet because comparisons against NaN
+    return False, not True. The validator must complete without
+    raising on a column pandas reads as a numeric column of NaNs."""
+    # An empty CSV cell is read by pandas as NaN; stage 10 such rows.
+    csv_path = tmp_path / "all_nan.csv"
+    with csv_path.open("w") as f:
+        f.write("a,b,y\n")
+        for i in range(10):
+            f.write(f"{i},{i + 1},\n")
+    _load_data(client, str(csv_path))
+
+    config = _set_metrics(_regression_defaults(client), ["mae", "mape", "rmsle", "r2"])
+    # Helper must not raise; whether r2 is flagged depends on whether
+    # pandas treats the empty target as numeric — both outcomes are
+    # acceptable as long as no exception escapes.
+    errors = _validate(client, config)
+    metric_paths = [e["path"] for e in _metric_warnings(errors)]
+    # mape / rmsle never fire on all-NaN (NaN comparisons are False)
+    for warn in _metric_warnings(errors):
+        assert "mape" not in warn["message"].lower()
+        assert "rmsle" not in warn["message"].lower()
+    # And the helper definitely completed — duplicate-path is fine
+    assert all(p == "evaluation.metrics" for p in metric_paths)
+
+
+def test_target_with_inf_does_not_crash(client: TestClient, tmp_path: Path) -> None:
+    """Inf and -inf in the target column are pandas-numeric (float64)
+    and must not break the helper. Specifically:
+
+    * ``mape`` does NOT fire on ``inf`` because ``inf == 0`` is False
+    * ``rmsle`` DOES fire on ``-inf`` because ``-inf < 0`` is True
+    * neither check raises a Python exception
+    """
+    csv_path = _create_regression_csv(
+        tmp_path,
+        target_values=[
+            float("inf"),
+            float("-inf"),
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+            5.0,
+            6.0,
+            7.0,
+            8.0,
+        ],
+    )
+    _load_data(client, csv_path)
+
+    config = _set_metrics(_regression_defaults(client), ["mape", "rmsle"])
+    errors = _validate(client, config)
+    warnings = _metric_warnings(errors)
+    messages = [w["message"].lower() for w in warnings]
+
+    # MAPE quiet — no exact zero in the target
+    assert not any("mape" in m for m in messages), warnings
+    # RMSLE fires — -inf qualifies as negative
+    assert any("rmsle" in m for m in messages), warnings
+
+
+def test_target_int64_and_float64_yield_consistent_warnings(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """The validator should not depend on whether pandas inferred the
+    target as int64 or float64. A target of ``[0, 1, 2, ...]`` (int64)
+    and ``[0.0, 1.0, 2.0, ...]`` (float64) must both flag MAPE and
+    neither one extra metric."""
+    int_path = _create_regression_csv(
+        tmp_path,
+        target_values=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],  # type: ignore[list-item]
+        name="int_target.csv",
+    )
+    _load_data(client, int_path)
+    config = _set_metrics(_regression_defaults(client), ["mape"])
+    int_warnings = _metric_warnings(_validate(client, config))
+
+    float_path = _create_regression_csv(
+        tmp_path,
+        target_values=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+        name="float_target.csv",
+    )
+    _load_data(client, float_path)
+    float_warnings = _metric_warnings(_validate(client, config))
+
+    assert len(int_warnings) == len(float_warnings) == 1
+    # Same metric flagged, identical suggested_fix text
+    assert int_warnings[0]["suggested_fix"] == float_warnings[0]["suggested_fix"]
+
+
+def test_duplicate_metric_names_emit_a_single_warning(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Backend dedup uses a set, so ``["mae", "mape", "mape"]`` must
+    surface exactly one MAPE warning. Frontends that copy-paste metric
+    chips can produce duplicates and we should not punish that with
+    duplicated banners."""
+    csv_path = _create_regression_csv(
+        tmp_path, target_values=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    )
+    _load_data(client, csv_path)
+    config = _set_metrics(_regression_defaults(client), ["mae", "mape", "mape"])
+    warnings = _metric_warnings(_validate(client, config))
+    assert len(warnings) == 1
+    assert "mape" in warnings[0]["message"].lower()
+
+
+def test_malformed_metric_entries_are_skipped(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """``_metric_entry_name`` returns None for empty dicts, multi-key
+    dicts, and dicts with non-string keys. Such entries must be silently
+    skipped — they may also be rejected by Pydantic, but that is not
+    this helper's responsibility. The contract here is purely that we
+    do not raise."""
+    csv_path = _create_regression_csv(
+        tmp_path, target_values=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    )
+    _load_data(client, csv_path)
+    config = _set_metrics(_regression_defaults(client), ["mae"])
+    # The Pydantic schema may reject these; we still want the helper to
+    # be defensive enough that a backend round-trip would not 500.
+    config["evaluation"]["metrics"].extend(
+        [
+            {},  # empty dict — no key
+            {"mape": {}, "rmsle": {}},  # multi-key dict — ambiguous
+        ]
+    )
+    res = client.post("/api/workspace/config/validate", json=config)
+    # Whatever Pydantic does, this must not 5xx.
+    assert res.status_code == 200, res.text
+    # The malformed entries are dropped; metric-compat watchlist sees
+    # only the plain-string ``mae``, which is not on the watchlist, so
+    # no metric warnings.
+    warnings = _metric_warnings(res.json()["errors"])
+    for w in warnings:
+        # If anything is flagged it must reference one of the watchlist
+        # names — we never invent a name from a malformed entry.
+        msg = w["message"].lower()
+        assert any(k in msg for k in ("mape", "rmsle", "r2"))
+
+
+def test_evaluation_field_non_dict_does_not_crash(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """``config["evaluation"]`` may arrive as a list, ``None``, or be
+    omitted entirely. Each shape must short-circuit to "no metric
+    warning" without raising — the Pydantic layer handles its own
+    rejection separately."""
+    csv_path = _create_regression_csv(
+        tmp_path, target_values=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    )
+    _load_data(client, csv_path)
+    base = _regression_defaults(client)
+
+    # 1) evaluation = []  -> not a dict -> no metric warning
+    list_config = dict(base)
+    list_config["evaluation"] = []
+    res_list = client.post("/api/workspace/config/validate", json=list_config)
+    assert res_list.status_code == 200, res_list.text
+    assert _metric_warnings(res_list.json()["errors"]) == []
+
+    # 2) evaluation = None
+    none_config = dict(base)
+    none_config["evaluation"] = None
+    res_none = client.post("/api/workspace/config/validate", json=none_config)
+    assert res_none.status_code == 200, res_none.text
+    assert _metric_warnings(res_none.json()["errors"]) == []
+
+    # 3) evaluation key absent entirely
+    missing_config = {k: v for k, v in base.items() if k != "evaluation"}
+    res_missing = client.post("/api/workspace/config/validate", json=missing_config)
+    assert res_missing.status_code == 200, res_missing.text
+    assert _metric_warnings(res_missing.json()["errors"]) == []


### PR DESCRIPTION
## release: v0.4.2 — v0.5 prep + spec reconciliation

The **v0.5 prep** maintenance release. **No user-facing behaviour changes** — the on-disk job format, REST API surface, and frontend UX are byte-for-byte identical to v0.4.1. This release exists so downstream consumers can pin against a stable artifact while the v0.5 R-1 reliability sprint lands phase by phase over the coming weeks.

## What's bundled (4 PRs since v0.4.1)

| PR | Type | Summary |
|---|---|---|
| #406 | docs(spec) | HISTORY P-0100 / P-0101 post-hoc Decisions, BLUEPRINT §5.2 envelope spec, ROADMAP / readiness-plan v0.2 / architecture-as-implemented §5.4 reconciled |
| #407 | test | 6 backend cases on metric-compat edge cases (#404), 4 frontend `isBlockingError` cases (#404), 2 frontend integration cases on validate-debounce → warning banner (#405) |
| #408 | docs(history,plan) | HISTORY P-0099 Change Gate Proposal — 7 invariants (INV-1..INV-7) + `paused` job state. PLAN.md v3-17..v3-26 with Entry / Exit criteria + DoD pointing at INV-N tests |
| #409 | chore(release) | Finalises CHANGELOG header for v0.4.2 |

Cross-repo: [`LizyML #105`](https://github.com/nbx-liz/LizyML/issues/105) filed — Optuna persistent storage (`JournalStorage`) for resumable tuning. **Critical path for v0.5 R-1.4** (Issue #360). v3-20 cannot start until this lands upstream.

Internal follow-up: Issue #403 (BackendAdapter metric-compat refactor) deferred to v0.6 alongside any second `BackendAdapter` implementation. Watchlist behaviour stays locked by the contract suite.

## Compatibility

- **Wire format**: validate envelope (`severity` + `suggested_fix`) is unchanged from v0.4.1. Pre-PR-B4 entries with no severity continue to default to `"error"`.
- **Storage format**: `meta.json` `format_version=1` unchanged. Bump to v=2 (paused state) ships in v0.5 R-1.4.
- **API**: zero new endpoints; zero schema changes.
- **Frontend**: zero UI changes.
- **Dependencies**: no version bumps.

A user upgrading from v0.4.1 to v0.4.2 sees no functional difference. The only on-disk change inside the installed wheel is the updated `CHANGELOG.md`.

## v0.5 roadmap (next 8-12 weeks, blocked on this release)

PLAN.md `v3-17` through `v3-26` are now declared:

- **v3-17** R-1.1 Slot release invariant 6 paths (INV-1 / INV-5)
- **v3-18** R-1.2 Cancel race fix (Issue #358, INV-5)
- **v3-19** R-1.3 Subprocess crash + atomic meta.json (INV-2 / INV-6)
- **v3-20** R-1.4 Tune long-run resumability (Issue #360, INV-3 / INV-4) — **waits for LizyML #105**
- **v3-21** R-1.5 job-num drift (Issue #359)
- **v3-22** R-1.5b Server Restart Recovery (Issue #384, INV-7)
- **v3-23** R-2.1 WebSocket reconnection
- **v3-24** R-2.2 Browser reload restore
- **v3-25** R-4.1 format_version migration matrix CI gate
- **v3-26** R-4.2 Pickle compatibility test (P-0095 extension)

v3-17 unblocked once user approves P-0099 Decision row.

## Test plan

- [x] All 4 bundled PRs (#406 / #407 / #408 / #409) merged green
- [x] `pyproject.toml` unchanged — hatch-vcs derives version from `v0.4.2` git tag at build time
- [x] CHANGELOG.md `[0.4.2]` entry follows Keep a Changelog format and matches the merged PRs
- [x] No diff in `src/lizystudio/**` between v0.4.1 and v0.4.2 (only docs + tests)
- [x] `feedback_release_flow_pattern`: chore PR (CHANGELOG → develop) ✅, release PR (develop → main with `--merge`) — this PR
- [x] Tag `v0.4.2` triggers `publish.yml` after merge

## Refs

- v0.4.1 release: https://github.com/nbx-liz/LizyStudio/releases/tag/v0.4.1
- v0.4.0 release: https://github.com/nbx-liz/LizyStudio/releases/tag/v0.4.0
- LizyML #105 (cross-repo, blocking v3-20)
- Issues #358 / #359 / #360 / #384 / #403 (v0.5 + v0.6 follow-ups)
