### PR TITLE
docs(v3-23): handoff doc for next session — v3-24/25/release candidates

### DIFF
--- a/docs/v3-23-handoff-2026-05-07.md
+++ b/docs/v3-23-handoff-2026-05-07.md
@@ -1,0 +1,211 @@
+# v0.5 R-1 + R-2.1 完了引き継ぎ資料 — 2026-05-07
+
+> **Status**: 🟢 v3-17〜v3-23 全完了 (R-1 + R-2.1 shipped)
+> **次セッションの最優先タスク**: ユーザー判断 (3 候補 §6 参照)
+> **設計の根拠**: HISTORY.md P-0099 (R-1 invariants) / `docs/v3-20-tune-resume-design.md` (R-1.4 設計) / `docs/v0.4-business-readiness-plan.md` (R-2 / R-4)
+
+---
+
+## 1. 現在の状況スナップショット
+
+### 1.1 マージ済 PR (2026-05-06 / 05-07 セッション)
+
+| PR | フェーズ | 内容 | 状態 |
+|---|---|---|---|
+| #416 | v3-20-prep | 設計レビュー資料 landing | ✅ |
+| #417 | v3-20a | format_version 1→2 + Job.status="paused" | ✅ |
+| #418 | v3-20b | BackendAdapter tune storage / study_name passthrough | ✅ |
+| #419 | docs | v3-20c handoff doc | ✅ |
+| #420 | v3-20c | JobStore pause primitives + INV-3 runtime guard | ✅ |
+| #421 | v3-20d | POST /pause + /unpause API + subprocess finally fix | ✅ |
+| #422 | v3-20e | WsPaused message + send_paused + frontend handler | ✅ |
+| #423 | v3-20f | Frontend Pause/Resume buttons | ✅ |
+| #424 | v3-20g | INV-4 round-trip + Playwright tune-resume E2E | ✅ |
+| #425 | v3-22a | Server startup reconciliation (orphan + paused slot re-attach) | ✅ |
+| #426 | v3-22b | INV-7 cross-restart unified test | ✅ |
+| #427 | v3-23 | WS reconnect 5min ceiling + indefinite retry + jitter + e2e + subprocess paused fix | ✅ |
+
+### 1.2 ローカル状態
+
+- **ブランチ**: `develop` (origin と同期、HEAD `b12d626`)
+- **作業ツリー**: clean
+- **Open PRs**: なし
+
+### 1.3 v0.5 R-x 進捗
+
+| Phase | 内容 | 状態 |
+|---|---|---|
+| v3-17 | R-1.1 Slot release 6 経路 | ✅ |
+| v3-18 | R-1.2 Cancel + completion interleaving | ✅ rescoped |
+| v3-19 | R-1.3 INV-2 fsync + INV-6 crash recovery | ✅ rescoped |
+| v3-20 | R-1.4 Tune long-run resumability | ✅ (8/8 sub-phase) |
+| v3-21 | R-1.5 | ❌ subsumed by PR #366 |
+| v3-22 | R-1.5b Server Restart Recovery | ✅ a + b shipped, c (Playwright real-restart) deferred |
+| **v3-23** | **R-2.1 WebSocket 再接続** | ✅ **a + b + c** |
+| v3-24 | R-2.2 Browser reload state | ⏳ **次の候補** |
+| v3-25 | R-4.1 format_version migration matrix CI | ⏳ |
+| v3-26 | R-4.2 Pickle compatibility | ⏳ |
+
+---
+
+## 2. 確定した不変条件 (Invariants)
+
+P-0099 R-1.x 期間中の宣言不変条件と invariant test 配置:
+
+| ID | 内容 | テスト |
+|---|---|---|
+| INV-1 | active_job_id holds at most one running-or-paused job | `test_inv_slot_release.py` (6 paths) |
+| INV-2 | meta.json atomic write (tmpfile + fsync + rename) | `test_inv_meta_json_atomic.py` |
+| INV-3 | state machine LEGAL_TRANSITIONS runtime assert | `test_inv_state_machine.py` (table) + `test_inv_pause_keeps_slot.py::test_set_status_*` (5 件) |
+| INV-4 | Optuna study reattach via `(storage, study_name)` + `load_if_exists=True` | `tests/integration/test_tune_resume_round_trip.py` + `tune-resume.spec.ts` |
+| INV-5 | cancel observation monotonic | `test_inv_slot_release.py::test_inv5_*` |
+| INV-6 | subprocess crash recovery → terminal write within bounded time | `test_inv_subprocess_crash_recovery.py` |
+| INV-7 | WebSocket disconnect MUST NOT release active slot | `test_inv_ws_disconnect_does_not_release.py` (4 件) + `test_inv1_path5` |
+| **INV-pause-1〜7** | paused 関連の slot retention / cb observability / count budget / set_status / cascade-delete / subprocess parent finally / send_paused | `test_inv_pause_keeps_slot.py` (13 件) |
+| **INV-restart-1〜3** | server restart 時の orphan reconcile / paused slot re-attach / terminal 不可侵 | `test_inv_startup_reconcile.py` (9 件) |
+| **INV-WS-5** | paused は terminal cache に入れない | `test_ws_messages.py::test_send_paused_does_not_populate_terminal_replay_cache` |
+
+---
+
+## 3. v3-24 (R-2.2 Browser reload state) 着手プラン
+
+### 3.1 スコープ
+
+PLAN.md Phase v3-24 の 3 sub-phase:
+
+| Sub-phase | 内容 |
+|---|---|
+| v3-24a | Frontend で workspace state を localStorage / IndexedDB に persist (or 既存 GET /status を活用) |
+| v3-24b | `beforeunload` で form ダーティ警告 |
+| v3-24c | Playwright で reload 後の data + config + running job 復元を Visual diff verification |
+
+**Entry criteria**: v3-23 完了 (✅ 達成済)。
+
+### 3.2 設計判断ポイント (着手前に user 確認推奨)
+
+1. **Persistence backend**: localStorage (5MB) か IndexedDB (容量大) か **既存 backend GET /status を活用**するか
+   - localStorage: シンプル、frontend のみ。data fingerprint + config + selected job_id を保存
+   - IndexedDB: dataframe そのものまで保存可能だが overengineering 寸前
+   - **推奨**: backend GET /workspace/status + GET /jobs?status=running が既に存在するため、reload 後にこれらを再 fetch するだけで data + config + running job を復元できる。frontend にカスタムキー保存は最小限 (selected job_id ぐらい) で済む可能性が高い
+2. **Form dirty 警告**: react-hook-form の `formState.isDirty` を `beforeunload` event に bind するパターンが定石
+3. **既存 session-restore.spec.ts の再利用**: 既に Playwright spec が存在 (`frontend/tests/e2e/session-restore.spec.ts`)。何が covered で何が gap かを確認してから新規 spec 追加判断
+
+### 3.3 必須事前作業
+
+```bash
+# v3-24 着手時の前提確認
+git checkout develop && git pull origin develop
+ls frontend/tests/e2e/session-restore.spec.ts  # 既存 spec の現状確認
+grep -n "useEffect\|beforeunload" frontend/src/pages/JobsPage.tsx frontend/src/App.tsx 2>/dev/null
+```
+
+### 3.4 PR サイズ目安
+
+- v3-24a: ~200 行 (frontend hook + WorkspaceContext 拡張)
+- v3-24b: ~50 行 (beforeunload event listener + dirty form gate)
+- v3-24c: ~150 行 (Playwright spec)
+- **合計 ~400 行 + 数件のテスト追加**
+
+---
+
+## 4. v3-25 / v3-26 メモ
+
+### v3-25 (R-4.1 format_version migration matrix CI)
+
+**Entry criteria**: v3-20 完了 (✅ format_version=2 定義済)。**v3-24 と独立に着手可能**。
+
+サブフェーズ:
+- v3-25a: `tests/regression/test_format_version_migration_matrix.py` で v0 → v1 → v2 round-trip
+- v3-25b: CI workflow で過去 fixture (v0 / v1) を fetch + load + 新 release で save → load → 同値 assertion
+- v3-25c: 古い format_version を read-only で開く保護
+
+### v3-26 (R-4.2 Pickle compatibility test)
+
+**Entry criteria**: v3-25 完了。
+
+`cloudpickle` 互換切れ検出を Nightly CI に追加。`tests/bench/test_bench_pickle_compat.py` で過去 lizyml 版で fit → 現行で load の round-trip。
+
+---
+
+## 5. v0.5 Exit Criteria (PLAN.md §1500)
+
+**現状**: 5/5 のうち 3/5 完了。
+
+- [x] 24h Tune が SIGKILL / network 切断 / browser リロードで再開可能 (INV-3 / INV-4) — v3-20g + v3-22 + v3-23 で達成
+- [x] Slot release が 6 経路全てで test カバー済 (INV-1) — v3-17 で達成
+- [ ] **ブラウザリロード後に data + config + 進行中 job が完全復元** — **v3-24 で対応**
+- [ ] **format_version migration matrix が CI で gating** — **v3-25 で対応**
+- [ ] 業務利用 KPI (`docs/business-use-definition.md` v0.2 §16) 達成 — 別途 verification
+
+→ **v3-24 + v3-25 完了で v0.5 リリース候補**。
+
+---
+
+## 6. 次セッションでの選択肢 (user 判断要)
+
+### 候補 A: v3-24 (Browser reload state) 着手
+- **Pros**: v0.5 Exit Criteria の 1 つを直接消化、UX 改善で実利大
+- **Cons**: Persistence backend 設計判断が必要 (§3.2)
+- **見積もり**: 1 週間 (3 sub-phase)
+
+### 候補 B: v3-25 (format_version migration matrix CI) 着手
+- **Pros**: v3-24 と独立、CI gate 追加で v0.5 release 安全性向上
+- **Cons**: 既存 fixture の整備が必要 (v0 / v1 workspace の保存場所決定)
+- **見積もり**: 1 週間 (3 sub-phase)
+
+### 候補 C: v0.5 release prep (v3-24/25 を v0.6 に slip)
+- **Pros**: R-1 + R-2.1 完了で実用上は release 可能、user feedback を早く取れる
+- **Cons**: Exit Criteria 2/5 未達 → リリースノートで明示的に "v0.5 partial / v0.5.x で残作業" にする必要
+- **見積もり**: 2-3 日 (CHANGELOG + リリース branch + tag + PyPI publish)
+
+---
+
+## 7. 注意事項
+
+### 7.1 PR DIRTY が CI を block する (新メモリに記録済)
+
+`develop` に新 PR を立てる前に必ず以下を確認:
+```bash
+gh pr view <N> --json mergeStateStatus
+```
+`DIRTY` の場合は `git merge origin/develop` で conflict 解消してから push。conflicting PR は `pull_request` event を発火しないため main CI が無音になる。
+
+### 7.2 ProgressBroadcaster と _FileBroadcaster は対称に保つ
+
+`ProgressBroadcaster` に新メソッド追加時 (e.g., v3-20e の `send_paused`) は以下も同時更新:
+1. `_FileBroadcaster` (subprocess child 用、`subprocess_runner.py:620`)
+2. `_forward_progress` (parent 側 dispatcher、`subprocess_runner.py:447`)
+
+→ v3-23 e2e CI で `AttributeError: '_FileBroadcaster' object has no attribute 'send_paused'` 検出。修正コミット `109f57b` で gate test 追加済。
+
+### 7.3 コミットメッセージは英語必須
+
+`validate-commit-msg.sh` hook が日本語をブロック。HISTORY.md / PLAN.md / コメントは日本語可、コード / commit / PR は英語のみ。
+
+### 7.4 Frontend `schema.d.ts` 再生成
+
+backend で API model 変更時は必ず再生成:
+```bash
+uv run python -c "from fastapi.testclient import TestClient; from lizystudio.server import create_app; import json, pathlib; pathlib.Path('/tmp/openapi.json').write_text(json.dumps(TestClient(create_app()).get('/openapi.json').json()))"
+cd frontend && ./node_modules/.bin/openapi-typescript /tmp/openapi.json -o src/api/generated/schema.d.ts
+```
+
+---
+
+## 8. 関連ドキュメント
+
+| ドキュメント | 用途 |
+|---|---|
+| `docs/v3-20-tune-resume-design.md` | v3-20 全体設計 (Approved 2026-05-06) |
+| `docs/v3-20-handoff-2026-05-06.md` | 前回 handoff (v3-20 中盤、参考用) |
+| `PLAN.md` v3-22 / v3-23 / v3-24 / v3-25 / v3-26 セクション | 各 phase の DoD と進捗 |
+| `HISTORY.md` P-0099 | Change Gate Proposal、R-1 invariants 完全リスト |
+| `docs/ROADMAP.md` §7 Tier 4 phase 表 | Next Action ROI 順 |
+| `tests/regression/test_inv_state_machine.py` | INV-3 LEGAL_TRANSITIONS canonical table |
+| `tests/regression/test_inv_pause_keeps_slot.py` | INV-pause-1〜7 (13 件) |
+| `tests/regression/test_inv_startup_reconcile.py` | INV-restart-1〜3 (9 件) |
+| `tests/regression/test_inv_ws_disconnect_does_not_release.py` | INV-7 cross-restart (4 件) |
+
+---
+
+最終更新: 2026-05-07、セッション終了時。次セッション開始時に最初に読むこと。


### PR DESCRIPTION
## Summary

Session handoff doc for the v3-17 -> v3-23 R-1 + R-2.1 work shipped 2026-05-06 / 05-07. Records:

- All 12 PRs merged (v3-20-prep -> v3-23 + handoff for v3-20c)
- Confirmed invariants (INV-1..7, INV-pause-1..7, INV-restart-1..3, INV-WS-5)
- v0.5 Exit Criteria status: 3/5 done, 2 remaining (v3-24 / v3-25)
- 3 next-session candidates with pros/cons + estimates: v3-24 / v3-25 / v0.5 release prep

Also documents two operational lessons surfaced this session:
- PR DIRTY blocks CI trigger (memory file logged)
- ProgressBroadcaster + _FileBroadcaster + _forward_progress symmetry requirement

## Test plan

- [x] No source changes — pure documentation
- [x] Markdown lint clean (heading hierarchy + list nesting)