### PR TITLE
docs(v3-20): handoff doc for next session — v3-20c next (P-0099 R-1.4)

### DIFF
--- a/docs/v3-20-handoff-2026-05-06.md
+++ b/docs/v3-20-handoff-2026-05-06.md
@@ -1,0 +1,185 @@
+# v3-20 (R-1.4 Tune Resume) 引き継ぎ資料 — 2026-05-06
+
+> **Status**: 🟡 進行中 — v3-20-prep / v3-20a 完了、v3-20b マージ待ち、v3-20c〜g 未着手
+> **次セッションの最優先タスク**: PR #418 マージ確認 → develop sync → v3-20c 着手
+> **設計の根拠**: `docs/v3-20-tune-resume-design.md` (Approved 2026-05-06)
+
+---
+
+## 1. 現在の状況スナップショット
+
+### 1.1 ブランチ / マージ済 PR
+
+| PR | タイトル | 状態 | コミット先 |
+|---|---|---|---|
+| #411 | chore(deps,docs): bump lizyml 0.11 -> 0.12 + approve P-0099 + reflect v0.5 unblock | ✅ Merged | develop |
+| #412 | test(regression): INV-1 / INV-5 slot-release invariant matrix (v3-17) | ✅ Merged | develop |
+| #413 | test(e2e): INV-1 paths 5+6 / INV-7 slot-release Playwright spec (v3-17c) | ✅ Merged | develop |
+| #414 | test(regression): cancel + completion interleaving + v3-18/v3-21 rescope | ✅ Merged | develop |
+| #415 | feat(storage,test): INV-2 fsync durability + INV-6 crash recovery (v3-19) | ✅ Merged | develop |
+| #416 | docs(plan,history): v3-20 tune resumability design doc landing (v3-20-prep) | ✅ Merged | develop |
+| #417 | feat(storage,api): format_version 1->2 + Job.status "paused" (v3-20a) | ✅ Merged | develop |
+| **#418** | **feat(backends,services): tune storage / study_name passthrough (v3-20b)** | 🟡 **CI Pending + auto-merge** | develop |
+
+### 1.2 現在のローカル状態
+
+- **ブランチ**: `feat/v3-20b-backend-adapter-storage` (#418 のソースブランチ)
+- **作業ツリー**: clean
+- **次セッション開始時の手順**:
+  1. `gh pr view 418 --json state` で MERGED を確認
+  2. `git checkout develop && git pull origin develop`
+  3. v3-20c のブランチを作成: `git checkout -b feat/v3-20c-pause-primitives`
+
+---
+
+## 2. v3-20 全体ロードマップ
+
+| Sub-phase | 内容 | 状態 |
+|---|---|---|
+| v3-20-prep | 設計レビュー資料 landing | ✅ Done (#416) |
+| v3-20a | format_version 1→2 + `Job.status="paused"` 拡張 | ✅ Done (#417) |
+| v3-20b | BackendAdapter `tune(storage=, study_name=)` passthrough | 🟡 PR #418 |
+| **v3-20c** | **`JobStore.request_pause` + `PausedError` + `_run_job_core` paused 分岐** | ⏳ **次セッション** |
+| v3-20d | `POST /jobs/{id}/pause` + `/unpause` API | ⏳ |
+| v3-20e | `WsPaused` WS message + frontend handler | ⏳ |
+| v3-20f | Frontend Pause/Resume buttons | ⏳ |
+| v3-20g | Invariants + Playwright tune-resume E2E | ⏳ |
+
+---
+
+## 3. v3-20c の着手プラン (次セッションの最優先)
+
+### 3.1 スコープ
+
+設計資料 §3.3 の通り、3 つのファイルに変更が入ります:
+
+1. **`src/lizystudio/backends/exceptions.py`**: 新例外 `PausedError` を追加 (`CancelledError` と同様のパターン)
+2. **`src/lizystudio/services/jobs.py:JobStore`**: 新メソッド 3 件
+   - `request_pause(job_id)` — in-memory set + cancel と同じ disk flag IPC パターン
+   - `is_pause_requested(job_id)` — bool 返却
+   - `clear_pause(job_id)` — finally で呼ぶ
+3. **`src/lizystudio/services/_training_core.py`**:
+   - `_make_cancel_aware_cb` 内で cancel チェックの後に pause チェック追加 → `PausedError` raise
+   - `_run_job_core` に `except PausedError` 分岐: `status = "paused"`, `completed_at = None`, broadcaster 通知 (v3-20e で `send_paused` 追加)
+   - **重要**: finally ブロックで status="paused" の場合は `release_active` / `clear_cancel` を **skip** する
+   - 状態遷移ガード: `JobStore.set_status(job_id, new_status)` を新規追加し、`(current, new)` が `LEGAL_TRANSITIONS` にあることを assert
+
+### 3.2 v3-20c で flip させる xfail
+
+**`tests/regression/test_inv_state_machine.py::test_runtime_guard_rejects_illegal_transitions`** を `xfail(strict=True)` から green に flip。新規 `JobStore.set_status` を呼んで illegal transitions が `AssertionError` を raise することを assert。
+
+### 3.3 v3-20c 用の新規テスト
+
+新規 `tests/regression/test_inv_pause_keeps_slot.py` を作成:
+
+- `test_paused_state_does_not_release_slot`: `_run_job_core` が PausedError を catch したとき active_job_id が解放されないことを assert (INV-1 拡張)
+- `test_paused_state_clears_pause_flag_only_after_terminal_transition`: paused → unpaused で再走時、pause flag が clear されること
+- `test_request_pause_is_observable_at_cb_boundary`: cancel と同じパターンで cb 経由で `PausedError` が raise されること
+- `test_8_concurrent_pause_during_tune_count_balanced`: count-based assertion (memory `feedback_count_budget_assertions` lesson)
+
+### 3.4 既存コードの paused 対応 (v3-20c の scope に含む)
+
+audit で見つかった「`status in ("pending", "running")` を check している箇所」のうち paused も含めるべきもの:
+
+| ファイル:行 | 現在の挙動 | v3-20c 後の挙動 |
+|---|---|---|
+| `src/lizystudio/api/jobs.py:233` `cancel_job` | `if status != "running": raise` | paused も cancel 可能に拡張 (案 a) |
+| `src/lizystudio/api/jobs.py:203,215` cascade delete | pending/running の child を cancel | paused も対象に追加 |
+| `src/lizystudio/services/jobs.py:419` orphan terminate | running の orphan を terminate | paused も再 attach 可能性ありなので慎重に対応 (v3-22 まで延期可能) |
+| `src/lizystudio/services/jobs.py:642` `_is_slot_holder_stale_locked` | terminal 3 状態を stale 判定 | paused は stale ではない (slot 保持) — 変更不要 |
+| `src/lizystudio/services/subprocess_runner.py:255` reconcile | pending/running を `failed` に reconcile | paused は reconcile しない (paused は意図的状態) |
+
+### 3.5 PR サイズ目安
+
+- 実装: `exceptions.py` (~10 行), `jobs.py` (~80 行), `_training_core.py` (~40 行), `api/jobs.py` (~10 行)
+- テスト: `test_inv_pause_keeps_slot.py` (新規, 4 件 ~150 行), `test_inv_state_machine.py` (xfail flip ~5 行)
+- **合計 ~300 行 + 数件の整合修正**
+
+---
+
+## 4. v3-20c 着手前のチェックリスト
+
+新セッション開始時に必ず以下を確認:
+
+- [ ] `git status` が clean
+- [ ] `git log --oneline -5` の HEAD に v3-20b (#418) のコミットがある (= マージ済)
+- [ ] develop が origin/develop と同期済
+- [ ] `uv run pytest tests/regression/test_inv_state_machine.py -v` で 7 passed + 1 xfail
+- [ ] `uv run pytest tests/regression/test_inv_tune_storage_passthrough.py -v` で 9 passed
+- [ ] `docs/v3-20-tune-resume-design.md` を読んで全体感を再確認
+
+---
+
+## 5. v3-20 設計判断 (採用済 — 変更しないこと)
+
+設計資料 §6 で確定した 5 件:
+
+1. **API 設計 (案 B)** — 新規 `POST /api/jobs/{id}/unpause` を追加。既存 `/resume` (failed→child job) は変更しない
+2. **paused 中の Cancel UX (案 a)** — paused 状態でも `POST /cancel` 有効、UI で「Resume か Cancel が必要」を明示
+3. **format_version 順序** — v3-20 で v1→v2 を導入し、v3-25 で migration matrix CI gate
+4. **Playwright tune-resume** — 1 trial=1s mock、24h 実機テストは defer
+5. **Optuna storage** — SQLite (`sqlite:///`) で着手、lock 競合があれば JournalFileStorage 検討
+
+---
+
+## 6. 重要なリスクと既知の問題 (v3-20 期間中)
+
+設計資料 §4 のリスクレジスタ:
+
+| ID | リスク | 対応方針 |
+|---|---|---|
+| R-1 | Subprocess + pause の同期点 | 既存 `_make_cancel_aware_cb` パターン拡張で対応 |
+| R-2 | paused が slot 占有する usability 低下 | UI 明示通知 + Cancel 経路 (案 a) で緩和 |
+| R-3 | Optuna sqlite ロック競合 | 実装中に確認、必要なら lizyml に Issue (実装後発生時) |
+| R-4 | format_version=2 の外部影響 | v3-20 → v3-25 順固定で緩和 |
+| R-5 | server restart で paused 復元 | v3-22 R-1.5b に切り分け |
+
+---
+
+## 7. 関連ドキュメント (新セッションで読むべきもの)
+
+| ドキュメント | 用途 |
+|---|---|
+| `docs/v3-20-tune-resume-design.md` | v3-20 全体設計 (Approved 2026-05-06) |
+| `PLAN.md` v3-20 セクション (lines ~1326-1370) | 各 sub-phase の DoD と進捗 |
+| `HISTORY.md` P-0099 (lines 3187-3290) | Change Gate Proposal、Approved 状態、設計判断記録 |
+| `docs/ROADMAP.md` §7 Tier 4 phase 表 | Next Action ROI 順 |
+| `tests/regression/test_inv_state_machine.py` | INV-3 legal transitions 宣言 (v3-20c で xfail flip) |
+| `tests/regression/test_inv_tune_storage_passthrough.py` | v3-20b の契約 |
+
+---
+
+## 8. v0.5 R-1 全体の進捗 (v3-20 完了後の見通し)
+
+| Phase | 状態 |
+|---|---|
+| v3-17 (R-1.1 Slot release 6 経路) | ✅ Done |
+| v3-18 (R-1.2 Cancel + completion interleaving) | ✅ Done (rescoped) |
+| v3-19 (R-1.3 INV-2 fsync + INV-6 crash recovery) | ✅ Done (rescoped) |
+| **v3-20 (R-1.4 Tune resume)** | 🟡 **2/8 sub-phase done** |
+| ~~v3-21 (R-1.5 job-num drift)~~ | ❌ Subsumed by PR #366 |
+| v3-22 (R-1.5b Server Restart Recovery) | ⏳ v3-20 後 |
+| v3-23 (R-2.1 WS 再接続) | ⏳ v3-22 後 |
+| v3-24 (R-2.2 Browser reload 復元) | ⏳ v3-23 後 |
+| v3-25 (R-4.1 format_version migration matrix CI) | ⏳ v3-20a の v2 を gating |
+| v3-26 (R-4.2 Pickle compatibility) | ⏳ v3-25 と並行可 |
+
+v3-20 完了で v0.5 R-1 の主要 5/6 が片付き、R-2 / R-4 + v3-22 を残すのみ。**v0.5 リリースまでの残期間は約 6-8 週間** の見積。
+
+---
+
+## 9. 注意事項
+
+- **#418 がマージされる前に v3-20c に着手してはいけない**: v3-20c は v3-20a の `Job.status="paused"` Literal と v3-20b の storage passthrough 両方に依存します
+- **Auto-merge は CI 全 green の後に発火**: e2e-chromium だけが pending の場合 ~14 分待つ
+- **コミットメッセージは英語**: 既存の `feat(scope): ... (v3-20X, P-0099 R-1.4)` パターンを踏襲
+- **PR タイトルも英語**: `validate-pr-language.sh` hook が日本語をブロック
+- **Frontend `schema.d.ts` 再生成**: backend で API model を変更したら必ず再生成 (v3-20a で経験した drift 失敗の再発防止)
+  ```bash
+  uv run python -c "from fastapi.testclient import TestClient; from lizystudio.server import create_app; import json, pathlib; pathlib.Path('/tmp/openapi.json').write_text(json.dumps(TestClient(create_app()).get('/openapi.json').json()))"
+  cd frontend && ./node_modules/.bin/openapi-typescript /tmp/openapi.json -o src/api/generated/schema.d.ts
+  ```
+
+---
+
+最終更新: 2026-05-06、セッション終了時。次セッション開始時に最初に読むこと。


### PR DESCRIPTION
## Summary

Lands `docs/v3-20-handoff-2026-05-06.md` so a fresh Claude session can resume v3-20c (R-1.4 pause primitives) with full context. Docs only — no production code changes.

## Why a separate PR

The handoff doc references PR #418 (v3-20b BackendAdapter passthrough) extensively but is intentionally unrelated to the source files there. Landing the handoff as its own scope-pure PR keeps the v3-20b review focused on the backend adapter + storage URL contract.

## Contents of the handoff doc

| Section | Purpose |
|---|---|
| §1 Status snapshot | Tracks every PR landed for v0.5 R-1 (411..418); flags #418 as auto-merge pending |
| §2 v3-20 roadmap | Sub-phase status table: prep/a done, b merging, c-g pending |
| §3 v3-20c kickoff plan | Files to touch (`exceptions.py` / `jobs.py` / `_training_core.py`), xfail to flip (`test_runtime_guard_rejects_illegal_transitions`), new test file outline (`test_inv_pause_keeps_slot.py`), audit of `status in ("pending", "running")` callsites |
| §4 Pre-flight checklist | What to verify before writing code in the next session |
| §5 Approved design decisions | Pinned 5 items from `docs/v3-20-tune-resume-design.md` §6 |
| §6 Risk register | R-1..R-5 with mitigation pointers |
| §7 Reference doc list | Reading order for next session |
| §8 v0.5 R-1 progress | Overall phase tracker |
| §9 Operational gotchas | Auto-merge timing, `schema.d.ts` regeneration recipe, language constraints |

## Test plan

- [x] `uv run ruff check .` and `uv run ruff format --check .` green (docs file is `.md`, not lint-targeted)
- [ ] CI passes on this PR

## After this PR

Next Claude session reads `docs/v3-20-handoff-2026-05-06.md` first, then runs the pre-flight checklist (§4), then begins v3-20c on a new branch `feat/v3-20c-pause-primitives`.
