### PR TITLE
feat(frontend): beforeunload dirty-config warning during in-flight PUTs (v3-24b, P-0102)

### DIFF
--- a/frontend/src/hooks/useBeforeUnloadDirty.test.ts
+++ b/frontend/src/hooks/useBeforeUnloadDirty.test.ts
@@ -1,0 +1,96 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useBeforeUnloadDirty } from "./useBeforeUnloadDirty";
+
+describe("useBeforeUnloadDirty", () => {
+  let listeners: Array<(event: Event) => void>;
+  let originalAdd: typeof window.addEventListener;
+  let originalRemove: typeof window.removeEventListener;
+
+  beforeEach(() => {
+    listeners = [];
+    originalAdd = window.addEventListener;
+    originalRemove = window.removeEventListener;
+    window.addEventListener = vi.fn(
+      (type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type === "beforeunload" && typeof listener === "function") {
+          listeners.push(listener as (event: Event) => void);
+        }
+      },
+    ) as typeof window.addEventListener;
+    window.removeEventListener = vi.fn(
+      (type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type === "beforeunload" && typeof listener === "function") {
+          const idx = listeners.indexOf(listener as (event: Event) => void);
+          if (idx >= 0) listeners.splice(idx, 1);
+        }
+      },
+    ) as typeof window.removeEventListener;
+  });
+
+  afterEach(() => {
+    window.addEventListener = originalAdd;
+    window.removeEventListener = originalRemove;
+  });
+
+  function fireBeforeUnload(): {
+    preventDefault: ReturnType<typeof vi.fn>;
+    returnValue: string;
+  } {
+    const event = {
+      preventDefault: vi.fn(),
+      returnValue: "initial",
+    };
+    for (const listener of listeners) {
+      listener(event as unknown as Event);
+    }
+    return event;
+  }
+
+  it("registers a beforeunload listener on mount", () => {
+    renderHook(() => useBeforeUnloadDirty(() => false));
+    expect(listeners.length).toBe(1);
+  });
+
+  it("removes the listener on unmount", () => {
+    const { unmount } = renderHook(() => useBeforeUnloadDirty(() => false));
+    expect(listeners.length).toBe(1);
+    unmount();
+    expect(listeners.length).toBe(0);
+  });
+
+  it("does NOT prompt when isDirty returns false", () => {
+    renderHook(() => useBeforeUnloadDirty(() => false));
+    const event = fireBeforeUnload();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    // Modern browsers gate the confirm dialog on a non-empty
+    // returnValue assignment; if we leave the user's initial sentinel
+    // in place that is also acceptable, but our handler must not
+    // overwrite it on a clean form.
+    expect(event.returnValue).toBe("initial");
+  });
+
+  it("prompts when isDirty returns true (preventDefault + returnValue)", () => {
+    renderHook(() => useBeforeUnloadDirty(() => true));
+    const event = fireBeforeUnload();
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    // Assignment is what arms the dialog on legacy Chromium/Safari.
+    // The string content itself is ignored by modern browsers — the
+    // assignment side-effect is the contract.
+    expect(event.returnValue).toBe("");
+  });
+
+  it("re-evaluates isDirty at unload time, not registration time", () => {
+    // The funnel's dirty state can change between mount and unload —
+    // the handler must call the latest getter rather than capturing
+    // the boolean from the first render.
+    let dirty = false;
+    renderHook(() => useBeforeUnloadDirty(() => dirty));
+    let event = fireBeforeUnload();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+
+    dirty = true;
+    event = fireBeforeUnload();
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useBeforeUnloadDirty.ts
+++ b/frontend/src/hooks/useBeforeUnloadDirty.ts
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+
+/**
+ * Show the browser's native "leave this page?" confirm dialog when
+ * `isDirty()` returns true at unload time (P-0102 INV-reload-4).
+ *
+ * The Workspace funnel auto-saves user edits on a microtask boundary
+ * after each `onChange`, but a burst of edits coalesced into a single
+ * pending PUT can still be in-flight when the user reloads. Calling
+ * `event.preventDefault()` and assigning `event.returnValue` arms
+ * Chromium / WebKit / Firefox to surface their default confirmation
+ * dialog. Modern browsers ignore custom messages — only the boolean
+ * "is this page dirty?" signal matters.
+ *
+ * `isDirty` is read at unload time so the consumer can derive the
+ * answer from a ref / funnel getter without re-registering the
+ * listener on every render. This also matches the funnel's
+ * `isFlushing()` shape, which is itself a getter rather than reactive
+ * state.
+ */
+export function useBeforeUnloadDirty(isDirty: () => boolean): void {
+  useEffect(() => {
+    const handler = (event: BeforeUnloadEvent) => {
+      if (!isDirty()) return;
+      event.preventDefault();
+      // Legacy Chromium / Safari path: returnValue must be set to
+      // anything truthy. The string itself is ignored by modern
+      // browsers, but assignment is what triggers the dialog there.
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [isDirty]);
+}

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -19,6 +19,7 @@ import {
 import { ModelPanel } from "@/components/workspace/ModelPanel";
 import { ResultsPanel } from "@/components/workspace/ResultsPanel";
 import { useBackgroundNotification } from "@/hooks/useBackgroundNotification";
+import { useBeforeUnloadDirty } from "@/hooks/useBeforeUnloadDirty";
 import { useConfigWriteFunnel } from "@/hooks/useConfigWriteFunnel";
 import { ConfigWriteFunnelProvider } from "@/hooks/useConfigWriteFunnelContext";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
@@ -114,6 +115,16 @@ export function WorkspacePage() {
       }
     },
   });
+
+  // P-0102 v3-24b: warn the user before reload / tab-close while a
+  // config write is still in flight. The funnel batches per-microtask
+  // bursts then drains; during the queue + PUT window an unintended
+  // reload would lose the queued edit. ``isFlushing`` covers both
+  // ``pending.length > 0`` and the in-flight PUT, so it is the
+  // canonical "dirty" signal for INV-reload-4. Clean form (queue
+  // drained, no in-flight PUT) → no dialog, matching browser
+  // best-practice of not warning on read-only navigation.
+  useBeforeUnloadDirty(writeFunnel.isFlushing);
 
   const handleDataChanged = useCallback(() => {
     setHasData(true);


### PR DESCRIPTION
## Summary

P-0102 v3-24b (R-2.2 Browser reload state, INV-reload-4): warn the user before reload / tab-close while a config write funnel is draining. The funnel batches per-microtask edit bursts then PUTs to the backend; reloading during the queue + PUT window would silently lose the queued edit.

## Changes

- New `useBeforeUnloadDirty(isDirty: () => boolean)` hook registers a `beforeunload` listener that calls `preventDefault()` and assigns `returnValue` only when the getter returns true
- `WorkspacePage` passes `writeFunnel.isFlushing` directly — `isFlushing()` is true when either `pending.length > 0` OR a PUT is in-flight, so it covers the full unsaved-edit window without a separate dirty flag
- Clean form (queue drained, no in-flight PUT) → no dialog

## Invariants

- INV-reload-4: dirty form (`isFlushing() === true`) + `beforeunload` → browser default confirm dialog. Clean form → no dialog.

## Failure Paths Covered

- [x] Mount registers listener, unmount removes it
- [x] Clean form does NOT call preventDefault
- [x] Dirty form sets returnValue=`""` and calls preventDefault
- [x] Late state change re-evaluates dirty at unload time, not registration time

## Tests

- 5 new unit tests (5/5 pass)
- Full WorkspacePage 38/38, Vitest green
- `pnpm build` green, `biome check` clean

## Related

- HISTORY.md P-0102
- PLAN.md Phase v3-24 (R-2.2)
- Builds on PR #429 (v3-24a auto-restore) — independent merge order

## Notes for reviewers

- Modern browsers (Chrome, Firefox, Safari) ignore custom messages on `beforeunload`. Only the `preventDefault()` + `returnValue` assignment side-effect arms the dialog. No user-visible string to maintain.
- Considered using `react-hook-form`'s `formState.isDirty`, but the project does not use react-hook-form; the funnel's `isFlushing()` is the canonical equivalent for this codebase.