### PR TITLE
feat(services,server): startup reconciliation for orphan + paused jobs (v3-22a, P-0099 R-1.5b)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3285,6 +3285,16 @@ R-1.1〜R-1.5b の各 phase に invariant test を割り当てる。本 Proposal
     - `API: unpause on a non-paused job is rejected with JOB_NOT_PAUSED`
   - **R-1.4 完了** — v3-20a〜g 全 7 sub-phase shipped、v0.5 の Tune long-run resumability invariants が確定
   - 後続 (v3-22): server restart で paused 状態を復元 (R-1.5b、別 Proposal で Issue #384 child として進める)
+- 2026-05-07 **v3-22a (R-1.5b server restart reconciliation) 実装** — `feat/v3-22a-startup-reconcile` ブランチ:
+  - `JobStore.reconcile_at_startup()` 新メソッド: server lifespan 起動時に on-disk meta.json をスキャンし以下の reconciliation を実施
+    - `running` / `pending` 状態の orphan job → `failed` 化（worker thread/subprocess は前プロセスと共に消えているため）。`error` に "Server restarted before this job could complete" を記録
+    - `paused` 状態の job → in-memory `_active_job_id` に再 attach し、active-jobs gauge を 1 に設定（INV-1 の slot 占有を restart 越しに維持、INV-restart-2）
+    - 多重 paused（ありえない corruption ケース）→ `created_at` newest を survivor、他は failed 化（INV-1 deterministic restoration）
+    - terminal states (`completed` / `failed` / `cancelled`) は **rewrite しない**（INV-restart-3）
+    - idempotent: 2 回呼んでも同じ結果（既に reconcile 済の状態に対して候補なし）
+  - `server.py:lifespan` で `JobStore` 構築直後に `reconcile_at_startup()` を呼び出し
+  - tests: `test_inv_startup_reconcile.py` 9 件で 3 不変条件（INV-restart-1/2/3）+ JOB_CONFLICT cross-restart + idempotence を gate
+  - 後続 (v3-22b/c): INV-7 unified test、Playwright 実 server-restart e2e は本 PR の scope 外
 - 2026-05-07 **v3-20f (R-1.4 frontend Pause/Resume buttons) 実装** — `feat/v3-20f-frontend-pause-resume-buttons` ブランチ:
   - `frontend/src/api/jobs.ts`: `pauseJob(jobId)` / `unpauseJob(jobId)` API helpers 追加
   - `frontend/src/api/queries/usePauseJob.ts` + `useUnpauseJob.ts`: TanStack Query mutation hooks (jobs / job(id) invalidation)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1391,7 +1391,7 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 
 | サブフェーズ | 内容 | 状態 | PR |
 |---|---|---|---|
-| v3-22a | server lifespan startup で paused jobs を `meta.json` から再 attach | 🟡 | — |
+| v3-22a | server lifespan startup で paused jobs を `meta.json` から再 attach + orphaned running/pending を failed に reconcile + 多重 paused は newest 残し他 failed | 🟢 | feat/v3-22a-startup-reconcile |
 | v3-22b | `tests/regression/test_inv_ws_disconnect_does_not_release.py` で INV-7 検証 | 🟡 | — |
 | v3-22c | Playwright `tests/e2e/server-restart-recovery.spec.ts` で実 restart シナリオ | 🟡 | — |
 

--- a/src/lizystudio/server.py
+++ b/src/lizystudio/server.py
@@ -126,6 +126,10 @@ def create_app() -> FastAPI:
         application.state.metrics = metrics
         application.state.workspace = WorkspaceState(backend=adapter)
         application.state.job_store = JobStore(jobs_dir, metrics=metrics)
+        # P-0099 v3-22a (R-1.5b): reconcile orphaned running/pending
+        # rows to failed and re-attach the paused job's active slot
+        # so the in-place /unpause contract survives restart.
+        application.state.job_store.reconcile_at_startup()
         broadcaster = ProgressBroadcaster(metrics=metrics)
         broadcaster.set_loop(asyncio.get_running_loop())
         application.state.broadcaster = broadcaster

--- a/src/lizystudio/services/jobs.py
+++ b/src/lizystudio/services/jobs.py
@@ -721,6 +721,83 @@ class JobStore:
         job.status = new_status  # type: ignore[assignment]
         self.update(job)
 
+    # --- Startup reconciliation (P-0099 v3-22a, R-1.5b) ---
+
+    def reconcile_at_startup(self) -> None:
+        """Reconcile in-memory state with disk after server (re)start.
+
+        At fresh process start the in-memory ``_active_job_id`` is
+        ``None`` while ``meta.json`` files survive the restart. Three
+        invariants must be restored:
+
+          INV-restart-1: ``running`` / ``pending`` rows on disk are
+            orphaned — no thread / subprocess survived. Reconcile to
+            ``failed`` with a clear error so the UI does not dangle.
+
+          INV-restart-2: at most ONE ``paused`` job survives (newest
+            by ``created_at`` wins). The survivor claims the active
+            slot so a concurrent /tune is rejected with
+            ``JOB_CONFLICT`` until the user clicks Resume or Cancel
+            (in-place /unpause contract from v3-20d).
+
+          INV-restart-3: terminal rows (completed / failed / cancelled)
+            are NEVER rewritten — reconciliation is a one-way forward
+            arrow.
+
+        Idempotent: running a second time on already-reconciled state
+        is a no-op (paused survivor stays paused, terminals stay
+        terminal, no further candidates exist).
+        """
+        paused_candidates: list[Job] = []
+        running_orphans: list[Job] = []
+        for job in self.list():
+            if job.status in ("running", "pending"):
+                running_orphans.append(job)
+            elif job.status == "paused":
+                paused_candidates.append(job)
+
+        now = datetime.now(timezone.utc).isoformat()
+
+        for job in running_orphans:
+            _logger.warning(
+                "Reconciling orphaned %s job %s to failed at startup",
+                job.status,
+                job.job_id,
+            )
+            job.status = "failed"
+            job.error = "Server restarted before this job could complete"
+            job.completed_at = now
+            self.update(job)
+
+        if len(paused_candidates) > 1:
+            paused_candidates.sort(key=lambda j: j.created_at, reverse=True)
+            winner = paused_candidates[0]
+            _logger.warning(
+                "Multiple paused jobs at startup (%d); keeping newest %s, "
+                "reconciling the rest to failed",
+                len(paused_candidates),
+                winner.job_id,
+            )
+            for job in paused_candidates[1:]:
+                job.status = "failed"
+                job.error = (
+                    "Multiple paused jobs found at startup; only the newest "
+                    "is preserved (INV-1: at most one paused job)"
+                )
+                job.completed_at = now
+                self.update(job)
+            paused_candidates = [winner]
+
+        if paused_candidates:
+            survivor = paused_candidates[0]
+            with self._active_lock:
+                self._active_job_id = survivor.job_id
+                self._set_active_gauge(1)
+            _logger.info(
+                "Re-attached paused job %s to active slot at startup",
+                survivor.job_id,
+            )
+
     # --- Active job tracking (concurrency control) ---
 
     def create_and_claim_active(

--- a/tests/regression/test_inv_startup_reconcile.py
+++ b/tests/regression/test_inv_startup_reconcile.py
@@ -1,0 +1,281 @@
+"""INV-7 / INV-1 cross-restart reconciliation (P-0099 v3-22a, R-1.5b).
+
+When the server (re)starts, the in-memory ``JobStore`` is empty —
+``_active_job_id`` is ``None`` and ``_pause_requested`` / ``_cancel_requested``
+are empty sets. The on-disk ``meta.json`` files survive, so the disk
+records may carry mid-flight state from the previous process:
+
+  * ``status="running"`` jobs whose worker thread / subprocess is now
+    dead. Without reconciliation the UI would show "running forever"
+    and ``_is_slot_holder_stale_locked`` would only catch this AFTER
+    the next /fit or /tune request.
+
+  * ``status="paused"`` jobs that were holding the active slot via
+    INV-1. Without reconciliation the slot is silently free and a
+    concurrent /tune could steal it before the user clicks Resume,
+    breaking the in-place /unpause contract from v3-20d.
+
+This module pins the startup reconciliation contract:
+
+  INV-restart-1: every ``running`` record on disk transitions to
+                 ``failed`` with a clear error message at startup.
+
+  INV-restart-2: at most ONE ``paused`` job survives startup (newest
+                 by ``created_at`` wins); the survivor claims the
+                 active slot so concurrent /tune is rejected with
+                 ``JOB_CONFLICT``.
+
+  INV-restart-3: terminal states (completed / failed / cancelled)
+                 are NEVER rewritten — the reconciliation is a one-way
+                 forward arrow.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from lizystudio.backends.types import DataRef
+from lizystudio.services.jobs import Job, JobStore
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def fresh_store(tmp_path: Path) -> JobStore:
+    return JobStore(tmp_path / "jobs")
+
+
+def _make_data_ref() -> DataRef:
+    return DataRef(
+        source_type="path",
+        path="/data/x.csv",
+        filename="x.csv",
+        fingerprint="f",
+        shape=(10, 2),
+    )
+
+
+JobType = Literal["fit", "tune"]
+
+
+def _create_with_status(
+    store: JobStore,
+    status: str,
+    *,
+    job_type: JobType = "tune",
+) -> Job:
+    """Create a job and force-write *status* to disk.
+
+    Mirrors how a previous process would have left meta.json — we
+    bypass the runtime guard because the test is exactly about disk
+    state surviving across restart, not the live transition path.
+    """
+    job = store.create(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=_make_data_ref(),
+        job_type=job_type,
+    )
+    job.status = status  # type: ignore[assignment]
+    store.update(job)
+    return job
+
+
+# ---------------------------------------------------------------------------
+# INV-restart-1: orphaned ``running`` rows transition to ``failed``.
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_at_startup_running_orphan_transitions_to_failed(
+    fresh_store: JobStore,
+) -> None:
+    job = _create_with_status(fresh_store, "running")
+
+    # Simulate a fresh process: re-instantiate the JobStore against
+    # the same on-disk directory (in-memory state reset) and run the
+    # reconciliation entry point.
+    reborn = JobStore(fresh_store.jobs_dir)
+    reborn.reconcile_at_startup()
+
+    reloaded = reborn.get(job.job_id)
+    assert reloaded is not None
+    assert reloaded.status == "failed", (
+        "INV-restart-1: running rows must reconcile to failed at startup"
+    )
+    assert reloaded.error is not None
+    assert "server" in reloaded.error.lower(), (
+        "Error must explain the cause (server restart) for the user"
+    )
+    assert reloaded.completed_at is not None, (
+        "INV-restart-1: failed is terminal — completed_at must be stamped"
+    )
+
+
+def test_reconcile_at_startup_pending_orphan_transitions_to_failed(
+    fresh_store: JobStore,
+) -> None:
+    """``pending`` jobs that never got a worker also count as orphans.
+
+    Without reconciliation the UI would dangle on "pending" forever
+    because the worker thread that would normally flip it to running
+    is gone with the previous process.
+    """
+    job = _create_with_status(fresh_store, "pending")
+
+    reborn = JobStore(fresh_store.jobs_dir)
+    reborn.reconcile_at_startup()
+
+    reloaded = reborn.get(job.job_id)
+    assert reloaded is not None
+    assert reloaded.status == "failed"
+
+
+# ---------------------------------------------------------------------------
+# INV-restart-2: paused job re-claims the active slot.
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_at_startup_paused_claims_active_slot(
+    fresh_store: JobStore,
+) -> None:
+    job = _create_with_status(fresh_store, "paused")
+
+    reborn = JobStore(fresh_store.jobs_dir)
+    assert reborn.active_job_id is None, "precondition: fresh store has no slot"
+
+    reborn.reconcile_at_startup()
+
+    assert reborn.active_job_id == job.job_id, (
+        "INV-restart-2: paused job must re-attach the active slot at startup"
+    )
+
+    # And the on-disk status remains paused (NOT rewritten to running
+    # or anything else — the user must click Resume to advance).
+    reloaded = reborn.get(job.job_id)
+    assert reloaded is not None
+    assert reloaded.status == "paused"
+
+
+def test_reconcile_at_startup_concurrent_claim_blocked_by_paused(
+    fresh_store: JobStore,
+) -> None:
+    """After reconciliation the paused job's slot blocks new tunes.
+
+    This is the JOB_CONFLICT contract that the v3-20d /tune endpoint
+    relies on — without slot re-attach, a /tune POST seconds after
+    startup would silently steal the slot the user thought they had
+    paused.
+    """
+    paused = _create_with_status(fresh_store, "paused")
+
+    reborn = JobStore(fresh_store.jobs_dir)
+    reborn.reconcile_at_startup()
+
+    new_job = reborn.create_and_claim_active(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=_make_data_ref(),
+        job_type="tune",
+    )
+    assert new_job is None, (
+        "INV-restart-2: concurrent /tune must be rejected while a "
+        "reconciled paused job holds the slot"
+    )
+    # And the original paused job is still the slot holder.
+    assert reborn.active_job_id == paused.job_id
+
+
+def test_reconcile_at_startup_multiple_paused_keeps_newest_only(
+    fresh_store: JobStore,
+) -> None:
+    """If the disk somehow holds multiple paused jobs (corruption),
+    only the newest by ``created_at`` survives — the others are
+    reconciled to ``failed`` so INV-1 ("at most one paused job") is
+    restored deterministically.
+    """
+    older = _create_with_status(fresh_store, "paused")
+    # Force the second to be objectively newer.
+    newer = _create_with_status(fresh_store, "paused")
+    assert newer.created_at >= older.created_at
+
+    reborn = JobStore(fresh_store.jobs_dir)
+    reborn.reconcile_at_startup()
+
+    # Only the newer one keeps the paused state and the slot.
+    survivor = reborn.get(newer.job_id)
+    loser = reborn.get(older.job_id)
+    assert survivor is not None and survivor.status == "paused"
+    assert loser is not None and loser.status == "failed"
+    assert reborn.active_job_id == newer.job_id
+
+
+# ---------------------------------------------------------------------------
+# INV-restart-3: terminal states are NEVER rewritten.
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_at_startup_completed_job_unchanged(
+    fresh_store: JobStore,
+) -> None:
+    job = _create_with_status(fresh_store, "completed")
+
+    reborn = JobStore(fresh_store.jobs_dir)
+    reborn.reconcile_at_startup()
+
+    reloaded = reborn.get(job.job_id)
+    assert reloaded is not None
+    assert reloaded.status == "completed"
+
+
+def test_reconcile_at_startup_failed_job_unchanged(
+    fresh_store: JobStore,
+) -> None:
+    job = _create_with_status(fresh_store, "failed")
+
+    reborn = JobStore(fresh_store.jobs_dir)
+    reborn.reconcile_at_startup()
+
+    reloaded = reborn.get(job.job_id)
+    assert reloaded is not None
+    assert reloaded.status == "failed"
+
+
+def test_reconcile_at_startup_cancelled_job_unchanged(
+    fresh_store: JobStore,
+) -> None:
+    job = _create_with_status(fresh_store, "cancelled")
+
+    reborn = JobStore(fresh_store.jobs_dir)
+    reborn.reconcile_at_startup()
+
+    reloaded = reborn.get(job.job_id)
+    assert reloaded is not None
+    assert reloaded.status == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# Idempotence: a second reconcile call after a normal startup is a no-op.
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_at_startup_is_idempotent(fresh_store: JobStore) -> None:
+    """Calling reconcile twice in the same process is harmless.
+
+    Practical scenarios where this matters: a test fixture invokes
+    reconcile, then production lifespan code (also calling reconcile)
+    runs against the same JobStore — the second call must observe the
+    same already-reconciled state and not re-rewrite anything.
+    """
+    paused = _create_with_status(fresh_store, "paused")
+    completed = _create_with_status(fresh_store, "completed")
+
+    reborn = JobStore(fresh_store.jobs_dir)
+    reborn.reconcile_at_startup()
+    reborn.reconcile_at_startup()  # no-op on already-reconciled state
+
+    assert reborn.active_job_id == paused.job_id
+    assert reborn.get(completed.job_id) is not None
+    assert reborn.get(completed.job_id).status == "completed"  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary

v0.5 R-1.5b (P-0099 / Issue #384) v3-22a sub-phase. Lands the server-restart recovery primitive that v3-20 (R-1.4) deferred: the in-memory `_active_job_id` resets to `None` on process start while `meta.json` files survive, so the disk records can carry mid-flight state from the previous process.

Pre-fix risks:
- Orphaned `running` rows would show "running forever" in the UI because no thread is actually working on them
- A `paused` job's active slot would silently free up so a concurrent `/tune` could steal it before the user clicked Resume — defeating the v3-20d in-place `/unpause` contract across restart

What ships here:
- **`JobStore.reconcile_at_startup()`** — scans on-disk `meta.json`:
  - `running` / `pending` orphans → `failed` with error `"Server restarted before this job could complete"`
  - `paused` survivor → claims `_active_job_id` so concurrent `/tune` is rejected with `JOB_CONFLICT` (INV-1 preserved across restart)
  - Multiple `paused` (corruption) → newest by `created_at` wins, others reconcile to `failed` (deterministic INV-1 restoration)
  - Terminal states (`completed` / `failed` / `cancelled`) **NEVER** rewritten
  - **Idempotent** — second call on already-reconciled state is a no-op
- **`server.py:lifespan`** — calls `reconcile_at_startup()` right after `JobStore` is constructed, before broadcaster setup, so the API surface is consistent the first time it serves a request

What is intentionally NOT in this PR (deferred):
- Cross-link with `test_inv_ws_disconnect_does_not_release.py` for INV-7 (v3-22b)
- Playwright real server-restart E2E spec (v3-22c)

## Invariants

- **INV-restart-1**: every `running` / `pending` row on disk transitions to `failed` at startup — no UI dangling on dead worker state.
- **INV-restart-2**: at most ONE `paused` job survives startup (newest by `created_at` wins); the survivor claims the active slot so concurrent `/tune` is rejected.
- **INV-restart-3**: terminal states are NEVER rewritten — reconciliation is a one-way forward arrow.

## Failure Paths Covered

- [x] Running orphan → failed (running thread dead at restart)
- [x] Pending orphan → failed (worker thread never spawned)
- [x] Paused → active slot re-attached
- [x] Cross-restart JOB_CONFLICT — concurrent /tune rejected while paused holds slot
- [x] Multiple paused (corruption) → newest wins, others failed
- [x] Completed unchanged
- [x] Failed unchanged
- [x] Cancelled unchanged
- [x] Idempotent — second call on reconciled state is a no-op
- [ ] WS disconnect cross-link (out of scope, v3-22b)
- [ ] Real server kill + restart E2E (out of scope, v3-22c)

## Test plan

- [x] `tests/regression/test_inv_startup_reconcile.py` — 9 new cases (INV-restart-1 / 2 / 3 + JOB_CONFLICT cross-restart + idempotence)
- [x] Backend regression + contract: **283 passed / 6 skipped** in 2:03
- [x] `ruff check` + `ruff format --check` + `mypy` clean on changed files
- [x] No frontend changes; `schema.d.ts` not affected