### PR TITLE
feat(retune): add enabled Switch + null payload for Re-tune Settings (#458 Finding A, P-0104 Wave 2.1)

### DIFF
--- a/frontend/src/components/retune/RetuneSettingsSection.test.tsx
+++ b/frontend/src/components/retune/RetuneSettingsSection.test.tsx
@@ -15,149 +15,227 @@ function renderWithAccordion(
 }
 
 describe("RetuneSettingsSection", () => {
-  it("reads default values when tuning.re_tune is absent", () => {
-    renderWithAccordion({}, vi.fn());
-    const nRounds = screen.getByLabelText(
-      /number of rounds/i,
-    ) as HTMLInputElement;
-    const threshold = screen.getByLabelText(
-      /boundary threshold/i,
-    ) as HTMLInputElement;
-    expect(nRounds.value).toBe("1");
-    expect(threshold.value).toBe("0.05");
-  });
+  describe("read: Switch state derived from tuning.re_tune", () => {
+    it("renders Switch OFF and hides sub-inputs when tuning.re_tune is absent", () => {
+      renderWithAccordion({}, vi.fn());
+      const sw = screen.getByRole("switch", {
+        name: /enable re-tune/i,
+      }) as HTMLButtonElement;
+      expect(sw.getAttribute("aria-checked")).toBe("false");
+      expect(screen.queryByLabelText(/number of rounds/i)).toBeNull();
+      expect(screen.queryByLabelText(/boundary threshold/i)).toBeNull();
+    });
 
-  it("reads existing tuning.re_tune values", () => {
-    const config = {
-      tuning: {
-        re_tune: {
-          n_rounds: 4,
-          expand_boundary: false,
-          boundary_threshold: 0.2,
+    it("renders Switch OFF and hides sub-inputs when tuning.re_tune is null", () => {
+      renderWithAccordion({ tuning: { re_tune: null } }, vi.fn());
+      const sw = screen.getByRole("switch", {
+        name: /enable re-tune/i,
+      }) as HTMLButtonElement;
+      expect(sw.getAttribute("aria-checked")).toBe("false");
+      expect(screen.queryByLabelText(/number of rounds/i)).toBeNull();
+    });
+
+    it("auto-migrates legacy {n_rounds:1, ...} to Switch OFF (D2 backward-compat)", () => {
+      // Pre-Wave-2.1 the UI saved the buggy off-state as a populated object
+      // with n_rounds=1. The new contract treats this as OFF on read and
+      // will write null on the next save.
+      const config = {
+        tuning: {
+          re_tune: {
+            n_rounds: 1,
+            expand_boundary: true,
+            boundary_threshold: 0.05,
+          },
         },
-      },
-    };
-    renderWithAccordion(config, vi.fn());
-    expect(
-      (screen.getByLabelText(/number of rounds/i) as HTMLInputElement).value,
-    ).toBe("4");
-    expect(
-      (screen.getByLabelText(/boundary threshold/i) as HTMLInputElement).value,
-    ).toBe("0.2");
-  });
-
-  it("writes n_rounds via onChange patched into tuning.re_tune", () => {
-    const onChange = vi.fn();
-    renderWithAccordion({}, onChange);
-    fireEvent.change(screen.getByLabelText(/number of rounds/i), {
-      target: { value: "3" },
-    });
-    expect(onChange).toHaveBeenCalledTimes(1);
-    const patched = onChange.mock.calls[0][0] as {
-      tuning: { re_tune: { n_rounds: number } };
-    };
-    expect(patched.tuning.re_tune.n_rounds).toBe(3);
-  });
-
-  it("clamps n_rounds to [1, 10]", () => {
-    const onChange = vi.fn();
-    renderWithAccordion({}, onChange);
-    fireEvent.change(screen.getByLabelText(/number of rounds/i), {
-      target: { value: "999" },
-    });
-    const patched = onChange.mock.calls[0][0] as {
-      tuning: { re_tune: { n_rounds: number } };
-    };
-    expect(patched.tuning.re_tune.n_rounds).toBe(10);
-  });
-
-  it("clamps boundary_threshold to [0, 0.49]", () => {
-    const onChange = vi.fn();
-    renderWithAccordion(
-      {
-        tuning: { re_tune: { n_rounds: 2 } },
-      },
-      onChange,
-    );
-    fireEvent.change(screen.getByLabelText(/boundary threshold/i), {
-      target: { value: "0.99" },
-    });
-    const patched = onChange.mock.calls[0][0] as {
-      tuning: { re_tune: { boundary_threshold: number } };
-    };
-    expect(patched.tuning.re_tune.boundary_threshold).toBe(0.49);
-  });
-
-  it("disables the form controls at the HTML level when n_rounds === 1", () => {
-    renderWithAccordion({}, vi.fn());
-    const checkbox = screen.getByLabelText(
-      /expand boundary between rounds/i,
-    ) as HTMLButtonElement;
-    const threshold = screen.getByLabelText(
-      /boundary threshold/i,
-    ) as HTMLInputElement;
-    expect(checkbox).toBeDisabled();
-    expect(threshold).toBeDisabled();
-    // n_rounds input stays enabled so the user can escape the disabled state
-    const nRounds = screen.getByLabelText(
-      /number of rounds/i,
-    ) as HTMLInputElement;
-    expect(nRounds).not.toBeDisabled();
-  });
-
-  it("enables expand_boundary + threshold controls when n_rounds > 1", () => {
-    const config = {
-      tuning: { re_tune: { n_rounds: 3 } },
-    };
-    renderWithAccordion(config, vi.fn());
-    const checkbox = screen.getByLabelText(
-      /expand boundary between rounds/i,
-    ) as HTMLButtonElement;
-    const threshold = screen.getByLabelText(
-      /boundary threshold/i,
-    ) as HTMLInputElement;
-    expect(checkbox).not.toBeDisabled();
-    expect(threshold).not.toBeDisabled();
-  });
-
-  it("toggles expand_boundary via checkbox click when enabled", () => {
-    const onChange = vi.fn();
-    const config = {
-      tuning: { re_tune: { n_rounds: 3, expand_boundary: true } },
-    };
-    renderWithAccordion(config, onChange);
-    const checkbox = screen.getByLabelText(
-      /expand boundary between rounds/i,
-    ) as HTMLButtonElement;
-    fireEvent.click(checkbox);
-    expect(onChange).toHaveBeenCalledTimes(1);
-    const patched = onChange.mock.calls[0][0] as {
-      tuning: { re_tune: { expand_boundary: boolean } };
-    };
-    expect(patched.tuning.re_tune.expand_boundary).toBe(false);
-  });
-
-  it("preserves other tuning fields when writing re_tune", () => {
-    const onChange = vi.fn();
-    const config = {
-      tuning: {
-        optuna: { params: { n_trials: 100 } },
-        evaluation: { metrics: ["auc"] },
-      },
-    };
-    renderWithAccordion(config, onChange);
-    fireEvent.change(screen.getByLabelText(/number of rounds/i), {
-      target: { value: "2" },
-    });
-    const patched = onChange.mock.calls[0][0] as {
-      tuning: {
-        optuna: { params: { n_trials: number } };
-        evaluation: { metrics: string[] };
-        re_tune: { n_rounds: number };
       };
-    };
-    expect(patched.tuning.optuna.params.n_trials).toBe(100);
-    expect(patched.tuning.evaluation.metrics).toEqual(["auc"]);
-    expect(patched.tuning.re_tune.n_rounds).toBe(2);
+      renderWithAccordion(config, vi.fn());
+      const sw = screen.getByRole("switch", {
+        name: /enable re-tune/i,
+      }) as HTMLButtonElement;
+      expect(sw.getAttribute("aria-checked")).toBe("false");
+      expect(screen.queryByLabelText(/number of rounds/i)).toBeNull();
+    });
+
+    it("renders Switch ON and shows sub-inputs when n_rounds > 1", () => {
+      const config = {
+        tuning: {
+          re_tune: {
+            n_rounds: 4,
+            expand_boundary: false,
+            boundary_threshold: 0.2,
+          },
+        },
+      };
+      renderWithAccordion(config, vi.fn());
+      const sw = screen.getByRole("switch", {
+        name: /enable re-tune/i,
+      }) as HTMLButtonElement;
+      expect(sw.getAttribute("aria-checked")).toBe("true");
+      expect(
+        (screen.getByLabelText(/number of rounds/i) as HTMLInputElement).value,
+      ).toBe("4");
+      expect(
+        (screen.getByLabelText(/boundary threshold/i) as HTMLInputElement)
+          .value,
+      ).toBe("0.2");
+    });
+  });
+
+  describe("write: Switch toggling drives the wire payload", () => {
+    it("writes tuning.re_tune = null when toggled OFF", () => {
+      const onChange = vi.fn();
+      const config = {
+        tuning: {
+          re_tune: {
+            n_rounds: 3,
+            expand_boundary: true,
+            boundary_threshold: 0.05,
+          },
+        },
+      };
+      renderWithAccordion(config, onChange);
+      const sw = screen.getByRole("switch", { name: /enable re-tune/i });
+      fireEvent.click(sw);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const patched = onChange.mock.calls[0][0] as {
+        tuning: { re_tune: unknown };
+      };
+      expect(patched.tuning.re_tune).toBeNull();
+    });
+
+    it("writes ON_DEFAULTS {n_rounds:3, ...} when toggled from absent to ON", () => {
+      const onChange = vi.fn();
+      renderWithAccordion({}, onChange);
+      const sw = screen.getByRole("switch", { name: /enable re-tune/i });
+      fireEvent.click(sw);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const patched = onChange.mock.calls[0][0] as {
+        tuning: {
+          re_tune: {
+            n_rounds: number;
+            expand_boundary: boolean;
+            boundary_threshold: number;
+          };
+        };
+      };
+      expect(patched.tuning.re_tune).toEqual({
+        n_rounds: 3,
+        expand_boundary: true,
+        boundary_threshold: 0.05,
+      });
+    });
+
+    it("writes ON_DEFAULTS when toggled from legacy {n_rounds:1, ...} to ON", () => {
+      // Auto-migrated legacy payload is treated as OFF; toggling ON starts
+      // fresh from ON_DEFAULTS rather than restoring the legacy n_rounds=1.
+      const onChange = vi.fn();
+      const config = {
+        tuning: {
+          re_tune: {
+            n_rounds: 1,
+            expand_boundary: false,
+            boundary_threshold: 0.1,
+          },
+        },
+      };
+      renderWithAccordion(config, onChange);
+      const sw = screen.getByRole("switch", { name: /enable re-tune/i });
+      fireEvent.click(sw);
+      const patched = onChange.mock.calls[0][0] as {
+        tuning: {
+          re_tune: {
+            n_rounds: number;
+            expand_boundary: boolean;
+            boundary_threshold: number;
+          };
+        };
+      };
+      expect(patched.tuning.re_tune.n_rounds).toBe(3);
+    });
+  });
+
+  describe("edits while ON", () => {
+    it("writes n_rounds via onChange patched into tuning.re_tune", () => {
+      const onChange = vi.fn();
+      const config = {
+        tuning: { re_tune: { n_rounds: 3 } },
+      };
+      renderWithAccordion(config, onChange);
+      fireEvent.change(screen.getByLabelText(/number of rounds/i), {
+        target: { value: "5" },
+      });
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const patched = onChange.mock.calls[0][0] as {
+        tuning: { re_tune: { n_rounds: number } };
+      };
+      expect(patched.tuning.re_tune.n_rounds).toBe(5);
+    });
+
+    it("clamps n_rounds to [1, 10]", () => {
+      const onChange = vi.fn();
+      const config = { tuning: { re_tune: { n_rounds: 3 } } };
+      renderWithAccordion(config, onChange);
+      fireEvent.change(screen.getByLabelText(/number of rounds/i), {
+        target: { value: "999" },
+      });
+      const patched = onChange.mock.calls[0][0] as {
+        tuning: { re_tune: { n_rounds: number } };
+      };
+      expect(patched.tuning.re_tune.n_rounds).toBe(10);
+    });
+
+    it("clamps boundary_threshold to [0, 0.49]", () => {
+      const onChange = vi.fn();
+      renderWithAccordion({ tuning: { re_tune: { n_rounds: 2 } } }, onChange);
+      fireEvent.change(screen.getByLabelText(/boundary threshold/i), {
+        target: { value: "0.99" },
+      });
+      const patched = onChange.mock.calls[0][0] as {
+        tuning: { re_tune: { boundary_threshold: number } };
+      };
+      expect(patched.tuning.re_tune.boundary_threshold).toBe(0.49);
+    });
+
+    it("toggles expand_boundary via checkbox click", () => {
+      const onChange = vi.fn();
+      const config = {
+        tuning: { re_tune: { n_rounds: 3, expand_boundary: true } },
+      };
+      renderWithAccordion(config, onChange);
+      const checkbox = screen.getByLabelText(
+        /expand boundary between rounds/i,
+      ) as HTMLButtonElement;
+      fireEvent.click(checkbox);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const patched = onChange.mock.calls[0][0] as {
+        tuning: { re_tune: { expand_boundary: boolean } };
+      };
+      expect(patched.tuning.re_tune.expand_boundary).toBe(false);
+    });
+
+    it("preserves other tuning fields when writing re_tune", () => {
+      const onChange = vi.fn();
+      const config = {
+        tuning: {
+          optuna: { params: { n_trials: 100 } },
+          evaluation: { metrics: ["auc"] },
+          re_tune: { n_rounds: 3 },
+        },
+      };
+      renderWithAccordion(config, onChange);
+      fireEvent.change(screen.getByLabelText(/number of rounds/i), {
+        target: { value: "5" },
+      });
+      const patched = onChange.mock.calls[0][0] as {
+        tuning: {
+          optuna: { params: { n_trials: number } };
+          evaluation: { metrics: string[] };
+          re_tune: { n_rounds: number };
+        };
+      };
+      expect(patched.tuning.optuna.params.n_trials).toBe(100);
+      expect(patched.tuning.evaluation.metrics).toEqual(["auc"]);
+      expect(patched.tuning.re_tune.n_rounds).toBe(5);
+    });
   });
 });

--- a/frontend/src/components/retune/RetuneSettingsSection.tsx
+++ b/frontend/src/components/retune/RetuneSettingsSection.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import {
   AccordionContent,
   AccordionItem,
@@ -6,11 +7,11 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import {
   extractTuningField,
   updateTuningField,
 } from "@/components/workspace/tune-config-utils";
-import { cn } from "@/lib/utils";
 import type { RetuneConfig } from "./types";
 
 export interface RetuneSettingsSectionProps {
@@ -18,8 +19,11 @@ export interface RetuneSettingsSectionProps {
   onChange: (config: Record<string, unknown>) => void;
 }
 
-const DEFAULTS: RetuneConfig = {
-  n_rounds: 1,
+// ON-state defaults instantiated when the user flips the Switch ON for the
+// first time. `n_rounds=3` matches BLUEPRINT.md section 4.2.2 default and
+// P-0104 Wave 2.1; the previous default of 1 was the buggy off-state proxy.
+const ON_DEFAULTS: RetuneConfig = {
+  n_rounds: 3,
   expand_boundary: true,
   boundary_threshold: 0.05,
 };
@@ -28,32 +32,52 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
 
+// Re-tune is considered active only when the payload exists AND n_rounds > 1.
+// Legacy saves carrying `{n_rounds: 1, ...}` are auto-migrated to OFF on read
+// per P-0104 Decision (D2 backward-compat / Q-2.1.1 = Option (b)).
+function isReTuneActive(raw: unknown): raw is RetuneConfig {
+  if (!raw || typeof raw !== "object") return false;
+  const obj = raw as Partial<RetuneConfig>;
+  return typeof obj.n_rounds === "number" && obj.n_rounds > 1;
+}
+
 export function RetuneSettingsSection({
   config,
   onChange,
 }: RetuneSettingsSectionProps) {
-  const raw = extractTuningField<Partial<RetuneConfig>>(
-    config,
-    "re_tune",
-    DEFAULTS,
-  );
+  const raw = extractTuningField<unknown>(config, "re_tune", null);
+  const active = isReTuneActive(raw);
 
-  const cfg: RetuneConfig = {
-    n_rounds: raw.n_rounds ?? DEFAULTS.n_rounds,
-    expand_boundary: raw.expand_boundary ?? DEFAULTS.expand_boundary,
-    boundary_threshold: raw.boundary_threshold ?? DEFAULTS.boundary_threshold,
+  // Preserves the last ON-state values so toggling OFF -> ON restores the
+  // user's edits instead of resetting to defaults (Q-2.1.3 = Option (b)).
+  const draftRef = useRef<RetuneConfig>(
+    active ? (raw as RetuneConfig) : ON_DEFAULTS,
+  );
+  if (active) {
+    draftRef.current = raw as RetuneConfig;
+  }
+
+  const cfg: RetuneConfig = active ? (raw as RetuneConfig) : draftRef.current;
+
+  const writeActive = (next: RetuneConfig) => {
+    draftRef.current = next;
+    onChange(updateTuningField(config, "re_tune", next));
   };
 
-  const update = (patch: Partial<RetuneConfig>) => {
-    onChange(updateTuningField(config, "re_tune", { ...cfg, ...patch }));
+  const handleSwitchChange = (checked: boolean) => {
+    if (checked) {
+      writeActive({ ...draftRef.current });
+    } else {
+      onChange(updateTuningField(config, "re_tune", null));
+    }
   };
 
   const handleNRoundsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const parsed = Number(e.target.value);
     const value = Number.isNaN(parsed)
-      ? DEFAULTS.n_rounds
+      ? ON_DEFAULTS.n_rounds
       : clamp(parsed, 1, 10);
-    update({ n_rounds: value });
+    writeActive({ ...cfg, n_rounds: value });
   };
 
   const handleBoundaryThresholdChange = (
@@ -61,101 +85,107 @@ export function RetuneSettingsSection({
   ) => {
     const parsed = Number(e.target.value);
     const value = Number.isNaN(parsed)
-      ? DEFAULTS.boundary_threshold
+      ? ON_DEFAULTS.boundary_threshold
       : clamp(parsed, 0, 0.49);
-    update({ boundary_threshold: value });
+    writeActive({ ...cfg, boundary_threshold: value });
   };
 
   const handleExpandBoundaryChange = (checked: boolean | "indeterminate") => {
-    // Radix Checkbox's type signature allows "indeterminate" but a
-    // controlled boolean checkbox never emits it — ignore defensively.
     if (checked === "indeterminate") return;
-    update({ expand_boundary: checked });
+    writeActive({ ...cfg, expand_boundary: checked });
   };
-
-  const multiRoundDisabled = cfg.n_rounds === 1;
 
   return (
     <AccordionItem value="retune" className="border-b">
-      <AccordionTrigger className="py-1.5 text-sm font-medium hover:bg-muted/50">
-        Re-tune (multi-round)
-      </AccordionTrigger>
+      <div className="flex items-center gap-2">
+        <AccordionTrigger className="py-1.5 text-sm font-medium hover:bg-muted/50 flex-1">
+          Re-tune (multi-round)
+        </AccordionTrigger>
+        <Switch
+          aria-label="Enable Re-tune (multi-round)"
+          checked={active}
+          onCheckedChange={handleSwitchChange}
+          onClick={(e) => e.stopPropagation()}
+          className="mr-2"
+        />
+      </div>
       <AccordionContent>
-        <div className="lzs-form space-y-2 pl-[18px] px-1">
-          {/* Number of rounds */}
-          <div className="space-y-1">
-            <Label
-              htmlFor="retune-n-rounds"
-              className="text-sm text-muted-foreground"
-            >
-              Number of rounds
-            </Label>
-            <Input
-              id="retune-n-rounds"
-              type="number"
-              min={1}
-              max={10}
-              step={1}
-              value={cfg.n_rounds}
-              onChange={handleNRoundsChange}
-              aria-describedby="retune-n-rounds-hint"
-            />
-            <p
-              id="retune-n-rounds-hint"
-              className="text-xs text-muted-foreground"
-            >
-              Total tuning rounds. 1 = classic single-round tune.
-            </p>
-          </div>
-
-          {/* Expand boundary */}
-          <div className={cn("space-y-1", multiRoundDisabled && "opacity-50")}>
-            <div className="flex items-center gap-2">
-              <Checkbox
-                id="retune-expand-boundary"
-                checked={cfg.expand_boundary}
-                onCheckedChange={handleExpandBoundaryChange}
-                disabled={multiRoundDisabled}
-              />
+        {active && (
+          <div className="lzs-form space-y-2 pl-[18px] px-1">
+            {/* Number of rounds */}
+            <div className="space-y-1">
               <Label
-                htmlFor="retune-expand-boundary"
+                htmlFor="retune-n-rounds"
                 className="text-sm text-muted-foreground"
               >
-                Expand boundary between rounds
+                Number of rounds
               </Label>
+              <Input
+                id="retune-n-rounds"
+                type="number"
+                min={1}
+                max={10}
+                step={1}
+                value={cfg.n_rounds}
+                onChange={handleNRoundsChange}
+                aria-describedby="retune-n-rounds-hint"
+              />
+              <p
+                id="retune-n-rounds-hint"
+                className="text-xs text-muted-foreground"
+              >
+                Total tuning rounds (2-10 for multi-round; set Switch to OFF for
+                a single-round tune).
+              </p>
             </div>
-            <p className="text-xs text-muted-foreground pl-6">
-              Grow the search space when the best value is near an edge.
-            </p>
-          </div>
 
-          {/* Boundary threshold */}
-          <div className={cn("space-y-1", multiRoundDisabled && "opacity-50")}>
-            <Label
-              htmlFor="retune-boundary-threshold"
-              className="text-sm text-muted-foreground"
-            >
-              Boundary threshold
-            </Label>
-            <Input
-              id="retune-boundary-threshold"
-              type="number"
-              min={0}
-              max={0.49}
-              step={0.01}
-              value={cfg.boundary_threshold}
-              onChange={handleBoundaryThresholdChange}
-              disabled={multiRoundDisabled}
-              aria-describedby="retune-threshold-hint"
-            />
-            <p
-              id="retune-threshold-hint"
-              className="text-xs text-muted-foreground"
-            >
-              Relative distance from edge that triggers expansion (0–0.49).
-            </p>
+            {/* Expand boundary */}
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="retune-expand-boundary"
+                  checked={cfg.expand_boundary}
+                  onCheckedChange={handleExpandBoundaryChange}
+                />
+                <Label
+                  htmlFor="retune-expand-boundary"
+                  className="text-sm text-muted-foreground"
+                >
+                  Expand boundary between rounds
+                </Label>
+              </div>
+              <p className="text-xs text-muted-foreground pl-6">
+                Grow the search space when the best value is near an edge.
+              </p>
+            </div>
+
+            {/* Boundary threshold */}
+            <div className="space-y-1">
+              <Label
+                htmlFor="retune-boundary-threshold"
+                className="text-sm text-muted-foreground"
+              >
+                Boundary threshold
+              </Label>
+              <Input
+                id="retune-boundary-threshold"
+                type="number"
+                min={0}
+                max={0.49}
+                step={0.01}
+                value={cfg.boundary_threshold}
+                onChange={handleBoundaryThresholdChange}
+                aria-describedby="retune-threshold-hint"
+              />
+              <p
+                id="retune-threshold-hint"
+                className="text-xs text-muted-foreground"
+              >
+                Relative distance from edge that triggers expansion (0–0.49).
+              </p>
+            </div>
           </div>
-        </div>
+        )}
       </AccordionContent>
     </AccordionItem>
   );

--- a/tests/test_training_service.py
+++ b/tests/test_training_service.py
@@ -689,6 +689,35 @@ class TestExtractReTune:
     def test_non_dict_re_tune_yields_none(self) -> None:
         assert _extract_re_tune({"tuning": {"re_tune": "bad"}}) is None
 
+    def test_explicit_null_re_tune_yields_none(self) -> None:
+        # P-0104 Wave 2.1: the Re-tune Settings Switch writes
+        # ``tuning.re_tune = null`` to the wire payload when OFF. The
+        # extractor MUST treat this as a non-multi-round request so the
+        # legacy single-round path (no re_tune kwargs) is taken.
+        assert _extract_re_tune({"tuning": {"re_tune": None}}) is None
+
+    def test_legacy_n_rounds_1_payload_still_accepted(self) -> None:
+        # P-0104 Decision D2: legacy persisted jobs may carry
+        # ``{n_rounds: 1, expand_boundary: True, boundary_threshold: 0.05}``
+        # from the pre-Wave-2.1 UI (which used n_rounds=1 as the off-state
+        # proxy). The backend MUST keep accepting the populated payload
+        # without normalisation; the front-end auto-migrates the display
+        # state but the wire shape is permitted unchanged.
+        legacy = {
+            "tuning": {
+                "re_tune": {
+                    "n_rounds": 1,
+                    "expand_boundary": True,
+                    "boundary_threshold": 0.05,
+                }
+            }
+        }
+        assert _extract_re_tune(legacy) == {
+            "n_rounds": 1,
+            "expand_boundary": True,
+            "boundary_threshold": 0.05,
+        }
+
     def test_explicit_null_tuning_yields_none(self) -> None:
         # Some persisted configs explicitly set tuning to null.
         assert _extract_re_tune({"tuning": None}) is None


### PR DESCRIPTION
## Summary

Implements **P-0104 Wave 2.1** -- Re-tune Settings enabled Switch (Issue #458 Finding A).

Adds a "Re-tune (multi-round)" Switch at the top of the `RetuneSettingsSection` Accordion. The Switch state drives the wire payload directly:

- **OFF** -> `tuning.re_tune = null` (sub-inputs hidden)
- **ON** -> `tuning.re_tune = { n_rounds, expand_boundary, boundary_threshold }`

The previous design used `n_rounds=1` as an off-state proxy, which always sent a populated object regardless of intent and made the off state indistinguishable from a single-round multi-round tune.

## Design decisions (recorded in P-0104 Decision row, 2026-05-11)

| Question | Resolution |
|---|---|
| Q-2.1.1: legacy `{n_rounds: 1, ...}` payload UI display | **auto-migrate** to Switch OFF on read (Option b). Next save writes null. Backend accepts legacy shape per D2 (no shim) |
| Q-2.1.2: Switch placement | **trigger-row** (Option a). Inside AccordionTrigger row with `onClick` stopPropagation so toggling does not collapse the Accordion |
| Q-2.1.3: OFF -> ON restore | **preserve draft** (Option b). `useRef`-backed draft keeps last ON-state edits |
| Q-2.1.4: OFF-state sub-inputs | **hidden** (Option a). Removed from DOM when Switch is OFF |

## Behaviour changes

- **n_rounds default when toggling Switch ON for the first time**: 3 (was 1)
- Hint "1 = classic single-round tune" removed (`n_rounds=1` is no longer the off-state proxy)
- `multiRoundDisabled` gate on Checkbox + threshold input removed (sub-inputs only render when active)

## Test changes

- `frontend/src/components/retune/RetuneSettingsSection.test.tsx` fully rewritten around the new Switch contract:
  - empty config / explicit null / legacy `n_rounds=1` -> Switch OFF, sub-inputs not in DOM
  - `n_rounds > 1` -> Switch ON, sub-inputs visible
  - toggling Switch writes `null` (OFF) vs ON_DEFAULTS / draft (ON)
  - editing while ON preserves clamping + onChange contracts + other tuning fields
- `tests/test_training_service.py::TestExtractReTune` adds 2 regression cases:
  - `test_explicit_null_re_tune_yields_none` -- protects the new wire shape (P-0104 Wave 2.1)
  - `test_legacy_n_rounds_1_payload_still_accepted` -- protects D2 backward compatibility

Backend `_extract_re_tune` already handled both shapes (None and the legacy `{n_rounds: 1, ...}` payload); no production code change was needed there.

## Out of scope (deferred to Wave 2.2 / 3.1)

- BLUEPRINT.md section 4.2.2 default-range table update (Issue #458 Finding B; bundled with Wave 2.2 backend canonical defaults)
- objective / metric SSOT integration (Wave 3.1)

## Test plan

- [x] `uv run pytest tests/test_training_service.py::TestExtractReTune -v` -- 9/9 passed
- [x] `pnpm test -- --run RetuneSettingsSection` -- 1880/1880 frontend tests passed
- [x] `pnpm check` -- biome lint + format clean
- [x] `pnpm build` -- 2085 modules transformed, no TS errors
- [x] `uv run ruff check tests/test_training_service.py` + `ruff format --check` -- clean
- [ ] CI green on full backend + e2e matrix
- [ ] Reviewer confirms Q-2.1.1 auto-migrate behaviour matches D2 intent (legacy `{n_rounds: 1, ...}` -> OFF, next save writes null)

## Related

- Proposal P-0104 (PR #463 merged)
- Issue #458 -- "Re-tune Settings: missing enabled Switch + wrong n_rounds default"
- `docs/issue-cleanup-plan-2026-05-10.md` Wave 2.1 (merged in #462)
