### PR TITLE
feat(api,services): pause/unpause endpoints + subprocess finally paused-skip (v3-20d, P-0099 R-1.4)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3277,6 +3277,12 @@ R-1.1〜R-1.5b の各 phase に invariant test を割り当てる。本 Proposal
   - **API 構成変更 (案 B 採用)**: 既存 `POST /api/jobs/{id}/resume` (H-0062 Phase B、failed→child job) は **変更しない**。`paused → running` 用に **新規 `POST /api/jobs/{id}/unpause`** を追加して semantically 別の操作を別 URL に分離。理由: 既存 frontend 実装 (`ResumeActionButton`) と child job creation 経路を破壊しない、新機能を opt-in で導入できる
   - **paused 中の Cancel UX**: paused 状態でも `POST /api/jobs/{id}/cancel` を有効化し INV-1 release path として活用 (slot 占有による usability 低下の緩和)
   - 残りの impact (format_version 1→2、`WsPaused` message、`paused → cancelled|failed` 遷移、Pause/Resume UI) は当初の Impact 通り
+- 2026-05-06 **v3-20d (R-1.4 pause/unpause API) 実装** — `feat/v3-20d-pause-unpause-api` ブランチで HTTP エントリーポイント + subprocess parent finally の paused-skip を実装:
+  - `POST /api/jobs/{id}/pause` — tune-only、status=running を要求、`request_pause` を呼ぶ。エラーコード: `JOB_NOT_PAUSEABLE` (fit ジョブ拒否) / `JOB_NOT_RUNNING` (paused/completed 等)
+  - `POST /api/jobs/{id}/unpause` — tune-only、status=paused を要求、ws.dataframe 再ロード必須、`clear_pause` 後に `start_tune_async` を **同 job_id** で呼び（in-place 復帰）。lizyml の Optuna `load_if_exists=True` で trial 継続。エラーコード: `JOB_NOT_PAUSED` / `WORKSPACE_NO_DATA`
+  - `_run_subprocess_job.finally` を修正: child が `status="paused"` を書き込んだ場合は `release_active` を skip (v3-20c の in-process 修正と対称、subprocess mode で見落としていた INV-pause-1 violation を修復)
+  - `tests/test_jobs_api.py` に 10 件の HTTP コントラクトテスト + `tests/regression/test_inv_pause_keeps_slot.py::test_subprocess_finally_keeps_slot_when_child_wrote_paused` 追加
+  - 後続 (v3-20e 以降): `WsPaused` WS message、frontend Pause/Resume button、Playwright tune-resume E2E は本 PR の scope 外
 - 2026-05-06 **v3-20c (R-1.4 pause primitives) 実装** — `feat/v3-20c-pause-primitives` ブランチで以下を実装、`tests/regression/test_inv_pause_keeps_slot.py` (12 件) + `test_inv_state_machine.py` xfail flip で INV-pause 1〜5 + INV-3 runtime guard を green に固定:
   - `lizystudio.backends.exceptions.PausedError` 新例外（`CancelledError` と同じ identity / re-export 戦略）
   - `JobStore.request_pause` / `is_pause_requested` / `clear_pause` — cancel と同じ in-memory set + `<job_dir>/PAUSE` IPC flag pattern (subprocess child 用)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1354,7 +1354,7 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 | v3-20a | format_version 1→2 migration + `Job.status` に `"paused"` 追加 + Pydantic `JobStatus` Literal 拡張 | 🟢 | #417 |
 | v3-20b | `backends/lizyml/lifecycle_mixin.py` で `tune(storage=, study_name=)` passthrough + `BackendAdapter` Protocol に新引数 | 🟢 | #418 |
 | v3-20c | `JobStore.request_pause/is_pause_requested/clear_pause` + `PausedError` + `_run_job_core` の paused 分岐 (finally で release_active を skip) + `JobStore.set_status` runtime guard + `cancel_job` paused 対応 + `has_active_children` paused 包含 | 🟢 | feat/v3-20c-pause-primitives |
-| v3-20d | `POST /api/jobs/{id}/pause` + `POST /api/jobs/{id}/unpause` API + service layer wiring | 🟡 | — |
+| v3-20d | `POST /api/jobs/{id}/pause` + `POST /api/jobs/{id}/unpause` API + service layer wiring + subprocess parent finally paused-skip | 🟢 | feat/v3-20d-pause-unpause-api |
 | v3-20e | `WsPaused` message + frontend WS `case "paused"` handler + openapi-typescript 再生成 | 🟡 | — |
 | v3-20f | Frontend Jobs UI Pause/Resume buttons + Storybook story + component test | 🟡 | — |
 | v3-20g | INV-3 / INV-4 invariant tests + Playwright `tests/e2e/tune-resume.spec.ts` (1 trial=1s mock) | 🟡 | — |

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -569,6 +569,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/jobs/{job_id}/pause": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Pause Job
+         * @description Request a tune job to pause at the next cooperative-cb boundary.
+         *
+         *     Pause is a tune-only action — fit jobs are short-running by design
+         *     (training a single model with the user's chosen params), so a pause
+         *     primitive there has no usable resume target. The cooperative
+         *     callback inside the worker observes the on-disk PAUSE flag through
+         *     :meth:`JobStore.is_pause_requested` and unwinds via
+         *     :class:`PausedError`. ``_run_job_core`` writes ``status="paused"``
+         *     on disk and KEEPS slot ownership so the user's subsequent /unpause
+         *     click resumes the same job in place (P-0099 v3-20c invariant).
+         */
+        post: operations["pause_job_api_jobs__job_id__pause_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/jobs/{job_id}/unpause": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Unpause Job
+         * @description Re-launch a paused tune in place (P-0099 v3-20d, R-1.4).
+         *
+         *     Unlike ``POST /resume`` (H-0062 Phase B, failed→child job), unpause
+         *     re-uses the SAME ``job_id``: the worker re-attaches to the same
+         *     Optuna study via ``load_if_exists=True`` and continues from
+         *     ``trial N+1``.  Slot ownership stays with the original job_id from
+         *     paused into running (paused→running is a legal INV-3 transition),
+         *     so the active-slot lock is never released across the round-trip.
+         *
+         *     Workspace dataframe must still be loaded and matching the job's
+         *     original ``data_ref``; mismatched data would silently corrupt the
+         *     Optuna study (best_value compared across different data).
+         */
+        post: operations["unpause_job_api_jobs__job_id__unpause_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/jobs/{job_id}/metrics": {
         parameters: {
             query?: never;
@@ -1674,6 +1734,14 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /**
+         * PauseJobResponse
+         * @description POST /api/jobs/{job_id}/pause (P-0099 v3-20d, R-1.4).
+         */
+        PauseJobResponse: {
+            /** Status */
+            status: string;
+        };
         /** PlotResponseModel */
         PlotResponseModel: {
             /** Plotly Json */
@@ -1949,6 +2017,16 @@ export interface components {
             key: string;
             /** Title */
             title: string;
+        };
+        /**
+         * UnpauseJobResponse
+         * @description POST /api/jobs/{job_id}/unpause (P-0099 v3-20d, R-1.4).
+         */
+        UnpauseJobResponse: {
+            /** Status */
+            status: string;
+            /** Job Id */
+            job_id: string;
         };
         /** ValidationError */
         ValidationError: {
@@ -2873,6 +2951,68 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CancelJobResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    pause_job_api_jobs__job_id__pause_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PauseJobResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    unpause_job_api_jobs__job_id__unpause_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnpauseJobResponse"];
                 };
             };
             /** @description Validation Error */

--- a/src/lizystudio/api/jobs.py
+++ b/src/lizystudio/api/jobs.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, Query, Response
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
+from lizystudio.api.deps import get_broadcaster
 from lizystudio.api.errors import (
     BackendError,
     ExportError,
@@ -24,6 +25,7 @@ from lizystudio.api.errors import (
     ParentHasActiveChildrenError,
     PlotNotAvailableError,
     StudioError,
+    WorkspaceNoDataError,
 )
 from lizystudio.api.models import (
     CancelJobResponse,
@@ -33,7 +35,9 @@ from lizystudio.api.models import (
     JobDetailResponse,
     JobLogResponse,
     JobSummaryResponse,
+    PauseJobResponse,
     PlotResponseModel,
+    UnpauseJobResponse,
 )
 from lizystudio.backends.exceptions import (
     PlotNotAvailableError as _BackendPlotNotAvailable,
@@ -51,7 +55,9 @@ from lizystudio.services.jobs import (
     get_metrics_table,
     get_split_summary,
 )
+from lizystudio.services.training import start_tune_async
 from lizystudio.services.workspace import WorkspaceState, get_workspace
+from lizystudio.ws.progress import ProgressBroadcaster
 
 _MAX_METRICS = 20
 _VALID_PARAM_RE = re.compile(r"^[a-zA-Z0-9_]+$")
@@ -270,6 +276,93 @@ def cancel_job(
         f"Job {job_id} is not running or paused (status: {job.status})",
         400,
     )
+
+
+# --- Pause / Unpause (P-0099 v3-20d, R-1.4 / Issue #360) ---
+
+
+@router.post("/{job_id}/pause", response_model=PauseJobResponse)
+def pause_job(
+    job_id: str,
+    job_store: JobStore = Depends(get_job_store),
+) -> dict[str, str]:
+    """Request a tune job to pause at the next cooperative-cb boundary.
+
+    Pause is a tune-only action — fit jobs are short-running by design
+    (training a single model with the user's chosen params), so a pause
+    primitive there has no usable resume target. The cooperative
+    callback inside the worker observes the on-disk PAUSE flag through
+    :meth:`JobStore.is_pause_requested` and unwinds via
+    :class:`PausedError`. ``_run_job_core`` writes ``status="paused"``
+    on disk and KEEPS slot ownership so the user's subsequent /unpause
+    click resumes the same job in place (P-0099 v3-20c invariant).
+    """
+    job = _get_job_or_404(job_id, job_store)
+    if job.job_type != "tune":
+        raise StudioError(
+            "JOB_NOT_PAUSEABLE",
+            f"Pause is only available on tune jobs (job_type: {job.job_type})",
+            400,
+        )
+    if job.status != "running":
+        raise StudioError(
+            "JOB_NOT_RUNNING",
+            f"Pause requires a running job (status: {job.status})",
+            400,
+        )
+    job_store.request_pause(job_id)
+    return {"status": "pause_requested"}
+
+
+@router.post("/{job_id}/unpause", response_model=UnpauseJobResponse)
+def unpause_job(
+    job_id: str,
+    job_store: JobStore = Depends(get_job_store),
+    ws: WorkspaceState = Depends(get_workspace),
+    broadcaster: ProgressBroadcaster = Depends(get_broadcaster),
+) -> dict[str, str]:
+    """Re-launch a paused tune in place (P-0099 v3-20d, R-1.4).
+
+    Unlike ``POST /resume`` (H-0062 Phase B, failed→child job), unpause
+    re-uses the SAME ``job_id``: the worker re-attaches to the same
+    Optuna study via ``load_if_exists=True`` and continues from
+    ``trial N+1``.  Slot ownership stays with the original job_id from
+    paused into running (paused→running is a legal INV-3 transition),
+    so the active-slot lock is never released across the round-trip.
+
+    Workspace dataframe must still be loaded and matching the job's
+    original ``data_ref``; mismatched data would silently corrupt the
+    Optuna study (best_value compared across different data).
+    """
+    job = _get_job_or_404(job_id, job_store)
+    if job.job_type != "tune":
+        raise StudioError(
+            "JOB_NOT_PAUSEABLE",
+            f"Unpause is only available on tune jobs (job_type: {job.job_type})",
+            400,
+        )
+    if job.status != "paused":
+        raise StudioError(
+            "JOB_NOT_PAUSED",
+            f"Unpause requires a paused job (status: {job.status})",
+            400,
+        )
+    if ws.dataframe is None or ws.data_ref is None:
+        raise WorkspaceNoDataError()
+
+    # Clear the pause flag BEFORE re-launching so the cb does not
+    # immediately raise PausedError again on its first observation.
+    job_store.clear_pause(job_id)
+
+    start_tune_async(
+        ws=ws,
+        job_store=job_store,
+        broadcaster=broadcaster,
+        config=job.config,
+        dataframe=ws.dataframe,
+        job=job,
+    )
+    return {"status": "unpause_started", "job_id": job_id}
 
 
 # --- Result viewing ---

--- a/src/lizystudio/api/models.py
+++ b/src/lizystudio/api/models.py
@@ -261,6 +261,19 @@ class CancelJobResponse(BaseModel):
     status: str
 
 
+class PauseJobResponse(BaseModel):
+    """POST /api/jobs/{job_id}/pause (P-0099 v3-20d, R-1.4)."""
+
+    status: str
+
+
+class UnpauseJobResponse(BaseModel):
+    """POST /api/jobs/{job_id}/unpause (P-0099 v3-20d, R-1.4)."""
+
+    status: str
+    job_id: str
+
+
 class DeleteJobResponse(BaseModel):
     """DELETE /api/jobs/{job_id}."""
 

--- a/src/lizystudio/services/_training_core.py
+++ b/src/lizystudio/services/_training_core.py
@@ -396,12 +396,19 @@ def _run_subprocess_job(
         )
         return finished
     finally:
-        job_store.release_active(job.job_id)
         # H-0065 / H-0066: subprocess child writes the terminal status
         # on disk; re-read it here so the parent emits exactly one
         # counter increment per job in either mode.
-        if not terminal_already_recorded:
-            latest = job_store.get(job.job_id)
+        #
+        # P-0099 v3-20d: ``paused`` is non-terminal — the parent must
+        # KEEP slot ownership so the user's /unpause click can resume
+        # in place. v3-20c handled this on the in-process branch
+        # (``_run_job_core.finally``); the subprocess wrapper missed
+        # the same skip and would otherwise drop ``active_job_id`` to
+        # ``None`` after the child exited via PausedError.
+        latest = job_store.get(job.job_id) if not terminal_already_recorded else None
+        if latest is None or latest.status != "paused":
+            job_store.release_active(job.job_id)
             if latest is not None:
                 duration = _subprocess_duration_seconds(latest)
                 _emit_terminal_metric(job_store, latest, duration=duration)

--- a/tests/regression/test_inv_pause_keeps_slot.py
+++ b/tests/regression/test_inv_pause_keeps_slot.py
@@ -352,3 +352,59 @@ def test_has_active_children_counts_paused_as_active(job_store: JobStore) -> Non
     assert job_store.has_active_children(parent.job_id) is True, (
         "INV-pause-5: paused children block non-cascade parent delete"
     )
+
+
+# ---------------------------------------------------------------------------
+# INV-pause-6 (v3-20d): subprocess parent finally MUST also skip release
+# when the child wrote ``status="paused"``.
+#
+# v3-20c covered the in-process branch (``_run_job_core.finally``) but
+# missed the subprocess wrapper (``_run_subprocess_job.finally``), which
+# unconditionally calls ``release_active`` after the child exits. With
+# the bug live, /pause in subprocess mode would correctly write paused
+# to disk in the child but the parent process would immediately drop
+# slot ownership — defeating in-place /unpause because the next /tune
+# could steal the slot before the user clicks Resume.
+# ---------------------------------------------------------------------------
+
+
+def test_subprocess_finally_keeps_slot_when_child_wrote_paused(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from lizystudio.services import _training_core as tc
+
+    job_store = JobStore(tmp_path / "jobs")
+    job = _claim_job(job_store)
+    # Simulate the subprocess child having persisted paused status.
+    job_store.set_status(job.job_id, "running")
+    job_store.set_status(job.job_id, "paused")
+    assert job_store.active_job_id == job.job_id
+
+    # Stub the actual subprocess run so the test stays in-process.
+    def _fake_run_job_in_subprocess(*_args: Any, **_kwargs: Any) -> Job:
+        reloaded = job_store.get(job.job_id)
+        assert reloaded is not None
+        return reloaded
+
+    from lizystudio.services import subprocess_runner
+
+    monkeypatch.setattr(
+        subprocess_runner,
+        "run_job_in_subprocess",
+        _fake_run_job_in_subprocess,
+    )
+
+    # Mock workspace so _run_subprocess_job sees a valid data_ref.
+    from unittest.mock import MagicMock
+
+    ws = MagicMock()
+    ws.data_ref = _make_data_ref()
+    ws.record_completion = MagicMock()
+
+    tc._run_subprocess_job(ws, job, job_store, broadcaster=None)
+
+    assert job_store.active_job_id == job.job_id, (
+        "INV-pause-6: subprocess parent finally must NOT release the slot "
+        "when the child wrote status=paused on disk"
+    )

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -463,6 +463,239 @@ def test_cancel_job_not_found(client: TestClient) -> None:
     assert res.status_code == 404
 
 
+def test_cancel_paused_tune_transitions_to_cancelled(
+    client: TestClient, sample_data_ref: DataRef
+) -> None:
+    """POST cancel on a paused job transitions it to cancelled and frees the slot.
+
+    P-0099 v3-20c §6 (案 a): paused-as-zombie is worse UX than letting
+    Cancel be a fast exit, so /cancel accepts paused.
+    """
+    app = client.app  # type: ignore[union-attr]
+    job_store: JobStore = app.state.job_store
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=sample_data_ref,
+        job_type="tune",
+    )
+    job_store.set_status(job.job_id, "running")
+    job_store.set_status(job.job_id, "paused")
+    job_store.claim_active(job.job_id)
+    assert job_store.active_job_id == job.job_id
+
+    res = client.post(f"/api/jobs/{job.job_id}/cancel")
+    assert res.status_code == 200
+    assert res.json()["status"] == "cancelled"
+
+    reloaded = job_store.get(job.job_id)
+    assert reloaded is not None
+    assert reloaded.status == "cancelled"
+    assert job_store.active_job_id is None, (
+        "Cancel on paused must release the active slot directly"
+    )
+
+
+# --- Pause / Unpause (P-0099 v3-20d, R-1.4) ---
+
+
+def test_pause_running_tune_returns_pause_requested(
+    client: TestClient, sample_data_ref: DataRef
+) -> None:
+    app = client.app  # type: ignore[union-attr]
+    job_store: JobStore = app.state.job_store
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=sample_data_ref,
+        job_type="tune",
+    )
+    job_store.set_status(job.job_id, "running")
+
+    res = client.post(f"/api/jobs/{job.job_id}/pause")
+    assert res.status_code == 200, res.text
+    assert res.json()["status"] == "pause_requested"
+    assert job_store.is_pause_requested(job.job_id) is True
+
+
+def test_pause_fit_job_rejected(client: TestClient, sample_data_ref: DataRef) -> None:
+    """Pause is a tune-only action — fit jobs are short-running by design."""
+    app = client.app  # type: ignore[union-attr]
+    job_store: JobStore = app.state.job_store
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=sample_data_ref,
+        job_type="fit",
+    )
+    job_store.set_status(job.job_id, "running")
+
+    res = client.post(f"/api/jobs/{job.job_id}/pause")
+    assert res.status_code == 400
+    assert res.json()["error"]["code"] == "JOB_NOT_PAUSEABLE"
+
+
+def test_pause_non_running_tune_rejected(
+    client: TestClient, sample_data_ref: DataRef
+) -> None:
+    """Pausing a tune that is not currently running is rejected."""
+    app = client.app  # type: ignore[union-attr]
+    job_store: JobStore = app.state.job_store
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=sample_data_ref,
+        job_type="tune",
+    )  # status defaults to pending
+
+    res = client.post(f"/api/jobs/{job.job_id}/pause")
+    assert res.status_code == 400
+    assert res.json()["error"]["code"] == "JOB_NOT_RUNNING"
+
+
+def test_pause_already_paused_rejected(
+    client: TestClient, sample_data_ref: DataRef
+) -> None:
+    app = client.app  # type: ignore[union-attr]
+    job_store: JobStore = app.state.job_store
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=sample_data_ref,
+        job_type="tune",
+    )
+    job_store.set_status(job.job_id, "running")
+    job_store.set_status(job.job_id, "paused")
+
+    res = client.post(f"/api/jobs/{job.job_id}/pause")
+    assert res.status_code == 400
+    assert res.json()["error"]["code"] == "JOB_NOT_RUNNING"
+
+
+def test_pause_job_not_found(client: TestClient) -> None:
+    res = client.post("/api/jobs/nonexistent/pause")
+    assert res.status_code == 404
+
+
+def test_unpause_paused_tune_clears_flag_and_starts_worker(
+    client: TestClient,
+    sample_data_ref: DataRef,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST /unpause clears the pause flag and re-launches the tune worker.
+
+    The worker thread spawn is mocked here — full Optuna trial-resume
+    coverage lives in the v3-20g Playwright spec.  This test pins the
+    contract that the API endpoint (a) clears the on-disk PAUSE flag and
+    (b) calls ``start_tune_async`` with the original job id (in-place
+    resume, NOT a new child job like /resume).
+    """
+    from lizystudio.api import workspace as workspace_api
+
+    app = client.app  # type: ignore[union-attr]
+    job_store: JobStore = app.state.job_store
+    ws = app.state.workspace
+    ws.set_data(_make_tiny_dataframe(), sample_data_ref)
+
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=sample_data_ref,
+        job_type="tune",
+    )
+    job_store.set_status(job.job_id, "running")
+    job_store.set_status(job.job_id, "paused")
+    job_store.claim_active(job.job_id)
+    job_store.request_pause(job.job_id)
+    assert job_store.is_pause_requested(job.job_id) is True
+
+    captured: dict[str, object] = {}
+
+    def _fake_start_tune_async(**kwargs: object) -> str:
+        captured.update(kwargs)
+        return str(kwargs["job"].job_id)  # type: ignore[union-attr]
+
+    monkeypatch.setattr(
+        workspace_api, "start_tune_async", _fake_start_tune_async, raising=False
+    )
+    # The unpause endpoint imports the launcher from services.training too;
+    # patch both to be safe.
+    from lizystudio.api import jobs as jobs_api
+
+    monkeypatch.setattr(
+        jobs_api, "start_tune_async", _fake_start_tune_async, raising=False
+    )
+
+    res = client.post(f"/api/jobs/{job.job_id}/unpause")
+    assert res.status_code == 200, res.text
+    assert res.json()["status"] == "unpause_started"
+
+    assert job_store.is_pause_requested(job.job_id) is False, (
+        "Unpause must clear the pause flag before the worker re-runs"
+    )
+    assert "job" in captured
+    assert captured["job"].job_id == job.job_id  # type: ignore[union-attr]
+
+
+def test_unpause_non_paused_rejected(
+    client: TestClient, sample_data_ref: DataRef
+) -> None:
+    app = client.app  # type: ignore[union-attr]
+    job_store: JobStore = app.state.job_store
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=sample_data_ref,
+        job_type="tune",
+    )
+    job_store.set_status(job.job_id, "running")
+
+    res = client.post(f"/api/jobs/{job.job_id}/unpause")
+    assert res.status_code == 400
+    assert res.json()["error"]["code"] == "JOB_NOT_PAUSED"
+
+
+def test_unpause_without_loaded_data_rejected(
+    client: TestClient, sample_data_ref: DataRef
+) -> None:
+    """Unpause requires the workspace data to still be loaded (matching data_ref).
+
+    Pre-fix risk: a paused tune resumed against a different dataset
+    would silently corrupt the Optuna study (best_value compared across
+    different data).
+    """
+    app = client.app  # type: ignore[union-attr]
+    job_store: JobStore = app.state.job_store
+    ws = app.state.workspace
+    ws.dataframe = None
+    ws.data_ref = None
+
+    job = job_store.create(
+        backend_name="lizyml",
+        config={"task": "binary"},
+        data_ref=sample_data_ref,
+        job_type="tune",
+    )
+    job_store.set_status(job.job_id, "running")
+    job_store.set_status(job.job_id, "paused")
+
+    res = client.post(f"/api/jobs/{job.job_id}/unpause")
+    assert res.status_code == 400
+    assert res.json()["error"]["code"] == "WORKSPACE_NO_DATA"
+
+
+def test_unpause_job_not_found(client: TestClient) -> None:
+    res = client.post("/api/jobs/nonexistent/unpause")
+    assert res.status_code == 404
+
+
+def _make_tiny_dataframe() -> object:
+    """Minimal DataFrame for unpause tests — not used for actual training."""
+    import pandas as pd
+
+    return pd.DataFrame({"y": [0, 1, 0, 1], "x": [1.0, 2.0, 3.0, 4.0]})
+
+
 # --- Shared mock-backend helper ---
 
 


### PR DESCRIPTION
## Summary

v0.5 R-1.4 (P-0099 / Issue #360 / Tune long-run resumability) v3-20d sub-phase. Lands the user-facing **`POST /pause`** + **`POST /unpause`** API endpoints on top of the v3-20c primitives, and patches a missed corner of v3-20c — `_run_subprocess_job.finally` was unconditionally calling `release_active`, which would have defeated in-place /unpause whenever the worker ran in **subprocess mode** (the default on macOS / OpenMP-detected systems).

What ships here:
- **`POST /api/jobs/{id}/pause`** — tune-only, status=running required; calls `request_pause` and returns `{"status": "pause_requested"}`. Error codes: `JOB_NOT_PAUSEABLE` (fit jobs rejected), `JOB_NOT_RUNNING` (paused/completed/failed/cancelled rejected), `JOB_NOT_FOUND` (404).
- **`POST /api/jobs/{id}/unpause`** — tune-only, status=paused required, `ws.dataframe` must still be loaded; clears the pause flag and calls `start_tune_async` with the **ORIGINAL** job_id (in-place resume — NOT a child job like /resume). The Optuna study re-attaches via `load_if_exists=True` and continues from `trial N+1`. Error codes: `JOB_NOT_PAUSEABLE`, `JOB_NOT_PAUSED`, `WORKSPACE_NO_DATA`, 404.
- **Subprocess finally fix** — `_run_subprocess_job.finally` now reads the child's persisted status before calling `release_active`. When `latest.status == "paused"` the slot stays owned by the same job_id, mirroring the v3-20c in-process branch.

What is intentionally NOT in this PR (deferred to subsequent sub-phases):
- `WsPaused` WebSocket message + frontend handler — v3-20e
- Frontend Pause/Resume button — v3-20f
- Playwright tune-resume E2E + INV-4 round-trip — v3-20g

## Invariants

- **INV-pause-1 (extension)**: subprocess parent finally MUST also skip `release_active` when the child wrote `status="paused"` to disk. Pre-fix the in-process branch was correct (v3-20c) but the subprocess wrapper would have dropped slot ownership the moment the child exited via `PausedError`.
- **API contract**: pause/unpause are tune-only. Fit jobs reject both with `JOB_NOT_PAUSEABLE` because there is no usable resume target — fit trains a single model with the user's chosen params and a partial result has no meaning.
- **In-place resume**: `/unpause` re-uses the same `job_id` (not a child job), so the active-slot lock is never released across the round-trip. `paused → running` is a legal INV-3 edge.

## Failure Paths Covered

- [x] Pause on running tune → 200 + flag set
- [x] Pause on running fit → 400 `JOB_NOT_PAUSEABLE`
- [x] Pause on pending tune → 400 `JOB_NOT_RUNNING`
- [x] Pause on already-paused → 400 `JOB_NOT_RUNNING`
- [x] Pause on missing job → 404
- [x] Unpause on paused tune → 200 + flag cleared + `start_tune_async` called with original job_id
- [x] Unpause on running → 400 `JOB_NOT_PAUSED`
- [x] Unpause without loaded data → 400 `WORKSPACE_NO_DATA`
- [x] Unpause on missing job → 404
- [x] Cancel on paused tune → 200 + paused→cancelled + slot released (existing v3-20c behaviour, additionally regression-tested in this PR)
- [x] Subprocess child wrote `status="paused"` → parent finally MUST keep slot
- [ ] Server restart with paused state surviving on disk (out-of-scope, v3-22)
- [ ] Real Optuna trial-resume after /unpause (out-of-scope, covered by v3-20g Playwright spec)

## Test plan

- [x] `tests/test_jobs_api.py` — 10 new HTTP contract tests (pause × 5, unpause × 4, cancel-paused × 1) — all green
- [x] `tests/regression/test_inv_pause_keeps_slot.py::test_subprocess_finally_keeps_slot_when_child_wrote_paused` — pins INV-pause-1 extension on subprocess parent finally
- [x] `tests/regression/` (215 + 1 = 216 tests) — all green
- [x] `tests/contract/` — 54 passed
- [x] `tests/integration/` — 3 passed
- [x] `tests/test_jobs_api.py + test_retune_api.py + test_job_state_transitions.py` — green
- [x] `tests/test_training_service.py + test_subprocess_runner.py` — green
- [x] Combined run: **511 passed / 6 skipped** in 3:20
- [x] `ruff check` + `ruff format --check` + `mypy` — all green on modified files
- [x] `frontend/src/api/generated/schema.d.ts` regenerated (PauseJobResponse / UnpauseJobResponse + new endpoint paths picked up by openapi-typescript)