### PR TITLE
fix(server): suppress SHAP 0.51.0 LightGBM-binary UserWarning noise

### DIFF
--- a/src/lizystudio/server.py
+++ b/src/lizystudio/server.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import time
+import warnings
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -41,6 +42,42 @@ from lizystudio.ws.progress import ProgressBroadcaster, websocket_progress
 logger = logging.getLogger(__name__)
 
 STATIC_DIR = Path(__file__).parent / "static"
+
+
+def _install_upstream_warning_filters() -> None:
+    """Install ``warnings.filterwarnings`` entries for upstream noise.
+
+    Currently filters:
+
+    - SHAP 0.51.0's ``UserWarning`` for LightGBM binary classifiers.
+      The notice ("shap values output has changed to a list of
+      ndarray") fires on every ``TreeExplainer.shap_values`` call.
+      The lizyml SHAP adapter (``lizyml/explain/shap_explainer.py``)
+      already handles BOTH the legacy ndarray and the new list-of-
+      ndarray shapes, so the warning is purely informational. With
+      5 folds x 2 importance kinds per fit, the noise drowns out
+      actionable log entries during normal use.
+
+    Exposed as a function (vs. a module-level statement) so test
+    contexts that snapshot ``warnings.filters`` per-test (pytest
+    does this via ``_pytest.warnings``) can re-install the filter
+    deterministically and assert it is present.
+    """
+    warnings.filterwarnings(
+        "ignore",
+        message=(
+            r"LightGBM binary classifier with TreeExplainer shap values "
+            r"output has changed to a list of ndarray"
+        ),
+        category=UserWarning,
+    )
+
+
+# Install at module import so production runs (uvicorn, ``lizystudio``
+# CLI) get the filter without any explicit call. Tests re-invoke the
+# function directly because pytest's per-test ``catch_warnings``
+# snapshot resets ``warnings.filters`` between tests.
+_install_upstream_warning_filters()
 
 # --- Security headers (H-0039) ---
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -275,3 +275,113 @@ def test_h0083_cors_parse_allowed_origins_helper() -> None:
         "https://x.example",
         "https://y.example",
     ]
+
+
+class TestShapWarningSuppression:
+    """Importing ``lizystudio.server`` registers a filter for the SHAP
+    0.51.0 LightGBM-binary ``UserWarning`` so the lizyml SHAP adapter
+    (which already handles both old and new output shapes) does not
+    spam the log with N x folds copies of an upstream API-change
+    notice on every fit.
+    """
+
+    def test_shap_userwarning_filter_is_registered(self) -> None:
+        """Calling ``_install_upstream_warning_filters`` registers an
+        ``ignore`` entry for the SHAP LightGBM-binary message.
+
+        We invoke the installer explicitly because pytest snapshots
+        ``warnings.filters`` per-test (via ``_pytest.warnings``), so
+        the module-import-time filter set up at production startup
+        is restored to the pre-test state before each test runs. The
+        installer is idempotent: production calls it once at module
+        load, this test re-invokes it inside the per-test snapshot.
+        """
+        import warnings as _warnings
+
+        from lizystudio.server import _install_upstream_warning_filters
+
+        _install_upstream_warning_filters()
+
+        matching = [
+            f
+            for f in _warnings.filters
+            if f[0] == "ignore"
+            and f[1] is not None
+            and "TreeExplainer shap values" in f[1].pattern
+        ]
+        assert matching, (
+            "Expected an ``ignore`` filter for the SHAP TreeExplainer "
+            "UserWarning to be registered after calling "
+            "_install_upstream_warning_filters. Current filters: "
+            f"{[(a, p.pattern if p else None) for a, p, *_ in _warnings.filters]}"
+        )
+        # Filter must target UserWarning specifically — broader
+        # categories would silently swallow unrelated signal.
+        assert matching[0][2] is UserWarning, (
+            f"SHAP filter should target UserWarning, got {matching[0][2].__name__}"
+        )
+
+    def test_filter_does_not_swallow_unrelated_userwarnings(self) -> None:
+        """The filter regex must scope tightly to the SHAP message.
+
+        Pin so a future broadening (e.g. a typo turning the regex into
+        ``.*``) does not silently swallow legitimate signal from
+        elsewhere in the stack.
+        """
+        import re
+        import warnings as _warnings
+
+        from lizystudio.server import _install_upstream_warning_filters
+
+        _install_upstream_warning_filters()
+
+        shap_filter = next(
+            (
+                f
+                for f in _warnings.filters
+                if f[0] == "ignore"
+                and f[1] is not None
+                and "TreeExplainer shap values" in f[1].pattern
+            ),
+            None,
+        )
+        assert shap_filter is not None
+        regex = shap_filter[1]
+        assert isinstance(regex, re.Pattern)
+        assert not regex.match("this is an unrelated warning about something else")
+        assert not regex.match("LightGBM regression model warning")
+        # And the actual SHAP message MUST match.
+        assert regex.match(
+            "LightGBM binary classifier with TreeExplainer shap "
+            "values output has changed to a list of ndarray"
+        )
+
+    def test_module_import_invokes_the_installer_in_production(self) -> None:
+        """The module-level installer call survives ``import``.
+
+        Pytest's per-test snapshot does NOT roll back the module-level
+        side effect of the FIRST production import. We assert the
+        installer name is exposed at module top-level so a future
+        refactor cannot accidentally remove the line that wires it
+        into normal startup.
+        """
+        from lizystudio import server
+
+        assert hasattr(server, "_install_upstream_warning_filters"), (
+            "Module must expose _install_upstream_warning_filters so "
+            "tests + production share a single installation surface."
+        )
+        # The installer must be a callable taking no required args.
+        import inspect
+
+        sig = inspect.signature(server._install_upstream_warning_filters)
+        required = [
+            p
+            for p in sig.parameters.values()
+            if p.default is inspect.Parameter.empty
+            and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+        ]
+        assert required == [], (
+            "_install_upstream_warning_filters must be callable with no "
+            "required arguments so it works at module import."
+        )


### PR DESCRIPTION
## Summary

SHAP 0.51.0 emits a `UserWarning` on every `TreeExplainer.shap_values()` call against a LightGBM binary classifier:

```
LightGBM binary classifier with TreeExplainer shap values output has changed to a list of ndarray
```

The lizyml SHAP adapter ([`shap_explainer.py:70-86`](https://github.com/nbx-liz/LizyML/blob/main/src/lizyml/explain/shap_explainer.py)) already handles BOTH the legacy ndarray and the new list-of-ndarray shapes, so the warning is purely informational. With **5 folds x 2 importance kinds (split + shap) per fit**, the noise drowns out actionable log entries during normal use — making real errors harder to spot in production logs.

## Reported as user-facing

A user observed the noise on Fit #55 and reported it as "an error appearing when loading data and selecting target". The investigation traced it to this upstream SHAP warning.

## Changes

- New `_install_upstream_warning_filters()` function in `server.py` that registers an `ignore` filter scoped tightly to the SHAP message + `UserWarning` category.
- Called once at module import so production runs (uvicorn, `lizystudio` CLI) get the filter without any explicit caller.
- Exposed as a function (vs. a module-level one-liner) so test contexts that snapshot `warnings.filters` per-test (pytest's `_pytest.warnings`) can re-install deterministically and assert it is present.

## Tests (3 new in `TestShapWarningSuppression`)

- `test_shap_userwarning_filter_is_registered` — asserts the filter entry lands with `action=ignore` + `category=UserWarning` + matching regex
- `test_filter_does_not_swallow_unrelated_userwarnings` — pins the regex to NOT match unrelated `UserWarning`s (guards against a future broadening typo)
- `test_module_import_invokes_the_installer_in_production` — pins the public surface so a refactor cannot accidentally remove the module-level call

## Runtime verification

Pre-fix uvicorn log around fit #55:
```
GET /api/jobs/job_64689cad/plot/importance?kind=split HTTP/1.1 200 OK
.venv/.../shap/explainers/_tree.py:620: UserWarning: LightGBM binary classifier with TreeExplainer shap values output has changed to a list of ndarray
.venv/.../shap/explainers/_tree.py:620: UserWarning: ...  (x5 per fold)
.venv/.../shap/explainers/_tree.py:620: UserWarning: ...
... 10+ repetitions per fit
```

Post-fix (re-issued the same SHAP plot/importance endpoints):
```
INFO:     127.0.0.1:45842 - "GET /api/jobs/job_64689cad/importance?kind=shap&top_n=30 HTTP/1.1" 200 OK
INFO:     127.0.0.1:45852 - "GET /api/jobs/job_64689cad/plot/importance?kind=shap HTTP/1.1" 200 OK
```

Zero warnings. Functional behaviour unchanged.

## Tests

- 21/21 `tests/test_server.py` ✅
- `ruff check + format` clean ✅
- `mypy --strict` clean ✅

## Why option A (LizyStudio-side) over option B (lizyml-side)

Discussed three options at investigation time:
- A: Suppress in LizyStudio's server startup → **chosen** for immediacy + no upstream coordination
- B: Wrap the SHAP call in `warnings.catch_warnings()` in lizyml → cleaner long-term, file as upstream issue follow-up
- C: Wait for SHAP to remove the warning → unbounded timeline

A ships now; B as upstream follow-up later.