### PR TITLE
test(regression): cancel + completion interleaving + v3-18/v3-21 rescope (P-0099)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3250,15 +3250,15 @@ CLAUDE.md §2 Change Gate 対象（state machine 変更 / 並行性・所有権�
 
 R-1.1〜R-1.5b の各 phase に invariant test を割り当てる。本 Proposal の DoD は「invariant declaration が PLAN.md の各 phase に reflectee されている」こと。実装は phase 単位で行う。
 
-- [ ] PLAN.md v3-17 (R-1.1) に **INV-1 / INV-5** の invariant test を Acceptance criteria として明記
-- [ ] PLAN.md v3-18 (R-1.2) に **INV-5** + #358 の regression test を明記
+- [x] PLAN.md v3-17 (R-1.1) に **INV-1 / INV-5** の invariant test を Acceptance criteria として明記 — PR #408 で起票、PR #412 (Python) / #413 (Playwright) で実装
+- [x] PLAN.md v3-18 (R-1.2) を **INV-5 write-side defense-in-depth** へ rescope — Issue #358 は cancel race ではなく frontend cv.strategy revert (PR #368 で 2026-05-03 close 済) と判明したため `tests/regression/test_inv_cancel_completion_interleaving.py` の 3 件 (cooperative cancel deterministic / 16 並行 count balance / post-terminal non-mutation) で write-side coverage を強化、0.5 週へ短縮
 - [ ] PLAN.md v3-19 (R-1.3) に **INV-2 / INV-6** の invariant test を明記
-- [ ] PLAN.md v3-20 (R-1.4) に **INV-3 / INV-4** の invariant test + LizyML #105 dependency を明記
-- [ ] PLAN.md v3-21 (R-1.5) に Issue #359 (job-num drift) の regression test を明記
+- [ ] PLAN.md v3-20 (R-1.4) に **INV-3 / INV-4** の invariant test + LizyML 0.12.0 (H-0072 storage) dependency を明記
+- [x] ~~PLAN.md v3-21 (R-1.5)~~ — Issue #359 は PR #366 (`fix(inference): derive dropdown #N from allJobs`, 2026-05-03 close) で実装済のため subsumed、v3-21 は欠番として保持
 - [ ] PLAN.md v3-22 (R-1.5b) に **INV-7** + Issue #384 の regression test を明記
 - [ ] BLUEPRINT.md §3.4 (Job lifecycle) に上記 INV-1〜INV-7 を明記
 - [ ] CHANGELOG.md (v0.5.0 release notes drafting 時) に `paused` 状態追加を Breaking 寸前 (Added) で記述
-- [ ] Issues #358 / #359 / #360 / #384 を本 Proposal の child Issue として label
+- [x] Issues #358 / #359 は本 Proposal の child から外す (drift 解消)、#360 / #384 のみ child として保持
 
 #### Alternatives considered
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1263,13 +1263,15 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 
 ---
 
-## Phase v3-18: v0.5 R-1.2 — Cancel race の修復（P-0099 INV-5 / Issue #358）
+## Phase v3-18: v0.5 R-1.2 — Cancel + completion interleaving defense-in-depth（P-0099 INV-5）
 
-**期間:** v3-17 完了後 1 週間
+**期間:** v3-17 完了後 0.5 週間（rescope 済 — 当初 1 週間想定）
 
-**対象 Proposal:** P-0099, Issue #358 (BlockedGroup race)
+**対象 Proposal:** P-0099 INV-5（write-side defense-in-depth）
 
-**動機:** Cancel + 完了通知の競合で「キャンセル押下後の `cancelled` 状態が completion で上書きされる」regression を構造的に閉じる。memory `feedback_count_budget_assertions` の lesson を踏まえ、count-based assertion で証明する。
+**動機 (rescope, 2026-05-06):** 当初 v3-18 は Issue #358 を cancel race の reproducer として固定する想定だったが、audit 結果 #358 は frontend の cv.strategy revert (config-sync race、cancel race ではない) で 2026-05-03 に PR #368 で close 済。実装コードの cancel-write は cooperative cancel として構造的に正しい（`_run_job_core` の cb が `CancelledError` を raise → `except` で `status="cancelled"`、completion 経路と排他、`clear_cancel` は finally 内で `release_active` の後 → INV-5 monotonic は structural 保証）。v3-17 で read-side INV-5 は既にカバー済。
+
+このため v3-18 は **cancel + completion interleaving の write-side を defense-in-depth で test pin する 0.5 週フェーズ** に再 scope する。memory `feedback_count_budget_assertions` の lesson を踏まえ count-based assertion を採用、「storm/race の test は count しろ、eventually settle で済ませるな」。
 
 **Entry criteria:** v3-17 完了。
 
@@ -1277,14 +1279,15 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 
 | サブフェーズ | 内容 | 状態 | PR |
 |---|---|---|---|
-| v3-18a | Issue #358 の reproducer を `tests/regression/test_reg_358_blocked_group_cancel_race.py` に固定 | 🟡 | — |
-| v3-18b | cancel + terminal write の race を count-based assertion で test | 🟡 | — |
-| v3-18c | services/training.py で cancel observation を pre-terminal-write に固定 | 🟡 | — |
+| v3-18a | `tests/regression/test_inv_cancel_completion_interleaving.py` で 3 件の interleaving test を pin（cb 間 cancel→cancelled / 16 並行 count-balance / post-terminal cancel non-mutation） | 🟢 完了 | feat/v3-18-r12-cancel-race-rescope |
+| ~~v3-18b~~ | ~~Issue #358 reproducer~~ | ❌ 不要 — #358 は別バグ系で PR #368 で close 済 | — |
+| ~~v3-18c~~ | ~~services/training.py で cancel observation を pre-terminal-write に固定~~ | ❌ 不要 — 既存の cooperative cancel 設計で structural 保証済（audit 結果） | — |
 
 **DoD:**
-- [ ] Issue #358 が close 済（reproducer green）
-- [ ] count-based assertion: 100 並行 cancel-during-completion で `cancelled` 状態が常に observable 1 件以上
-- [ ] INV-5 の monotonic 性が cancel race のすべての interleaving で破れない
+- [x] cancel-between-cb-calls の cooperative-cancel が `status="cancelled"` を produce する deterministic test
+- [x] 16 並行 cancel-during-completion で `count(cancelled) + count(completed) == n_runs` の count-based assertion
+- [x] post-terminal `request_cancel` が persisted `completed` を mutate しない negative test
+- [x] PLAN.md / ROADMAP.md / HISTORY.md の Issue #358 / #359 drift 整理（#358 = frontend bug, fixed by #368; #359 = job-num drift, fixed by #366）
 
 ---
 
@@ -1349,27 +1352,11 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 
 ---
 
-## Phase v3-21: v0.5 R-1.5 — Issue #359 job-num drift 解消
+## ~~Phase v3-21: v0.5 R-1.5 — Issue #359 job-num drift 解消~~（subsumed）
 
-**期間:** v3-20 と並行可（state machine 変更を含まない）、0.5 週間
+**状態:** ❌ 不要 — Issue #359 は 2026-05-03 に PR #366 (`fix(inference): derive dropdown #N from allJobs not completedJobs`) で close 済。当初 v3-21 は `meta.json` に不変 `job_num` を保存する v0.5 path を想定していたが、PR #366 は **frontend 側の dropdown 番号導出を `completedJobs` から `allJobs` に切替える**ことで failed/cancelled job 含む全 job を一貫した番号で扱うアプローチを採用済。実装が既に問題を解決しているため、本フェーズは v0.5 の作業対象から除外する。
 
-**対象:** Issue #359
-
-**動機:** `job_num` を frontend 側で計算せず API レスポンスに含めることで、削除や cancel 後の番号 drift を解消。
-
-**Entry criteria:** v3-17 完了（slot release が安定したら着手可）。
-
-**サブフェーズ:**
-
-| サブフェーズ | 内容 | 状態 | PR |
-|---|---|---|---|
-| v3-21a | `meta.json` に不変 `job_num: int` を保存（format_version=2 と同 PR が望ましい） | 🟡 | — |
-| v3-21b | API `GET /api/jobs` / `GET /api/jobs/{id}` レスポンスに `job_num` 追加（openapi-typescript 再生成） | 🟡 | — |
-| v3-21c | Frontend で `job_num` を index 計算から API レスポンス参照に切替 | 🟡 | — |
-
-**DoD:**
-- [ ] Issue #359 が close 済
-- [ ] `tests/regression/test_reg_359_job_num_stable.py` で削除 + 新規作成サイクル後の番号 stability 確認
+**正式番号は欠番として保持** — 後続 phase の参照 (v3-22 / v3-23 / v3-24 / v3-25 / v3-26) はそのまま使用可。新規 phase は v3-27 以降を採番（採番ガイダンス参照）。
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 - このファイルは **横串インデックス** であり、詳細はリンク先で確認すること。
 - 着手する際は HISTORY に Proposal を起票（変更ゲート対象の場合）→ PLAN にフェーズ追加 → 実装、の順で進める。
 
-最終更新: 2026-05-06（v0.4.2 リリース + lizyml 0.12.0 受領反映：P-0099 Approved / R-1.4 上流ブロッカー解消 / Open Issues #403..#405 / v0.5 R-1 Next Action）
+最終更新: 2026-05-06（v0.5 R-1 着手：v3-17 完了 (PR #412/#413), v3-18 rescoped to 0.5 週 (PR drafting), v3-21 closed as subsumed by #366）
 
 ---
 
@@ -308,18 +308,18 @@ v0.4.1 リリース後の Open Issue は 5 件。
 
 | Phase | 内容 | 期間 | 並行可否 |
 |---|---|---|---|
-| v3-17 | R-1.1 Slot release 6 経路 invariant test (INV-1/INV-5) | 1 週 | — |
-| v3-18 | R-1.2 Cancel race + #358 | 1 週 | — |
+| ~~v3-17~~ | R-1.1 Slot release 6 経路 invariant test (INV-1/INV-5) | 1 週 | ✅ 完了 (PR #412 + #413) |
+| v3-18 | R-1.2 Cancel + completion interleaving defense-in-depth (INV-5 write-side) | **0.5 週 (rescoped)** — 進行中 | — |
 | v3-19 | R-1.3 Subprocess crash + atomic meta.json (INV-2/INV-6) | 1 週 | — |
 | v3-20 | R-1.4 Tune resume (INV-3/INV-4 / #360) | 3 週 | ✅ 上流解消（lizyml 0.12.0） |
-| v3-21 | R-1.5 #359 job-num drift | 0.5 週 | v3-17 完了後並行可 |
+| ~~v3-21~~ | ~~R-1.5 #359 job-num drift~~ | — | ❌ subsumed by PR #366 (closed 2026-05-03), 欠番 |
 | v3-22 | R-1.5b Server Restart Recovery (INV-7 / #384) | 1 週 | v3-20 後 |
 | v3-23 | R-2.1 WS 再接続 | 1 週 | v3-22 後 |
 | v3-24 | R-2.2 ブラウザリロード復元 | 1 週 | v3-23 後 |
 | v3-25 | R-4.1 format_version migration matrix | 1 週 | v3-20 完了後並行可 |
 | v3-26 | R-4.2 Pickle compatibility | 1 週 | v3-25 と並行可 |
 
-直近の next: **v3-17 (R-1.1)** — `tests/regression/test_inv_slot_release.py` で 6 経路の invariant test を RED phase で書く。
+直近の next: **v3-19 (R-1.3)** — subprocess crash watchdog の実装で `tests/regression/test_inv_slot_release.py::test_inv1_path4_*` の `xfail(strict=True)` を green に flip。
 
 ### Tier 5：要長期計画（v0.6 以降）
 

--- a/tests/regression/test_inv_cancel_completion_interleaving.py
+++ b/tests/regression/test_inv_cancel_completion_interleaving.py
@@ -1,0 +1,257 @@
+"""INV-5 cancel + completion interleaving tests (v0.5 R-1.2 / v3-18).
+
+The v3-17 invariant matrix already covers the *read* side of INV-5
+(``is_cancel_requested`` monotonic until terminal write). This module
+adds defense-in-depth coverage for the *write* side:
+
+  * **Cancel-before-last-cb wins.** When ``request_cancel`` lands
+    between two cooperative-callback observations, the next callback
+    must raise ``CancelledError`` and the worker must land on
+    ``status="cancelled"`` — not silently swallow the cancel and
+    proceed to completion.
+
+  * **Cancel-during-completion race is structurally exclusive.** The
+    cancel flag is observed only at cb boundaries; once ``execute_fn``
+    has returned successfully the worker writes ``completed``. Both
+    outcomes are valid for any single run, but across N concurrent
+    runs the count of ``cancelled`` plus ``completed`` must equal N
+    (no run may end in an inconsistent intermediate state, no run may
+    be lost). This is the count-based assertion form for
+    ``feedback_count_budget_assertions``: storms must be counted, not
+    asserted to "eventually settle".
+
+These tests exercise ``_run_job_core`` directly. The PLAN.md v3-18
+phase rescope (away from the misattributed Issue #358 and toward this
+defensive coverage) is recorded in HISTORY.md P-0099 acceptance
+criteria.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any, Literal
+
+import pytest
+
+from lizystudio.backends.types import DataRef, FitSummary
+from lizystudio.services._training_core import _run_job_core
+from lizystudio.services.jobs import Job, JobStore
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def job_store(tmp_path: Path) -> JobStore:
+    return JobStore(tmp_path / "jobs")
+
+
+def _make_data_ref() -> DataRef:
+    return DataRef(
+        source_type="path",
+        path="/data/x.csv",
+        filename="x.csv",
+        fingerprint="f",
+        shape=(10, 2),
+    )
+
+
+def _claim_job(store: JobStore, job_type: Literal["fit", "tune"] = "fit") -> Job:
+    job = store.create_and_claim_active(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=_make_data_ref(),
+        job_type=job_type,
+    )
+    assert job is not None
+    return job
+
+
+def _stub_fit_summary() -> FitSummary:
+    return FitSummary(metrics={}, fold_count=1, params=[])
+
+
+# ---------------------------------------------------------------------------
+# Test 1: cancel-between-cb-calls wins over completion (deterministic)
+# ---------------------------------------------------------------------------
+
+
+def test_inv5_cancel_request_between_cb_calls_lands_on_cancelled(
+    job_store: JobStore,
+) -> None:
+    """``request_cancel`` between cb calls must propagate before completion.
+
+    The cooperative-cancel contract: once the cancel flag is set, the
+    next progress callback must raise ``CancelledError``. This test
+    pins that contract by interleaving ``request_cancel`` with a
+    deterministic 5-step ``execute_fn`` and asserting the worker lands
+    on ``status="cancelled"`` — never reaches the completion branch.
+    """
+    job = _claim_job(job_store)
+    cb_calls: list[int] = []
+    cancel_after_step = 2
+
+    def execute_fn(
+        cb: Any,
+    ) -> tuple[FitSummary, None, str]:
+        for i in range(5):
+            cb_calls.append(i)
+            cb(current=i, total=5, message=f"step {i}")
+            if i == cancel_after_step:
+                # Set the cancel flag AFTER step ``cancel_after_step``
+                # observed; the NEXT cb invocation must raise
+                # CancelledError.
+                job_store.request_cancel(job.job_id)
+        # If the loop exits without raising, the cancel was lost — bug.
+        return _stub_fit_summary(), None, "/tmp/model"
+
+    result = _run_job_core(
+        job=job,
+        job_store=job_store,
+        broadcaster=None,
+        execute_fn=execute_fn,
+    )
+
+    assert result.status == "cancelled", (
+        "INV-5: cancel observed at cb boundary must override completion"
+    )
+    # The cb at i=cancel_after_step + 1 is the one that raises. We
+    # appended `i` to cb_calls BEFORE the raising cb call, so the list
+    # ends at that index inclusive.
+    assert cb_calls == [0, 1, 2, 3], (
+        f"cb call sequence diverged from the cooperative-cancel contract: "
+        f"{cb_calls}. Expected the cb at i=3 to raise without further "
+        f"loop progress."
+    )
+    assert job_store.active_job_id is None, (
+        "INV-1 cross-link: cancelled job must release the slot via finally"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: concurrent cancel-during-completion race is count-balanced
+# ---------------------------------------------------------------------------
+
+
+def test_inv5_cancel_completion_race_count_balanced_under_concurrency(
+    tmp_path: Path,
+) -> None:
+    """N concurrent runs with timed cancel: count(cancelled) + count(completed) == N.
+
+    Each run uses its own ``JobStore`` (isolated jobs_dir) so the
+    test does not contend with a single active slot. Half of the runs
+    fire ``request_cancel`` between cb calls; half let the worker
+    finish naturally. Across all runs, the worker either lands on
+    ``cancelled`` or ``completed`` — never an inconsistent
+    intermediate state, never silently lost.
+
+    This is the count-based assertion variant called out in memory
+    ``feedback_count_budget_assertions``: for race regressions, the
+    test must count occurrences across the input axis, not just
+    assert that "eventually" the right thing happens.
+    """
+    n_runs = 16
+
+    def run_one(idx: int) -> str:
+        store = JobStore(tmp_path / f"jobs_{idx}")
+        job = store.create_and_claim_active(
+            backend_name="lizyml",
+            config={"task": "binary", "data": {"target": "y"}},
+            data_ref=_make_data_ref(),
+            job_type="fit",
+        )
+        assert job is not None
+        will_cancel = idx % 2 == 0
+
+        def execute_fn(cb: Any) -> tuple[FitSummary, None, str]:
+            for i in range(4):
+                cb(current=i, total=4, message=f"step {i}")
+                if will_cancel and i == 1:
+                    store.request_cancel(job.job_id)
+            return _stub_fit_summary(), None, "/tmp/model"
+
+        result = _run_job_core(
+            job=job,
+            job_store=store,
+            broadcaster=None,
+            execute_fn=execute_fn,
+        )
+        return result.status
+
+    results: list[str] = []
+    results_lock = threading.Lock()
+
+    def worker(idx: int) -> None:
+        status = run_one(idx)
+        with results_lock:
+            results.append(status)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_runs)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    cancelled_count = sum(1 for s in results if s == "cancelled")
+    completed_count = sum(1 for s in results if s == "completed")
+    other_count = len(results) - cancelled_count - completed_count
+
+    assert other_count == 0, (
+        f"INV-5: every run must land on cancelled or completed, never "
+        f"an intermediate or unknown status. Saw {other_count} other "
+        f"statuses across {n_runs} runs: {results}"
+    )
+    assert cancelled_count + completed_count == n_runs, (
+        f"INV-5: count must balance — saw {cancelled_count} cancelled + "
+        f"{completed_count} completed across {n_runs} runs"
+    )
+    assert cancelled_count == n_runs // 2, (
+        f"INV-5: every will_cancel=True run must land on cancelled — saw "
+        f"{cancelled_count} (expected {n_runs // 2})"
+    )
+    assert completed_count == n_runs // 2, (
+        f"INV-5: every will_cancel=False run must land on completed — saw "
+        f"{completed_count} (expected {n_runs // 2})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: cancel after terminal write must not corrupt persisted status
+# ---------------------------------------------------------------------------
+
+
+def test_inv5_cancel_after_terminal_does_not_overwrite_completed(
+    job_store: JobStore,
+) -> None:
+    """``request_cancel`` arriving after terminal MUST NOT mutate the status.
+
+    The worker's finally-block runs ``clear_cancel`` AFTER
+    ``release_active`` AFTER the terminal status write. After that,
+    any new ``request_cancel`` for the same job_id sets the in-memory
+    flag again, but no worker is observing it — and ``Job.status``
+    is already ``completed`` on disk. This test pins that boundary so
+    a future "post-terminal cancel rewrites status" regression cannot
+    ship silently.
+    """
+    job = _claim_job(job_store)
+
+    def execute_fn(_cb: Any) -> tuple[FitSummary, None, str]:
+        return _stub_fit_summary(), None, "/tmp/model"
+
+    result = _run_job_core(
+        job=job,
+        job_store=job_store,
+        broadcaster=None,
+        execute_fn=execute_fn,
+    )
+    assert result.status == "completed"
+
+    # Now fire a cancel for the same id AFTER terminal. The persisted
+    # status must NOT change.
+    job_store.request_cancel(job.job_id)
+    reloaded = job_store.get(job.job_id)
+    assert reloaded is not None
+    assert reloaded.status == "completed", (
+        "INV-5: post-terminal request_cancel must not rewrite a completed "
+        f"status (saw {reloaded.status})"
+    )


### PR DESCRIPTION
## Summary

v3-18 (R-1.2) rescope + interleaving defense-in-depth. Closes the v0.5 R-1.2 phase as a 0.5-week tests-only PR (down from the originally planned 1 week) and rolls v3-21 into "subsumed" status now that PR #366 already implemented its scope.

## Audit findings — PLAN.md drift cleanup

Two phase entries pointed to issues that were already resolved on develop:

1. **v3-18 referenced Issue #358** ("BlockedGroup race") as the cancel race reproducer. Re-reading the issue shows #358 was a **frontend cv.strategy revert** (config-sync race in `useDataPanel`'s reconcile effect), unrelated to cancel race. Closed by PR #368 on 2026-05-03.
2. **v3-21 referenced Issue #359** (job-num drift). Already closed by PR #366 on 2026-05-03; the frontend derives the dropdown number from `allJobs` instead of `completedJobs`, structurally resolving the drift without any `meta.json job_num` persistence.

A fresh audit of `_run_job_core` (`src/lizystudio/services/_training_core.py:120-191`) confirmed the cancel-write side is structurally correct:
- `cb` raises `CancelledError` on `is_cancel_requested` between trials
- `except (CancelledError, KeyboardInterrupt):` writes `status="cancelled"` mutually exclusive with the completion branch
- `clear_cancel` runs in `finally` AFTER `release_active` AFTER the terminal write — so INV-5 monotonic is structurally guaranteed without further code change

## Changes

### `tests/regression/test_inv_cancel_completion_interleaving.py` (new, 3 tests)

| Test | Coverage |
|---|---|
| `test_inv5_cancel_request_between_cb_calls_lands_on_cancelled` | Cooperative-cancel deterministic: `request_cancel` between cb #2 and cb #3 -> next cb raises `CancelledError` -> worker lands on `status="cancelled"`. Pins the cb call sequence so future drift in cancel-handling order trips the test. |
| `test_inv5_cancel_completion_race_count_balanced_under_concurrency` | 16 concurrent runs (each with its own JobStore so they don't contend on the active slot). Half fire cancel between cb #1 and cb #2; half complete naturally. Asserts `count(cancelled) + count(completed) == n_runs` AND `count(cancelled) == n_runs/2`. Implements the count-based assertion form from memory `feedback_count_budget_assertions` ("storms must be counted, not asserted to eventually settle"). |
| `test_inv5_cancel_after_terminal_does_not_overwrite_completed` | Negative invariant: post-terminal `request_cancel` for the same job_id must not mutate the persisted `completed` status. Pins the boundary so a future regression that re-runs the worker on a stale cancel flag would fail loudly. |

### Doc reconciliation

- **`PLAN.md` v3-18**: rescoped to 0.5 week defense-in-depth; v3-18b/c sub-phases struck through with rationale; DoD checkboxes updated to reflect the 3 interleaving tests landing.
- **`PLAN.md` v3-21**: marked as subsumed by PR #366; phase number left vacant; subsequent IDs (v3-22..v3-26) unchanged.
- **`docs/ROADMAP.md` §7 Tier 4**: phase table now shows v3-17 done, v3-18 in progress at 0.5 week, v3-21 struck through. Last-updated note bumped.
- **`HISTORY.md` P-0099 Acceptance criteria**: v3-17 / v3-18 lines marked done; v3-21 marked subsumed; #358 / #359 removed from child Issue list (drift acknowledged); #360 / #384 retained.

### Why no production-code change in this PR

The audit said so: `_run_job_core` is structurally correct, and v3-17 already pins INV-5 monotonic on the read side. v3-18's job is to encode the write-side contract as tests. The 3 tests above each fail loudly if the cooperative-cancel order, the count balance, or the post-terminal boundary regresses.

## Invariants (write-side)

- **INV-5 (write side)**: Once `request_cancel` is observed at a cb boundary, the worker raises `CancelledError`, the `except` branch writes `status="cancelled"`, and the completion path is never reached. Across N concurrent runs the count of cancelled and completed must sum to N.

## Failure paths covered

- [x] cb-boundary cancel -> cancelled (deterministic)
- [x] N-concurrent cancel-during-completion -> count balanced
- [x] Post-terminal cancel -> persisted status unchanged

## Test plan

- [x] `uv run ruff check .` and `uv run ruff format --check .` green (173 files formatted)
- [x] `uv run mypy src/lizystudio/ tests/regression/test_inv_cancel_completion_interleaving.py` green (56 source files, no issues)
- [x] `uv run pytest` of slot+cancel regression set (test_inv_slot_release + test_inv_cancel_completion_interleaving + test_reg_0071/0072/0075/0152): **32 passed, 1 xfailed** (path 4 watchdog still pinned for v3-19), 25.34s
- [ ] Full backend suite via CI

## Phase status after this PR

| Phase | Status |
|---|---|
| v3-17 (R-1.1) | Done (PR #412 + #413) |
| v3-18 (R-1.2, rescoped) | This PR |
| v3-21 (R-1.5) | Subsumed by PR #366 |
| v3-19 (R-1.3) | Next — flips path 4 xfail to green |
| v3-20 (R-1.4) | lizyml 0.12.0 unblocked |
| v3-22 / v3-23 / v3-24 | After v3-20 |
| v3-25 / v3-26 | Parallel after v3-20 |
