### PR TITLE
feat(backends,services): tune storage / study_name passthrough (v3-20b, P-0099 R-1.4)

### DIFF
--- a/src/lizystudio/backends/base.py
+++ b/src/lizystudio/backends/base.py
@@ -91,8 +91,25 @@ class BackendCore(Protocol):
         re_tune: dict[str, Any] | None = None,
         checkpoint_dir: Any = None,
         resume: bool = False,
+        storage: str | None = None,
+        study_name: str | None = None,
     ) -> TuningSummary:
-        """Run hyperparameter tuning.  See H-0061 / H-0062 for kwargs."""
+        """Run hyperparameter tuning.
+
+        See H-0061 / H-0062 for ``re_tune`` / ``checkpoint_dir`` / ``resume``.
+
+        ``storage`` and ``study_name`` (P-0099 v3-20b / R-1.4) are passed
+        through to the backend's tuner so trial state is persisted to a
+        durable, on-disk Optuna storage instead of an in-memory study.
+        ``None`` (default) preserves the legacy in-memory behavior so
+        existing callers and tests remain unchanged.
+
+        Adapters that do not support persistent storage MUST raise
+        :class:`NotImplementedError` when *storage* is non-None and
+        document the limitation in their adapter README. The lizyml
+        adapter accepts any URL form supported by Optuna 0.12.0+
+        (e.g. ``"sqlite:///path/to.db"``).
+        """
         ...
 
     def predict(

--- a/src/lizystudio/backends/lizyml/lifecycle_mixin.py
+++ b/src/lizystudio/backends/lizyml/lifecycle_mixin.py
@@ -56,9 +56,35 @@ class LifecycleMixin:
         re_tune: dict[str, Any] | None = None,
         checkpoint_dir: Path | None = None,
         resume: bool = False,
+        storage: str | None = None,
+        study_name: str | None = None,
     ) -> TuningSummary:
-        """Run hyperparameter tuning via lizyml's Model.tune()."""
+        """Run hyperparameter tuning via lizyml's Model.tune().
+
+        ``storage`` and ``study_name`` (P-0099 v3-20b / R-1.4) are
+        forwarded to ``model.tune`` (lizyml >= 0.12.0, H-0072). When
+        provided together, Optuna persists trial state to the URL
+        after every completed trial; re-invoking ``tune`` with the
+        same identifiers re-attaches via ``load_if_exists=True`` and
+        picks up where the prior run stopped. When both arguments are
+        ``None`` (default), the legacy in-memory study path is used,
+        so existing callers and re-tune flows continue to behave
+        exactly as before.
+        """
         n_rounds, extra_kwargs = parse_re_tune(re_tune)
+        # P-0099 v3-20b: storage / study_name are pass-through kwargs
+        # for lizyml's persistent-storage path. They are added to
+        # every model.tune() call (first round + every re-tune round)
+        # so a multi-round resume sees the same study identity across
+        # rounds. lizyml 0.12.0 accepts None to mean "use the in-memory
+        # default" — the local dict guarantees we only inject the
+        # kwargs when both are set, which keeps the call signature
+        # compatible with hypothetical future lizyml releases that add
+        # a non-None default.
+        storage_kwargs: dict[str, Any] = {}
+        if storage is not None or study_name is not None:
+            storage_kwargs["storage"] = storage
+            storage_kwargs["study_name"] = study_name
 
         lizyml_callback: Any = None
         accumulated_trials: list[dict[str, Any]] = []
@@ -150,6 +176,7 @@ class LifecycleMixin:
             first_round_kwargs.update(extra_kwargs)
         tune_result = model.tune(
             progress_callback=lizyml_callback,
+            **storage_kwargs,
             **first_round_kwargs,
         )
         for round_idx in range(2, n_rounds + 1):
@@ -165,6 +192,7 @@ class LifecycleMixin:
             tune_result = model.tune(
                 progress_callback=lizyml_callback,
                 resume=True,
+                **storage_kwargs,
                 **extra_kwargs,
             )
 

--- a/src/lizystudio/services/training.py
+++ b/src/lizystudio/services/training.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import copy
 import logging
 import threading
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from lizystudio.backends.base import BackendAdapter, ProgressCallback
@@ -183,6 +184,32 @@ def _prepare_tune_config(config: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _build_optuna_storage_url(job_dir: Path) -> str:
+    """Build the per-job Optuna SQLite URL (P-0099 v3-20b / R-1.4).
+
+    Each tune job owns its own SQLite database at
+    ``{job_dir}/optuna.db`` so concurrent jobs cannot race on a
+    shared store, and so deleting a job directory cleans up its
+    persistent tune state with no extra bookkeeping. The URL form is
+    ``sqlite:///{absolute_path}`` (three slashes — Optuna treats the
+    fourth character as the start of the path).
+    """
+    db_path = job_dir / "optuna.db"
+    return f"sqlite:///{db_path.resolve()}"
+
+
+def _build_optuna_study_name(job_id: str) -> str:
+    """Build the Optuna study identifier (P-0099 v3-20b / R-1.4).
+
+    The ``studio-tune-`` prefix lets a casual SQLite inspection
+    distinguish LizyStudio's studies from any user-created ones in
+    the same database (we do not share a database across jobs, but
+    the prefix is cheap insurance against accidental cross-pollution
+    if a future deployment chooses a single shared store).
+    """
+    return f"studio-tune-{job_id}"
+
+
 def run_tune(
     *,
     job: Job,
@@ -198,6 +225,12 @@ def run_tune(
     # H-0062: checkpoint directory for incremental trial persistence.
     checkpoint_dir = job_store.job_dir(job.job_id)
     _run_pickle_preflight(backend, checkpoint_dir)
+    # P-0099 v3-20b: persistent Optuna storage per job. The job
+    # directory is created lazily by the JobStore, so by the time
+    # we hit lizyml's tuner the parent dir already exists for
+    # SQLite to populate.
+    storage_url = _build_optuna_storage_url(checkpoint_dir)
+    study_name = _build_optuna_study_name(job.job_id)
 
     def execute(cb: ProgressCallback) -> tuple[FitSummary, TuningSummary | None, str]:
         model = backend.create_model(tune_config, dataframe)
@@ -206,6 +239,8 @@ def run_tune(
             on_progress=cb,
             re_tune=re_tune,
             checkpoint_dir=checkpoint_dir,
+            storage=storage_url,
+            study_name=study_name,
         )
 
         # Capture tuning plot from the tune model before creating model2.

--- a/tests/regression/test_inv_tune_storage_passthrough.py
+++ b/tests/regression/test_inv_tune_storage_passthrough.py
@@ -1,0 +1,382 @@
+"""Tune persistent-storage passthrough tests (P-0099 v3-20b / R-1.4).
+
+Coverage matrix:
+
+  * **BackendAdapter Protocol contract** — the abstract ``tune``
+    signature exposes ``storage`` and ``study_name`` keyword-only
+    arguments with ``None`` defaults so existing callers see no
+    behavior change.
+
+  * **LizyML adapter passthrough** — the lizyml adapter forwards both
+    arguments to ``model.tune`` only when at least one is non-None,
+    keeping the call signature backward compatible with hypothetical
+    future lizyml releases.
+
+  * **services/training URL builder** — ``run_tune`` constructs the
+    per-job ``sqlite:///{job_dir}/optuna.db`` URL plus the
+    ``studio-tune-{job_id}`` study identifier and passes them through
+    to ``backend.tune``.
+
+These tests run against the production code paths but stub
+``model.tune`` (lizyml internals) and ``BackendAdapter.tune``
+(services) to keep the assertion focus on the wiring rather than the
+ML internals.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from lizystudio.backends.base import BackendAdapter
+from lizystudio.backends.lizyml import LizyMLAdapter
+from lizystudio.backends.types import FitSummary, TuningSummary
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Protocol contract
+# ---------------------------------------------------------------------------
+
+
+def test_backend_adapter_tune_protocol_exposes_storage_kwargs() -> None:
+    """``BackendAdapter.tune`` must declare ``storage`` and
+    ``study_name`` as optional keyword-only arguments with ``None``
+    defaults.
+
+    A future Adapter implementation that breaks this contract (e.g.
+    drops the kwargs or makes them positional) would silently change
+    semantics for ``services/training.run_tune``; this test pins the
+    signature.
+    """
+    sig = inspect.signature(BackendAdapter.tune)
+    params = sig.parameters
+
+    assert "storage" in params, "BackendAdapter.tune must accept storage"
+    assert "study_name" in params, "BackendAdapter.tune must accept study_name"
+
+    storage_param = params["storage"]
+    study_name_param = params["study_name"]
+
+    assert storage_param.kind == inspect.Parameter.KEYWORD_ONLY
+    assert study_name_param.kind == inspect.Parameter.KEYWORD_ONLY
+    assert storage_param.default is None
+    assert study_name_param.default is None
+
+
+# ---------------------------------------------------------------------------
+# LizyML adapter passthrough
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_tune_result() -> MagicMock:
+    return MagicMock(
+        best_params={"lr": 0.1},
+        best_score=0.9,
+        trials=[],
+        metric_name="auc",
+        direction="maximize",
+    )
+
+
+def test_lizyml_adapter_omits_storage_kwargs_when_both_none() -> None:
+    """When ``storage`` and ``study_name`` are both ``None``, the
+    adapter MUST NOT include them in ``model.tune`` kwargs so the
+    legacy in-memory study path is preserved bit-for-bit.
+    """
+    adapter = LizyMLAdapter()
+    mock_model = MagicMock()
+    mock_model.tune.return_value = _make_mock_tune_result()
+
+    adapter.tune(mock_model)
+
+    mock_model.tune.assert_called_once()
+    _, kwargs = mock_model.tune.call_args
+    assert "storage" not in kwargs, (
+        "Legacy in-memory path must NOT pass storage to lizyml — saw "
+        f"{kwargs.get('storage')!r}"
+    )
+    assert "study_name" not in kwargs
+
+
+def test_lizyml_adapter_passes_storage_and_study_name_through() -> None:
+    """When both arguments are provided, they MUST appear in
+    ``model.tune`` kwargs verbatim.
+    """
+    adapter = LizyMLAdapter()
+    mock_model = MagicMock()
+    mock_model.tune.return_value = _make_mock_tune_result()
+
+    adapter.tune(
+        mock_model,
+        storage="sqlite:///tmp/test.db",
+        study_name="studio-tune-abc",
+    )
+
+    mock_model.tune.assert_called_once()
+    _, kwargs = mock_model.tune.call_args
+    assert kwargs.get("storage") == "sqlite:///tmp/test.db"
+    assert kwargs.get("study_name") == "studio-tune-abc"
+
+
+def test_lizyml_adapter_passes_storage_when_only_one_set() -> None:
+    """If only ``storage`` is provided (a misuse case), the adapter
+    still forwards both kwargs so lizyml can validate / reject. The
+    adapter does NOT silently drop a half-specified pair — the
+    caller's intent should reach the backend's validation layer.
+    """
+    adapter = LizyMLAdapter()
+    mock_model = MagicMock()
+    mock_model.tune.return_value = _make_mock_tune_result()
+
+    adapter.tune(mock_model, storage="sqlite:///tmp/x.db")
+
+    _, kwargs = mock_model.tune.call_args
+    assert "storage" in kwargs
+    assert kwargs["storage"] == "sqlite:///tmp/x.db"
+    assert "study_name" in kwargs
+    assert kwargs["study_name"] is None
+
+
+def test_lizyml_adapter_storage_kwargs_propagate_through_re_tune_rounds() -> None:
+    """In a multi-round re-tune flow the storage identity MUST stay
+    consistent across rounds so Optuna re-attaches to the same study.
+    """
+    adapter = LizyMLAdapter()
+    mock_model = MagicMock()
+    mock_model.tune.return_value = _make_mock_tune_result()
+
+    re_tune = {"n_rounds": 3, "n_trials": 5}
+    adapter.tune(
+        mock_model,
+        re_tune=re_tune,
+        storage="sqlite:///tmp/rt.db",
+        study_name="studio-tune-rt",
+    )
+
+    # 3 rounds = 3 model.tune() calls, each carrying the same storage
+    # identity.
+    assert mock_model.tune.call_count == 3
+    for call in mock_model.tune.call_args_list:
+        _, kwargs = call
+        assert kwargs.get("storage") == "sqlite:///tmp/rt.db", (
+            "Optuna study identity must be stable across re-tune rounds"
+        )
+        assert kwargs.get("study_name") == "studio-tune-rt"
+
+
+# ---------------------------------------------------------------------------
+# services/training URL builders
+# ---------------------------------------------------------------------------
+
+
+def test_build_optuna_storage_url_per_job(tmp_path: Path) -> None:
+    """``_build_optuna_storage_url`` produces a per-job sqlite URL
+    rooted at ``{job_dir}/optuna.db`` with the ``sqlite:///`` prefix
+    that Optuna expects.
+    """
+    from lizystudio.services.training import _build_optuna_storage_url
+
+    job_dir = tmp_path / "jobs" / "abc"
+    job_dir.mkdir(parents=True)
+
+    url = _build_optuna_storage_url(job_dir)
+
+    assert url.startswith("sqlite:///"), (
+        f"Optuna SQLite URL must use the three-slash form; got {url!r}"
+    )
+    # Trailing absolute path resolves under the job dir (not a
+    # relative path that could escape on a chdir).
+    expected = (job_dir / "optuna.db").resolve()
+    assert url == f"sqlite:///{expected}"
+
+
+def test_build_optuna_study_name_uses_job_id_prefix() -> None:
+    """``_build_optuna_study_name`` produces ``studio-tune-{job_id}``
+    so a casual SQLite inspection can identify LizyStudio's studies.
+    """
+    from lizystudio.services.training import _build_optuna_study_name
+
+    name = _build_optuna_study_name("xyz-123")
+    assert name == "studio-tune-xyz-123"
+
+
+def test_run_tune_passes_storage_kwargs_to_backend(tmp_path: Path) -> None:
+    """End-to-end: ``run_tune`` constructs the per-job URL +
+    study_name and forwards both to ``backend.tune``.
+
+    Stubs the backend (so no real ML work) and asserts the kwargs
+    carry the per-job SQLite URL plus the matching ``studio-tune-``
+    identifier.
+    """
+    from lizystudio.backends.types import DataRef
+    from lizystudio.services.jobs import JobStore
+    from lizystudio.services.training import run_tune
+
+    job_store = JobStore(tmp_path / "jobs")
+    job = job_store.create_and_claim_active(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=DataRef(
+            source_type="path",
+            path="/data/x.csv",
+            filename="x.csv",
+            fingerprint="f",
+            shape=(10, 2),
+        ),
+        job_type="tune",
+    )
+    assert job is not None
+
+    backend = MagicMock()
+    backend.create_model.return_value = MagicMock()
+    backend.tune.return_value = TuningSummary(
+        best_params={"lr": 0.1},
+        best_score=0.9,
+        trials=[],
+        metric_name="auc",
+        direction="maximize",
+    )
+    backend.fit.return_value = FitSummary(metrics={}, fold_count=1, params=[])
+    backend.export_model = MagicMock()
+    # _save_tuning_plot calls backend.plot(...).plotly_json — provide a
+    # string so Path.write_text accepts it. The plot persistence is a
+    # side concern of run_tune; the storage-passthrough invariant under
+    # test does not depend on its content.
+    backend.plot.return_value = MagicMock(plotly_json="{}")
+
+    config = {
+        "task": "binary",
+        "data": {"target": "y"},
+        "evaluation": {"metrics": ["auc"]},
+        "tuning": {"optuna": {"params": {"n_trials": 5}, "space": {}}},
+    }
+
+    run_tune(
+        job=job,
+        job_store=job_store,
+        backend=backend,
+        config=config,
+        dataframe=MagicMock(),
+        broadcaster=None,
+    )
+
+    backend.tune.assert_called_once()
+    _, kwargs = backend.tune.call_args
+
+    expected_url = (
+        f"sqlite:///{(job_store.job_dir(job.job_id) / 'optuna.db').resolve()}"
+    )
+    expected_study = f"studio-tune-{job.job_id}"
+
+    assert kwargs.get("storage") == expected_url, (
+        f"run_tune must pass per-job sqlite URL; saw {kwargs.get('storage')!r}"
+    )
+    assert kwargs.get("study_name") == expected_study, (
+        f"run_tune must pass studio-tune-{{job_id}}; saw {kwargs.get('study_name')!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Re-tune path keeps the legacy in-memory behavior (out of v3-20b scope).
+# ---------------------------------------------------------------------------
+
+
+def test_run_retune_does_not_pass_storage_kwargs_yet(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Re-tune (H-0062) is intentionally left on the legacy in-memory
+    study path until v0.6+ harmonisation. The v3-20b scope only
+    covers fresh tune jobs (R-1.4); a future PR (likely v0.6) will
+    decide whether to plumb storage into re-tune as well.
+
+    Pin: ``backend.tune`` called from ``run_retune`` MUST NOT carry
+    ``storage`` / ``study_name`` so the existing model.pkl-based
+    Optuna study continuation keeps working.
+    """
+    from lizystudio.backends.types import DataRef
+    from lizystudio.services.jobs import JobStore
+    from lizystudio.services.training_retune import run_retune
+
+    job_store = JobStore(tmp_path / "jobs")
+    parent = job_store.create_and_claim_active(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=DataRef(
+            source_type="path",
+            path="/data/x.csv",
+            filename="x.csv",
+            fingerprint="f",
+            shape=(10, 2),
+        ),
+        job_type="tune",
+    )
+    assert parent is not None
+    parent.status = "completed"
+    job_store.update(parent)
+    job_store.release_active(parent.job_id)
+    parent_dir = job_store.job_dir(parent.job_id)
+    (parent_dir / "model.pkl").write_bytes(b"stub")
+
+    child = job_store.create(
+        backend_name="lizyml",
+        config=parent.config,
+        data_ref=parent.data_ref,
+        job_type="tune",
+        parent_job_id=parent.job_id,
+    )
+    assert job_store.claim_active(child.job_id)
+
+    backend = MagicMock()
+    backend.load_checkpoint.return_value = MagicMock()
+    backend.create_model.return_value = MagicMock()
+    backend.tune.return_value = TuningSummary(
+        best_params={"lr": 0.1},
+        best_score=0.9,
+        trials=[],
+        metric_name="auc",
+        direction="maximize",
+    )
+    backend.fit.return_value = FitSummary(metrics={}, fold_count=1, params=[])
+    backend.export_model = MagicMock()
+    backend.plot.return_value = MagicMock(plotly_json="{}")
+
+    # Bypass the pickle preflight + checkpoint copy via the
+    # ``monkeypatch`` fixture so pytest auto-restores at teardown
+    # and the patches do not leak into other tests
+    # (see test_training_service.py:test_run_retune_*).
+    monkeypatch.setattr(
+        "lizystudio.services.training_retune._copy_checkpoint_to_child",
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        "lizystudio.services.training_retune._run_pickle_preflight",
+        MagicMock(),
+    )
+
+    run_retune(
+        parent_job=parent,
+        child_job=child,
+        job_store=job_store,
+        backend=backend,
+        dataframe=MagicMock(),
+        n_trials=3,
+        expand_boundary=None,
+        boundary_threshold=None,
+        broadcaster=None,
+    )
+
+    backend.tune.assert_called()
+    for call in backend.tune.call_args_list:
+        _, kwargs = call
+        assert "storage" not in kwargs, (
+            "Re-tune must keep using the legacy in-memory study; "
+            f"saw storage={kwargs.get('storage')!r}"
+        )
+        assert "study_name" not in kwargs, (
+            f"saw study_name={kwargs.get('study_name')!r}"
+        )


### PR DESCRIPTION
## Summary

v3-20b (P-0099 R-1.4) — second implementation PR for Tune long-run resumability. Plumbs lizyml 0.12.0's persistent-storage Optuna kwargs (`storage` + `study_name`, H-0072) through the BackendAdapter Protocol + the lizyml adapter + the `run_tune` launcher.

After this PR, every fresh tune job persists its trial state to a per-job SQLite database under the job directory. The actual `paused`/`unpause` state machine plumbing arrives in v3-20c — this PR sets up the storage substrate it depends on. Re-tune (H-0062) is intentionally left on the legacy in-memory study path; harmonising re-tune with persistent storage is a v0.6+ concern.

## Changes

### `src/lizystudio/backends/base.py` (Protocol)

`BackendAdapter.tune` widened with two keyword-only optional kwargs:

```python
def tune(
    self,
    model: Any,
    *,
    on_progress: ProgressCallback | None = None,
    re_tune: dict[str, Any] | None = None,
    checkpoint_dir: Any = None,
    resume: bool = False,
    storage: str | None = None,        # new
    study_name: str | None = None,     # new
) -> TuningSummary: ...
```

`None` defaults preserve the legacy in-memory path bit-for-bit, so every existing caller and adapter stays correct without changes. The Protocol docstring documents that adapters which cannot honour `storage` must raise `NotImplementedError` rather than silently ignoring it.

### `src/lizystudio/backends/lizyml/lifecycle_mixin.py`

The lizyml adapter forwards both kwargs to `model.tune` only when at least one is non-None — this avoids changing the call signature for legacy callers that pass `tune(model)` with no kwargs.

The kwargs are injected on every `model.tune` call across multi-round re-tune (the `for round_idx in range(2, n_rounds + 1)` loop), so a re-tune chain re-attaches to the same study identity across rounds when the caller specifies storage + study_name.

### `src/lizystudio/services/training.py`

Two helpers introduced:

- `_build_optuna_storage_url(job_dir) -> "sqlite:///{job_dir}/optuna.db"`. Per-job database — concurrent jobs cannot race on a shared store, and deleting a job directory cleans up the persistent tune state with no extra bookkeeping. Uses `Path.resolve()` so a chdir in a future code path cannot redirect the URL.
- `_build_optuna_study_name(job_id) -> "studio-tune-{job_id}"`. Prefix is cheap insurance against accidental cross-pollution if a future deployment chooses a single shared store.

`run_tune` now passes both into `backend.tune`. `run_retune` (`training_retune.py`) is intentionally untouched — see the `test_run_retune_does_not_pass_storage_kwargs_yet` regression test for the rationale.

### `tests/regression/test_inv_tune_storage_passthrough.py` (new, 9 tests)

| Test | Coverage |
|---|---|
| `test_backend_adapter_tune_protocol_exposes_storage_kwargs` | `BackendAdapter.tune` declares `storage` and `study_name` as keyword-only optional with `None` defaults |
| `test_lizyml_adapter_omits_storage_kwargs_when_both_none` | Legacy in-memory path: no kwargs leak into `model.tune` when the caller passes nothing |
| `test_lizyml_adapter_passes_storage_and_study_name_through` | Both kwargs forwarded verbatim when both provided |
| `test_lizyml_adapter_passes_storage_when_only_one_set` | Half-specified pair still forwards both kwargs so lizyml's validator rejects, instead of silently dropping the caller's intent |
| `test_lizyml_adapter_storage_kwargs_propagate_through_re_tune_rounds` | Multi-round re-tune carries the same study identity on every `model.tune` call so Optuna re-attaches |
| `test_build_optuna_storage_url_per_job` | URL form: `sqlite:///{absolute_job_dir}/optuna.db` |
| `test_build_optuna_study_name_uses_job_id_prefix` | Identifier form: `studio-tune-{job_id}` |
| `test_run_tune_passes_storage_kwargs_to_backend` | End-to-end through `run_tune` — backend receives the per-job URL + matching identifier |
| `test_run_retune_does_not_pass_storage_kwargs_yet` | Re-tune (H-0062) keeps using the legacy in-memory study path; v0.6+ concern documented inline |

## Why this is non-breaking

- New adapter kwargs default to `None` — every existing caller works unchanged.
- The lizyml adapter omits the kwargs from `model.tune` when both are `None`, so the call signature against lizyml ≤ 0.11 (which doesn't know `storage`) is unchanged for legacy code paths. New code paths only run on lizyml ≥ 0.12.0 (already pinned in `pyproject.toml`).
- Re-tune is explicitly out-of-scope — pinned with a regression test.

## Test plan

- [x] `uv run ruff check .` and `uv run ruff format --check .` green
- [x] `uv run mypy src/lizystudio/` green (55 source files)
- [x] `uv run pytest tests/regression/test_inv_tune_storage_passthrough.py -v`: **9 passed**
- [ ] Full backend suite via CI (currently running locally)

## Phase status after this PR

| Phase | Status |
|---|---|
| v3-17 / v3-18 / v3-19 / v3-20-prep / v3-20a | Done |
| **v3-20b** | This PR |
| v3-20c (`JobStore.request_pause` + `PausedError` + `_run_job_core` paused branch — flips `test_inv_state_machine` runtime-guard xfail to green) | Next |
| v3-20d / v3-20e / v3-20f / v3-20g | Sequenced after v3-20c |
| v3-21 (subsumed by #366) | — |
| v3-22 / v3-23 / v3-24 / v3-25 / v3-26 | After v3-20 |
