### PR TITLE
test(regression): INV-7 cross-restart WS disconnect coverage (v3-22b, P-0099 R-1.5b / Issue #384)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3285,6 +3285,14 @@ R-1.1〜R-1.5b の各 phase に invariant test を割り当てる。本 Proposal
     - `API: unpause on a non-paused job is rejected with JOB_NOT_PAUSED`
   - **R-1.4 完了** — v3-20a〜g 全 7 sub-phase shipped、v0.5 の Tune long-run resumability invariants が確定
   - 後続 (v3-22): server restart で paused 状態を復元 (R-1.5b、別 Proposal で Issue #384 child として進める)
+- 2026-05-07 **v3-22b (R-1.5b INV-7 unified test) 実装** — `feat/v3-22b-inv7-ws-disconnect-test` ブランチ:
+  - `tests/regression/test_inv_ws_disconnect_does_not_release.py` 新規 4 件で INV-7 (WebSocket disconnect は active slot を release しない) を multi-scenario で gate:
+    - Scenario A baseline: same-process subscribe→unsubscribe round-trip で paused job の slot が touched しない
+    - Scenario A continued: running + WS disconnect + crash → reconcile が orphan を failed 化、slot は crash recovery で free (WS disconnect 起因ではない)
+    - Scenario B: paused + WS disconnect + restart → reconcile が slot 再 attach、cross-restart JOB_CONFLICT で INV-7 維持
+    - Robustness: 16 回 subscribe/unsubscribe cycle で slot ownership に漏れがない
+  - 既存 `test_inv_slot_release.py::test_inv1_path5_*` (path 5 同 process) と組み合わせて INV-7 end-to-end coverage 完了
+  - Issue #384 close 条件 (INV-7 invariant test green) 達成
 - 2026-05-07 **v3-22a (R-1.5b server restart reconciliation) 実装** — `feat/v3-22a-startup-reconcile` ブランチ:
   - `JobStore.reconcile_at_startup()` 新メソッド: server lifespan 起動時に on-disk meta.json をスキャンし以下の reconciliation を実施
     - `running` / `pending` 状態の orphan job → `failed` 化（worker thread/subprocess は前プロセスと共に消えているため）。`error` に "Server restarted before this job could complete" を記録

--- a/PLAN.md
+++ b/PLAN.md
@@ -1392,7 +1392,7 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 | サブフェーズ | 内容 | 状態 | PR |
 |---|---|---|---|
 | v3-22a | server lifespan startup で paused jobs を `meta.json` から再 attach + orphaned running/pending を failed に reconcile + 多重 paused は newest 残し他 failed | 🟢 | feat/v3-22a-startup-reconcile |
-| v3-22b | `tests/regression/test_inv_ws_disconnect_does_not_release.py` で INV-7 検証 | 🟡 | — |
+| v3-22b | `tests/regression/test_inv_ws_disconnect_does_not_release.py` で INV-7 検証 (same-process baseline + cross-restart Scenario A 走行 orphan reconcile + Scenario B paused slot 復元 + 16 cycle robustness) | 🟢 | feat/v3-22b-inv7-ws-disconnect-test |
 | v3-22c | Playwright `tests/e2e/server-restart-recovery.spec.ts` で実 restart シナリオ | 🟡 | — |
 
 **DoD:**

--- a/tests/regression/test_inv_ws_disconnect_does_not_release.py
+++ b/tests/regression/test_inv_ws_disconnect_does_not_release.py
@@ -1,0 +1,239 @@
+"""INV-7: WebSocket disconnect MUST NOT release the active slot
+(P-0099 v3-22b, R-1.5b / Issue #384).
+
+INV-7 declaration (P-0099):
+
+  WebSocket disconnect は active slot を release **しない** — 進行中
+  job は subscriber 数に依らず completion または terminal failure まで
+  走る。
+
+The same-process invariant (subscribe -> unsubscribe within a single
+``ProgressBroadcaster`` instance) is pinned by
+``test_inv_slot_release.py::test_inv1_path5_ws_disconnect_does_not_release_until_terminal``.
+This module focuses on the **cross-restart** angle that v3-22a's
+``reconcile_at_startup`` introduced:
+
+  Scenario A (running + WS disconnect + crash):
+    User opens the WS, the worker starts a tune, the WS disconnects
+    (browser close / network drop), the server crashes mid-run. On
+    next startup the orphaned ``running`` row reconciles to ``failed``
+    — the slot is freed by the crash, NOT by the WS disconnect.
+
+  Scenario B (paused + WS disconnect + restart):
+    User clicks Pause, the WS disconnects, the server is restarted
+    cleanly (``uvicorn --reload`` or operational restart). The on-
+    disk paused row survives, ``reconcile_at_startup`` re-attaches
+    the slot, and a concurrent /tune is rejected with JOB_CONFLICT
+    just as if the WS had never been opened. INV-7 is preserved
+    across the restart boundary.
+
+Together these scenarios + the existing same-process test give INV-7
+end-to-end coverage and let us close Issue #384.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from lizystudio.backends.types import DataRef
+from lizystudio.services.jobs import Job, JobStore
+from lizystudio.ws.progress import ProgressBroadcaster
+
+pytestmark = pytest.mark.unit
+
+
+def _make_data_ref() -> DataRef:
+    return DataRef(
+        source_type="path",
+        path="/data/x.csv",
+        filename="x.csv",
+        fingerprint="f",
+        shape=(10, 2),
+    )
+
+
+JobType = Literal["fit", "tune"]
+
+
+def _create_with_status(
+    store: JobStore,
+    status: str,
+    *,
+    job_type: JobType = "tune",
+) -> Job:
+    """Create a job and force-write *status* to disk.
+
+    Bypasses the runtime guard so we can stage cross-restart fixtures
+    that mirror what a previous process would have left on disk.
+    """
+    job = store.create(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=_make_data_ref(),
+        job_type=job_type,
+    )
+    job.status = status  # type: ignore[assignment]
+    store.update(job)
+    return job
+
+
+# ---------------------------------------------------------------------------
+# Scenario A: WS disconnect on a running job is independent of crash recovery.
+# ---------------------------------------------------------------------------
+
+
+def test_ws_disconnect_does_not_release_slot_in_same_process(tmp_path: Path) -> None:
+    """Same-process baseline: subscribe + unsubscribe leaves the slot held.
+
+    Pre-fix the broadcaster's bookkeeping leaked into slot ownership
+    so a single WS round-trip on a paused / running job would silently
+    free the slot. This test pins the inverse contract.
+    """
+    store = JobStore(tmp_path / "jobs")
+    job = _create_with_status(store, "paused")
+    # Manually install the slot — paused jobs hold the slot per INV-1
+    # (claimed at /tune time, retained by the v3-20c paused branch).
+    store.claim_active(job.job_id)
+    assert store.active_job_id == job.job_id
+
+    broadcaster = ProgressBroadcaster()
+
+    async def subscribe_unsubscribe() -> None:
+        q = broadcaster.subscribe(job.job_id)
+        broadcaster.unsubscribe(job.job_id, q)
+
+    asyncio.run(subscribe_unsubscribe())
+
+    assert store.active_job_id == job.job_id, (
+        "INV-7: a WS subscribe / unsubscribe round-trip must not flip "
+        "active_job_id — slot ownership is the worker thread's concern, "
+        "not the broadcaster's"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario A continued: running + crash -> reconcile-to-failed (slot freed by
+# crash recovery, NOT by the prior WS disconnect).
+# ---------------------------------------------------------------------------
+
+
+def test_running_orphan_after_ws_disconnect_reconciles_to_failed(
+    tmp_path: Path,
+) -> None:
+    """A running job whose WS disconnected then died with the server
+    is reconciled to failed at next startup. The slot is freed by the
+    crash-recovery path, not by the WS disconnect — INV-7 preserved.
+    """
+    store = JobStore(tmp_path / "jobs")
+    running = _create_with_status(store, "running")
+    store.claim_active(running.job_id)
+
+    # Simulate a WS subscribe + disconnect mid-flight.
+    broadcaster = ProgressBroadcaster()
+
+    async def subscribe_unsubscribe() -> None:
+        q = broadcaster.subscribe(running.job_id)
+        broadcaster.unsubscribe(running.job_id, q)
+
+    asyncio.run(subscribe_unsubscribe())
+    # Pre-crash invariant: the slot is still held even though no one
+    # is watching.
+    assert store.active_job_id == running.job_id
+
+    # Simulate process restart: in-memory state goes away, on-disk
+    # rows survive, reconcile runs.
+    reborn = JobStore(store.jobs_dir)
+    reborn.reconcile_at_startup()
+
+    reloaded = reborn.get(running.job_id)
+    assert reloaded is not None
+    assert reloaded.status == "failed", (
+        "Crash-recovery branch must transition the orphan to failed"
+    )
+    # And the slot is now free — but it was freed by reconcile (the
+    # worker is gone), NOT by the WS disconnect that happened earlier.
+    assert reborn.active_job_id is None
+
+
+# ---------------------------------------------------------------------------
+# Scenario B: paused + WS disconnect + restart -> slot survives via reconcile.
+# ---------------------------------------------------------------------------
+
+
+def test_paused_slot_survives_ws_disconnect_and_restart(tmp_path: Path) -> None:
+    """The user pauses, closes the browser (WS disconnect), then the
+    operator restarts the server. INV-7 must hold across the restart:
+    a concurrent /tune the moment the server comes back up is rejected
+    because the paused job's slot is re-attached by reconcile.
+    """
+    store = JobStore(tmp_path / "jobs")
+    paused = _create_with_status(store, "paused")
+    store.claim_active(paused.job_id)
+
+    # User closes the browser; WS disconnects.
+    broadcaster = ProgressBroadcaster()
+
+    async def subscribe_unsubscribe() -> None:
+        q = broadcaster.subscribe(paused.job_id)
+        broadcaster.unsubscribe(paused.job_id, q)
+
+    asyncio.run(subscribe_unsubscribe())
+    assert store.active_job_id == paused.job_id  # still held
+
+    # Operational restart — in-memory state is wiped, disk survives.
+    reborn = JobStore(store.jobs_dir)
+    assert reborn.active_job_id is None  # fresh process
+    reborn.reconcile_at_startup()
+
+    # INV-7 across restart: the slot is restored, the paused row is
+    # untouched, and a concurrent /tune is rejected.
+    assert reborn.active_job_id == paused.job_id, (
+        "INV-7 cross-restart: paused job's slot must be re-attached so "
+        "WS disconnect + restart is observably equivalent to no-disconnect"
+    )
+    reloaded = reborn.get(paused.job_id)
+    assert reloaded is not None
+    assert reloaded.status == "paused"  # never rewritten
+
+    new_job = reborn.create_and_claim_active(
+        backend_name="lizyml",
+        config={"task": "binary", "data": {"target": "y"}},
+        data_ref=_make_data_ref(),
+        job_type="tune",
+    )
+    assert new_job is None, (
+        "Concurrent /tune after restart must be rejected with JOB_CONFLICT "
+        "because the reconciled slot is still held by the paused job"
+    )
+
+
+def test_repeated_ws_subscribe_unsubscribe_does_not_perturb_slot(
+    tmp_path: Path,
+) -> None:
+    """Robustness: many subscribe/unsubscribe cycles do not touch slot state.
+
+    A flaky network can produce dozens of WS reconnect cycles in a
+    minute. Each round must be inert with respect to slot ownership
+    so a long-running paused job survives noisy clients without
+    user-visible drift.
+    """
+    store = JobStore(tmp_path / "jobs")
+    job = _create_with_status(store, "paused")
+    store.claim_active(job.job_id)
+
+    broadcaster = ProgressBroadcaster()
+
+    async def subscribe_cycles() -> None:
+        for _ in range(16):
+            q = broadcaster.subscribe(job.job_id)
+            broadcaster.unsubscribe(job.job_id, q)
+
+    asyncio.run(subscribe_cycles())
+
+    assert store.active_job_id == job.job_id, (
+        "INV-7: 16 subscribe/unsubscribe cycles must leave slot ownership untouched"
+    )


### PR DESCRIPTION
## Summary

v0.5 R-1.5b (P-0099 / Issue #384) v3-22b sub-phase. **Test-only PR** — no source changes. Adds the dedicated test file pinning **INV-7** (WebSocket disconnect does NOT release the active slot) end-to-end across the same-process and cross-restart axes.

The functional implementation already landed:
- **v3-20c** — paused branch in `_run_job_core` keeps the active slot (same-process baseline).
- **v3-22a** — `reconcile_at_startup` re-attaches the paused slot at server boot (cross-restart).

This module consolidates the invariant in one file with a clear name so future regressions surface with `test_inv_ws_disconnect_does_not_release.py::*` in CI logs instead of buried inside the larger `test_inv_slot_release.py`.

## Scenarios Covered

- **Same-process baseline**: subscribe → unsubscribe round-trip on a paused job leaves `active_job_id` untouched
- **Cross-restart Scenario A** (running + WS disconnect + crash): the orphan running row reconciles to `failed` at next startup; the slot is freed by the crash-recovery branch, NOT by the prior WS disconnect
- **Cross-restart Scenario B** (paused + WS disconnect + restart): the paused slot is re-attached by `reconcile_at_startup` so a concurrent `/tune` is rejected with `JOB_CONFLICT` — INV-7 preserved across the restart boundary
- **Robustness**: 16 subscribe/unsubscribe cycles do not perturb slot ownership (INV-7 under flaky-network noise)

## Failure Paths Covered

- [x] Same-process subscribe/unsubscribe is inert with respect to slot ownership
- [x] Running orphan + WS disconnect + crash → reconcile to failed; slot freed by crash recovery, not WS
- [x] Paused + WS disconnect + restart → reconcile re-attaches slot; JOB_CONFLICT enforces INV-1 across restart
- [x] 16-cycle subscribe/unsubscribe noise does not flip slot

## Test plan

- [x] `tests/regression/test_inv_ws_disconnect_does_not_release.py` — 4 new tests, all green
- [x] `ruff check` + `ruff format --check` clean

## Closes
- Closes #384 (Server Restart Recovery — INV-7 cross-restart coverage)