### PR TITLE
feat(frontend): Pause/Resume buttons on Jobs UI (v3-20f, P-0099 R-1.4)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3277,6 +3277,14 @@ R-1.1〜R-1.5b の各 phase に invariant test を割り当てる。本 Proposal
   - **API 構成変更 (案 B 採用)**: 既存 `POST /api/jobs/{id}/resume` (H-0062 Phase B、failed→child job) は **変更しない**。`paused → running` 用に **新規 `POST /api/jobs/{id}/unpause`** を追加して semantically 別の操作を別 URL に分離。理由: 既存 frontend 実装 (`ResumeActionButton`) と child job creation 経路を破壊しない、新機能を opt-in で導入できる
   - **paused 中の Cancel UX**: paused 状態でも `POST /api/jobs/{id}/cancel` を有効化し INV-1 release path として活用 (slot 占有による usability 低下の緩和)
   - 残りの impact (format_version 1→2、`WsPaused` message、`paused → cancelled|failed` 遷移、Pause/Resume UI) は当初の Impact 通り
+- 2026-05-07 **v3-20f (R-1.4 frontend Pause/Resume buttons) 実装** — `feat/v3-20f-frontend-pause-resume-buttons` ブランチ:
+  - `frontend/src/api/jobs.ts`: `pauseJob(jobId)` / `unpauseJob(jobId)` API helpers 追加
+  - `frontend/src/api/queries/usePauseJob.ts` + `useUnpauseJob.ts`: TanStack Query mutation hooks (jobs / job(id) invalidation)
+  - `frontend/src/components/jobs/PauseActionButton.tsx`: running tune に対する小型ボタン (dialog なし、PauseCircle icon、`onPauseRequested` callback)
+  - `frontend/src/components/jobs/UnpauseActionButton.tsx`: paused tune に対する Resume ボタン (dialog なし、PlayCircle icon、`disabledReason` 対応、`onUnpauseStarted` callback)。**注**: 既存 `ResumeActionButton` (failed→child job) とは責務が分離 (in-place vs lineage)
+  - `JobDetail.tsx` に `isPaused` 分岐 + paused 状態の説明文 + Pause/Resume/Cancel アクションバー条件分岐。Cancel 確認 dialog の本文も paused 状態用に切り替え
+  - tests: `PauseActionButton.test.tsx` (4 件)、`UnpauseActionButton.test.tsx` (5 件)、`JobDetail.test.tsx` に paused branch + running tune Pause + running fit no-Pause の 3 件追加
+  - 後続 (v3-20g): Playwright tune-resume E2E + INV-4 round-trip
 - 2026-05-06 **v3-20e (R-1.4 WsPaused WS message + frontend handler) 実装** — `feat/v3-20e-wspaused-message` ブランチ:
   - `lizystudio.ws.messages.WsPaused` 新 Pydantic モデル (`type="paused"`, `job_id`, `trial_number: int | None`, `message: str`, `extra="forbid"`)
   - `WsMessage` discriminated union に `WsPaused` を追加

--- a/PLAN.md
+++ b/PLAN.md
@@ -1356,7 +1356,7 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 | v3-20c | `JobStore.request_pause/is_pause_requested/clear_pause` + `PausedError` + `_run_job_core` の paused 分岐 (finally で release_active を skip) + `JobStore.set_status` runtime guard + `cancel_job` paused 対応 + `has_active_children` paused 包含 | 🟢 | feat/v3-20c-pause-primitives |
 | v3-20d | `POST /api/jobs/{id}/pause` + `POST /api/jobs/{id}/unpause` API + service layer wiring + subprocess parent finally paused-skip | 🟢 | feat/v3-20d-pause-unpause-api |
 | v3-20e | `WsPaused` message + frontend WS `case "paused"` handler + openapi-typescript 再生成 | 🟢 | feat/v3-20e-wspaused-message |
-| v3-20f | Frontend Jobs UI Pause/Resume buttons + Storybook story + component test | 🟡 | — |
+| v3-20f | Frontend Jobs UI Pause/Resume buttons + component test (PauseActionButton + UnpauseActionButton + JobDetail isPaused branch) | 🟢 | feat/v3-20f-frontend-pause-resume-buttons |
 | v3-20g | INV-3 / INV-4 invariant tests + Playwright `tests/e2e/tune-resume.spec.ts` (1 trial=1s mock) | 🟡 | — |
 
 **DoD:**

--- a/frontend/src/api/jobs.ts
+++ b/frontend/src/api/jobs.ts
@@ -151,6 +151,32 @@ export async function cancelJob(jobId: string): Promise<{ status: string }> {
   return unwrap(data, "/api/jobs/{job_id}/cancel");
 }
 
+/**
+ * P-0099 v3-20d: request a tune job to pause at the next cooperative
+ * callback boundary. Tune-only — fit jobs reject with
+ * ``JOB_NOT_PAUSEABLE``.
+ */
+export async function pauseJob(jobId: string): Promise<{ status: string }> {
+  const { data } = await apiClient.POST("/api/jobs/{job_id}/pause", {
+    params: { path: { job_id: jobId } },
+  });
+  return unwrap(data, "/api/jobs/{job_id}/pause");
+}
+
+/**
+ * P-0099 v3-20d: re-launch a paused tune in place (same job_id). The
+ * Optuna study re-attaches via ``load_if_exists=True`` and continues
+ * from the next trial.
+ */
+export async function unpauseJob(
+  jobId: string,
+): Promise<{ status: string; job_id: string }> {
+  const { data } = await apiClient.POST("/api/jobs/{job_id}/unpause", {
+    params: { path: { job_id: jobId } },
+  });
+  return unwrap(data, "/api/jobs/{job_id}/unpause");
+}
+
 export async function deleteJob(
   jobId: string,
   options: { cascade?: boolean } = {},

--- a/frontend/src/api/queries/index.ts
+++ b/frontend/src/api/queries/index.ts
@@ -24,9 +24,11 @@ export { useJobLog } from "./useJobLog";
 export { useJobPlots } from "./useJobPlots";
 export { useJobsInvalidator } from "./useJobsInvalidator";
 export { useJobsList } from "./useJobsList";
+export { usePauseJob } from "./usePauseJob";
 export { useResumeJob } from "./useResumeJob";
 export { useRetuneJob } from "./useRetuneJob";
 export { useRunInference } from "./useRunInference";
+export { useUnpauseJob } from "./useUnpauseJob";
 // Workspace config
 export {
   useBackends,

--- a/frontend/src/api/queries/usePauseJob.ts
+++ b/frontend/src/api/queries/usePauseJob.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { pauseJob } from "@/api/jobs";
+import { queryKeys } from "../queryKeys";
+
+/**
+ * P-0099 v3-20d/f: request a running tune to pause.
+ *
+ * Invalidates the per-job and jobs-list queries on success so the UI
+ * reflects the new ``paused`` state without waiting for the next WS
+ * frame (the WS broadcaster also emits ``WsPaused``, but the cache
+ * invalidation guarantees a consistent UI even when the WS is slow
+ * or temporarily disconnected).
+ */
+export function usePauseJob() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (jobId: string) => pauseJob(jobId),
+    onSuccess: (_data, jobId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
+    },
+  });
+}

--- a/frontend/src/api/queries/useUnpauseJob.ts
+++ b/frontend/src/api/queries/useUnpauseJob.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { unpauseJob } from "@/api/jobs";
+import { queryKeys } from "../queryKeys";
+
+/**
+ * P-0099 v3-20d/f: re-launch a paused tune in place. The Optuna study
+ * re-attaches via ``load_if_exists=True`` and continues from the next
+ * trial — same ``job_id`` is preserved (in-place resume, not a child
+ * job like /resume).
+ */
+export function useUnpauseJob() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (jobId: string) => unpauseJob(jobId),
+    onSuccess: (_data, jobId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
+    },
+  });
+}

--- a/frontend/src/components/jobs/JobDetail.test.tsx
+++ b/frontend/src/components/jobs/JobDetail.test.tsx
@@ -16,6 +16,12 @@ vi.mock("@/api/jobs", () => ({
   fetchJob: (...args: unknown[]) => mockFetchJob(...args),
   fetchJobLog: vi.fn().mockResolvedValue({ log: "test log" }),
   cancelJob: vi.fn(),
+  // P-0099 v3-20f: pause / unpause used by Pause-/UnpauseActionButton.
+  pauseJob: vi.fn().mockResolvedValue({ status: "pause_requested" }),
+  unpauseJob: vi.fn().mockResolvedValue({
+    status: "unpause_started",
+    job_id: "test-job-1",
+  }),
   // H-0067: retune / resume / lineage surface used by the embedded
   // RetuneActionButton / ResumeActionButton / JobLineageTree.
   retuneJob: vi.fn().mockResolvedValue({
@@ -180,6 +186,95 @@ describe("JobDetailPanel", () => {
     expect(screen.queryByText("Delete")).not.toBeInTheDocument();
     expect(screen.queryByText("Inference")).not.toBeInTheDocument();
     expect(screen.queryByText("Export")).not.toBeInTheDocument();
+  });
+
+  it("renders running tune job with Pause and Cancel actions", async () => {
+    // P-0099 v3-20f: a running tune exposes Pause + Cancel.
+    const runningTune = makeJob({
+      status: "running",
+      job_type: "tune",
+      completed_at: null,
+    });
+    mockFetchJob.mockResolvedValue(runningTune);
+
+    renderWithProviders(
+      <JobDetailPanel
+        jobId="test-job-1"
+        jobNumber={1}
+        onJobDeleted={vi.fn()}
+        onJobChanged={vi.fn()}
+      />,
+    );
+
+    await screen.findByText("Running");
+    expect(
+      screen.getByRole("button", { name: /Pause tuning at next trial/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+  });
+
+  it("renders paused tune job with Resume + Cancel and a notice paragraph", async () => {
+    // P-0099 v3-20f: paused is non-terminal — the user must explicitly
+    // Resume (in-place /unpause) or Cancel to free the slot.
+    const pausedTune = makeJob({
+      status: "paused",
+      job_type: "tune",
+      completed_at: null,
+    });
+    mockFetchJob.mockResolvedValue(pausedTune);
+
+    renderWithProviders(
+      <JobDetailPanel
+        jobId="test-job-1"
+        jobNumber={1}
+        onJobDeleted={vi.fn()}
+        onJobChanged={vi.fn()}
+      />,
+    );
+
+    await screen.findByTestId("paused-notice");
+    expect(
+      screen.getByRole("button", { name: /Resume paused tuning/i }),
+    ).toBeInTheDocument();
+    // Cancel action bar button — the bare "Cancel" label rendered by
+    // the action-bar Button (matching it by accessible role + name
+    // avoids collision with "Cancel job?" dialog text or "Yes, Cancel"
+    // confirm button if the dialog were open).
+    const cancelButtons = screen.getAllByRole("button", { name: /^Cancel$/ });
+    expect(cancelButtons.length).toBeGreaterThan(0);
+
+    // Paused jobs are non-terminal: Delete / Inference / Export must
+    // remain hidden so the user is funnelled to Resume / Cancel.
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Inference")).not.toBeInTheDocument();
+    expect(screen.queryByText("Export")).not.toBeInTheDocument();
+  });
+
+  it("does NOT show Pause on a running fit job", async () => {
+    // P-0099 v3-20f: pause is tune-only. Fit jobs train a single model
+    // with the user's chosen params and have no usable resume target.
+    const runningFit = makeJob({
+      status: "running",
+      job_type: "fit",
+      completed_at: null,
+    });
+    mockFetchJob.mockResolvedValue(runningFit);
+
+    renderWithProviders(
+      <JobDetailPanel
+        jobId="test-job-1"
+        jobNumber={1}
+        onJobDeleted={vi.fn()}
+        onJobChanged={vi.fn()}
+      />,
+    );
+
+    await screen.findByText("Running");
+    expect(
+      screen.queryByRole("button", { name: /Pause tuning at next trial/i }),
+    ).not.toBeInTheDocument();
+    // Cancel still appears for a running fit.
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
   });
 
   it("renders header with model name and job number", async () => {

--- a/frontend/src/components/jobs/JobDetail.tsx
+++ b/frontend/src/components/jobs/JobDetail.tsx
@@ -40,6 +40,8 @@ import { CompletedContent } from "./CompletedContent";
 import { ConfigTreeView } from "./ConfigTreeView";
 import { DeleteDialog } from "./DeleteDialog";
 import { ExportDialog } from "./ExportDialog";
+import { PauseActionButton } from "./PauseActionButton";
+import { UnpauseActionButton } from "./UnpauseActionButton";
 
 interface JobDetailProps {
   jobId: string;
@@ -153,6 +155,10 @@ export function JobDetailPanel({
   const isFailed = job.status === "failed";
   const isRunning = job.status === "running";
   const isCancelled = job.status === "cancelled";
+  // P-0099 v3-20f: paused is non-terminal — the job still owns the
+  // workspace's training slot and can be resumed in place via
+  // POST /api/jobs/{id}/unpause OR cancelled outright.
+  const isPaused = job.status === "paused";
 
   return (
     <div className="flex h-full flex-col">
@@ -177,6 +183,18 @@ export function JobDetailPanel({
         {isCancelled && (
           <p className="text-sm text-muted-foreground">
             This job was cancelled before completion.
+          </p>
+        )}
+
+        {/* Paused state — non-terminal; the user must click Resume or
+         Cancel to free the workspace's training slot. */}
+        {isPaused && (
+          <p
+            className="text-sm text-muted-foreground"
+            data-testid="paused-notice"
+          >
+            This tune is paused. Click <strong>Resume</strong> to continue from
+            the next trial, or <strong>Cancel</strong> to discard.
           </p>
         )}
 
@@ -283,6 +301,29 @@ export function JobDetailPanel({
             onStarted={handleRetuneStarted}
           />
         )}
+        {/* P-0099 v3-20f: Pause for running tune jobs. Pause is a
+         tune-only action — fit jobs are short-running by design and
+         have no useful resume target. */}
+        {isRunning && job.job_type === "tune" && (
+          <PauseActionButton jobId={job.job_id} />
+        )}
+        {/* P-0099 v3-20f: Resume + Cancel for paused tune jobs. The
+         user is reminded by HTTP 400 + JOB_NOT_PAUSED that the
+         resume action is in-place (same job_id), distinct from the
+         /resume child-job lineage on failed parents. */}
+        {isPaused && job.job_type === "tune" && (
+          <>
+            <UnpauseActionButton jobId={job.job_id} />
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setCancelConfirm(true)}
+            >
+              <X className="mr-1 h-3 w-3" />
+              Cancel
+            </Button>
+          </>
+        )}
         {isRunning && (
           <Button
             variant="outline"
@@ -293,7 +334,7 @@ export function JobDetailPanel({
             Cancel
           </Button>
         )}
-        {!isRunning && (
+        {!isRunning && !isPaused && (
           // text-danger-fg maps onto --lzs-danger-fg (hsl(0 63% 31%)
           // light / hsl(0 94% 75%) dark), which matches the previous
           // red-700/red-400 pair and preserves WCAG 2 AA contrast
@@ -320,7 +361,9 @@ export function JobDetailPanel({
             <DialogTitle>Cancel job?</DialogTitle>
           </DialogHeader>
           <p className="text-sm">
-            Are you sure you want to cancel this running job?
+            {isPaused
+              ? "Are you sure you want to cancel this paused job? The saved Optuna study will be discarded."
+              : "Are you sure you want to cancel this running job?"}
           </p>
           <div className="flex justify-end gap-2">
             <Button variant="outline" onClick={() => setCancelConfirm(false)}>

--- a/frontend/src/components/jobs/PauseActionButton.test.tsx
+++ b/frontend/src/components/jobs/PauseActionButton.test.tsx
@@ -1,0 +1,84 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PauseActionButton } from "./PauseActionButton";
+
+const mockPauseJob = vi.fn();
+
+vi.mock("@/api/jobs", () => ({
+  pauseJob: (...args: unknown[]) => mockPauseJob(...args),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+function renderButton(
+  props: Partial<Parameters<typeof PauseActionButton>[0]> = {},
+) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <PauseActionButton jobId="job_paused_target" {...props} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockPauseJob.mockReset();
+});
+
+describe("PauseActionButton", () => {
+  it("renders the Pause label with accessible name", () => {
+    renderButton();
+    const trigger = screen.getByRole("button", {
+      name: /Pause tuning at next trial/i,
+    });
+    expect(trigger.textContent ?? "").toContain("Pause");
+  });
+
+  it("calls pauseJob with the supplied jobId on click", async () => {
+    mockPauseJob.mockResolvedValue({ status: "pause_requested" });
+
+    renderButton();
+    await userEvent.click(
+      screen.getByRole("button", { name: /Pause tuning at next trial/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockPauseJob).toHaveBeenCalledWith("job_paused_target");
+    });
+  });
+
+  it("invokes onPauseRequested after a successful pause", async () => {
+    mockPauseJob.mockResolvedValue({ status: "pause_requested" });
+    const onPauseRequested = vi.fn();
+
+    renderButton({ onPauseRequested });
+    await userEvent.click(
+      screen.getByRole("button", { name: /Pause tuning at next trial/i }),
+    );
+
+    await waitFor(() => {
+      expect(onPauseRequested).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not call onPauseRequested when the request fails", async () => {
+    mockPauseJob.mockRejectedValue(new Error("400: JOB_NOT_RUNNING"));
+    const onPauseRequested = vi.fn();
+
+    renderButton({ onPauseRequested });
+    await userEvent.click(
+      screen.getByRole("button", { name: /Pause tuning at next trial/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockPauseJob).toHaveBeenCalled();
+    });
+    expect(onPauseRequested).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/jobs/PauseActionButton.tsx
+++ b/frontend/src/components/jobs/PauseActionButton.tsx
@@ -1,0 +1,55 @@
+import { PauseCircle } from "lucide-react";
+import { toast } from "sonner";
+import { usePauseJob } from "@/api/queries";
+import { Button } from "@/components/ui/button";
+
+export interface PauseActionButtonProps {
+  /** Tune Job id (must be in `running` state to be pauseable). */
+  jobId: string;
+  /**
+   * Called when the pause request is acknowledged by the backend. The
+   * worker observes the on-disk PAUSE flag at the next cooperative
+   * callback boundary and persists ``status="paused"``; the WS handler
+   * will then flip the UI through ``WsPaused`` (P-0099 v3-20e).
+   */
+  onPauseRequested?: () => void;
+}
+
+/**
+ * P-0099 v3-20f: request a running tune to pause at the next trial
+ * boundary. The job stays the same (in-place resumable via
+ * :class:`UnpauseActionButton`) — no child job is created here.
+ */
+export function PauseActionButton({
+  jobId,
+  onPauseRequested,
+}: PauseActionButtonProps) {
+  const mutation = usePauseJob();
+
+  const handleClick = () => {
+    mutation.mutate(jobId, {
+      onSuccess: () => {
+        toast.success(
+          "Pause requested. The tune will pause at the next trial.",
+        );
+        onPauseRequested?.();
+      },
+      onError: (err: Error) => {
+        toast.error(`Pause failed: ${err.message}`);
+      },
+    });
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleClick}
+      disabled={mutation.isPending}
+      aria-label="Pause tuning at next trial"
+    >
+      <PauseCircle className="mr-1 h-3 w-3" />
+      {mutation.isPending ? "Pausing..." : "Pause"}
+    </Button>
+  );
+}

--- a/frontend/src/components/jobs/UnpauseActionButton.test.tsx
+++ b/frontend/src/components/jobs/UnpauseActionButton.test.tsx
@@ -1,0 +1,99 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UnpauseActionButton } from "./UnpauseActionButton";
+
+const mockUnpauseJob = vi.fn();
+
+vi.mock("@/api/jobs", () => ({
+  unpauseJob: (...args: unknown[]) => mockUnpauseJob(...args),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+function renderButton(
+  props: Partial<Parameters<typeof UnpauseActionButton>[0]> = {},
+) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <UnpauseActionButton jobId="job_paused_target" {...props} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockUnpauseJob.mockReset();
+});
+
+describe("UnpauseActionButton", () => {
+  it("renders the Resume label with accessible name", () => {
+    renderButton();
+    const trigger = screen.getByRole("button", {
+      name: /Resume paused tuning/i,
+    });
+    expect(trigger.textContent ?? "").toContain("Resume");
+  });
+
+  it("calls unpauseJob with the supplied jobId on click", async () => {
+    mockUnpauseJob.mockResolvedValue({
+      status: "unpause_started",
+      job_id: "job_paused_target",
+    });
+
+    renderButton();
+    await userEvent.click(
+      screen.getByRole("button", { name: /Resume paused tuning/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockUnpauseJob).toHaveBeenCalledWith("job_paused_target");
+    });
+  });
+
+  it("disables the trigger when disabledReason is provided", () => {
+    renderButton({ disabledReason: "Workspace data not loaded" });
+    const trigger = screen.getByRole("button", {
+      name: /Resume paused tuning/i,
+    });
+    expect(trigger).toBeDisabled();
+    expect(trigger).toHaveAttribute("title", "Workspace data not loaded");
+  });
+
+  it("invokes onUnpauseStarted after a successful resume", async () => {
+    mockUnpauseJob.mockResolvedValue({
+      status: "unpause_started",
+      job_id: "job_paused_target",
+    });
+    const onUnpauseStarted = vi.fn();
+
+    renderButton({ onUnpauseStarted });
+    await userEvent.click(
+      screen.getByRole("button", { name: /Resume paused tuning/i }),
+    );
+
+    await waitFor(() => {
+      expect(onUnpauseStarted).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not call onUnpauseStarted when the request fails", async () => {
+    mockUnpauseJob.mockRejectedValue(new Error("400: WORKSPACE_NO_DATA"));
+    const onUnpauseStarted = vi.fn();
+
+    renderButton({ onUnpauseStarted });
+    await userEvent.click(
+      screen.getByRole("button", { name: /Resume paused tuning/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockUnpauseJob).toHaveBeenCalled();
+    });
+    expect(onUnpauseStarted).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/jobs/UnpauseActionButton.tsx
+++ b/frontend/src/components/jobs/UnpauseActionButton.tsx
@@ -1,0 +1,66 @@
+import { PlayCircle } from "lucide-react";
+import { toast } from "sonner";
+import { useUnpauseJob } from "@/api/queries";
+import { Button } from "@/components/ui/button";
+
+export interface UnpauseActionButtonProps {
+  /** Tune Job id (must be in `paused` state). */
+  jobId: string;
+  /**
+   * Optional reason to disable the button (e.g. workspace data was
+   * cleared since pause; the backend would 400 with WORKSPACE_NO_DATA).
+   * When provided the button renders disabled with a tooltip.
+   */
+  disabledReason?: string | null;
+  /**
+   * Called when the unpause request is acknowledged by the backend.
+   * The same ``job_id`` is preserved (in-place resume — NOT a child
+   * job like /resume), so the parent view does not need to switch
+   * its selection.
+   */
+  onUnpauseStarted?: () => void;
+}
+
+/**
+ * P-0099 v3-20f: re-launch a paused tune in place. The Optuna study
+ * re-attaches via ``load_if_exists=True`` and continues from the next
+ * trial — same ``job_id`` is preserved.
+ *
+ * Distinct from ``ResumeActionButton`` (failed→child-job lineage,
+ * H-0062 Phase B): unpause is the v3-20 "in-place" path for jobs the
+ * user paused on purpose mid-run.
+ */
+export function UnpauseActionButton({
+  jobId,
+  disabledReason,
+  onUnpauseStarted,
+}: UnpauseActionButtonProps) {
+  const mutation = useUnpauseJob();
+  const disabled = disabledReason != null || mutation.isPending;
+
+  const handleClick = () => {
+    mutation.mutate(jobId, {
+      onSuccess: () => {
+        toast.success("Tune resumed.");
+        onUnpauseStarted?.();
+      },
+      onError: (err: Error) => {
+        toast.error(`Resume failed: ${err.message}`);
+      },
+    });
+  };
+
+  return (
+    <Button
+      variant="default"
+      size="sm"
+      onClick={handleClick}
+      disabled={disabled}
+      title={disabledReason ?? undefined}
+      aria-label="Resume paused tuning"
+    >
+      <PlayCircle className="mr-1 h-3 w-3" />
+      {mutation.isPending ? "Resuming..." : "Resume"}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary

v0.5 R-1.4 (P-0099 / Issue #360 / Tune long-run resumability) v3-20f sub-phase. Adds the user-facing Pause and Resume affordances on top of the v3-20d `/pause` and `/unpause` API endpoints. Running tune jobs now show a **Pause** button; paused tunes show **Resume** + **Cancel** + a notice paragraph explaining the user must explicitly act to free the workspace's training slot.

What ships here:
- **`api/jobs.ts`** — `pauseJob(jobId)` + `unpauseJob(jobId)` helpers wired to the typed apiClient.
- **`api/queries/usePauseJob.ts` + `useUnpauseJob.ts`** — TanStack Query mutations that invalidate `jobs` and `job(id)` queries on success so the UI reflects the new state immediately.
- **`components/jobs/PauseActionButton.tsx`** — small outline button with PauseCircle icon. No dialog — pause is a one-click action.
- **`components/jobs/UnpauseActionButton.tsx`** — filled Resume button with PlayCircle icon. Distinct from `ResumeActionButton` in the retune family (failed→child-job lineage); the v3-20 unpause is in-place (same `job_id`). Accepts `disabledReason` for client-side blocking.
- **`JobDetail.tsx`** adds `isPaused` branch:
  - Action bar: Pause for running tune; Resume + Cancel for paused tune.
  - Body: explanatory notice paragraph for paused state.
  - Cancel-confirm dialog text adjusts for paused vs running.

What is intentionally NOT in this PR (deferred):
- Playwright tune-resume E2E + INV-4 round-trip with real Optuna trial-resume — v3-20g.

## Failure Paths Covered

- [x] Pause click → `pauseJob` dispatched → on success `onPauseRequested` fires; toast shows confirmation
- [x] Pause failure (e.g. backend already paused) → toast shows error, callback NOT fired
- [x] Resume click → `unpauseJob` dispatched → on success `onUnpauseStarted` fires; toast confirms
- [x] Resume failure (e.g. backend `WORKSPACE_NO_DATA`) → toast shows error, callback NOT fired
- [x] `disabledReason` provided → Resume button disabled with title attribute as tooltip
- [x] JobDetail running tune → shows Pause + Cancel
- [x] JobDetail paused tune → shows Resume + Cancel + notice paragraph; hides Delete / Inference / Export
- [x] JobDetail running fit → does NOT show Pause (tune-only)

## Test plan

- [x] `PauseActionButton.test.tsx` — 4 cases (label, dispatch, success callback, failure callback)
- [x] `UnpauseActionButton.test.tsx` — 5 cases (label, dispatch, disabledReason, success/failure callbacks)
- [x] `JobDetail.test.tsx` — 3 new cases (running tune Pause, paused tune Resume+Cancel+notice, running fit no Pause)
- [x] Frontend Vitest full: 1833 passed / 125 files
- [x] Backend regression + contract + jobs API + inference: **338 passed / 6 skipped** in 2:51
- [x] `tsc --noEmit` clean
- [x] `biome check src/` clean
- [x] `frontend/src/api/generated/schema.d.ts` no changes (v3-20d already added the new endpoints)