### PR TITLE
feat(ws,frontend): WsPaused message + send_paused + frontend handler (v3-20e, P-0099 R-1.4)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3277,6 +3277,15 @@ R-1.1〜R-1.5b の各 phase に invariant test を割り当てる。本 Proposal
   - **API 構成変更 (案 B 採用)**: 既存 `POST /api/jobs/{id}/resume` (H-0062 Phase B、failed→child job) は **変更しない**。`paused → running` 用に **新規 `POST /api/jobs/{id}/unpause`** を追加して semantically 別の操作を別 URL に分離。理由: 既存 frontend 実装 (`ResumeActionButton`) と child job creation 経路を破壊しない、新機能を opt-in で導入できる
   - **paused 中の Cancel UX**: paused 状態でも `POST /api/jobs/{id}/cancel` を有効化し INV-1 release path として活用 (slot 占有による usability 低下の緩和)
   - 残りの impact (format_version 1→2、`WsPaused` message、`paused → cancelled|failed` 遷移、Pause/Resume UI) は当初の Impact 通り
+- 2026-05-06 **v3-20e (R-1.4 WsPaused WS message + frontend handler) 実装** — `feat/v3-20e-wspaused-message` ブランチ:
+  - `lizystudio.ws.messages.WsPaused` 新 Pydantic モデル (`type="paused"`, `job_id`, `trial_number: int | None`, `message: str`, `extra="forbid"`)
+  - `WsMessage` discriminated union に `WsPaused` を追加
+  - `ProgressBroadcaster.send_paused(job_id, *, trial_number=None, message="Paused.")` 追加。`_TERMINAL_TYPES` には**含まない** — pause は resumable なので late-subscriber replay cache に載せない (INV-WS-5)
+  - `_run_job_core.except PausedError` 分岐に `broadcaster.send_paused(job.job_id)` を追加 (v3-20c で deferred していた WS notification を完成)
+  - Frontend: `connectJobProgress` に `onPaused` callback 追加、`case "paused"` で **jobDone を立てない** (WS 接続を維持して unpause 復帰時の live stream 継続を保証)
+  - Frontend: `useJobProgress` に `onPaused` ハンドラ追加 — `setProgress(null)` + jobs/job query invalidate のみ、`fireTerminal` は呼ばない
+  - openapi-typescript 再生成で `WsMessage` union が自動的に `paused` variant を含む (frontend の hand-written 重複なし)
+  - tests: `test_ws_messages.py` に 5 件 (round-trip / wire-format / send_paused / cache-exclusion / extra-field reject)、`test_inv_pause_keeps_slot.py` に 1 件 (`test_paused_branch_invokes_broadcaster_send_paused` for INV-pause-7)
 - 2026-05-06 **v3-20d (R-1.4 pause/unpause API) 実装** — `feat/v3-20d-pause-unpause-api` ブランチで HTTP エントリーポイント + subprocess parent finally の paused-skip を実装:
   - `POST /api/jobs/{id}/pause` — tune-only、status=running を要求、`request_pause` を呼ぶ。エラーコード: `JOB_NOT_PAUSEABLE` (fit ジョブ拒否) / `JOB_NOT_RUNNING` (paused/completed 等)
   - `POST /api/jobs/{id}/unpause` — tune-only、status=paused を要求、ws.dataframe 再ロード必須、`clear_pause` 後に `start_tune_async` を **同 job_id** で呼び（in-place 復帰）。lizyml の Optuna `load_if_exists=True` で trial 継続。エラーコード: `JOB_NOT_PAUSED` / `WORKSPACE_NO_DATA`

--- a/PLAN.md
+++ b/PLAN.md
@@ -1355,7 +1355,7 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 | v3-20b | `backends/lizyml/lifecycle_mixin.py` で `tune(storage=, study_name=)` passthrough + `BackendAdapter` Protocol に新引数 | 🟢 | #418 |
 | v3-20c | `JobStore.request_pause/is_pause_requested/clear_pause` + `PausedError` + `_run_job_core` の paused 分岐 (finally で release_active を skip) + `JobStore.set_status` runtime guard + `cancel_job` paused 対応 + `has_active_children` paused 包含 | 🟢 | feat/v3-20c-pause-primitives |
 | v3-20d | `POST /api/jobs/{id}/pause` + `POST /api/jobs/{id}/unpause` API + service layer wiring + subprocess parent finally paused-skip | 🟢 | feat/v3-20d-pause-unpause-api |
-| v3-20e | `WsPaused` message + frontend WS `case "paused"` handler + openapi-typescript 再生成 | 🟡 | — |
+| v3-20e | `WsPaused` message + frontend WS `case "paused"` handler + openapi-typescript 再生成 | 🟢 | feat/v3-20e-wspaused-message |
 | v3-20f | Frontend Jobs UI Pause/Resume buttons + Storybook story + component test | 🟡 | — |
 | v3-20g | INV-3 / INV-4 invariant tests + Playwright `tests/e2e/tune-resume.spec.ts` (1 trial=1s mock) | 🟡 | — |
 

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -2153,6 +2153,41 @@ export interface components {
             [key: string]: unknown;
         };
         /**
+         * WsPaused
+         * @description Non-terminal pause notification (P-0099 v3-20e, R-1.4).
+         *
+         *     Emitted when ``_run_job_core`` catches :class:`PausedError`.  Unlike
+         *     :class:`WsCompleted` / :class:`WsError`, this message is **NOT**
+         *     cached for late-subscriber replay — pause is a resumable state, so
+         *     a subscriber that connects after the user clicked Resume must
+         *     observe the live progress stream rather than a stale "you were
+         *     paused at trial 7" frame from a previous session.
+         *
+         *     Frontends switch on ``msg.type === "paused"`` and update the Jobs
+         *     list / detail view to show the Resume / Cancel actions.  The WS
+         *     connection itself stays open: pause is non-terminal, so the
+         *     reconnect / suppress logic must NOT close the channel here.
+         */
+        WsPaused: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "paused";
+            /** Job Id */
+            job_id: string;
+            /**
+             * Trial Number
+             * @default null
+             */
+            trial_number: number | null;
+            /**
+             * Message
+             * @default Paused.
+             */
+            message: string;
+        };
+        /**
          * WsPing
          * @description 30-second keepalive ping (H-0058).
          *
@@ -2213,7 +2248,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        WsMessage: components["schemas"]["WsProgress"] | components["schemas"]["WsCompleted"] | components["schemas"]["WsError"] | components["schemas"]["WsPing"];
+        WsMessage: components["schemas"]["WsProgress"] | components["schemas"]["WsCompleted"] | components["schemas"]["WsError"] | components["schemas"]["WsPing"] | components["schemas"]["WsPaused"];
     };
     responses: never;
     parameters: never;

--- a/frontend/src/api/websocket.ts
+++ b/frontend/src/api/websocket.ts
@@ -7,6 +7,11 @@ const MAX_DELAY = 30000;
 /**
  * Connect to job progress WebSocket with exponential backoff
  * reconnection (H-0035).
+ *
+ * P-0099 v3-20e: ``paused`` is a NON-terminal message — the WS
+ * connection stays open so the frontend can observe the live progress
+ * stream after the user clicks Resume.  Only ``completed`` / ``error``
+ * suppress the reconnect path.
  */
 export function connectJobProgress(
   jobId: string,
@@ -14,6 +19,7 @@ export function connectJobProgress(
     onProgress?: (msg: WsMessage & { type: "progress" }) => void;
     onCompleted?: (msg: WsMessage & { type: "completed" }) => void;
     onError?: (msg: WsMessage & { type: "error" }) => void;
+    onPaused?: (msg: WsMessage & { type: "paused" }) => void;
     onReconnect?: () => void;
   },
 ): () => void {
@@ -21,7 +27,8 @@ export function connectJobProgress(
   let retryCount = 0;
   let retryTimer: ReturnType<typeof setTimeout> | null = null;
   let closed = false;
-  // Suppress reconnection after terminal messages (completed/error)
+  // Suppress reconnection after terminal messages (completed/error).
+  // Pause is non-terminal — see the case "paused" branch below.
   let jobDone = false;
 
   function connect() {
@@ -48,6 +55,11 @@ export function connectJobProgress(
           case "error":
             jobDone = true;
             callbacks.onError?.(msg);
+            break;
+          case "paused":
+            // Non-terminal: do NOT set jobDone, keep the WS open so
+            // the live stream resumes when the user clicks Resume.
+            callbacks.onPaused?.(msg);
             break;
         }
       } catch {

--- a/frontend/src/hooks/useJobProgress.ts
+++ b/frontend/src/hooks/useJobProgress.ts
@@ -132,6 +132,21 @@ export function useJobProgress({
         invalidateOnce();
         fireTerminal();
       },
+      onPaused: () => {
+        // P-0099 v3-20e: paused is non-terminal — invalidate the
+        // cached job state so the UI flips to the Resume / Cancel
+        // affordances, but do NOT call fireTerminal: the WebSocket
+        // stays open and the user can /unpause back to running on
+        // the same connection.
+        setProgress(null);
+        if (trackFoldLog) setFoldLog([]);
+        // Reset invalidation guard so a subsequent /unpause -> running
+        // -> completed cycle still fires the terminal invalidation
+        // exactly once for the new run.
+        terminalInvalidatedRef.current = null;
+        queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
+      },
     });
 
     return () => disconnect();

--- a/src/lizystudio/services/_training_core.py
+++ b/src/lizystudio/services/_training_core.py
@@ -196,10 +196,14 @@ def _run_job_core(
         job.status = "paused"
         job.completed_at = None
         job_store.update(job)
-        # WS notification lands in v3-20e (WsPaused message).  Until
-        # then the frontend observes the status flip via the next jobs
-        # list refresh; this is acceptable because pause is a user-
-        # initiated action so the click already updates the UI.
+        # P-0099 v3-20e: notify subscribers via WsPaused so the
+        # frontend Jobs UI flips state without waiting for the next
+        # jobs list refresh. The broadcaster does NOT cache this
+        # message for late-subscriber replay — pause is resumable, so
+        # a stale paused frame from a previous session would mislead a
+        # subscriber that connects after the user clicked Resume.
+        if broadcaster is not None:
+            broadcaster.send_paused(job.job_id)
     except (CancelledError, KeyboardInterrupt):
         job.status = "cancelled"
         job.completed_at = datetime.now(timezone.utc).isoformat()

--- a/src/lizystudio/ws/messages.py
+++ b/src/lizystudio/ws/messages.py
@@ -98,8 +98,36 @@ class WsPing(BaseModel):
     job_id: str
 
 
+class WsPaused(BaseModel):
+    """Non-terminal pause notification (P-0099 v3-20e, R-1.4).
+
+    Emitted when ``_run_job_core`` catches :class:`PausedError`.  Unlike
+    :class:`WsCompleted` / :class:`WsError`, this message is **NOT**
+    cached for late-subscriber replay — pause is a resumable state, so
+    a subscriber that connects after the user clicked Resume must
+    observe the live progress stream rather than a stale "you were
+    paused at trial 7" frame from a previous session.
+
+    Frontends switch on ``msg.type === "paused"`` and update the Jobs
+    list / detail view to show the Resume / Cancel actions.  The WS
+    connection itself stays open: pause is non-terminal, so the
+    reconnect / suppress logic must NOT close the channel here.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["paused"]
+    job_id: str
+    # Optuna trial index at the time of pause observation. ``None`` is
+    # legal for fit jobs that gain a /pause endpoint in the future and
+    # for safety on the first paused emit before the worker has reached
+    # any trial-emitting callback.
+    trial_number: int | None = None
+    message: str = "Paused."
+
+
 WsMessage = Annotated[
-    WsProgress | WsCompleted | WsError | WsPing,
+    WsProgress | WsCompleted | WsError | WsPing | WsPaused,
     Field(discriminator="type"),
 ]
 
@@ -108,6 +136,7 @@ __all__ = [
     "WsCompleted",
     "WsError",
     "WsMessage",
+    "WsPaused",
     "WsPing",
     "WsProgress",
 ]

--- a/src/lizystudio/ws/progress.py
+++ b/src/lizystudio/ws/progress.py
@@ -26,7 +26,13 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import WebSocket, WebSocketDisconnect
 
-from lizystudio.ws.messages import WsCompleted, WsError, WsPing, WsProgress
+from lizystudio.ws.messages import (
+    WsCompleted,
+    WsError,
+    WsPaused,
+    WsPing,
+    WsProgress,
+)
 
 # ``functools.lru_cache`` wraps ``get_allowed_ws_origins`` below (H-0083).
 
@@ -315,6 +321,30 @@ class ProgressBroadcaster:
     ) -> None:
         """Convenience: send an error message (H-0069)."""
         model = WsError(type="error", job_id=job_id, message=message, code=code)
+        self.send(job_id, model.model_dump(exclude_none=True))
+
+    def send_paused(
+        self,
+        job_id: str,
+        *,
+        trial_number: int | None = None,
+        message: str = "Paused.",
+    ) -> None:
+        """Convenience: send a non-terminal paused message (P-0099 v3-20e).
+
+        Pause is intentionally NOT in :data:`_TERMINAL_TYPES` so the
+        in-flight WebSocket connection stays open AND the message is
+        not stashed in :attr:`_last_terminal` for late-subscriber
+        replay.  A user who reconnects after the worker has resumed
+        must observe the live progress stream, not a stale paused
+        frame from a previous session.
+        """
+        model = WsPaused(
+            type="paused",
+            job_id=job_id,
+            trial_number=trial_number,
+            message=message,
+        )
         self.send(job_id, model.model_dump(exclude_none=True))
 
     def make_callback(self, job_id: str) -> Any:

--- a/tests/regression/test_inv_pause_keeps_slot.py
+++ b/tests/regression/test_inv_pause_keeps_slot.py
@@ -368,6 +368,42 @@ def test_has_active_children_counts_paused_as_active(job_store: JobStore) -> Non
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# INV-pause-7 (v3-20e): _run_job_core notifies the broadcaster on PausedError.
+# Pre-fix the paused branch only persisted to disk — the frontend would not
+# observe the transition until the next jobs list refresh, leaving the user
+# staring at a "running" state for the WS retention window.
+# ---------------------------------------------------------------------------
+
+
+def test_paused_branch_invokes_broadcaster_send_paused(
+    job_store: JobStore,
+) -> None:
+    from unittest.mock import MagicMock
+
+    job = _claim_job(job_store)
+    broadcaster = MagicMock()
+
+    def execute_pause(_cb: Any) -> tuple[FitSummary, None, str]:
+        raise PausedError
+
+    _run_job_core(
+        job=job,
+        job_store=job_store,
+        broadcaster=broadcaster,
+        execute_fn=execute_pause,
+    )
+
+    broadcaster.send_paused.assert_called_once()
+    call = broadcaster.send_paused.call_args
+    assert call.args[0] == job.job_id or call.kwargs.get("job_id") == job.job_id, (
+        "INV-pause-7: the broadcaster must observe the paused job_id"
+    )
+    # Slot still held + terminal-emit pathways unused (paused is non-terminal).
+    broadcaster.send_completed.assert_not_called()
+    broadcaster.send_error.assert_not_called()
+
+
 def test_subprocess_finally_keeps_slot_when_child_wrote_paused(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_ws_messages.py
+++ b/tests/test_ws_messages.py
@@ -35,9 +35,16 @@ def test_ws_messages_module_exports_union() -> None:
     import importlib
 
     mod = importlib.import_module("lizystudio.ws.messages")
-    for name in ("WsProgress", "WsCompleted", "WsError", "WsPing", "WsMessage"):
+    for name in (
+        "WsProgress",
+        "WsCompleted",
+        "WsError",
+        "WsPing",
+        "WsPaused",
+        "WsMessage",
+    ):
         assert hasattr(mod, name), (
-            f"lizystudio.ws.messages must expose `{name}` (H-0069)"
+            f"lizystudio.ws.messages must expose `{name}` (H-0069 / P-0099 v3-20e)"
         )
 
 
@@ -332,3 +339,103 @@ def test_frontend_no_handwritten_ws_message_types() -> None:
         "frontend/src/api/types.ts must not hand-write the WS message "
         f"variants. Import from the generated schema instead. Offenders: {offenders}"
     )
+
+
+# --- P-0099 v3-20e: WsPaused message + send_paused -------------------------
+
+
+def test_ws_paused_round_trips_through_ws_message_union() -> None:
+    """A ``paused`` payload parses as :class:`WsPaused` via the union.
+
+    INV-WS-5 (v3-20e): the discriminated union accepts ``type="paused"``
+    so frontends switching on ``msg.type`` see a typed branch instead of
+    falling through the unhandled-type path.
+    """
+    from pydantic import TypeAdapter
+
+    from lizystudio.ws.messages import WsMessage, WsPaused
+
+    payload = {
+        "type": "paused",
+        "job_id": "job_paused_1",
+        "trial_number": 7,
+        "message": "Paused at trial 7.",
+    }
+    parsed = TypeAdapter(WsMessage).validate_python(payload)
+    assert isinstance(parsed, WsPaused)
+    assert parsed.job_id == "job_paused_1"
+    assert parsed.trial_number == 7
+    assert parsed.message == "Paused at trial 7."
+
+
+def test_ws_paused_wire_format_bit_identical() -> None:
+    """Wire format pins the canonical paused dict (no surprise keys)."""
+    from lizystudio.ws.messages import WsPaused
+
+    legacy = {
+        "type": "paused",
+        "job_id": "j",
+        "trial_number": 5,
+        "message": "Paused.",
+    }
+    produced = WsPaused(
+        type="paused", job_id="j", trial_number=5, message="Paused."
+    ).model_dump(exclude_none=True)
+    assert produced == legacy
+
+
+def test_broadcaster_send_paused_round_trips() -> None:
+    """``ProgressBroadcaster.send_paused`` enqueues a parseable WsPaused."""
+    from pydantic import TypeAdapter
+
+    from lizystudio.ws.messages import WsMessage, WsPaused
+    from lizystudio.ws.progress import ProgressBroadcaster
+
+    captured: list[dict[str, Any]] = []
+
+    class _Capture(ProgressBroadcaster):
+        def send(self, job_id: str, message: dict[str, Any]) -> None:  # type: ignore[override]
+            captured.append(message)
+
+    _Capture().send_paused("job_p", trial_number=12, message="Paused.")
+    parsed = TypeAdapter(WsMessage).validate_python(captured[0])
+    assert isinstance(parsed, WsPaused)
+    assert parsed.trial_number == 12
+    assert parsed.message == "Paused."
+
+
+def test_send_paused_does_not_populate_terminal_replay_cache() -> None:
+    """Pause is non-terminal — it must NOT be stashed for late-subscriber replay.
+
+    Cached terminal replay exists so a subscriber that connects after a
+    short-lived job sees the final state.  Pause is deliberately
+    resumable, so the user resuming and reconnecting MUST observe the
+    live progress stream (or whatever state the worker has reached by
+    then), not a stale "you were paused at trial 7" frame from a
+    previous session.
+    """
+    from lizystudio.ws.progress import ProgressBroadcaster
+
+    b = ProgressBroadcaster()
+    b.send_paused("job_no_replay", trial_number=3, message="Paused.")
+    # Internal field is private, but the contract is "no entry for this
+    # job_id in the terminal cache after a paused send".
+    assert "job_no_replay" not in b._last_terminal, (  # noqa: SLF001
+        "INV-WS-5: paused must NOT enter the terminal-replay cache"
+    )
+
+
+def test_extra_field_rejected_on_paused() -> None:
+    """``WsPaused`` uses ``extra='forbid'`` like its siblings."""
+    from pydantic import ValidationError
+
+    from lizystudio.ws.messages import WsPaused
+
+    with pytest.raises(ValidationError):
+        WsPaused(  # type: ignore[call-arg]
+            type="paused",
+            job_id="j",
+            trial_number=1,
+            message="m",
+            mystery_field="not allowed",
+        )


### PR DESCRIPTION
## Summary

v0.5 R-1.4 (P-0099 / Issue #360 / Tune long-run resumability) v3-20e sub-phase. Completes the WebSocket notification surface for pause: backend now emits a `WsPaused` message on the existing `/ws/jobs/{id}/progress` channel, and the frontend WS handler dispatches a typed `case "paused"` branch without closing the connection.

What ships here:
- **Backend `WsPaused` Pydantic model** — `type="paused"`, `trial_number: int | None`, `message: str`, `extra="forbid"`. Added to the `WsMessage` discriminated union so consumers switching on `msg.type` get a typed branch.
- **`ProgressBroadcaster.send_paused`** — intentionally NOT in `_TERMINAL_TYPES`; the message is **NOT** stashed in `_last_terminal` so a subscriber that reconnects after `/unpause` observes the live progress stream, not a stale paused frame from the previous session (INV-WS-5).
- **`_run_job_core.except PausedError`** — now calls `broadcaster.send_paused(job.job_id)`. Pre-fix the paused branch only persisted to disk; the frontend would not observe the transition until the next jobs-list poll (INV-pause-7).
- **Frontend `connectJobProgress`** — accepts `onPaused` callback. The `case "paused"` branch dispatches the callback WITHOUT setting `jobDone`, so the resume worker's live progress stream lands on the same WebSocket connection.
- **Frontend `useJobProgress`** — wires `onPaused` to invalidate the jobs / job queries so the UI flips to Resume / Cancel affordances, but does NOT call `fireTerminal`. Resets the invalidation guard so a subsequent resume → completed cycle fires the terminal invalidation exactly once.
- **`frontend/src/api/generated/schema.d.ts`** regenerated; the hand-written `WsMessage` re-export at `frontend/src/api/types.ts` automatically picks up the new union variant.

What is intentionally NOT in this PR (deferred to subsequent sub-phases):
- Frontend Pause / Resume buttons in Jobs UI — v3-20f
- Playwright tune-resume E2E + INV-4 round-trip — v3-20g

## Invariants

- **INV-WS-5 (new)**: pause is non-terminal — `send_paused` MUST NOT enter `_last_terminal` and the WS connection MUST stay open after a paused emit so the live stream resumes when the user clicks Resume.
- **INV-pause-7 (new)**: `_run_job_core.except PausedError` MUST notify the broadcaster (in addition to persisting `status="paused"` on disk) so the frontend sees the transition without polling.

## Failure Paths Covered

- [x] Send a paused message → no entry in `_last_terminal` cache → late subscriber connecting after Resume sees live progress, not a stale paused frame
- [x] `_run_job_core` catches `PausedError` → `send_paused` is called once, `send_completed` / `send_error` are NOT called (slot-still-held + non-terminal contract)
- [x] Frontend `case "paused"` dispatches without setting `jobDone` → reconnect logic stays armed → user clicks Resume → WS receives running progress on the same connection
- [x] Frontend `useJobProgress.onPaused` invalidates queries → UI flips to Resume affordances without firing `fireTerminal` (would otherwise close the WS subscriber)
- [x] WsMessage union includes `paused` variant — TypeScript discriminated-union narrowing works in the switch
- [ ] Real subprocess child paused → parent observes WsPaused via the progress queue (covered structurally via the existing send queue; explicit subprocess test deferred to v3-20g E2E)

## Test plan

- [x] `tests/test_ws_messages.py` — 5 new cases:
  - `test_ws_paused_round_trips_through_ws_message_union`
  - `test_ws_paused_wire_format_bit_identical`
  - `test_broadcaster_send_paused_round_trips`
  - `test_send_paused_does_not_populate_terminal_replay_cache` (INV-WS-5)
  - `test_extra_field_rejected_on_paused`
- [x] `tests/regression/test_inv_pause_keeps_slot.py::test_paused_branch_invokes_broadcaster_send_paused` (INV-pause-7)
- [x] Backend broad regression + contract + API + training: **491 passed / 6 skipped** in 2:50
- [x] Frontend Vitest (124 files / 1853 tests): all passed
- [x] `tsc --noEmit` clean
- [x] `biome check src/` clean
- [x] `ruff check` + `ruff format --check` + `mypy` clean on changed files
- [x] `frontend/src/api/generated/schema.d.ts` regenerated with WsPaused