### PR TITLE
fix(storage): tighten _peek_existing_format_version against tampered stamps (post-v3-25c review)

### DIFF
--- a/src/lizystudio/backends/exceptions.py
+++ b/src/lizystudio/backends/exceptions.py
@@ -14,6 +14,8 @@ match the same class.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 
 class CancelledError(Exception):
     """Raised when a long-running backend operation is cancelled.
@@ -104,7 +106,7 @@ class LegacyFormatProtectionError(Exception):
     env var set after explicitly backing up the legacy workspace.
     """
 
-    def __init__(self, path: object, detected_version: int) -> None:
+    def __init__(self, path: Path | str, detected_version: int) -> None:
         super().__init__(
             f"Refusing to overwrite legacy artefact at {path} "
             f"(format_version={detected_version}). Set "

--- a/src/lizystudio/storage/versions.py
+++ b/src/lizystudio/storage/versions.py
@@ -58,12 +58,12 @@ def _legacy_write_allowed() -> bool:
 def _peek_existing_format_version(path: Path) -> int | None:
     """Return the on-disk ``format_version`` of ``path`` without migrating.
 
-    Returns ``None`` when the file does not exist, is unreadable, or
-    is not valid JSON — the caller treats those as "no legacy artefact
-    to protect" and the writer proceeds to overwrite normally. Read
-    errors are deliberately swallowed because the writer's own retry
-    loop will surface a meaningful failure if the path is genuinely
-    corrupt.
+    Returns ``None`` when the file does not exist, is unreadable, is
+    not valid JSON, or carries a non-integer ``format_version`` — the
+    caller treats those as "no legacy artefact to protect" and the
+    writer proceeds to overwrite normally. Read errors are deliberately
+    swallowed because the writer's own retry loop will surface a
+    meaningful failure if the path is genuinely corrupt.
     """
     if not path.exists():
         return None
@@ -73,7 +73,17 @@ def _peek_existing_format_version(path: Path) -> int | None:
         return None
     if not isinstance(raw, dict):
         return None
-    return int(raw.get(_FORMAT_VERSION_KEY, 0))
+    # Accept only true Python int values (and reject ``bool``, which
+    # is technically an int subclass but never a legitimate version
+    # stamp). A tampered file with a string, float, list, or null in
+    # the slot returns ``None`` so the protection gate treats it as
+    # "unknown / no legacy file" instead of raising or silently
+    # truncating (e.g. ``int(1.5) == 1`` would mis-classify a tampered
+    # float as v1).
+    raw_version: Any = raw.get(_FORMAT_VERSION_KEY, 0)
+    if isinstance(raw_version, bool) or not isinstance(raw_version, int):
+        return None
+    return int(raw_version)
 
 
 STUDIO_FORMAT_VERSION: int = 2

--- a/tests/test_storage_versions.py
+++ b/tests/test_storage_versions.py
@@ -494,3 +494,40 @@ class TestLegacyFormatProtection:
         _write_raw_json(path, {"job_id": "j1"})  # v0 fixture
         with pytest.raises(LegacyFormatProtectionError):
             write_versioned_json(path, {"job_id": "j1"})
+
+    @pytest.mark.parametrize(
+        "tampered",
+        ["not-a-number", "v2", None, [], {}, 1.5],
+    )
+    def test_non_integer_format_version_does_not_crash_writer(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        tampered: object,
+    ) -> None:
+        """Writer tolerates a non-integer ``format_version`` on disk.
+
+        A tampered or hand-edited workspace can carry a string,
+        float, list, or null in the version slot. The peek helper
+        must NOT raise out of write_versioned_json — the docstring
+        promises the read errors are swallowed. Regression for the
+        post-v3-25c review finding (bare ``int()`` was raising
+        ValueError on non-numeric stamps and propagating out of the
+        protection gate).
+        """
+        from lizystudio.storage.versions import (
+            STUDIO_FORMAT_VERSION,
+            read_versioned_json,
+            write_versioned_json,
+        )
+
+        monkeypatch.delenv("LIZYSTUDIO_ALLOW_LEGACY_WRITE", raising=False)
+        path = tmp_path / "meta.json"
+        _write_raw_json(path, {"format_version": tampered, "job_id": "j1"})
+
+        # Should NOT raise — the non-integer stamp is treated as
+        # "unknown / no legacy file" and the writer proceeds.
+        write_versioned_json(path, {"job_id": "j1", "status": "running"})
+        # Post-condition: file now carries the current version.
+        detected, _ = read_versioned_json(path)
+        assert detected == STUDIO_FORMAT_VERSION

--- a/tests/test_storage_versions.py
+++ b/tests/test_storage_versions.py
@@ -531,3 +531,51 @@ class TestLegacyFormatProtection:
         # Post-condition: file now carries the current version.
         detected, _ = read_versioned_json(path)
         assert detected == STUDIO_FORMAT_VERSION
+
+    def test_unreadable_or_corrupt_json_does_not_crash_writer(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A corrupt JSON file at the target path is treated as no-legacy.
+
+        ``_peek_existing_format_version`` must return ``None`` (not raise)
+        when ``json.loads`` fails. Otherwise the writer's docstring
+        promise (read errors swallowed) would be violated. Branch
+        coverage for the OSError / JSONDecodeError except clause.
+        """
+        from lizystudio.storage.versions import write_versioned_json
+
+        monkeypatch.delenv("LIZYSTUDIO_ALLOW_LEGACY_WRITE", raising=False)
+        path = tmp_path / "meta.json"
+        # Truncated JSON — json.loads raises JSONDecodeError.
+        path.write_text("{not valid json", encoding="utf-8")
+
+        # Should NOT raise — peek returns None, gate sees no legacy
+        # artefact, write proceeds.
+        write_versioned_json(path, {"job_id": "j1"})
+        assert path.read_text(encoding="utf-8").startswith('{"format_version"')
+
+    def test_non_dict_json_root_does_not_crash_writer(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A JSON file whose root is not an object is treated as no-legacy.
+
+        ``_peek_existing_format_version`` checks ``isinstance(raw, dict)``
+        before extracting the version. Branch coverage for the non-dict
+        guard (e.g. a tampered file with ``[1, 2, 3]`` at the root).
+        """
+        import json as _json
+
+        from lizystudio.storage.versions import write_versioned_json
+
+        monkeypatch.delenv("LIZYSTUDIO_ALLOW_LEGACY_WRITE", raising=False)
+        path = tmp_path / "meta.json"
+        path.write_text(_json.dumps([1, 2, 3]), encoding="utf-8")
+
+        # Should NOT raise — the array root is treated as "unknown
+        # legacy" → None → gate skipped → write proceeds.
+        write_versioned_json(path, {"job_id": "j1"})
+        assert path.read_text(encoding="utf-8").startswith('{"format_version"')


### PR DESCRIPTION
## Summary

Code-review follow-up to PR #434 (v3-25c LegacyFormatProtectionError). Two findings from post-merge review fixed in one PR.

## Findings

### MEDIUM: bare `int()` cast could raise ValueError on tampered stamp

`_peek_existing_format_version` ran `int(raw.get(_FORMAT_VERSION_KEY, 0))` without exception handling. A tampered file with `"format_version": "not-a-number"` would propagate `ValueError` out of `write_versioned_json` despite the docstring promising read errors are swallowed.

**Fix**: require a true `int` instance (rejecting `bool` subclass and floats — `int(1.5) == 1` would silently mis-classify a tampered float as v1).

### LOW: `path: object` type was too loose

`LegacyFormatProtectionError.__init__` accepted `object`. Tightened to `Path | str` for parity with other module exceptions and to enable mypy at call sites.

## Test coverage added

`TestLegacyFormatProtection.test_non_integer_format_version_does_not_crash_writer` — parametric over 6 tampered values (string, `"v2"`, `None`, list, dict, float). All must NOT raise out of the writer.

## Tests

- 32/32 `tests/test_storage_versions.py` ✅
- 55/55 across format_version suite ✅
- `mypy --strict src/lizystudio/` ✅ (55 source files clean)
- `ruff check + format` ✅

## Out of scope (filed separately)

The reviewer also flagged that `LegacyFormatProtectionError` surfaces as a generic 500 with `BackendError` envelope at the API layer. That is a legitimate UX gap but requires API error-mapping work — file as a follow-up issue, not blocking the v0.5 release.

## Related

- PR #434 (v3-25c, original work)
- HISTORY.md P-0103