### PR TITLE
chore(deps,docs): bump lizyml 0.11 -> 0.12 + approve P-0099 + reflect v0.5 unblock

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3186,8 +3186,8 @@ frontend で virtualization / top-N を入れても、転送する payload 自�
 
 ### P-0099: v0.5 R-1 状態整合性 invariants + `paused` job state（Change Gate）
 
-- **Date:** 2026-05-06 起票
-- **Related:** Issue #360 (Tune long-run resumability), Issue #358 (BlockedGroup race), Issue #359 (job-num drift), Issue #384 (Server Restart Recovery), LizyML #105 (Optuna persistent storage), `docs/v0.4-business-readiness-plan.md` §2 (R-1), `~/.claude/rules/common/invariants-first.md`
+- **Date:** 2026-05-06 起票 / 同日 Approved
+- **Related:** Issue #360 (Tune long-run resumability), Issue #358 (BlockedGroup race), Issue #359 (job-num drift), Issue #384 (Server Restart Recovery), LizyML #105 (Optuna persistent storage, shipped in lizyml 0.12.0 / 2026-05-06), `docs/v0.4-business-readiness-plan.md` §2 (R-1), `~/.claude/rules/common/invariants-first.md`
 
 #### Motivation
 
@@ -3244,7 +3244,7 @@ CLAUDE.md §2 Change Gate 対象（state machine 変更 / 並行性・所有権�
 - v0.4 までで作成した `meta.json` (format_version=1) は `paused` フィールドを持たない → migration で `paused: false` を default に挿入。read-only で読める
 - POST /api/jobs/{job_id}/pause は新規追加なのでクライアント側で 404 をハンドルする legacy path は不要
 - WebSocket `paused` メッセージは未知タイプとして無視されるよう既存 client の switch に default branch を追加 (R-2.1 で別途扱う)
-- LizyML 0.11.x で `storage=` パラメタが無いため、LizyML #105 が merged するまでは `paused` 経路を feature flag (`LIZYSTUDIO_TUNE_RESUME_ENABLED=0`) で off にする
+- LizyML #105 (Optuna persistent storage) は lizyml 0.12.0 (2026-05-06) で shipped。LizyStudio 側は `pyproject.toml` を `>=0.12.0,<0.13.0` に bump 済 (本 PR)。当初検討していた feature flag (`LIZYSTUDIO_TUNE_RESUME_ENABLED`) は **不要に縮退** — `paused` 経路を default で有効化する
 
 #### Acceptance criteria
 
@@ -3272,6 +3272,7 @@ R-1.1〜R-1.5b の各 phase に invariant test を割り当てる。本 Proposal
 #### Decision
 
 - 2026-05-06 **Proposed** — v0.5 R-1.1 着手前に user 承認を取り、PLAN.md に v3-17〜v3-22 を追加した時点で **Approved**。実装は phase 単位、各 phase の PR が invariant test を含む
+- 2026-05-06 **Approved** — user 承認 (LizyML 0.12.0 リリース受領後)。PLAN.md v3-17〜v3-26 は #408 で既に追加済。本 Proposal の DoD (invariant declaration が PLAN.md の各 phase に reflectee されている) は満了。R-1.4 の上流ブロッカー (LizyML #105) も解消したため、v3-17 (R-1.1) から phase 単位の実装に着手可
 
 
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1316,7 +1316,7 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 
 ## Phase v3-20: v0.5 R-1.4 — Tune long-run resumability（P-0099 INV-3 / INV-4 / Issue #360）
 
-**期間:** v3-19 完了後 3 週間。**LizyML #105 (Optuna persistent storage) merged が前提。**
+**期間:** v3-19 完了後 3 週間。**上流ブロッカー (LizyML #105) は lizyml 0.12.0 (2026-05-06) で解消済。**
 
 **対象 Proposal:** P-0099 + Issue #360
 
@@ -1324,8 +1324,9 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 
 **Entry criteria:**
 - v3-19 完了
-- LizyML #105 merged + LizyStudio 側 `pyproject.toml` で対応 minor version へ bump
-- `LIZYSTUDIO_TUNE_RESUME_ENABLED=1` を default に切り替え可能
+- ✅ lizyml 0.12.0 + LizyStudio `pyproject.toml` `>=0.12.0,<0.13.0` bump 済（本 phase 開始前に bundle 済）
+- ✅ `Tuner` / `Model.tune()` の `storage` / `study_name` 引数経由で永続化可能（LizyML H-0072）
+- ~~`LIZYSTUDIO_TUNE_RESUME_ENABLED` feature flag~~ → **不要に縮退**（lizyml 0.12.0 で常時利用可能）
 
 **サブフェーズ:**
 
@@ -1344,7 +1345,7 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 - [ ] Issue #360 が close 済
 - [ ] format_version=2 への migration が P-0095 round-trip CI gate に組み込まれている
 - [ ] CHANGELOG (v0.5 draft) に `paused` 状態が Added で記載
-- [ ] `LIZYSTUDIO_TUNE_RESUME_ENABLED` を `1` で default 化、feature flag 経由で off にも切替可
+- [ ] `Model.tune(storage=..., study_name=...)` 経由で trial 永続化、process kill → restart で同 study_name へ resume が e2e 検証済
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 - このファイルは **横串インデックス** であり、詳細はリンク先で確認すること。
 - 着手する際は HISTORY に Proposal を起票（変更ゲート対象の場合）→ PLAN にフェーズ追加 → 実装、の順で進める。
 
-最終更新: 2026-05-05（v0.4.1 リリース反映：CHANGELOG / HISTORY P-0095..P-0098 / Open Issues #403..#405 / v0.5 R-1 Next Action）
+最終更新: 2026-05-06（v0.4.2 リリース + lizyml 0.12.0 受領反映：P-0099 Approved / R-1.4 上流ブロッカー解消 / Open Issues #403..#405 / v0.5 R-1 Next Action）
 
 ---
 
@@ -134,12 +134,12 @@
 
 ## 3. アクティブ：仕様変更を伴う Proposal
 
-### 3.-1 v0.5 R-1 invariants Proposal（採番予約：P-0099, P-0100, P-0101）
+### 3.-1 v0.5 R-1 invariants Proposal（P-0099, P-0100, P-0101 — すべて Decision 確定済）
 
-- **状態**: 🟡 未起票（v0.5 R-1 着手直前に書く。`docs/pre-v05-handoff-2026-05-05.md` §3.1 M-2 / M-3 参照）
-- **P-0099**: Job state machine invariants + `paused` state（R-1 全体の Change Gate）
-- **P-0100**: severity envelope formalization (PR-B4) — Pydantic Literal 化、`_blocking_errors` セマンティクス（PR-D1 #400 で確立、未記録）
-- **P-0101**: metric-compat watchlist — `_workspace_metric_compatibility_errors` の検出ルール（PR-C2 #399 / PR-D1 #400 で確立、未記録）
+- **状態**: ✅ Approved／確定済（P-0099 = 2026-05-06 Approved、P-0100 / P-0101 = 2026-05-05 確定 with #406）
+- **P-0099**: Job state machine invariants + `paused` state（R-1 全体の Change Gate）— **Approved 2026-05-06**, v3-17 着手可
+- **P-0100**: severity envelope formalization (PR-B4) — Pydantic Literal 化、`_blocking_errors` セマンティクス（PR-D1 #400 で確立、#406 で記録）
+- **P-0101**: metric-compat watchlist — `_workspace_metric_compatibility_errors` の検出ルール（PR-C2 #399 / PR-D1 #400 で確立、#406 で記録）
 - **次回採番**: P-0102 以降
 
 ### 3.0 P-0094 (済)：pytest-benchmark performance baseline（Issue #27 (a)）
@@ -250,7 +250,7 @@ v0.4.1 リリース後の Open Issue は 5 件。
 
 | Issue | タイトル | priority | 推奨アクション |
 |---|---|---|---|
-| **#360** | feat(tune): long-run resumability (24h+, all termination paths) | tier-4 / high | **v0.5 core (R-1.4, 3 週間)**。LizyML 上流対応待ち（M-1 で起票予定） |
+| **#360** | feat(tune): long-run resumability (24h+, all termination paths) | tier-4 / high | **v0.5 core (R-1.4, 3 週間)**。✅ 上流解消（lizyml 0.12.0 / 2026-05-06 で `storage` 引数 shipped）— v3-17→v3-19 完了後に着手 |
 | **#384** | [Testing] #28 follow-up — Server Restart Recovery (blocked on #360) | tier-3 / medium | **R-1.5b (v0.5)** — #360 解消後 |
 | **#403** | refactor(backend): move metric-compat watchlist behind BackendAdapter abstraction (HIGH-2) | tier-3 / medium | **v0.6 defer 推奨** — 第 2 backend が見えてから |
 | **#404** | test: add edge-case coverage for `_workspace_metric_compatibility_errors` | tier-2 / medium | **S-1 (Day 3 着手)** — 7 cases (NaN/inf/dtype/dedup/malformed) |
@@ -280,14 +280,14 @@ v0.4.1 リリース後の Open Issue は 5 件。
 
 > v0.4.1 リリース完了 (2026-05-05)。詳細な v0.5 着手前の作業内訳は `docs/pre-v05-handoff-2026-05-05.md` 参照（MUST 6 + SHOULD 4 + OPTIONAL 3 = 13 件、計 4-7 日）。
 
-### Tier 1：v0.5 着手前必須（MUST、4-6 日）
+### Tier 1：v0.5 着手前必須（MUST、すべて完了）
 
-1. **M-1**: LizyML 側に Optuna persistent storage Issue を起票（`/home/rem/repos/LizyML`、cross-repo）— v0.5 R-1.4 (#360) のクリティカルパス
-2. **M-2**: HISTORY.md P-0099 起票（R-1 invariants + `paused` state Change Gate）
-3. **M-3**: HISTORY.md P-0100 / P-0101 起票（severity envelope / metric-compat watchlist Decision）
-4. **M-4**: BLUEPRINT.md §5 (API) に severity / suggested_fix を反映
-5. **M-5**: PLAN.md v3-N (R-1 〜 R-2) phase 追加 + v0.4.0 / v0.4.1 phase 確定
-6. **M-6**: handoff docs cleanup（5 ファイル削除） — 一部完了（3 ファイル削除済、本 ROADMAP 更新後 `pre-v05-handoff-2026-05-05.md` 削除予定）
+1. ✅ **M-1**: LizyML 側 Optuna persistent storage — lizyml 0.12.0 (2026-05-06) で shipped (H-0072)。LizyStudio 側 `pyproject.toml` を `>=0.12.0,<0.13.0` に bump 済（本 ROADMAP 更新と同 PR）
+2. ✅ **M-2**: HISTORY.md P-0099 起票 — 2026-05-06 起票 + Approved（PR #408 + 本 PR）
+3. ✅ **M-3**: HISTORY.md P-0100 / P-0101 確定 — PR #406 で記録済
+4. ✅ **M-4**: BLUEPRINT.md §5 (API) に severity / suggested_fix を反映 — PR #406
+5. ✅ **M-5**: PLAN.md v3-17〜v3-26 (R-1 〜 R-4) phase 追加 — PR #408 + 本 PR で v3-20 entry criteria 確定
+6. ✅ **M-6**: handoff docs cleanup — `pre-v05-handoff-2026-05-05.md` は ROADMAP §0 に内容統合済、参照不要
 
 ### Tier 2：高 ROI 準備（SHOULD、1-2 日）
 
@@ -302,13 +302,24 @@ v0.4.1 リリース後の Open Issue は 5 件。
 12. **O-2**: #403 BackendAdapter metric-compat refactor — 第 2 backend が見えるまで defer 推奨
 13. **O-3**: P-0087 Phase 3 (`cv_strategy_fields` 自動派生) — LizyML 構造化 export 待ち、defer 推奨
 
-### Tier 4：v0.5 core（着手後 8-12 週間）
+### Tier 4：v0.5 core（着手可、8-12 週間）
 
-- **#360** Tune long-run resumability (R-1.4, 3 週間) — M-1 上流対応待ち
-- **#384** Server Restart Recovery (R-1.5b, 1 週間) — #360 解消後
-- **#358** BlockedGroup race (R-1.2)
-- **#359** job-num drift (R-1.5)
-- WS 再接続 / ブラウザリロード復元 (R-2)
+直列 R-1 → 並行 R-2 / R-4 の順で進める。各 phase の DoD は `PLAN.md` v3-17〜v3-26 を参照。
+
+| Phase | 内容 | 期間 | 並行可否 |
+|---|---|---|---|
+| v3-17 | R-1.1 Slot release 6 経路 invariant test (INV-1/INV-5) | 1 週 | — |
+| v3-18 | R-1.2 Cancel race + #358 | 1 週 | — |
+| v3-19 | R-1.3 Subprocess crash + atomic meta.json (INV-2/INV-6) | 1 週 | — |
+| v3-20 | R-1.4 Tune resume (INV-3/INV-4 / #360) | 3 週 | ✅ 上流解消（lizyml 0.12.0） |
+| v3-21 | R-1.5 #359 job-num drift | 0.5 週 | v3-17 完了後並行可 |
+| v3-22 | R-1.5b Server Restart Recovery (INV-7 / #384) | 1 週 | v3-20 後 |
+| v3-23 | R-2.1 WS 再接続 | 1 週 | v3-22 後 |
+| v3-24 | R-2.2 ブラウザリロード復元 | 1 週 | v3-23 後 |
+| v3-25 | R-4.1 format_version migration matrix | 1 週 | v3-20 完了後並行可 |
+| v3-26 | R-4.2 Pickle compatibility | 1 週 | v3-25 と並行可 |
+
+直近の next: **v3-17 (R-1.1)** — `tests/regression/test_inv_slot_release.py` で 6 経路の invariant test を RED phase で書く。
 
 ### Tier 5：要長期計画（v0.6 以降）
 

--- a/docs/v0.4-business-readiness-plan.md
+++ b/docs/v0.4-business-readiness-plan.md
@@ -37,7 +37,7 @@
 
 スケジュールは「ソロ作業」を前提とした見積。チームで取り組む場合は短縮可能。
 
-> **2026-05-05 時点の進捗**: R-5 (Wide DataFrame + Large CSV) と R-3.4 (Validate API + suggested_fix) は v0.4.0 / v0.4.1 リリースで完了。残り R-1 / R-2 / R-4 は **v0.5 のスコープ**として `docs/pre-v05-handoff-2026-05-05.md` で着手計画を引き継ぐ。R-1.4 (Tune resume) は LizyML #105 (Optuna persistent storage) のクリティカルパス上にある。
+> **2026-05-06 時点の進捗**: R-5 (Wide DataFrame + Large CSV) と R-3.4 (Validate API + suggested_fix) は v0.4.0 / v0.4.1 リリースで完了。残り R-1 / R-2 / R-4 は **v0.5 のスコープ**として `PLAN.md` v3-17〜v3-26 / `docs/ROADMAP.md` §7 Tier 4 で実行。R-1.4 (Tune resume) の上流ブロッカー LizyML #105 (Optuna persistent storage) は **lizyml 0.12.0 (2026-05-06) で解消済** — `Tuner` / `Model.tune()` に `storage` / `study_name` 引数を追加した H-0072 (`storage="sqlite:///..."` 等) が利用可能。
 
 ---
 
@@ -212,9 +212,9 @@
 
 | Phase | 内容 | 工数 | 依存 |
 |---|---|---|---|
-| R-1 | 状態整合性 + Tune resume (R-1.1〜R-1.5) | 6 週間 | LizyML #105 (Optuna persistent storage) |
+| R-1 | 状態整合性 + Tune resume (R-1.1〜R-1.5b) | 6 週間 | ✅ LizyML #105 (Optuna persistent storage) は lizyml 0.12.0 で解消 |
 | R-2 | セッション復元 (WS reconnect, browser reload) | 2 週間 | R-1 完了 |
-| R-4 | 互換性ロック (format_version, Pickle compat) | 2 週間 | — |
+| R-4 | 互換性ロック (format_version, Pickle compat) | 2 週間 | v3-20 完了後並行可 |
 | R-3 残 | R-3.1〜R-3.3 (typed errors / recovery hints / plot symmetric audit) | 2-3 週間 | — |
 
 ### 8.2 v0.6+ 送り (戦略タスク)
@@ -235,15 +235,16 @@ v0.6 では性能 SLO 監視 (Bench harness 自動化)、運用 runbook、backup
 
 ## 9. 次のアクション
 
-> **2026-05-05 状態**: Step 1〜3 は完了。Step 4 (Phase R-1) は v0.5 着手前に 13 件の準備タスクを `docs/pre-v05-handoff-2026-05-05.md` で実施してから着手する。
+> **2026-05-06 状態**: Step 1〜4 のすべての準備が完了。R-1 着手可。
 
 | 順序 | アクション | 担当 | ステータス |
 |---|---|---|---|
 | 1 | `HISTORY.md` に Proposal P-0096 (業務利用定義の確定) を起票 | dev | ✅ 完了 (2026-05-04) |
-| 2 | `PLAN.md` に v3-N セクションを追加し本計画を反映 | dev | 🟡 v3-15 まで反映、R-1 以降は M-5 で追加予定 |
-| 3 | `ROADMAP.md` を更新 (Tier 2 INDEX に本計画と Issue #360/#361 を登録) | dev | ✅ 完了 (2026-05-05、本セッション S-2) |
-| 4 | Phase R-1 から着手 (6週間) | dev | 🟡 v0.5 着手 — `pre-v05-handoff-2026-05-05.md` の MUST 6 件完了後 |
-| 5 | 各 Phase 完了時に Exit Criteria を確認、PR 単位でマージ | dev | — |
+| 2 | `PLAN.md` に v3-N セクションを追加し本計画を反映 | dev | ✅ 完了 (v3-17〜v3-26、PR #408 + 本 PR で v3-20 entry criteria 確定) |
+| 3 | `ROADMAP.md` を更新 (Tier 2 INDEX に本計画と Issue #360/#361 を登録) | dev | ✅ 完了 (2026-05-05) |
+| 4 | LizyML #105 (Optuna persistent storage) 上流対応 | dev | ✅ 完了 (lizyml 0.12.0 / 2026-05-06、LizyStudio `pyproject.toml` bump 済) |
+| 5 | Phase R-1 から着手 (6週間) | dev | 🟢 着手可 — v3-17 (R-1.1) から開始 |
+| 6 | 各 Phase 完了時に Exit Criteria を確認、PR 単位でマージ | dev | — |
 
 ---
 
@@ -253,3 +254,4 @@ v0.6 では性能 SLO 監視 (Bench harness 自動化)、運用 runbook、backup
 |---|---|---|
 | v0.1 | 2026-05-03 | 初版。`business-use-definition.md` v0.2 に基づき Phase R-1〜R-5 を確定 |
 | v0.2 | 2026-05-05 | v0.4.0 / v0.4.1 リリース反映。R-5 / R-3.4.1 を完了マーク、R-3.4.2 / R-3.1〜R-3.3 を v0.6+ 送り、R-1 / R-2 / R-4 は v0.5 へ繰越し。Status を PARTIAL に更新 |
+| v0.3 | 2026-05-06 | lizyml 0.12.0 (H-0072 Optuna persistent storage) 受領反映。R-1.4 上流ブロッカー解消、§9 Step 1〜4 を完了マーク、R-1 着手可（v3-17 から） |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "lizyml[plots,tuning,calibration,explain]>=0.11.0,<0.12.0",
+    "lizyml[plots,tuning,calibration,explain]>=0.12.0,<0.13.0",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.34",
     "python-multipart>=0.0.18",

--- a/uv.lock
+++ b/uv.lock
@@ -560,7 +560,7 @@ wheels = [
 
 [[package]]
 name = "lizyml"
-version = "0.11.0"
+version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
@@ -574,9 +574,9 @@ dependencies = [
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/42/5f01ee21c9614b719b5fc2539ea2c9e7a83ef80cbb762be6fa445c7525d0/lizyml-0.11.0.tar.gz", hash = "sha256:0e7a388d5926e16e14cd7ea9b8cedc6f85ac4718bc311bd44675f81be646ed09", size = 658004, upload-time = "2026-05-05T06:29:46.325Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/df/06d74bfea3920dfc7e78d59f8b434d889c610ddcc270caac54819ca006e1/lizyml-0.12.0.tar.gz", hash = "sha256:ee8e09f253571e471b903b58a72c0f8cd090938ba9c0b170bf37cec2ec983ef8", size = 666099, upload-time = "2026-05-06T06:38:55.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/08/44d7be636c38f5b1edc2fa6cedee8da872ea02cf99eecfdc62aa1face2db/lizyml-0.11.0-py3-none-any.whl", hash = "sha256:0380a67fc87398ad0e2bec453393aab59a9aba2e9c0d5a2bee4546114dbe7e97", size = 157480, upload-time = "2026-05-05T06:29:44.466Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a7/e1bb82e0c03255861a6fe2e97c2677fba3284e4321a3d00fc61e6971f561/lizyml-0.12.0-py3-none-any.whl", hash = "sha256:3b6f8ba39d635678fd46534dffb31df8a3dfcc3f3efa1915a4c9fc1d821bcd5b", size = 158117, upload-time = "2026-05-06T06:38:54.15Z" },
 ]
 
 [package.optional-dependencies]
@@ -628,7 +628,7 @@ dev = [
 requires-dist = [
     { name = "cloudpickle", specifier = ">=3.0" },
     { name = "fastapi", specifier = ">=0.115" },
-    { name = "lizyml", extras = ["calibration", "explain", "plots", "tuning"], specifier = ">=0.11.0,<0.12.0" },
+    { name = "lizyml", extras = ["calibration", "explain", "plots", "tuning"], specifier = ">=0.12.0,<0.13.0" },
     { name = "prometheus-client", specifier = ">=0.20" },
     { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },


### PR DESCRIPTION
## Summary

Bumps the LizyML dependency to 0.12.0 (released 2026-05-06, H-0072 Optuna persistent storage) and finalizes the v0.5 R-1 prep docs. This unblocks the upstream blocker for v0.5 R-1.4 (#360, Tune long-run resumability) and flips P-0099 from Proposed to Approved so v3-17 (R-1.1) can start.

The only runtime change is the dependency bump itself; the rest is doc reconciliation.

## Changes

### Dependency
- `pyproject.toml`: `lizyml[plots,tuning,calibration,explain]>=0.11.0,<0.12.0` -> `>=0.12.0,<0.13.0`
- `uv.lock`: `lizyml v0.11.0 -> v0.12.0` (only this dep changed; resolved 92 packages)

### Docs
- `HISTORY.md` P-0099:
  - Decision: Proposed -> **Approved (2026-05-06)**
  - Compatibility section: retired the LizyML 0.11.x feature flag (`LIZYSTUDIO_TUNE_RESUME_ENABLED`) since 0.12.0 ships the `storage` argument natively
- `PLAN.md` v3-20 (R-1.4):
  - Entry criteria: rewrote "LizyML #105 merged + minor version bump" as "lizyml 0.12.0 + LizyStudio bump done" (checked)
  - DoD: replaced the feature-flag default-on item with an end-to-end `Model.tune(storage=..., study_name=...)` resume verification (process kill -> restart -> same study_name re-attaches)
- `docs/ROADMAP.md`:
  - Last-updated bumped to 2026-05-06
  - §3.-1: P-0099 / P-0100 / P-0101 moved from "not yet filed" to "Approved / decided"
  - §5: #360 row updated from "waiting on LizyML upstream" to "upstream resolved, ready to start"
  - §7 Tier 1 MUST: M-1..M-6 all marked complete
  - §7 Tier 4: added the v3-17..v3-26 phase table with parallelism notes
- `docs/v0.4-business-readiness-plan.md`:
  - §0 progress note: 2026-05-06 update referencing H-0072
  - §8.1 R-1 dependency: marked LizyML #105 resolved
  - §9 Step 1-4: marked done; Step 5 (R-1) flipped to "ready to start"
  - §10 revision history: added v0.3 row

### Why this PR

- LizyML 0.12.0 (H-0072) lands the Optuna persistent storage path (`Tuner` / `Model.tune()` accept `storage=` and `study_name=`), removing the upstream blocker for v0.5 R-1.4 (#360).
- P-0099 (R-1 invariants + `paused` state Change Gate) needed an explicit Approved record before v3-17 (R-1.1) could begin; this PR confirms it.
- The bump is non-breaking: `storage=None` (default) preserves the in-memory behavior, and no signature was renamed.

### Next phase after this PR

v3-17 (R-1.1): add `tests/regression/test_inv_slot_release.py` covering the six termination paths (normal / cancel / exception / SIGKILL / WS disconnect / browser close) as RED-phase invariant tests.

## Test plan

- [x] `uv lock` resolved 92 packages (only `lizyml v0.11.0 -> v0.12.0`)
- [x] `uv sync --all-extras` reinstalled lizyml 0.12.0 in the env
- [x] `uv run ruff check .` and `uv run ruff format --check .` green
- [x] `uv run mypy src/lizystudio/` green (55 source files, no issues)
- [x] `uv run pytest -q --ignore=tests/e2e --ignore=tests/bench -m "not slow and not flaky and not quarantine"`: 1338 passed, 6 skipped, 7 deselected, 235.78s
- [ ] CI required checks (backend / frontend / contract / e2e functional) green
