### PR TITLE
test(e2e): reload restoration coverage for v3-24a + v3-24b (v3-24c, P-0102)

### DIFF
--- a/frontend/tests/e2e/reload-restore.spec.ts
+++ b/frontend/tests/e2e/reload-restore.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * E2E coverage for browser-reload state restoration (P-0102 v3-24c).
+ *
+ * Verifies the user-visible parts of the v3-24a + v3-24b contract:
+ *
+ *  - INV-reload-2: reload mid-running fit re-attaches the
+ *    ResultsPanel to the still-running job via
+ *    ``workspaceStatus.current_job_id`` (no ``?job_id=`` query param,
+ *    no manual click).
+ *  - INV-reload-4: a manual ``beforeunload`` event with the funnel
+ *    in-flight calls ``preventDefault()``; with a clean queue it does
+ *    not. We probe the event handler directly (Playwright auto-
+ *    dismisses real beforeunload dialogs by default), which is
+ *    sufficient because the unit suite already pins the
+ *    ``returnValue`` assignment.
+ */
+
+import { expect, test } from "@playwright/test";
+import { randomBytes } from "node:crypto";
+import { API, createTestCsv, setupAndFit, waitForJobDone } from "./helpers/api";
+import { openWorkspaceSectionIfMobile } from "./helpers/mobile";
+import { dismissOnboarding } from "./helpers/onboarding";
+
+const RUN_TAG = randomBytes(4).toString("hex");
+const tmp = (label: string) => `/tmp/e2e_reload_${RUN_TAG}_${label}.csv`;
+
+test.describe("Reload restoration", () => {
+  test.beforeEach(async ({ request }) => {
+    await request.post(`${API}/workspace/reset`);
+  });
+
+  // @ci-flaky: GitHub Actions runners occasionally kill the backend
+  // subprocess with SIGTERM mid-fit. The mid-running variant is more
+  // sensitive to that than the post-completion variant because it
+  // races the worker's status flip. Excluded from the blocking
+  // chromium job until the resource-pressure root cause is fixed.
+  test("UI: reload mid-running fit re-attaches Results panel @ci-flaky", async ({
+    page,
+    request,
+  }, testInfo) => {
+    test.setTimeout(120_000);
+
+    // Start the fit through the API so we control the timing — the
+    // reload must happen while ``status="running"``.
+    const csvPath = createTestCsv(200, tmp("running"));
+    const jobId = await setupAndFit(request, csvPath);
+
+    // The Workspace page is empty on first navigation; mounting it
+    // before the reload ensures dismissOnboarding does not pollute
+    // the post-reload viewport with the welcome modal.
+    await dismissOnboarding(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // INV-reload-2: reload without ``?job_id=`` must hydrate the
+    // current job id from workspaceStatus. The Running indicator
+    // appears only after currentJobId is non-null AND JobDetail's
+    // status is "running" / "pending", so it pins the contract.
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    await openWorkspaceSectionIfMobile(page, testInfo, "results");
+
+    // Either the still-running job ("Running") OR the just-finished
+    // job ("Completed") proves re-attachment succeeded — the test is
+    // intentionally tolerant so a fast-finishing fit on CI does not
+    // flake on the timing window between reload and assertion.
+    const completedOrRunning = page.locator(
+      'text=/(Completed|Running|Progress)/',
+    );
+    await expect(completedOrRunning.first()).toBeVisible({ timeout: 30_000 });
+
+    // Waits for the worker so the next test starts from a clean slot.
+    const finished = await waitForJobDone(request, jobId);
+    expect(["completed", "failed"]).toContain(finished.status as string);
+  });
+
+  test("UI: reload after completion auto-restores Results without ?job_id=", async ({
+    page,
+    request,
+  }, testInfo) => {
+    test.setTimeout(120_000);
+
+    const csvPath = createTestCsv(100, tmp("done"));
+    const jobId = await setupAndFit(request, csvPath);
+    const finished = await waitForJobDone(request, jobId);
+    expect(finished.status).toBe("completed");
+
+    await dismissOnboarding(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    await openWorkspaceSectionIfMobile(page, testInfo, "results");
+
+    // The Completed badge appears only after currentJobId is hydrated
+    // from the workspaceStatus fallback (no ``?job_id=`` is present
+    // in the URL across the reload).
+    await expect(page.getByText("Completed").first()).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+
+  test("UI: beforeunload is a no-op on a clean (idle) Workspace", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+
+    await dismissOnboarding(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Synchronously dispatch a beforeunload event and observe whether
+    // any handler called preventDefault on it. With no in-flight PUT
+    // (clean funnel) the handler must NOT prevent default, so the
+    // browser would let the navigation proceed without a dialog.
+    const wasDefaultPrevented = await page.evaluate(() => {
+      const ev = new Event("beforeunload", { cancelable: true });
+      window.dispatchEvent(ev);
+      return ev.defaultPrevented;
+    });
+    expect(wasDefaultPrevented).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

P-0102 v3-24c (R-2.2 Browser reload state): Playwright spec that pins the user-visible parts of the v3-24a + v3-24b contract.

**Stacked on PR #429 (v3-24a)** — base branch is `feat/v3-24a-reload-state-restoration`. After #429 merges, this PR's base auto-rebases to `develop`. Independent of PR #430 (v3-24b dirty-form warning) but conceptually completes the v3-24 trilogy.

## Tests

- `UI: reload mid-running fit re-attaches Results panel @ci-flaky` — INV-reload-2 with no `?job_id=` URL param
- `UI: reload after completion auto-restores Results without ?job_id=` — INV-reload-2 happy path
- `UI: beforeunload is a no-op on a clean (idle) Workspace` — INV-reload-4 negative case (positive case covered by unit suite, since Playwright auto-dismisses real `beforeunload` dialogs)

## Why a separate spec file

`session-restore.spec.ts` covers the deep-link `?job_id=` flow (Issue #101 / #91). The new file scopes the post-v3-24 behavior so future regressions are easy to bisect.

## Test plan

- [ ] CI runs the spec on chromium / chromium-tablet / chromium-mobile
- [ ] `@ci-flaky` mid-running test excluded from blocking job until subprocess SIGTERM resource-pressure root cause is fixed (existing pattern)

## Related

- HISTORY.md P-0102
- PLAN.md Phase v3-24 (R-2.2)
- PR #429 (v3-24a auto-restore — required base)
- PR #430 (v3-24b beforeunload — independent)