### PR TITLE
feat(frontend): auto-restore currentJobId from workspaceStatus on reload (v3-24a, P-0102)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3457,4 +3457,148 @@ PR-B4 で `ValidationError` payload に `severity: Literal["error", "warning", "
 
 - 2026-05-05 **Decided (post-hoc)** — PR-C2 / PR-D1 で実装済、本 Decision 記録は v0.4.1 リリース後の reconciliation。Issue #403 で BackendAdapter 抽象化、#404 で異常系 7 cases 追加が follow-up
 
+### P-0102: ブラウザリロード後の workspace state 自動復元（v3-24, R-2.2）
+
+- **Date:** 2026-05-07 起票
+- **Related:** PLAN.md Phase v3-24, `docs/v0.4-business-readiness-plan.md` §3.2, P-0099 (R-1 invariants), Issue #91 / #101 (deep-link recovery, prior art), `frontend/tests/e2e/session-restore.spec.ts`
+
+#### Motivation
+
+P-0099 で Tune long-run resumability が backend 側で完成 (v3-20) し、server restart recovery (v3-22) と WS reconnect (v3-23) も shipped した。残るは frontend のリロード対応で、現状 `?job_id=` query param が無い場合 Workspace は空状態に戻る。`workspaceStatus.current_job_id` は既に backend 側で露出されているのに、frontend は無視している。長時間学習中の user がリロードしただけで「Results will appear here after running a job.」が表示され、進捗を見失う UX がそのまま残っている。
+
+`UI: reload without ?job_id= leaves Workspace empty` (`frontend/tests/e2e/session-restore.spec.ts:91`) は現状動作を pin している。「将来的な auto-restore は明示的な議論を経てから」という意図で書かれているため、その議論を本 Proposal で行い、test を更新する。
+
+#### Purpose
+
+- リロード後 30 秒以内に form / data / progress / results が前と同じ状態を表示する
+- `?job_id=` 不在時に `workspaceStatus.current_job_id` をフォールバックとして自動 hydrate する
+- 入力途中の dirty config が beforeunload で確認ダイアログを出す（誤リロード防止）
+- 上記を Playwright で reload 後 visual diff 検証する
+
+#### Invariants
+
+- **INV-reload-1**: `?job_id=<id>` 明示時はその id を最優先（既存挙動を保つ）
+- **INV-reload-2**: `?job_id=` 不在 + `workspaceStatus.current_job_id` が non-null + page-local `running` flag が false の場合、initial mount で 1 回だけ `current_job_id` を hydrate する
+- **INV-reload-3**: hydrate latch (`restoredFromStatusRef`) は user の手動リセット（`workspace_reset` 経由）で解除されない限り再発火しない
+- **INV-reload-4**: dirty form (react-hook-form `formState.isDirty`) を持つ状態で `beforeunload` event が発火したら browser default confirm dialog を出す。clean form では出さない
+
+#### Impact
+
+**Public API:** 変更なし。既存 `GET /api/workspace/status` の `current_job_id` をそのまま使う。
+
+**Frontend (B-8 / WorkspacePage):**
+- `useJobIdParam` に `fallbackJobId?: string | null` option 追加。URL param 不在時のみ参照する
+- `WorkspacePage` で `workspaceStatus.current_job_id` を fallback として渡す
+- `ConfigForm` (or top-level form context) に `useBeforeUnloadDirty(formIsDirty)` カスタム hook を組み込む
+- 既存 `session-restore.spec.ts` の「reload without ?job_id= leaves Workspace empty」テストを「reload without ?job_id= restores last job from workspace status」に書き換え
+
+**Internal (no behavior change for backend):**
+- なし
+
+#### Compatibility
+
+- 既存 `?job_id=` 明示の deep-link 動作は不変（INV-reload-1）
+- `workspaceStatus.current_job_id` が null なら従来どおり空状態を表示（後方互換）
+- multi-tab で同じ workspace を開いている場合、両 tab が同じ `current_job_id` を hydrate する。1 名利用前提のため衝突制御は scope 外
+- `beforeunload` ダイアログは modern browser がカスタムメッセージを許可しないので default 文言固定。E2E では `dialog` event handler で accept/dismiss を制御
+
+#### Acceptance criteria
+
+- [ ] `frontend/src/hooks/useJobIdParam.ts` に `fallbackJobId` option 追加 + 単体テスト 4 ケース
+- [ ] `frontend/src/pages/WorkspacePage.tsx` で `workspaceStatus.current_job_id` を fallback として渡す
+- [ ] `useBeforeUnloadDirty` hook 新規 + 単体テスト
+- [ ] `session-restore.spec.ts` の "leaves Workspace empty" テストを反転させ "restores from workspace status" に
+- [ ] dirty form + reload で confirm dialog が出ることを Playwright で pin
+- [ ] reload 後 30s 以内に Results panel が同じ完了 job を表示する E2E spec
+
+#### Alternatives considered
+
+- **(a) localStorage / IndexedDB に独自永続化**: 拒否。backend に GET /workspace/status が既に存在するため重複、quota / cross-tab sync の追加実装が必要、SSR や private browsing の corner case 増加
+- **(b) URL を `?job_id=` で上書き**: 拒否。現状コメントの "URL は read-only" 設計を破る、deep-link 共有の意味論が変わる
+- **(c) auto-restore を opt-in 設定にする**: 拒否。1 名利用前提なのでデフォルト ON が UX 上自然。opt-out は localStorage で後付け可能だが現時点で需要なし
+
+→ 採用は **(d) backend GET /workspace/status を fallback として消費 + URL 上書きしない**。
+
+#### Decision
+
+- 2026-05-07 **Approved** — v3-24 phase で a (frontend hydrate) → b (beforeunload) → c (Playwright spec) の 3 PR 構成で着手
+
+### P-0103: 古い format_version の workspace を read-only で保護（v3-25, R-4.1）
+
+- **Date:** 2026-05-07 起票
+- **Related:** PLAN.md Phase v3-25, P-0095 (fit→load round-trip CI gate), `docs/v0.4-business-readiness-plan.md` §5.1, `src/lizystudio/storage/versions.py`
+
+#### Motivation
+
+`STUDIO_FORMAT_VERSION` は v3-20a で 1→2 に bump された (P-0099)。現状の v0/v1→v2 migration は識別 (identity) なので動作上の差は無いが、将来の structural change で v0 / v1 workspace を新 release で開いた際に **silent な data destruction** が起きるリスクがある。具体的には:
+
+1. v1 workspace を新 release で load → in-memory で v2 にマイグレ
+2. 同じ workspace に対して fit / tune を実行
+3. JobStore が new meta.json を v2 で write
+4. 残りの旧 v1 ファイルとの整合性が崩れる、あるいは新たな fields が抜け落ちる
+
+P-0095 の round-trip CI gate は単一 release 内のシリアライズ整合性しか保証しない。release 間の互換 (v1 で書いて v2 で読む / 書く) は別途 gating が必要。
+
+#### Purpose
+
+- `tests/regression/test_format_version_migration_matrix.py` で v0 → v1 → v2 round-trip を網羅
+- CI で過去 fixture (v0 / v1 workspace の小さな再現) を fetch + load + 新 release で save → load → 同値 assertion が pass しないと merge できない gate を新設
+- 古い workspace を新 CLI で開いた際に、`LIZYSTUDIO_ALLOW_LEGACY_WRITE` 環境変数なしでは write 操作 (jobs / config) を refuse する read-only mode を導入
+- 既存の auto-migration は in-memory 限定とし、disk 上の旧フォーマットを silently 上書きしない
+
+#### Invariants
+
+- **INV-fmt-1**: `read_versioned_json` は detected_version < STUDIO_FORMAT_VERSION でも raise しない（既存挙動を保つ）
+- **INV-fmt-2**: `write_versioned_json` は detected_version < STUDIO_FORMAT_VERSION の同名ファイルが既に disk に存在し、かつ `LIZYSTUDIO_ALLOW_LEGACY_WRITE` が未設定の場合、`LegacyFormatProtectionError` を raise する
+- **INV-fmt-3**: 新規ファイル (disk 上に存在しない) や同 version への上書きは常に許可される
+- **INV-fmt-4**: migration matrix CI job は v0 / v1 / v2 のフィクスチャを round-trip し、payload 内容が migration 後 idempotent であることを assert
+
+#### Impact
+
+**Public API:** 変更なし（HTTP endpoints は影響を受けない）。
+
+**Storage layer:**
+- `lizystudio.backends.exceptions.LegacyFormatProtectionError` 新規例外
+- `write_versioned_json` に detected-version check + env var gate 追加
+- `read_versioned_json` の戻り値 `(detected_version, payload)` を消費者が version を伝搬できるよう一部 caller (services/jobs.py 等) に detected log を追加。挙動は変えない
+
+**CI / fixtures:**
+- `tests/fixtures/legacy_workspaces/v0/meta.json` (pre-C-9 layout, no format_version key)
+- `tests/fixtures/legacy_workspaces/v1/meta.json` (C-9, format_version=1)
+- `tests/regression/test_format_version_migration_matrix.py` の round-trip テスト
+
+**Behavior change for users:**
+- v0 / v1 workspace を新 LizyStudio で開いて run job 試行 → `LegacyFormatProtectionError` (HTTP 500 経由で 4xx に変換) で停止
+- recovery: `LIZYSTUDIO_ALLOW_LEGACY_WRITE=1 lizystudio` で起動して explicit に upgrade を許可
+
+#### Compatibility
+
+- 既存ユーザは大半が v2 で書かれた workspace のみを持つ → 影響なし
+- v0 (pre-C-9) ユーザは存在自体が稀。FAQ に env var 経由の upgrade 手順を記載
+- v1 (C-9 〜 v3-20a 間) ユーザは数日分。同様に env var で upgrade
+- read-only での閲覧は影響を受けない（fit / tune を試行するまで Error は発火しない）
+
+#### Acceptance criteria
+
+- [ ] `LegacyFormatProtectionError` を `backends/exceptions.py` に追加 + docstring
+- [ ] `write_versioned_json` の env var gate + 既存ファイルの format_version peek + 新規例外 raise
+- [ ] `tests/regression/test_format_version_migration_matrix.py` で v0/v1/v2 fixture round-trip
+- [ ] `tests/fixtures/legacy_workspaces/{v0,v1}/meta.json` をコミット
+- [ ] `tests/test_storage_versions.py` に LegacyFormatProtectionError invariant test 追加
+- [ ] CI で migration matrix が gating（既存 ci.yml backend job に組み込み）
+- [ ] CHANGELOG v0.5 で env var 名と recovery 手順を明記
+
+#### Alternatives considered
+
+- **(a) Hard error on read for legacy versions**: 拒否。閲覧すら不可になり、復旧手段がさらに狭まる
+- **(b) Silently auto-upgrade on write (status quo)**: 拒否。silent destruction の risk が消えない
+- **(c) Per-file format_version (vs Studio-wide single constant)**: 拒否。H-0081 alternatives §b で却下済、本 Proposal の scope 外
+- **(d) New endpoint `POST /api/workspace/upgrade-format`**: defer。env var gate でまず最小実装、UI は user feedback を見てから
+
+→ 採用は **(e) env var (`LIZYSTUDIO_ALLOW_LEGACY_WRITE=1`) gate + matrix CI**。
+
+#### Decision
+
+- 2026-05-07 **Approved** — v3-25 phase で a (matrix regression test) → b (CI workflow + fixtures) → c (LegacyFormatProtectionError + env var gate) の 3 PR 構成で着手
+
 

--- a/frontend/src/hooks/useJobIdParam.test.ts
+++ b/frontend/src/hooks/useJobIdParam.test.ts
@@ -77,6 +77,86 @@ describe("useJobIdParam", () => {
     expect(result.current.jobId).toBe("job_local");
   });
 
+  it("fallbackJobId hydrates state when the URL has no ?job_id=", () => {
+    // P-0102 v3-24a: a server-derived fallback (workspaceStatus.current_job_id)
+    // takes over when the URL is empty, so a browser reload re-attaches
+    // the Workspace to the previously-running job without a deep link.
+    const { result } = renderHook(
+      ({ fallback }: { fallback: string | null }) =>
+        useJobIdParam({ fallbackJobId: fallback }),
+      {
+        wrapper: wrapperWith("/"),
+        initialProps: { fallback: null as string | null },
+      },
+    );
+    expect(result.current.jobId).toBeNull();
+  });
+
+  it("fallbackJobId arriving asynchronously is consumed once the value flips", () => {
+    // workspaceStatus is fetched async on mount, so the fallback is
+    // null at first render and becomes non-null on the next render.
+    type Props = { fallback: string | null };
+    const { result, rerender } = renderHook(
+      ({ fallback }: Props) => useJobIdParam({ fallbackJobId: fallback }),
+      {
+        wrapper: wrapperWith("/"),
+        initialProps: { fallback: null as string | null },
+      },
+    );
+    expect(result.current.jobId).toBeNull();
+    rerender({ fallback: "job_xyz" });
+    expect(result.current.jobId).toBe("job_xyz");
+  });
+
+  it("URL ?job_id= takes precedence over fallbackJobId", () => {
+    const { result } = renderHook(
+      () => useJobIdParam({ fallbackJobId: "job_fallback" }),
+      { wrapper: wrapperWith("/?job_id=job_url") },
+    );
+    expect(result.current.jobId).toBe("job_url");
+  });
+
+  it("fallbackJobId is consumed at most once — explicit clear sticks", () => {
+    // INV-reload-3: after the user clears the id (or a fresh fit
+    // writes a new one) a later workspaceStatus refetch must not
+    // re-pull the stale fallback.
+    type Props = { fallback: string | null };
+    const { result, rerender } = renderHook(
+      ({ fallback }: Props) => useJobIdParam({ fallbackJobId: fallback }),
+      {
+        wrapper: wrapperWith("/"),
+        initialProps: { fallback: "job_first" as string | null },
+      },
+    );
+    expect(result.current.jobId).toBe("job_first");
+    act(() => result.current.setJobId(null));
+    expect(result.current.jobId).toBeNull();
+    rerender({ fallback: "job_second" });
+    // Latch is locked — the new fallback is ignored.
+    expect(result.current.jobId).toBeNull();
+  });
+
+  it("suppress=true blocks fallbackJobId hydration", () => {
+    // A freshly-started fit/tune sets running=true (= suppress) before
+    // setCurrentJobId fires. A stale workspaceStatus fallback arriving
+    // mid-window must not back-fill the slot before the new id lands.
+    type Props = { suppress: boolean; fallback: string | null };
+    const { result, rerender } = renderHook(
+      ({ suppress, fallback }: Props) =>
+        useJobIdParam({ suppress, fallbackJobId: fallback }),
+      {
+        wrapper: wrapperWith("/"),
+        initialProps: {
+          suppress: true,
+          fallback: "job_stale" as string | null,
+        },
+      },
+    );
+    expect(result.current.jobId).toBeNull();
+    rerender({ suppress: false, fallback: "job_stale" });
+    expect(result.current.jobId).toBe("job_stale");
+  });
+
   it("filter change re-evaluates and promotes a previously-rejected id", () => {
     // Simulates the InferencePage flow: the URL already carries a
     // job_id on mount, but `completedJobs` is initially empty so the

--- a/frontend/src/hooks/useJobIdParam.ts
+++ b/frontend/src/hooks/useJobIdParam.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 
 /**
@@ -17,6 +17,11 @@ import { useSearchParams } from "react-router-dom";
  *   URL hasn't been rewritten yet).
  * - Let callers `filter` URL candidates (e.g. InferencePage only
  *   accepts a job_id once the job appears in the completed list).
+ * - Let callers provide a `fallbackJobId` (P-0102 v3-24a): when the URL
+ *   carries no param, fall back to a server-derived id (typically
+ *   `workspaceStatus.current_job_id`) so a browser reload re-attaches
+ *   the Workspace to the previously-running job. Consumed at most once
+ *   per mount; the URL remains the source of truth otherwise.
  * - Expose `setJobId(next, { writeUrl })` so the caller can update
  *   local state AND optionally push the new value back to
  *   `setSearchParams` in one call.
@@ -37,6 +42,16 @@ export interface UseJobIdParamOptions {
    * to require that the id already appears in the completed-jobs list.
    */
   filter?: (jobId: string) => boolean;
+  /**
+   * Optional server-derived fallback id (P-0102 v3-24a). Consumed only
+   * when the URL carries no `?job_id=` param AND no local override has
+   * been applied yet. Hydrated at most once per mount so a later
+   * `setJobId(null)` does not re-pull the fallback. `suppress` and
+   * `filter` apply to the fallback the same way they apply to the URL
+   * value, so a freshly-started fit (suppress=true) cannot be
+   * back-filled by a stale workspace status.
+   */
+  fallbackJobId?: string | null;
 }
 
 export interface UseJobIdParamResult {
@@ -58,11 +73,17 @@ function readParam(params: URLSearchParams): string | null {
 export function useJobIdParam(
   options: UseJobIdParamOptions = {},
 ): UseJobIdParamResult {
-  const { suppress = false, filter } = options;
+  const { suppress = false, filter, fallbackJobId = null } = options;
   const [searchParams, setSearchParams] = useSearchParams();
   const [jobId, setJobIdState] = useState<string | null>(() =>
     readParam(searchParams),
   );
+
+  // INV-reload-3 (P-0102): the fallback is consumed at most once per
+  // mount. After the user explicitly clears the id (setJobId(null)) or
+  // a fresh fit/tune writes a new value, a later workspaceStatus
+  // refetch must not re-hydrate from the now-stale fallback.
+  const fallbackConsumedRef = useRef(false);
 
   // Re-sync state when the URL param changes after mount (e.g. user
   // clicks a "view in Workspace" link while already on the page).
@@ -72,13 +93,27 @@ export function useJobIdParam(
   useEffect(() => {
     if (suppress) return;
     const candidate = readParam(searchParams);
-    if (candidate === null) return;
-    if (filter && !filter(candidate)) return;
-    setJobIdState(candidate);
-  }, [searchParams, suppress, filter]);
+    if (candidate !== null) {
+      if (filter && !filter(candidate)) return;
+      setJobIdState(candidate);
+      return;
+    }
+    // URL is empty — try the fallback once. The fallback is async
+    // (workspaceStatus arrives after mount), so we keep re-running
+    // until either the URL takes over or the fallback fires.
+    if (fallbackConsumedRef.current) return;
+    if (!fallbackJobId) return;
+    if (filter && !filter(fallbackJobId)) return;
+    fallbackConsumedRef.current = true;
+    setJobIdState(fallbackJobId);
+  }, [searchParams, suppress, filter, fallbackJobId]);
 
   const setJobId = useCallback(
     (next: string | null, opts?: { writeUrl?: boolean }) => {
+      // Lock the fallback latch on any explicit user write so a later
+      // workspaceStatus refetch cannot re-hydrate after the user
+      // intentionally cleared or replaced the id.
+      fallbackConsumedRef.current = true;
       setJobIdState(next);
       if (opts?.writeUrl) {
         setSearchParams(

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -45,14 +45,26 @@ export function WorkspacePage() {
 
   const isMobile = useMediaQuery(MOBILE_QUERY);
 
-  // Issue #101: hydrate currentJobId from the `?job_id=<id>` query
-  // param so the Jobs page (or any external link) can navigate the
-  // user directly into the Workspace with a specific completed job
-  // selected. The query-param name matches the convention already
-  // established by InferencePage so links stay consistent across
-  // the two destinations. `useJobIdParam` (B-8) owns URL→state sync;
-  // we pass `suppress: running` so a URL change does not clobber a
-  // freshly-started job id set from handleFit / handleTune.
+  // Issue #363: probe the server on mount so the UI knows whether a
+  // previous session left data + config persisted. When ``has_data``
+  // is true, we flip the local ``hasData`` flag (via the same
+  // ``handleDataChanged`` callback the manual load path uses) and
+  // hand the snapshot to ``DataPanel.hydrateFromServer`` so the Path
+  // textbox / Target combobox / Column Settings / etc. all repopulate.
+  //
+  // P-0102 v3-24a: also expose ``current_job_id`` to ``useJobIdParam``
+  // as a fallback so a browser reload without ``?job_id=`` re-attaches
+  // the Workspace to the previously-running / -completed job.
+  const { data: workspaceStatus } = useWorkspaceStatus();
+
+  // Issue #101 + P-0102 v3-24a: hydrate currentJobId from the
+  // `?job_id=<id>` query param (deep-link / Jobs-page navigation)
+  // and fall back to ``workspaceStatus.current_job_id`` when the URL
+  // is empty (browser reload mid-run). The query-param name matches
+  // the convention established by InferencePage. `useJobIdParam`
+  // (B-8) owns URL→state sync; we pass `suppress: running` so a URL
+  // / fallback change does not clobber a freshly-started job id set
+  // from handleFit / handleTune.
   //
   // Note on stale URL: after the user starts a fresh fit / tune via
   // the Workspace UI, we intentionally do NOT rewrite `?job_id=` in
@@ -61,19 +73,13 @@ export function WorkspacePage() {
   // matches the pre-Issue #101 behavior and we accept it consciously.
   const { jobId: currentJobId, setJobId: setCurrentJobId } = useJobIdParam({
     suppress: running,
+    fallbackJobId: workspaceStatus?.current_job_id ?? null,
   });
 
   useDocumentTitle(running ? "Running..." : null);
   const notify = useBackgroundNotification();
 
   const { data: uiSchema } = useUiSchema();
-  // Issue #363: probe the server on mount so the UI knows whether a
-  // previous session left data + config persisted. When ``has_data``
-  // is true, we flip the local ``hasData`` flag (via the same
-  // ``handleDataChanged`` callback the manual load path uses) and
-  // hand the snapshot to ``DataPanel.hydrateFromServer`` so the Path
-  // textbox / Target combobox / Column Settings / etc. all repopulate.
-  const { data: workspaceStatus } = useWorkspaceStatus();
   const { data: config } = useConfig({
     enabled: hasData || workspaceStatus?.has_data === true,
     retry: false,

--- a/frontend/tests/e2e/session-restore.spec.ts
+++ b/frontend/tests/e2e/session-restore.spec.ts
@@ -88,21 +88,19 @@ test.describe("Session Restore", () => {
     });
   });
 
-  test("UI: reload without ?job_id= leaves Workspace empty", async ({
+  test("UI: reload without ?job_id= restores last job from workspace status", async ({
     page,
     request,
   }, testInfo) => {
-    // Boundary: even when a current_job_id exists server-side, the
-    // Workspace page intentionally does NOT auto-hydrate it without a
-    // URL param (see WorkspacePage.tsx Issue #101 comment block).
-    // Lock this behavior in so a future "always restore" change cannot
-    // ship silently.
-    const csvPath = createTestCsv(100, tmp("empty"));
+    // P-0102 v3-24a (R-2.2): a browser reload without ``?job_id=``
+    // now auto-hydrates ``currentJobId`` from
+    // ``workspaceStatus.current_job_id`` so the Workspace re-attaches
+    // to the previously-running / -completed job. Inversion of the
+    // pre-v3-24 behavior pinned by Issue #101 ("leaves Workspace
+    // empty") — the change is gated by HISTORY P-0102 Decision.
+    const csvPath = createTestCsv(100, tmp("restore"));
     const jobId = await setupAndFit(request, csvPath);
     const finished = await waitForJobDone(request, jobId);
-    // Guard the boundary: if the fit itself failed we would not be
-    // testing the "current_job_id exists but is not auto-restored"
-    // case at all, so the assertion below would be vacuously true.
     expect(finished.status).toBe("completed");
 
     await dismissOnboarding(page);
@@ -110,8 +108,11 @@ test.describe("Session Restore", () => {
     await page.waitForLoadState("networkidle");
     await openWorkspaceSectionIfMobile(page, testInfo, "results");
 
-    await expect(
-      page.getByText("Results will appear here after running a job."),
-    ).toBeVisible({ timeout: 10_000 });
+    // The Completed badge appears only after currentJobId is hydrated
+    // and JobDetail has been fetched, so it pins INV-reload-2: URL
+    // empty + workspaceStatus.current_job_id non-null → state attaches.
+    await expect(page.getByText("Completed").first()).toBeVisible({
+      timeout: 30_000,
+    });
   });
 });


### PR DESCRIPTION
## Summary

P-0102 v3-24a (R-2.2 Browser reload state, Issue #101 follow-up): a browser reload without `?job_id=` now hydrates `currentJobId` from `workspaceStatus.current_job_id` so the Workspace re-attaches to the previously-running / -completed job. Inverts the pre-v3-24 behavior; gated by HISTORY.md P-0102 Decision (Approved 2026-05-07).

## Changes

- `useJobIdParam` gains an optional `fallbackJobId` consumed at most once per mount; URL param takes precedence; `suppress=true` blocks the fallback during freshly-started fits
- `WorkspacePage` passes `workspaceStatus.current_job_id` as the fallback
- Existing `session-restore.spec.ts` "leaves empty" test inverted to "restores from workspace status"

## Invariants

- INV-reload-1: `?job_id=` URL param always wins over fallback
- INV-reload-2: fallback hydrates exactly once when URL empty + value non-null
- INV-reload-3: explicit `setJobId` locks the fallback latch

## Failure Paths Covered

- [x] URL has `?job_id=` → fallback ignored
- [x] URL empty + fallback null → state stays null
- [x] URL empty + fallback arrives async → state hydrates
- [x] User clears state then fallback changes → state stays cleared
- [x] suppress=true during freshly-started fit → fallback blocked

## Tests

- 5 new unit tests on `useJobIdParam.test.ts` (13/13 pass)
- WorkspacePage existing 38/38 pass
- Full Vitest 1838/1838 pass
- `pnpm build` green
- `biome check` clean

## Related

- HISTORY.md P-0102
- PLAN.md Phase v3-24 (R-2.2)
- Issue #101 (deep-link recovery, prior art)
- Builds on v3-23 (#427 WS reconnect) for full reload flow