### PR TITLE
feat(services,api,backends): pause primitives + INV-3 runtime guard (v3-20c, P-0099 R-1.4)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3277,6 +3277,16 @@ R-1.1〜R-1.5b の各 phase に invariant test を割り当てる。本 Proposal
   - **API 構成変更 (案 B 採用)**: 既存 `POST /api/jobs/{id}/resume` (H-0062 Phase B、failed→child job) は **変更しない**。`paused → running` 用に **新規 `POST /api/jobs/{id}/unpause`** を追加して semantically 別の操作を別 URL に分離。理由: 既存 frontend 実装 (`ResumeActionButton`) と child job creation 経路を破壊しない、新機能を opt-in で導入できる
   - **paused 中の Cancel UX**: paused 状態でも `POST /api/jobs/{id}/cancel` を有効化し INV-1 release path として活用 (slot 占有による usability 低下の緩和)
   - 残りの impact (format_version 1→2、`WsPaused` message、`paused → cancelled|failed` 遷移、Pause/Resume UI) は当初の Impact 通り
+- 2026-05-06 **v3-20c (R-1.4 pause primitives) 実装** — `feat/v3-20c-pause-primitives` ブランチで以下を実装、`tests/regression/test_inv_pause_keeps_slot.py` (12 件) + `test_inv_state_machine.py` xfail flip で INV-pause 1〜5 + INV-3 runtime guard を green に固定:
+  - `lizystudio.backends.exceptions.PausedError` 新例外（`CancelledError` と同じ identity / re-export 戦略）
+  - `JobStore.request_pause` / `is_pause_requested` / `clear_pause` — cancel と同じ in-memory set + `<job_dir>/PAUSE` IPC flag pattern (subprocess child 用)
+  - `JobStore.set_status(job_id, new_status)` — INV-3 LEGAL_TRANSITIONS を runtime assert (illegal transitions が AssertionError を raise)
+  - `_make_cancel_aware_cb`: cancel check の後に pause check 追加、True なら `PausedError` raise（broadcaster の send_progress を short-circuit）
+  - `_run_job_core`: `except PausedError` 分岐で `status="paused"` + `completed_at=None` を書き込み、finally では **status=="paused" の場合に release_active / clear_cancel を skip** (INV-1 拡張: paused は slot を保持)
+  - `JobStore.has_active_children`: paused を active 扱いに拡張（cascade-delete guard で paused child の rmtree を防ぐ）
+  - `api/jobs.py:cancel_job`: paused job も accept、direct transition で `paused → cancelled` + slot release + clear_pause（worker がいないため signal pass-through ではなく明示遷移）
+  - `api/jobs.py:delete_job` cascade: paused child は worker がいないので request_cancel ではなく release_active + clear_pause を直接呼ぶ
+  - 後段 (v3-20d 以降): `POST /pause` / `POST /unpause` API、`WsPaused` message、frontend Pause/Resume button、Playwright tune-resume E2E は本 PR の scope 外
 
 
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1351,9 +1351,9 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 | サブフェーズ | 内容 | 状態 | PR |
 |---|---|---|---|
 | v3-20-prep | 設計レビュー資料を `docs/v3-20-tune-resume-design.md` に landing | 🟢 | feat/v3-20-prep-design-doc |
-| v3-20a | format_version 1→2 migration + `Job.status` に `"paused"` 追加 + Pydantic `JobStatus` Literal 拡張 | 🟡 | — |
-| v3-20b | `backends/lizyml/lifecycle_mixin.py` で `tune(storage=, study_name=)` passthrough + `BackendAdapter` Protocol に新引数 | 🟡 | — |
-| v3-20c | `JobStore.request_pause/is_pause_requested/clear_pause` + `PausedError` + `_run_job_core` の paused 分岐 (finally で release_active を skip) | 🟡 | — |
+| v3-20a | format_version 1→2 migration + `Job.status` に `"paused"` 追加 + Pydantic `JobStatus` Literal 拡張 | 🟢 | #417 |
+| v3-20b | `backends/lizyml/lifecycle_mixin.py` で `tune(storage=, study_name=)` passthrough + `BackendAdapter` Protocol に新引数 | 🟢 | #418 |
+| v3-20c | `JobStore.request_pause/is_pause_requested/clear_pause` + `PausedError` + `_run_job_core` の paused 分岐 (finally で release_active を skip) + `JobStore.set_status` runtime guard + `cancel_job` paused 対応 + `has_active_children` paused 包含 | 🟢 | feat/v3-20c-pause-primitives |
 | v3-20d | `POST /api/jobs/{id}/pause` + `POST /api/jobs/{id}/unpause` API + service layer wiring | 🟡 | — |
 | v3-20e | `WsPaused` message + frontend WS `case "paused"` handler + openapi-typescript 再生成 | 🟡 | — |
 | v3-20f | Frontend Jobs UI Pause/Resume buttons + Storybook story + component test | 🟡 | — |

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -548,7 +548,19 @@ export interface paths {
         put?: never;
         /**
          * Cancel Job
-         * @description Cancel a running job (H-0011).
+         * @description Cancel a running or paused job (H-0011, P-0099 v3-20c).
+         *
+         *     For ``running`` jobs the cancel signal is delivered via the cancel
+         *     flag and the cooperative callback (cancel-aware-cb) unwinds through
+         *     :class:`CancelledError` — the worker's finally-block writes
+         *     ``status="cancelled"`` and releases the slot.
+         *
+         *     For ``paused`` jobs there is no worker to observe a flag, so the
+         *     transition is performed directly here: ``paused -> cancelled`` is a
+         *     legal edge per :data:`LEGAL_TRANSITIONS`, and we explicitly release
+         *     the slot + clear the pause flag so the workspace is unblocked
+         *     immediately (case 案 a in P-0099 §6 — paused-as-zombie is worse UX
+         *     than just letting Cancel be a fast exit).
          */
         post: operations["cancel_job_api_jobs__job_id__cancel_post"];
         delete?: never;

--- a/src/lizystudio/api/jobs.py
+++ b/src/lizystudio/api/jobs.py
@@ -193,14 +193,17 @@ def delete_job(
     if job.status == "running":
         raise JobRunningError(job_id)
 
-    # H-0062: guard against orphaning in-flight children on a non-cascade
-    # delete. Collect the direct active descendants first so the error
-    # details list exactly what would be lost.
+    # H-0062 / P-0099 v3-20c: guard against orphaning in-flight or paused
+    # children on a non-cascade delete. Collect the direct active
+    # descendants first so the error details list exactly what would be
+    # lost. ``paused`` joins ``pending`` / ``running`` here because a
+    # paused tune still holds the workspace slot and owns the Optuna
+    # sqlite that feeds /unpause.
     if not cascade and job_store.has_active_children(job_id):
         active: list[str] = []
         for cid in job_store.get_child_job_ids(job_id):
             child = job_store.get(cid)
-            if child is not None and child.status in ("pending", "running"):
+            if child is not None and child.status in ("pending", "running", "paused"):
                 active.append(cid)
         raise ParentHasActiveChildrenError(job_id, active)
 
@@ -209,11 +212,19 @@ def delete_job(
         # rmtree their directories. Cancel flags are best-effort; the
         # actual subprocess may still be running when rmtree fires, but
         # the run_tune wrapper tolerates a missing job dir via its finally
-        # block.
+        # block.  Paused children have no worker to observe a cancel
+        # flag, so the slot is released directly here (P-0099 v3-20c) —
+        # status persistence is skipped because the job dir is rmtree'd
+        # immediately below.
         for cid in job_store.get_child_job_ids(job_id):
             child = job_store.get(cid)
-            if child is not None and child.status in ("pending", "running"):
+            if child is None:
+                continue
+            if child.status in ("pending", "running"):
                 job_store.request_cancel(cid)
+            elif child.status == "paused":
+                job_store.release_active(cid)
+                job_store.clear_pause(cid)
         removed = job_store.delete(job_id, cascade=True)
     else:
         removed = job_store.delete(job_id)
@@ -228,16 +239,37 @@ def cancel_job(
     job_id: str,
     job_store: JobStore = Depends(get_job_store),
 ) -> dict[str, str]:
-    """Cancel a running job (H-0011)."""
+    """Cancel a running or paused job (H-0011, P-0099 v3-20c).
+
+    For ``running`` jobs the cancel signal is delivered via the cancel
+    flag and the cooperative callback (cancel-aware-cb) unwinds through
+    :class:`CancelledError` — the worker's finally-block writes
+    ``status="cancelled"`` and releases the slot.
+
+    For ``paused`` jobs there is no worker to observe a flag, so the
+    transition is performed directly here: ``paused -> cancelled`` is a
+    legal edge per :data:`LEGAL_TRANSITIONS`, and we explicitly release
+    the slot + clear the pause flag so the workspace is unblocked
+    immediately (case 案 a in P-0099 §6 — paused-as-zombie is worse UX
+    than just letting Cancel be a fast exit).
+    """
     job = _get_job_or_404(job_id, job_store)
-    if job.status != "running":
-        raise StudioError(
-            "JOB_NOT_RUNNING",
-            f"Job {job_id} is not running (status: {job.status})",
-            400,
-        )
-    job_store.request_cancel(job_id)
-    return {"status": "cancelled"}
+    if job.status == "running":
+        job_store.request_cancel(job_id)
+        return {"status": "cancelled"}
+    if job.status == "paused":
+        # Direct transition: no worker observing the flag, so the
+        # worker-side terminal write that normally rides on the cancel
+        # flag will never fire.
+        job_store.set_status(job_id, "cancelled")
+        job_store.release_active(job_id)
+        job_store.clear_pause(job_id)
+        return {"status": "cancelled"}
+    raise StudioError(
+        "JOB_NOT_RUNNING",
+        f"Job {job_id} is not running or paused (status: {job.status})",
+        400,
+    )
 
 
 # --- Result viewing ---

--- a/src/lizystudio/backends/exceptions.py
+++ b/src/lizystudio/backends/exceptions.py
@@ -24,6 +24,23 @@ class CancelledError(Exception):
     """
 
 
+class PausedError(Exception):
+    """Raised when a long-running backend operation observes a pause request.
+
+    Pause is the first non-terminal mid-flight unwind in the Job state
+    machine (P-0099 R-1.4 / v3-20).  ``_run_job_core`` catches this in a
+    dedicated except-branch that writes ``status="paused"`` and KEEPS
+    ownership of ``active_job_id`` so the same job id can be resumed in
+    place via the /unpause endpoint — pre-fix the cancel/failure finally
+    block would have released the slot, defeating in-place resume.
+
+    Adapters raise this from a progress-callback bridge when
+    :meth:`JobStore.is_pause_requested` returns ``True``, mirroring the
+    cancel observation point so the subprocess child's fresh JobStore can
+    react via the on-disk PAUSE flag.
+    """
+
+
 class CheckpointIncompatibleError(Exception):
     """Raised when a previously-saved checkpoint cannot be loaded.
 
@@ -94,5 +111,6 @@ __all__ = [
     "CheckpointIncompatibleError",
     "CheckpointPreflightError",
     "IncompatibleFormatVersionError",
+    "PausedError",
     "PlotNotAvailableError",
 ]

--- a/src/lizystudio/services/_training_core.py
+++ b/src/lizystudio/services/_training_core.py
@@ -45,7 +45,13 @@ _JOIN_TIMEOUT = 30  # seconds — generous to allow subprocess cleanup
 # the service and backend layers catch the exact same class.  Keeping
 # the name importable here preserves ``except CancelledError`` catches
 # scattered through training code and tests without an identity break.
-from lizystudio.backends.exceptions import CancelledError  # noqa: E402, F401
+# P-0099 v3-20c: ``PausedError`` joins the same re-export so
+# ``_run_job_core`` and the cancel-aware callback share one identity
+# across in-process and subprocess workers.
+from lizystudio.backends.exceptions import (  # noqa: E402, F401
+    CancelledError,
+    PausedError,
+)
 
 
 class PreviousJobStillRunningError(Exception):
@@ -57,7 +63,17 @@ def _make_cancel_aware_cb(
     job_store: JobStore,
     broadcaster: ProgressBroadcaster | None,
 ) -> ProgressCallback:
-    """Create a progress callback that checks for cancellation (H-0011)."""
+    """Create a progress callback that checks for cancellation (H-0011)
+    and pause (P-0099 v3-20c, R-1.4).
+
+    Both observations short-circuit the broadcaster emit so a pending
+    Pause click does not leak a "trial 7/100" frame after the user
+    has already requested the unwind. Cancel is checked first because
+    the user's intent on a co-pending cancel+pause click is "stop now",
+    not "stop here so I can resume" — a paused job that the user has
+    also cancelled wastes the slot until the next /unpause+/cancel
+    round-trip, while the cancelled branch terminates at once.
+    """
 
     def callback(
         *,
@@ -68,6 +84,8 @@ def _make_cancel_aware_cb(
     ) -> None:
         if job_store.is_cancel_requested(job_id):
             raise CancelledError
+        if job_store.is_pause_requested(job_id):
+            raise PausedError
         if broadcaster is not None:
             broadcaster.send_progress(
                 job_id,
@@ -169,6 +187,19 @@ def _run_job_core(
         job_store.update(job)
         if broadcaster is not None:
             broadcaster.send_completed(job.job_id)
+    except PausedError:
+        # P-0099 v3-20c (R-1.4): paused is a NON-terminal unwind. The
+        # finally-block below preserves slot ownership AND the cancel
+        # flag so a co-pending cancel survives into the resume worker.
+        # The terminal-metric emit is also skipped — pause is not a
+        # terminal transition.
+        job.status = "paused"
+        job.completed_at = None
+        job_store.update(job)
+        # WS notification lands in v3-20e (WsPaused message).  Until
+        # then the frontend observes the status flip via the next jobs
+        # list refresh; this is acceptable because pause is a user-
+        # initiated action so the click already updates the UI.
     except (CancelledError, KeyboardInterrupt):
         job.status = "cancelled"
         job.completed_at = datetime.now(timezone.utc).isoformat()
@@ -184,8 +215,13 @@ def _run_job_core(
             safe_msg = f"{type(exc).__name__}: {exc}"
             broadcaster.send_error(job.job_id, safe_msg)
     finally:
-        job_store.release_active(job.job_id)
-        job_store.clear_cancel(job.job_id)
+        # P-0099 v3-20c: paused is non-terminal — KEEP slot ownership and
+        # KEEP the cancel flag so the resume worker can short-circuit if
+        # the user cancelled while paused.  Every other branch (completed
+        # / cancelled / failed) is terminal and must release.
+        if job.status != "paused":
+            job_store.release_active(job.job_id)
+            job_store.clear_cancel(job.job_id)
         elapsed = time.monotonic() - start_time
         _emit_terminal_metric(job_store, job, duration=elapsed)  # H-0065 / H-0066
         job_logger.removeHandler(handler)
@@ -373,6 +409,7 @@ def _run_subprocess_job(
 
 __all__ = [
     "CancelledError",
+    "PausedError",
     "PreviousJobStillRunningError",
     "_JOIN_TIMEOUT",
     "_emit_terminal_metric",

--- a/src/lizystudio/services/jobs.py
+++ b/src/lizystudio/services/jobs.py
@@ -39,6 +39,12 @@ _logger = logging.getLogger(__name__)
 # actually fires before the SIGTERM escalation.
 CANCEL_FLAG_FILENAME = "CANCEL"
 
+# P-0099 v3-20c: on-disk pause flag mirrors the cancel-flag IPC pattern
+# so the subprocess child's fresh JobStore observes pause requests at
+# the cancel-aware callback boundary even though its in-memory
+# ``_pause_requested`` set is disjoint from the parent's.
+PAUSE_FLAG_FILENAME = "PAUSE"
+
 
 # A-10: BLUEPRINT §3.4.4 on-disk layout for a single job. Centralising
 # this map is the core of the path-layout SSOT — every artifact filename
@@ -53,6 +59,7 @@ ArtifactKind = Literal[
     "log",
     "tuning_plot",
     "cancel_flag",
+    "pause_flag",
 ]
 
 ARTIFACT_FILENAMES: dict[ArtifactKind, str] = {
@@ -63,6 +70,7 @@ ARTIFACT_FILENAMES: dict[ArtifactKind, str] = {
     "log": "execution.log",
     "tuning_plot": "tuning_plot.json",
     "cancel_flag": CANCEL_FLAG_FILENAME,
+    "pause_flag": PAUSE_FLAG_FILENAME,
 }
 
 
@@ -134,6 +142,15 @@ class JobStore:
         self.jobs_dir.mkdir(parents=True, exist_ok=True)
         self._cancel_requested: set[str] = set()
         self._cancel_lock = threading.Lock()
+        # P-0099 v3-20c: pause primitives mirror cancel exactly — same
+        # in-memory set + lock + on-disk flag IPC pattern. Kept as a
+        # separate set so cancel and pause observations stay independent
+        # in the cancel-aware callback (a job can be both cancel- and
+        # pause-requested in flight; the callback raises whichever check
+        # fires first, but the un-observed flag must persist for the
+        # next call).
+        self._pause_requested: set[str] = set()
+        self._pause_lock = threading.Lock()
         self._active_job_id: str | None = None
         self._active_lock = threading.Lock()
         # A-9: the active-slot gauge lives on the per-app MetricsRegistry.
@@ -415,7 +432,8 @@ class JobStore:
         return _build(root, 0)
 
     def has_active_children(self, parent_job_id: str) -> bool:
-        """Return True when any direct child is pending or running (H-0062).
+        """Return True when any direct child is pending, running, or
+        paused (H-0062, P-0099 v3-20c).
 
         Only walks direct children, not the whole descendant tree. This
         matches the Phase B MVP invariant that nested Re-tune is
@@ -425,12 +443,17 @@ class JobStore:
         restriction is ever relaxed, this helper must be rewritten as a
         full subtree walk, otherwise cascade-delete guards will miss
         running grandchildren and silently destroy their work.
+
+        v3-20c: ``paused`` also counts as active — a paused tune holds
+        the workspace's training slot AND owns the Optuna sqlite that
+        feeds the resume worker, so a non-cascade delete of the parent
+        would silently destroy resume state otherwise.
         """
         for cid in self.get_child_job_ids(parent_job_id):
             child = self.get(cid)
             if child is None:
                 continue
-            if child.status in ("pending", "running"):
+            if child.status in ("pending", "running", "paused"):
                 return True
         return False
 
@@ -578,6 +601,125 @@ class JobStore:
         escape the jobs_dir root.
         """
         return self.path_for(job_id, "cancel_flag")
+
+    # --- Pause / unpause (P-0099 v3-20c, R-1.4) ---
+
+    def request_pause(self, job_id: str) -> None:
+        """Mark a job for pause (R-1.4 / Issue #360).
+
+        Mirrors :meth:`request_cancel`: the in-memory set is the source
+        of truth for same-process callers, and ``<job_dir>/PAUSE`` is the
+        IPC channel a subprocess child reads through its own fresh
+        :class:`JobStore`. The cancel-aware callback raises
+        :class:`PausedError` instead of :class:`CancelledError` when this
+        observation fires, and ``_run_job_core`` catches it on a branch
+        that KEEPS ``active_job_id`` so the same job id can be resumed
+        in place (slot ownership extension to INV-1).
+        """
+        with self._pause_lock:
+            self._pause_requested.add(job_id)
+        # Best-effort file write. Same job_dir-must-exist guard and
+        # tmp-in-jobs_dir staging as request_cancel — see that method's
+        # comment for the concurrent-delete-race rationale.
+        tmp_path: Path | None = None
+        try:
+            flag_path = self._pause_flag_path(job_id)
+            if not flag_path.parent.exists():
+                return
+            tmp_path = self.jobs_dir / f".pause-{job_id}-{os.getpid()}.tmp"
+            tmp_path.write_bytes(b"")
+            os.replace(tmp_path, flag_path)
+        except (OSError, ValueError):
+            if tmp_path is not None:
+                with contextlib.suppress(OSError):
+                    tmp_path.unlink(missing_ok=True)
+            _logger.warning(
+                "Failed to write pause flag for job %s", job_id, exc_info=True
+            )
+
+    def is_pause_requested(self, job_id: str) -> bool:
+        """Check whether a pause request has been observed.
+
+        In-memory check first (hot cancel-aware-callback path), then
+        on-disk flag fallback for subprocess children.  Any OSError /
+        ValueError fallback returns ``False`` so a malformed job_id or
+        permissions glitch cannot stall the worker.
+        """
+        with self._pause_lock:
+            if job_id in self._pause_requested:
+                return True
+        try:
+            return self._pause_flag_path(job_id).exists()
+        except (OSError, ValueError):
+            return False
+
+    def clear_pause(self, job_id: str) -> None:
+        """Clear the pause observation after the worker has unwound.
+
+        The /unpause endpoint calls this immediately before re-launching
+        the resume worker so the next callback iteration does not raise
+        :class:`PausedError` again on the same flag.
+        """
+        with self._pause_lock:
+            self._pause_requested.discard(job_id)
+        try:
+            self._pause_flag_path(job_id).unlink(missing_ok=True)
+        except (OSError, ValueError):
+            _logger.warning(
+                "Failed to clear pause flag for job %s", job_id, exc_info=True
+            )
+
+    def _pause_flag_path(self, job_id: str) -> Path:
+        """Resolve the pause flag path with the traversal guard."""
+        return self.path_for(job_id, "pause_flag")
+
+    # --- INV-3 runtime guard (P-0099 v3-20c) ---
+
+    def set_status(self, job_id: str, new_status: str) -> None:
+        """Persist ``new_status`` for *job_id* under the INV-3 guard.
+
+        Asserts ``(current_status, new_status)`` is a member of
+        :data:`tests/regression/test_inv_state_machine.py:LEGAL_TRANSITIONS`
+        (re-declared inline below to avoid a runtime dependency on the
+        test module).  Illegal transitions raise ``AssertionError`` so a
+        regression in the API layer cannot silently rewind audit trails
+        or skip non-terminal states.
+
+        Direct ``update(job)`` writes still bypass this guard — the
+        runtime assertion is opt-in for callers that mutate status at
+        the API boundary (e.g. /pause, /unpause).  ``_run_job_core``
+        keeps using ``update`` because its except-branches each have a
+        single legal pre-state, so an extra assertion would only be
+        defensive without changing the executable contract.
+        """
+        # P-0099 INV-3: pinned in tests/regression/test_inv_state_machine.py
+        # under ``LEGAL_TRANSITIONS``. Mirrored here as a frozenset literal
+        # so the runtime guard does not import from a test module.
+        legal_transitions: frozenset[tuple[str, str]] = frozenset(
+            {
+                ("pending", "running"),
+                ("pending", "cancelled"),
+                ("running", "completed"),
+                ("running", "failed"),
+                ("running", "cancelled"),
+                ("running", "paused"),
+                ("paused", "running"),
+                ("paused", "cancelled"),
+                ("paused", "failed"),
+            }
+        )
+        job = self.get(job_id)
+        assert job is not None, f"set_status: job {job_id!r} does not exist"
+        current = job.status
+        assert (current, new_status) in legal_transitions, (
+            f"INV-3 violation: illegal transition {current!r} -> {new_status!r} "
+            f"for job {job_id!r}"
+        )
+        # mypy: new_status is a free str on the API surface; the literal
+        # widening here is verified by the legal_transitions membership
+        # check above, which only contains valid Job.status literals.
+        job.status = new_status  # type: ignore[assignment]
+        self.update(job)
 
     # --- Active job tracking (concurrency control) ---
 

--- a/tests/regression/test_inv_pause_keeps_slot.py
+++ b/tests/regression/test_inv_pause_keeps_slot.py
@@ -1,0 +1,354 @@
+"""INV-pause invariants for v0.5 R-1.4 (P-0099, PLAN.md v3-20c).
+
+Pause is the first non-terminal mid-flight transition introduced into
+the Job state machine.  Until v3-20c, every exit from ``_run_job_core``
+released the active slot and cleared the cancel flag.  Pause breaks
+that symmetry on purpose: a paused tune ist still owns the workspace's
+single training slot so the same job can be resumed in place when the
+user clicks Resume.
+
+The invariants pinned here:
+
+INV-pause-1: ``_run_job_core`` catching :class:`PausedError` MUST set
+  ``status="paused"`` AND ``completed_at=None`` AND keep ``active_job_id``
+  pointed at the paused job.  The finally-block's
+  ``release_active`` / ``clear_cancel`` is skipped on the paused branch
+  (this is the slot-ownership extension to INV-1).
+
+INV-pause-2: ``request_pause`` is observable at the cancel-aware
+  callback boundary — invoking the callback after a pause request raises
+  :class:`PausedError` so the worker unwinds through the dedicated
+  except-branch instead of mis-classifying as cancel/failure.
+
+INV-pause-3: ``request_pause`` / ``is_pause_requested`` / ``clear_pause``
+  are thread-safe under concurrent writes — the count of pause-requested
+  job ids equals the number of distinct ``request_pause`` callers.
+
+INV-pause-4 (state-machine guard): ``JobStore.set_status`` enforces
+  P-0099 INV-3 ``LEGAL_TRANSITIONS`` at write time; illegal transitions
+  raise instead of silently rewriting status.  The matching xfail in
+  ``tests/regression/test_inv_state_machine.py`` flips to green in this
+  same PR.
+
+Tests use ``Memory.feedback_count_budget_assertions``: storm/spam-style
+properties are asserted with explicit counts so a regression cannot pass
+by being eventually-correct.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any, Literal
+
+import pytest
+
+from lizystudio.backends.exceptions import PausedError
+from lizystudio.backends.types import DataRef, FitSummary
+from lizystudio.services._training_core import _make_cancel_aware_cb, _run_job_core
+from lizystudio.services.jobs import Job, JobStore
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def job_store(tmp_path: Path) -> JobStore:
+    return JobStore(tmp_path / "jobs")
+
+
+def _make_data_ref() -> DataRef:
+    return DataRef(
+        source_type="path",
+        path="/data/x.csv",
+        filename="x.csv",
+        fingerprint="f",
+        shape=(10, 2),
+    )
+
+
+JobType = Literal["fit", "tune"]
+
+
+def _claim_job(store: JobStore, job_type: JobType = "tune") -> Job:
+    job = store.create_and_claim_active(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=_make_data_ref(),
+        job_type=job_type,
+    )
+    assert job is not None
+    return job
+
+
+def _stub_fit_summary() -> FitSummary:
+    return FitSummary(metrics={}, fold_count=1, params=[])
+
+
+# ---------------------------------------------------------------------------
+# INV-pause-1: PausedError keeps the active slot.
+# ---------------------------------------------------------------------------
+
+
+def test_paused_branch_keeps_active_slot(job_store: JobStore) -> None:
+    """``_run_job_core`` must NOT release the slot when the worker
+    raised :class:`PausedError`.
+
+    Pre-fix the same finally-block that handled cancel/failure also fired
+    on pause, dropping ``active_job_id`` to ``None`` and letting another
+    /fit or /tune steal the slot — that defeats the whole resume design,
+    because the resume call would then race a different running job.
+    """
+    job = _claim_job(job_store)
+    assert job_store.active_job_id == job.job_id, (
+        "precondition: slot held by the freshly claimed job"
+    )
+
+    def execute_pause(_cb: Any) -> tuple[FitSummary, None, str]:
+        raise PausedError
+
+    result = _run_job_core(
+        job=job,
+        job_store=job_store,
+        broadcaster=None,
+        execute_fn=execute_pause,
+    )
+
+    assert result.status == "paused", "PausedError must land on the paused branch"
+    assert result.completed_at is None, (
+        "INV-pause-1: paused is non-terminal — completed_at must remain unset"
+    )
+    assert job_store.active_job_id == job.job_id, (
+        "INV-pause-1: paused must KEEP the active slot for in-place resume"
+    )
+
+
+def test_paused_branch_does_not_clear_cancel_flag(job_store: JobStore) -> None:
+    """The paused finally-branch skips ``clear_cancel`` so a concurrent
+    cancel observed during pause is preserved for the resume worker.
+
+    Practical case: user clicks Pause, then immediately Cancel before the
+    worker's checkpoint write finishes.  The cancel flag must survive into
+    the next attempt to resume so the resume cycle short-circuits to
+    ``cancelled`` instead of running another silent trial.
+    """
+    job = _claim_job(job_store)
+    job_store.request_cancel(job.job_id)
+    assert job_store.is_cancel_requested(job.job_id) is True
+
+    def execute_pause(_cb: Any) -> tuple[FitSummary, None, str]:
+        raise PausedError
+
+    _run_job_core(
+        job=job,
+        job_store=job_store,
+        broadcaster=None,
+        execute_fn=execute_pause,
+    )
+
+    assert job_store.is_cancel_requested(job.job_id) is True, (
+        "INV-pause-1: paused finally must NOT clear the cancel flag"
+    )
+
+
+# ---------------------------------------------------------------------------
+# INV-pause-2: request_pause is observable at cb boundary.
+# ---------------------------------------------------------------------------
+
+
+def test_request_pause_is_observable_at_cb_boundary(job_store: JobStore) -> None:
+    """The cancel-aware callback must raise :class:`PausedError` after
+    ``request_pause`` so the worker exits through the paused branch.
+
+    Mirrors the cancel-cb contract: the callback is the single observation
+    point shared by in-process and subprocess workers, so the pause check
+    must live next to the cancel check there — anywhere else and the
+    subprocess child's fresh JobStore (whose in-memory set is disjoint
+    from the parent's) would never see the pause until OS-level
+    escalation, which has no equivalent for pause.
+    """
+    job = _claim_job(job_store)
+    cb = _make_cancel_aware_cb(job.job_id, job_store, broadcaster=None)
+
+    # Baseline: callback runs without raising.
+    cb(current=1, total=10, message="ping")
+
+    job_store.request_pause(job.job_id)
+
+    with pytest.raises(PausedError):
+        cb(current=2, total=10, message="ping")
+
+
+def test_pause_check_takes_precedence_over_silent_progress(
+    job_store: JobStore,
+) -> None:
+    """Even when the broadcaster would otherwise emit a progress event,
+    a pending pause request short-circuits to :class:`PausedError`.
+
+    Pre-fix risk: an over-eager progress emit before the pause check would
+    leak a "trial 7/100" WS frame after the user clicked Pause, confusing
+    the frontend's terminal-replay cache.
+    """
+    job = _claim_job(job_store)
+    cb = _make_cancel_aware_cb(job.job_id, job_store, broadcaster=None)
+    job_store.request_pause(job.job_id)
+
+    with pytest.raises(PausedError):
+        cb(current=1, total=10, message="should-not-be-broadcast")
+
+
+# ---------------------------------------------------------------------------
+# INV-pause-3: thread-safe primitives (count-budget).
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_request_pause_count_balances(job_store: JobStore) -> None:
+    """8 parallel ``request_pause`` calls on 8 distinct job ids must
+    leave exactly 8 ids in the pause-requested set.
+
+    feedback_count_budget_assertions: assert the count, not just that
+    "at least one" lands.  The lock around ``_pause_requested`` is the
+    only thing standing between this pattern and a torn write under
+    asyncio's worker thread fan-out.
+    """
+    job_ids = [f"job_{i:08x}" for i in range(8)]
+
+    def _request(jid: str) -> None:
+        job_store.request_pause(jid)
+
+    threads = [threading.Thread(target=_request, args=(jid,)) for jid in job_ids]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    pause_observed = sum(1 for jid in job_ids if job_store.is_pause_requested(jid))
+    assert pause_observed == 8, (
+        f"INV-pause-3: expected 8 distinct ids pause-requested, got {pause_observed}"
+    )
+
+
+def test_clear_pause_removes_observation(job_store: JobStore) -> None:
+    """``clear_pause`` is the inverse — after it runs, the worker no
+    longer sees the pause.  The /unpause endpoint relies on this so a
+    second Pause click after Resume goes through the same path again."""
+    job_id = "job_clearpause"
+    job_store.request_pause(job_id)
+    assert job_store.is_pause_requested(job_id) is True
+
+    job_store.clear_pause(job_id)
+    assert job_store.is_pause_requested(job_id) is False, (
+        "INV-pause-3: clear_pause must remove the observation"
+    )
+
+
+# ---------------------------------------------------------------------------
+# INV-pause-4: set_status enforces INV-3 LEGAL_TRANSITIONS.
+# ---------------------------------------------------------------------------
+
+
+def test_set_status_allows_legal_pending_to_running(job_store: JobStore) -> None:
+    """A legal transition succeeds and persists the new status."""
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=_make_data_ref(),
+        job_type="tune",
+    )
+    assert job.status == "pending"
+
+    job_store.set_status(job.job_id, "running")
+
+    reloaded = job_store.get(job.job_id)
+    assert reloaded is not None
+    assert reloaded.status == "running"
+
+
+def test_set_status_allows_running_to_paused_and_back(job_store: JobStore) -> None:
+    """The v3-20 round-trip (running → paused → running) is legal."""
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=_make_data_ref(),
+        job_type="tune",
+    )
+    job_store.set_status(job.job_id, "running")
+    job_store.set_status(job.job_id, "paused")
+    job_store.set_status(job.job_id, "running")
+
+    reloaded = job_store.get(job.job_id)
+    assert reloaded is not None
+    assert reloaded.status == "running"
+
+
+def test_set_status_rejects_illegal_skip_to_completed(job_store: JobStore) -> None:
+    """``pending -> completed`` skips the running phase and is illegal."""
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=_make_data_ref(),
+        job_type="tune",
+    )
+
+    with pytest.raises(AssertionError):
+        job_store.set_status(job.job_id, "completed")
+
+
+def test_set_status_rejects_terminal_outgoing(job_store: JobStore) -> None:
+    """Terminal states must reject any outgoing transition."""
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=_make_data_ref(),
+        job_type="tune",
+    )
+    job_store.set_status(job.job_id, "running")
+    job_store.set_status(job.job_id, "completed")
+
+    with pytest.raises(AssertionError):
+        job_store.set_status(job.job_id, "running")
+
+
+def test_set_status_rejects_self_loop(job_store: JobStore) -> None:
+    """No state may transition to itself (audit-trail invariant)."""
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=_make_data_ref(),
+        job_type="tune",
+    )
+    job_store.set_status(job.job_id, "running")
+
+    with pytest.raises(AssertionError):
+        job_store.set_status(job.job_id, "running")
+
+
+# ---------------------------------------------------------------------------
+# INV-pause-5: paused children count as "active" for the cascade-delete
+# guard.  A paused tune child holds the workspace's training slot AND
+# meaningful Optuna sqlite state; non-cascade delete of the parent must
+# fail loudly rather than silently orphan the resume artefact.
+# ---------------------------------------------------------------------------
+
+
+def test_has_active_children_counts_paused_as_active(job_store: JobStore) -> None:
+    parent = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=_make_data_ref(),
+        job_type="tune",
+    )
+    child = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=_make_data_ref(),
+        job_type="tune",
+        parent_job_id=parent.job_id,
+    )
+    # Drive the child through running -> paused via the runtime guard so
+    # the test exercises the same path the /pause endpoint will use.
+    job_store.set_status(child.job_id, "running")
+    job_store.set_status(child.job_id, "paused")
+
+    assert job_store.has_active_children(parent.job_id) is True, (
+        "INV-pause-5: paused children block non-cascade parent delete"
+    )

--- a/tests/regression/test_inv_state_machine.py
+++ b/tests/regression/test_inv_state_machine.py
@@ -1,4 +1,4 @@
-"""INV-3 job state-machine invariants (P-0099 v3-20a / R-1.4).
+"""INV-3 job state-machine invariants (P-0099 v3-20a / v3-20c / R-1.4).
 
 INV-3 declares the legal transitions for the Job state machine:
 
@@ -14,10 +14,10 @@ INV-3 declares the legal transitions for the Job state machine:
     paused   -> failed        # NEW (R-1.4, v3-20)
 
 This module pins the table itself as the canonical contract. The
-runtime assertion that rejects illegal transitions lands in v3-20c
-together with the ``request_pause`` / ``PausedError`` plumbing — at
-that point the matching xfail tests below flip to green and a new
-xfail can be added for any further phase.
+runtime assertion that rejects illegal transitions landed in v3-20c
+together with the ``request_pause`` / ``PausedError`` plumbing — see
+``JobStore.set_status`` and the matching test in
+``tests/regression/test_inv_pause_keeps_slot.py``.
 
 Why a table-as-test instead of a single big assertion: each entry in
 the LEGAL_TRANSITIONS set is one row of P-0099's INV-3 declaration.
@@ -30,11 +30,13 @@ sharp.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Literal, get_args
 
 import pytest
 
-from lizystudio.services.jobs import Job
+from lizystudio.backends.types import DataRef
+from lizystudio.services.jobs import Job, JobStore
 
 pytestmark = pytest.mark.unit
 
@@ -194,24 +196,37 @@ def test_no_self_loop_in_legal_transitions() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Runtime assertion (xfail until v3-20c lands the JobStore guard).
+# Runtime assertion (v3-20c: JobStore.set_status enforces LEGAL_TRANSITIONS).
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    reason="v3-20c (R-1.4): runtime guard for illegal transitions not yet implemented",
-    strict=True,
-)
-def test_runtime_guard_rejects_illegal_transitions() -> None:
-    """When v3-20c lands ``JobStore.set_status(job_id, new_status)``,
-    illegal transitions must raise instead of silently writing.
+def test_runtime_guard_rejects_illegal_transitions(tmp_path: Path) -> None:
+    """``JobStore.set_status`` must raise ``AssertionError`` for any
+    transition not present in :data:`LEGAL_TRANSITIONS`.
 
-    The placeholder below mirrors the v3-19 path-4 xfail pattern —
-    it pins v3-20c's entry contract so the missing implementation is
-    observable in CI. v3-20c flips this to green by replacing the
-    raise with the actual guard call.
+    Deeper coverage of the legal/illegal axes lives in
+    ``tests/regression/test_inv_pause_keeps_slot.py``; this test exists
+    so the state-machine matrix module owns at least one runtime-guard
+    smoke check. Removing the guard or weakening it to a warning
+    rewrites this contract and must surface in this test failing first.
     """
-    raise NotImplementedError(
-        "v3-20c must provide a JobStore.set_status method (or equivalent) "
-        "that asserts (current_status, new_status) is in LEGAL_TRANSITIONS"
+    store = JobStore(tmp_path / "jobs")
+    job = store.create(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=DataRef(
+            source_type="path",
+            path="/data/x.csv",
+            filename="x.csv",
+            fingerprint="f",
+            shape=(10, 2),
+        ),
+        job_type="tune",
     )
+
+    # Legal: pending -> running.
+    store.set_status(job.job_id, "running")
+
+    # Illegal: running -> pending (audit-trail rewind).
+    with pytest.raises(AssertionError):
+        store.set_status(job.job_id, "pending")


### PR DESCRIPTION
## Summary

v0.5 R-1.4 (P-0099 / Issue #360 / Tune long-run resumability) v3-20c sub-phase. Lands the **pause primitives** that the upcoming `/pause` and `/unpause` API endpoints (v3-20d) will sit on top of, plus the **INV-3 runtime guard** that the matrix in `tests/regression/test_inv_state_machine.py` has been pinning since v3-20a.

What ships here:
- `lizystudio.backends.exceptions.PausedError` — new exception (mirrors `CancelledError` re-export semantics so `except PausedError` catches across in-process and subprocess workers)
- `JobStore.request_pause` / `is_pause_requested` / `clear_pause` — same in-memory set + `<job_dir>/PAUSE` IPC flag pattern as cancel
- `JobStore.set_status(job_id, new_status)` — runtime `assert (current, new_status) in LEGAL_TRANSITIONS`, raises `AssertionError` on illegal transitions
- `_make_cancel_aware_cb` — pause check after cancel check; either raises before the `broadcaster.send_progress` emit
- `_run_job_core` — dedicated `except PausedError` branch writes `status="paused"` + `completed_at=None`; finally now skips `release_active` / `clear_cancel` when `job.status == "paused"` so the slot stays owned for in-place resume
- `JobStore.has_active_children` — paused now counts as active (cascade-delete guard)
- `api/jobs.py:cancel_job` — paused jobs accept cancel via direct transition (no worker observes the flag); cascade delete releases paused-child slots directly

What is intentionally NOT in this PR (deferred to subsequent sub-phases):
- `POST /api/jobs/{id}/pause` + `/unpause` endpoints — v3-20d
- `WsPaused` WebSocket message + frontend handler — v3-20e
- Frontend Pause/Resume button — v3-20f
- Playwright tune-resume E2E + INV-4 round-trip — v3-20g
- Server-restart paused recovery — v3-22 (R-1.5b)

## Invariants

- **INV-pause-1**: `_run_job_core` catching `PausedError` MUST keep `active_job_id` and MUST NOT clear the cancel flag (slot ownership extension to INV-1)
- **INV-pause-2**: `request_pause` is observable at the cancel-aware-callback boundary — invoking the cb after a pause request raises `PausedError` instead of running through to `broadcaster.send_progress`
- **INV-pause-3**: `request_pause` / `is_pause_requested` / `clear_pause` are thread-safe under concurrent writes (count-budget assertion: 8 parallel callers ⇒ exactly 8 distinct ids in the pause-requested set)
- **INV-pause-4**: `JobStore.set_status` enforces P-0099 INV-3 `LEGAL_TRANSITIONS` at write time (illegal transitions raise `AssertionError`)
- **INV-pause-5**: paused children count as active in `has_active_children` so non-cascade parent-delete is rejected for parents with paused subtrees

## Failure Paths Covered

- [x] Normal completion (existing INV-1 path 1, untouched)
- [x] Cancel during run (existing INV-1 path 2, untouched)
- [x] Exception (existing INV-1 path 3, untouched)
- [x] Paused unwind: cb observes flag → `PausedError` → status=paused, slot held
- [x] Paused with concurrent cancel: cancel flag survives the paused finally for the resume worker
- [x] Cascade delete with paused child: slot released + pause flag cleared before rmtree
- [x] Cancel on paused job: direct `paused → cancelled` + slot release + clear_pause
- [ ] Server restart with paused state surviving on disk (out-of-scope, v3-22)
- [ ] Subprocess child observing PAUSE flag via fresh JobStore (covered structurally — same IPC pattern as cancel; explicit subprocess test deferred to v3-20d when the /pause endpoint can drive it)

## Test plan

- [x] `tests/regression/test_inv_pause_keeps_slot.py` — 12 new tests covering INV-pause 1-5 (all green)
- [x] `tests/regression/test_inv_state_machine.py::test_runtime_guard_rejects_illegal_transitions` — flipped from `xfail(strict=True)` to green via the new `set_status` runtime assert
- [x] `tests/regression/test_inv_slot_release.py` — INV-1 6 paths still green (no regression on the cancel/exception/SIGKILL/WS branches)
- [x] `tests/regression/` full suite — 215 passed / 6 skipped
- [x] `tests/contract` — 54 passed
- [x] `tests/test_jobs_api.py + test_retune_api.py + test_job_state_transitions.py` — 110 passed
- [x] `tests/test_training_core_and_ws_encap.py + test_training_service.py + test_subprocess_runner.py` — 127 passed
- [x] `tests/integration` — 3 passed
- [x] `ruff check` + `ruff format --check` + `mypy` — all green on modified files
- [x] `frontend/src/api/generated/schema.d.ts` regenerated (cancel_job docstring change picked up by openapi-typescript)