### PR TITLE
feat(storage): LegacyFormatProtectionError + LIZYSTUDIO_ALLOW_LEGACY_WRITE gate (v3-25c, P-0103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Storage protection (P-0103, v3-25c)** — `write_versioned_json`
+  now refuses to overwrite a workspace artefact whose existing
+  on-disk `format_version` is older than the runtime's
+  `STUDIO_FORMAT_VERSION`. To opt in to upgrading a legacy workspace
+  in place, set `LIZYSTUDIO_ALLOW_LEGACY_WRITE=1` before launching
+  `lizystudio`. New artefacts and same-version overwrites are
+  unaffected. Recovery for users on v0 / v1 workspaces is documented
+  in HISTORY P-0103.
+
 ## [0.4.2] - 2026-05-06
 
 The **v0.5 prep** maintenance release. **No user-facing behaviour

--- a/src/lizystudio/backends/exceptions.py
+++ b/src/lizystudio/backends/exceptions.py
@@ -81,6 +81,40 @@ class IncompatibleFormatVersionError(Exception):
     """
 
 
+class LegacyFormatProtectionError(Exception):
+    """Raised when a write would overwrite a legacy on-disk artefact
+    without explicit opt-in (P-0103 v3-25c / R-4.1).
+
+    The storage layer auto-migrates v0 / v1 / ... artefacts to the
+    current ``STUDIO_FORMAT_VERSION`` in memory, but historically the
+    next ``write_versioned_json`` call would silently bump the on-disk
+    version and any future migration that loses fields would silently
+    truncate customer data.
+
+    To prevent that class of silent destruction:
+
+    - Reading a legacy file is always permitted (callers can still
+      browse historical workspaces).
+    - Writing back to a path whose existing file declares
+      ``format_version < STUDIO_FORMAT_VERSION`` requires the env var
+      ``LIZYSTUDIO_ALLOW_LEGACY_WRITE=1`` to opt in. Otherwise the
+      writer raises this exception.
+
+    Recovery: the user can re-run their ``lizystudio`` server with the
+    env var set after explicitly backing up the legacy workspace.
+    """
+
+    def __init__(self, path: object, detected_version: int) -> None:
+        super().__init__(
+            f"Refusing to overwrite legacy artefact at {path} "
+            f"(format_version={detected_version}). Set "
+            "LIZYSTUDIO_ALLOW_LEGACY_WRITE=1 to opt in to upgrading "
+            "this file to the current schema."
+        )
+        self.path = path
+        self.detected_version = detected_version
+
+
 class PlotNotAvailableError(Exception):
     """Raised when a plot type is not in the backend's dispatch table
     (Issue #355).
@@ -111,6 +145,7 @@ __all__ = [
     "CheckpointIncompatibleError",
     "CheckpointPreflightError",
     "IncompatibleFormatVersionError",
+    "LegacyFormatProtectionError",
     "PausedError",
     "PlotNotAvailableError",
 ]

--- a/src/lizystudio/storage/versions.py
+++ b/src/lizystudio/storage/versions.py
@@ -27,7 +27,54 @@ import os
 from pathlib import Path
 from typing import Any
 
-from lizystudio.backends.exceptions import IncompatibleFormatVersionError
+from lizystudio.backends.exceptions import (
+    IncompatibleFormatVersionError,
+    LegacyFormatProtectionError,
+)
+
+LEGACY_WRITE_OVERRIDE_ENV = "LIZYSTUDIO_ALLOW_LEGACY_WRITE"
+"""Env var to opt in to overwriting a legacy artefact (P-0103 v3-25c).
+
+Without this env set, ``write_versioned_json`` refuses to overwrite a
+file whose existing on-disk version is older than the current
+``STUDIO_FORMAT_VERSION``. The check protects v0 / v1 customer
+workspaces against silent destruction during an in-place release
+upgrade. New files (no existing artefact) and same-version overwrites
+are always permitted.
+"""
+
+
+def _legacy_write_allowed() -> bool:
+    """True when the operator has opted in via the env var.
+
+    Empty string and ``"0"`` are treated as opt-out — the only opt-in
+    surface is the canonical truthy value ``"1"``. This avoids
+    confusing semantics where ``LIZYSTUDIO_ALLOW_LEGACY_WRITE=0`` would
+    paradoxically enable the override on a naive ``bool(os.environ[...])``.
+    """
+    return os.environ.get(LEGACY_WRITE_OVERRIDE_ENV, "").strip() == "1"
+
+
+def _peek_existing_format_version(path: Path) -> int | None:
+    """Return the on-disk ``format_version`` of ``path`` without migrating.
+
+    Returns ``None`` when the file does not exist, is unreadable, or
+    is not valid JSON — the caller treats those as "no legacy artefact
+    to protect" and the writer proceeds to overwrite normally. Read
+    errors are deliberately swallowed because the writer's own retry
+    loop will surface a meaningful failure if the path is genuinely
+    corrupt.
+    """
+    if not path.exists():
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    return int(raw.get(_FORMAT_VERSION_KEY, 0))
+
 
 STUDIO_FORMAT_VERSION: int = 2
 """Current on-disk JSON format version for Studio-owned artefacts.
@@ -81,6 +128,20 @@ def write_versioned_json(path: Path, payload: dict[str, Any]) -> None:
     skipped on platforms that reject directory fds) so the rename's
     metadata reaches the disk inode table before the function returns.
     """
+    # P-0103 v3-25c: protect legacy on-disk artefacts. If a file
+    # already exists at ``path`` and declares an older format_version,
+    # refuse to overwrite unless the operator opts in via the
+    # LIZYSTUDIO_ALLOW_LEGACY_WRITE env var. The check runs BEFORE
+    # mkdir / tmp-file creation so a refusal is observably side-effect
+    # free.
+    existing = _peek_existing_format_version(path)
+    if (
+        existing is not None
+        and existing < STUDIO_FORMAT_VERSION
+        and not _legacy_write_allowed()
+    ):
+        raise LegacyFormatProtectionError(path, existing)
+
     path.parent.mkdir(parents=True, exist_ok=True)
     versioned: dict[str, Any] = {_FORMAT_VERSION_KEY: STUDIO_FORMAT_VERSION}
     versioned.update(payload)

--- a/tests/test_storage_versions.py
+++ b/tests/test_storage_versions.py
@@ -356,3 +356,141 @@ class TestMigrationChainGap:
 
         with pytest.raises(RuntimeError, match="No migration registered for version 1"):
             migrations.migrate_to_current({"job_id": "j1"}, from_version=0)
+
+
+class TestLegacyFormatProtection:
+    """P-0103 v3-25c / R-4.1: ``write_versioned_json`` refuses to
+    overwrite a legacy on-disk artefact unless the operator opts in
+    via ``LIZYSTUDIO_ALLOW_LEGACY_WRITE=1``.
+
+    Coverage:
+
+    - Refusal: legacy file exists + env unset → LegacyFormatProtectionError
+    - Override: legacy file exists + env=1 → write succeeds + bumps version
+    - Pass-through: no existing file → write always succeeds (greenfield)
+    - Pass-through: existing file at current version → write succeeds
+    - Edge: empty / 0 / unrelated env values do NOT enable the override
+
+    These invariants are what stops a v0 / v1 customer workspace from
+    being silently up-converted by an in-place LizyStudio upgrade.
+    """
+
+    def test_write_refuses_when_existing_file_is_legacy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """v0 file on disk + env unset → LegacyFormatProtectionError."""
+        from lizystudio.backends.exceptions import LegacyFormatProtectionError
+        from lizystudio.storage.versions import write_versioned_json
+
+        monkeypatch.delenv("LIZYSTUDIO_ALLOW_LEGACY_WRITE", raising=False)
+        path = tmp_path / "meta.json"
+        # Pin a v0 fixture (no format_version key).
+        _write_raw_json(path, {"job_id": "j1", "status": "completed"})
+
+        with pytest.raises(LegacyFormatProtectionError) as exc_info:
+            write_versioned_json(path, {"job_id": "j1", "status": "running"})
+
+        # Error message must guide the user to the override env var so
+        # the recovery path is self-evident from the traceback.
+        assert "LIZYSTUDIO_ALLOW_LEGACY_WRITE" in str(exc_info.value)
+        assert exc_info.value.detected_version == 0
+
+    def test_write_refuses_v1_file_under_v2_runtime(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """v1 file on disk + env unset → LegacyFormatProtectionError."""
+        from lizystudio.backends.exceptions import LegacyFormatProtectionError
+        from lizystudio.storage.versions import write_versioned_json
+
+        monkeypatch.delenv("LIZYSTUDIO_ALLOW_LEGACY_WRITE", raising=False)
+        path = tmp_path / "meta.json"
+        _write_raw_json(path, {"format_version": 1, "job_id": "j1"})
+
+        with pytest.raises(LegacyFormatProtectionError) as exc_info:
+            write_versioned_json(path, {"job_id": "j1", "status": "running"})
+        assert exc_info.value.detected_version == 1
+
+    def test_write_succeeds_when_env_var_opts_in(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """v0 file on disk + ``LIZYSTUDIO_ALLOW_LEGACY_WRITE=1`` → write succeeds.
+
+        After the override write, the on-disk version must be bumped
+        to current and the new payload must be readable through the
+        normal migration path.
+        """
+        import json
+
+        from lizystudio.storage.versions import (
+            STUDIO_FORMAT_VERSION,
+            read_versioned_json,
+            write_versioned_json,
+        )
+
+        monkeypatch.setenv("LIZYSTUDIO_ALLOW_LEGACY_WRITE", "1")
+        path = tmp_path / "meta.json"
+        _write_raw_json(path, {"job_id": "j1", "status": "completed"})
+
+        write_versioned_json(path, {"job_id": "j1", "status": "running"})
+
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        assert raw["format_version"] == STUDIO_FORMAT_VERSION
+        detected, payload = read_versioned_json(path)
+        assert detected == STUDIO_FORMAT_VERSION
+        assert payload["status"] == "running"
+
+    def test_write_succeeds_when_no_existing_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Greenfield write (no prior file) is unaffected by the gate."""
+        from lizystudio.storage.versions import write_versioned_json
+
+        monkeypatch.delenv("LIZYSTUDIO_ALLOW_LEGACY_WRITE", raising=False)
+        path = tmp_path / "meta.json"
+        # Path does not exist — the gate must NOT fire.
+        write_versioned_json(path, {"job_id": "j1"})
+        assert path.exists()
+
+    def test_write_succeeds_when_existing_file_is_current_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same-version overwrite is permitted without the env var.
+
+        The gate only triggers on legacy artefacts; routine writes to
+        an already-current file (every operational write the runtime
+        does after the workspace has been touched once) must remain
+        unblocked, otherwise the env var would be required for normal
+        operation.
+        """
+        from lizystudio.storage.versions import write_versioned_json
+
+        monkeypatch.delenv("LIZYSTUDIO_ALLOW_LEGACY_WRITE", raising=False)
+        path = tmp_path / "meta.json"
+        # First write creates a current-version artefact.
+        write_versioned_json(path, {"job_id": "j1", "status": "running"})
+        # Second write overwrites the same-version file — no error.
+        write_versioned_json(path, {"job_id": "j1", "status": "completed"})
+
+    @pytest.mark.parametrize("env_value", ["", "0", "false", "no", "True", "yes"])
+    def test_only_canonical_one_value_enables_override(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        env_value: str,
+    ) -> None:
+        """Only ``"1"`` opts in.
+
+        Naive ``bool(os.environ[...])`` would flip semantics: an
+        explicit ``LIZYSTUDIO_ALLOW_LEGACY_WRITE=0`` would still be
+        truthy and enable the override the user is trying to disable.
+        Pin the canonical truthy interpretation so the operator has a
+        predictable knob.
+        """
+        from lizystudio.backends.exceptions import LegacyFormatProtectionError
+        from lizystudio.storage.versions import write_versioned_json
+
+        monkeypatch.setenv("LIZYSTUDIO_ALLOW_LEGACY_WRITE", env_value)
+        path = tmp_path / "meta.json"
+        _write_raw_json(path, {"job_id": "j1"})  # v0 fixture
+        with pytest.raises(LegacyFormatProtectionError):
+            write_versioned_json(path, {"job_id": "j1"})


### PR DESCRIPTION
## Summary

P-0103 v3-25c / R-4.1: prevent silent destruction of v0 / v1 customer workspaces during in-place LizyStudio upgrades. `write_versioned_json` now refuses to overwrite an on-disk artefact whose existing `format_version` is older than `STUDIO_FORMAT_VERSION` unless the operator opts in via `LIZYSTUDIO_ALLOW_LEGACY_WRITE=1`.

Closes the v3-25 phase. Independent of PR #432 (matrix tests) / PR #433 (CI gate) — those land first to establish the regression coverage; this PR adds the runtime safety gate they protect.

## Invariants

- **INV-fmt-1**: `read_versioned_json` is unchanged — legacy reads keep working
- **INV-fmt-2**: `write_versioned_json` raises `LegacyFormatProtectionError` when on-disk version < current AND env var unset
- **INV-fmt-3**: Greenfield writes + same-version overwrites are always permitted
- **INV-fmt-4** (covered by PR #432 / #433): migration matrix gates schema bumps

## Failure Paths Covered

- [x] v0 file + env unset → raise (regression)
- [x] v1 file + env unset → raise (regression)
- [x] v0 file + env=1 → write + on-disk version bumped
- [x] No existing file → write succeeds
- [x] Same-version overwrite → write succeeds
- [x] env values empty, 0, false, no, True, yes keep protection enabled

## Tests

11 new in `TestLegacyFormatProtection`:
```bash
$ uv run pytest tests/test_storage_versions.py -v
============================== 26 passed in 2.49s ==============================
```

Plus 233/233 regression suite green, 90/90 jobs/inference API tests green.

## CHANGELOG

Added an Unreleased entry documenting the env var and recovery path. HISTORY.md P-0103 (on PR #429 for handoff convenience) carries the full rationale.

## Why "1" is the only opt-in value

Naive `bool(os.environ[...])` would flip the semantics: `LIZYSTUDIO_ALLOW_LEGACY_WRITE=0` is non-empty and therefore truthy in Python, paradoxically enabling the override the user is trying to disable. The canonical "1" interpretation pinned by `test_only_canonical_one_value_enables_override` makes the knob predictable.

## Related

- HISTORY.md P-0103 (in PR #429)
- PR #432 v3-25a runtime matrix
- PR #433 v3-25b legacy fixtures + CI gate
- PLAN.md Phase v3-25c
- Closes v0.5 Exit Criterion: format_version migration matrix CI gating