### PR TITLE
feat(tune): canonical Range/Choice defaults + Fit seed=1120 (#459 backend, P-0104 Wave 2.2)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -959,18 +959,48 @@ Fixed パラメータは `space` に含めず、`model.params` の値がその�
 | distribution | Select | `log: true/false` | Uniform（`log: false`）/ Log-uniform（`log: true`） |
 | step | NumberInput（integer のみ） | `step` | ステップ幅。省略可。float には表示しない |
 
-Range のデフォルト初期値:
+Range / Choice / Fixed のデフォルト初期値（P-0104 Wave 2.2 / Issue #459、binary task の canonical spec）。出典は `lizyml_ui_schema.search_space_catalog`。regression / multiclass のデフォルトは後続 Issue で確定する。
 
-| パラメータ | low | high | log | step |
-|-----------|-----|------|-----|------|
-| learning_rate | 0.005 | 0.3 | true | — |
-| num_leaves | 10 | 200 | false | 1 |
-| n_estimators | 100 | 3000 | false | 100 |
-| max_depth | 3 | 12 | false | 1 |
-| subsample | 0.5 | 1.0 | false | — |
-| colsample_bytree | 0.5 | 1.0 | false | — |
-| reg_alpha | 1e-8 | 10.0 | true | — |
-| reg_lambda | 1e-8 | 10.0 | true | — |
+**Smart Params グループ:**
+
+| パラメータ | default_mode | low / 値 | high | log | 備考 |
+|-----------|-------------|---------|------|-----|------|
+| `auto_num_leaves` | Fixed | `True` | — | — | true 時は `num_leaves_ratio`、false 時は `num_leaves` のみ表示 |
+| `num_leaves_ratio` | Range | 0.4 | 1.0 | false | `auto_num_leaves=True` で表示 |
+| `num_leaves` | Fixed | 256 | — | — | `auto_num_leaves=False` で表示 |
+| `min_data_in_leaf_ratio` | Range | 0.01 | 0.2 | false | — |
+| `min_data_in_bin_ratio` | Range | 0.01 | 0.2 | false | — |
+| `feature_weights` | Fixed | `None`（disabled） | — | — | — |
+| `balanced` | Fixed | `True` | — | — | — |
+
+**Model Params グループ:**
+
+| パラメータ | default_mode | low / 値 | high | log | 備考 |
+|-----------|-------------|---------|------|-----|------|
+| `objective` | Choice | `option_sets.objective[task]` 全列挙 | — | — | binary: `[binary, cross_entropy, cross_entropy_lambda]` |
+| `metric` | Choice | `option_sets.model_metric[task]` のサブセット | — | — | binary 推奨: `[auc, binary_logloss, binary_error, cross_entropy, brier]` |
+| `first_metric_only` | Fixed | `True` | — | — | — |
+| `n_estimators` | Range | 500 | 2000 | false | step=100（`step_map`） |
+| `learning_rate` | Range | 1e-4 | 1e-2 | **true** | log-uniform |
+| `max_depth` | Range | 3 | 9 | false | step=1 |
+| `max_bin` | Choice | `[15, 63, 127, 255, 511]` | — | — | 1023 は新 learning_rate 範囲で収束しにくいため除外 |
+| `feature_fraction` | Range | 0.5 | 1.0 | false | — |
+| `bagging_fraction` | Range | 0.5 | 1.0 | false | — |
+| `bagging_freq` | Range | 1 | 10 | false | 0（disabled）は許可しない |
+| `lambda_l1` | **Fixed** | 0 | — | — | デフォルトで L1 は無効、L2 のみで正則化 |
+| `lambda_l2` | Range | 1e-6 | 1e-2 | **true** | log-uniform |
+
+**Training グループ:**
+
+| パラメータ | default_mode | low / 値 | high | log | 備考 |
+|-----------|-------------|---------|------|-----|------|
+| `seed` | Fixed | **1120** | — | — | Studio が library default 42 を上書き（Fit / Tune 両タブで統一） |
+| `early_stopping.enabled` | Fixed | `True` | — | — | — |
+| `early_stopping.rounds` | Range | 50 | 200 | false | n_estimators 500-2000 に対応する短縮レンジ |
+| `validation_ratio` | Range | 0.1 | 0.3 | false | — |
+| `inner_valid` | Fixed | CV strategy 推奨値 | — | — | Wave 2.3 で `cv-state.ts::recommendedInnerValid(strategy)` 経由のピッカー化 |
+
+> **凡例 default_mode** — Fixed: `tuning.optuna.space` に出さず `model.params` 値で固定。Range: float / integer の探索範囲、log=true で log-uniform。Choice: 列挙からマルチ選択。step は integer の Range で `step_map` から供給。
 
 **Mode = Choice（categorical）:**
 

--- a/frontend/tests/e2e/fixtures/config-fields.ts
+++ b/frontend/tests/e2e/fixtures/config-fields.ts
@@ -88,8 +88,10 @@ const trainingSeed: FixtureEntry = {
   spec: {
     name: "training.seed via Seed NumberInput",
     configPath: "training.seed",
-    // lizyml defaults endpoint sets training.seed=42 for binary tasks.
-    defaultValue: 42,
+    // P-0104 Wave 2.2 / Issue #459: Studio overrides library seed=42 with
+    // 1120 at the default-config layer so fresh Fit-tab configs match the
+    // Tune-tab catalog seed default.
+    defaultValue: 1120,
     testValue: 7,
     // FormField wires <Label htmlFor> to the NumberInput's underlying
     // <input>. The schema-rendered Training section produces a

--- a/src/lizystudio/backends/lizyml/config_mixin.py
+++ b/src/lizystudio/backends/lizyml/config_mixin.py
@@ -39,12 +39,18 @@ class ConfigMixin:
 
         is_classification = task in ("binary", "multiclass")
         split_method = "stratified_kfold" if is_classification else "kfold"
+        # P-0104 Wave 2.2 / Issue #459: Studio overrides the library default
+        # ``TrainingConfig.seed = 42`` with 1120 at the default-config layer.
+        # This keeps fresh Fit-tab configs aligned with the Tune-tab seed
+        # default already at 1120 (see ``lizyml_ui_schema.search_space_catalog``)
+        # so the Fit / Tune split is reproducible without manual override.
         minimal = {
             "config_version": 1,
             "task": task,
             "data": {"target": target},
             "model": {"name": "lgbm"},
             "split": {"method": split_method},
+            "training": {"seed": 1120},
         }
         validated = LizyMLConfig.model_validate(minimal)
         return validated.model_dump(mode="json")

--- a/src/lizystudio/backends/lizyml_ui_schema.py
+++ b/src/lizystudio/backends/lizyml_ui_schema.py
@@ -39,7 +39,6 @@ def build_ui_schema(
                     "mae",
                     "quantile",
                     "mape",
-                    "cross_entropy",
                 ],
                 "binary": [
                     "binary",
@@ -217,7 +216,8 @@ def build_ui_schema(
                 "modes": ["fixed", "range"],
                 "group": "smart_params",
                 "default": 1.0,
-                "default_range": {"low": 0.5, "high": 1.0, "log": False},
+                "default_mode": "range",
+                "default_range": {"low": 0.4, "high": 1.0, "log": False},
             },
             {
                 "key": "num_leaves",
@@ -234,6 +234,7 @@ def build_ui_schema(
                 "modes": ["fixed", "range"],
                 "group": "smart_params",
                 "default": 0.01,
+                "default_mode": "range",
                 "default_range": {"low": 0.01, "high": 0.2, "log": False},
             },
             {
@@ -243,6 +244,7 @@ def build_ui_schema(
                 "modes": ["fixed", "range"],
                 "group": "smart_params",
                 "default": 0.01,
+                "default_mode": "range",
                 "default_range": {"low": 0.01, "high": 0.2, "log": False},
             },
             {
@@ -302,7 +304,7 @@ def build_ui_schema(
                 "group": "model_params",
                 "default": 1500,
                 "default_mode": "range",
-                "default_range": {"low": 600, "high": 2500, "log": False},
+                "default_range": {"low": 500, "high": 2000, "log": False},
             },
             {
                 "key": "learning_rate",
@@ -312,7 +314,7 @@ def build_ui_schema(
                 "group": "model_params",
                 "default": 0.001,
                 "default_mode": "range",
-                "default_range": {"low": 0.0001, "high": 0.1, "log": True},
+                "default_range": {"low": 0.0001, "high": 0.01, "log": True},
             },
             {
                 "key": "max_depth",
@@ -322,7 +324,7 @@ def build_ui_schema(
                 "group": "model_params",
                 "default": 5,
                 "default_mode": "range",
-                "default_range": {"low": 3, "high": 12, "log": False},
+                "default_range": {"low": 3, "high": 9, "log": False},
             },
             {
                 "key": "max_bin",
@@ -332,7 +334,7 @@ def build_ui_schema(
                 "group": "model_params",
                 "default": 511,
                 "default_mode": "choice",
-                "default_choices": [15, 63, 127, 255, 511, 1023],
+                "default_choices": [15, 63, 127, 255, 511],
             },
             {
                 "key": "feature_fraction",
@@ -362,17 +364,15 @@ def build_ui_schema(
                 "group": "model_params",
                 "default": 10,
                 "default_mode": "range",
-                "default_range": {"low": 0, "high": 20, "log": False},
+                "default_range": {"low": 1, "high": 10, "log": False},
             },
             {
                 "key": "lambda_l1",
                 "title": "Lambda L1",
                 "paramType": "number",
-                "modes": ["fixed", "range"],
+                "modes": ["fixed"],
                 "group": "model_params",
                 "default": 0.0,
-                "default_mode": "range",
-                "default_range": {"low": 1e-8, "high": 1.0, "log": True},
             },
             {
                 "key": "lambda_l2",
@@ -382,7 +382,7 @@ def build_ui_schema(
                 "group": "model_params",
                 "default": 0.000001,
                 "default_mode": "range",
-                "default_range": {"low": 1e-8, "high": 1.0, "log": True},
+                "default_range": {"low": 1e-6, "high": 1e-2, "log": True},
             },
             {
                 "key": "verbose",
@@ -417,7 +417,7 @@ def build_ui_schema(
                 "group": "training",
                 "default": 150,
                 "default_mode": "range",
-                "default_range": {"low": 40, "high": 240, "log": False},
+                "default_range": {"low": 50, "high": 200, "log": False},
             },
             {
                 "key": "validation_ratio",

--- a/tests/test_backends_lizyml.py
+++ b/tests/test_backends_lizyml.py
@@ -1168,6 +1168,27 @@ def test_get_default_config_multiclass() -> None:
     assert config["split"]["method"] == "stratified_kfold"
 
 
+def test_get_default_config_training_seed_overrides_library_default() -> None:
+    """get_default_config() injects training.seed=1120 across all tasks.
+
+    P-0104 Wave 2.2 / Issue #459: the library default ``TrainingConfig.seed=42``
+    is overridden at the Studio default-config layer so fresh Fit-tab configs
+    match the Tune-tab catalog seed default already at 1120. This keeps the
+    Fit / Tune split reproducible without manual override.
+    """
+    adapter = LizyMLAdapter()
+    for task, target in (
+        ("binary", "label"),
+        ("regression", "price"),
+        ("multiclass", "class"),
+    ):
+        config = adapter.get_default_config(task=task, target=target)
+        assert config["training"]["seed"] == 1120, (
+            f"task={task} default seed must be 1120 (Wave 2.2), got "
+            f"{config['training']['seed']}"
+        )
+
+
 # --- validate_config success path ---
 
 

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -119,7 +119,9 @@ def test_config_defaults_binary(client: TestClient) -> None:
     assert body["model"]["name"] == "lgbm"
     assert body["split"]["method"] == "stratified_kfold"
     assert body["split"]["n_splits"] == 5
-    assert body["training"]["seed"] == 42
+    # P-0104 Wave 2.2 / Issue #459: Studio overrides library seed=42 with 1120
+    # so fresh Fit-tab configs match the Tune-tab catalog seed default.
+    assert body["training"]["seed"] == 1120
     assert body["training"]["early_stopping"]["enabled"] is True
     assert body["training"]["early_stopping"]["rounds"] == 150
 

--- a/tests/test_ui_schema.py
+++ b/tests/test_ui_schema.py
@@ -673,12 +673,16 @@ class TestLizyMLAdapterUiSchema:
         assert ssf["metric"] == "model_metric"
 
     def test_search_space_catalog_learning_rate_default_mode_range(self) -> None:
-        """learning_rate must have default_mode='range' and default_range (H-0053)."""
+        """learning_rate must have default_mode='range' and default_range.
+
+        P-0104 Wave 2.2 / Issue #459 binary canonical spec narrows the
+        previous high=0.1 to high=0.01 (log-uniform).
+        """
         schema = LizyMLAdapter().get_ui_schema()
         catalog = {e["key"]: e for e in schema["search_space_catalog"]}
         lr = catalog["learning_rate"]
         assert lr["default_mode"] == "range"
-        assert lr["default_range"] == {"low": 0.0001, "high": 0.1, "log": True}
+        assert lr["default_range"] == {"low": 0.0001, "high": 0.01, "log": True}
 
     def test_search_space_catalog_num_leaves_no_default_range(self) -> None:
         """num_leaves must NOT have default_mode/default_range (Widget conformance).
@@ -692,23 +696,36 @@ class TestLizyMLAdapterUiSchema:
         assert "default_range" not in nl
 
     def test_search_space_catalog_n_estimators_default_mode_range(self) -> None:
-        """n_estimators must have default_mode='range' and default_range (H-0053)."""
+        """n_estimators must have default_mode='range' and default_range.
+
+        P-0104 Wave 2.2 / Issue #459 binary canonical spec narrows the
+        previous {600, 2500} range to {500, 2000}.
+        """
         schema = LizyMLAdapter().get_ui_schema()
         catalog = {e["key"]: e for e in schema["search_space_catalog"]}
         ne = catalog["n_estimators"]
         assert ne["default_mode"] == "range"
-        assert ne["default_range"] == {"low": 600, "high": 2500, "log": False}
+        assert ne["default_range"] == {"low": 500, "high": 2000, "log": False}
 
     def test_search_space_catalog_max_depth_default_mode_range(self) -> None:
-        """max_depth must have default_mode='range' and default_range (H-0053)."""
+        """max_depth must have default_mode='range' and default_range.
+
+        P-0104 Wave 2.2 / Issue #459 binary canonical spec narrows the
+        previous high=12 to high=9.
+        """
         schema = LizyMLAdapter().get_ui_schema()
         catalog = {e["key"]: e for e in schema["search_space_catalog"]}
         md = catalog["max_depth"]
         assert md["default_mode"] == "range"
-        assert md["default_range"] == {"low": 3, "high": 12, "log": False}
+        assert md["default_range"] == {"low": 3, "high": 9, "log": False}
 
     def test_search_space_catalog_max_bin_uses_choice_mode(self) -> None:
-        """max_bin uses default_mode=choice with default_choices."""
+        """max_bin uses default_mode=choice with default_choices.
+
+        P-0104 Wave 2.2 / Issue #459 drops 1023 from the binary spec
+        because high-bin training rarely converges under the new
+        narrower learning-rate range.
+        """
         schema = LizyMLAdapter().get_ui_schema()
         catalog = {e["key"]: e for e in schema["search_space_catalog"]}
         assert catalog["max_bin"]["default_mode"] == "choice"
@@ -718,7 +735,6 @@ class TestLizyMLAdapterUiSchema:
             127,
             255,
             511,
-            1023,
         ]
         assert "default_range" not in catalog["max_bin"]
 
@@ -731,6 +747,74 @@ class TestLizyMLAdapterUiSchema:
                 assert dr["low"] < dr["high"], (
                     f"default_range low >= high for '{entry['key']}': {dr}"
                 )
+
+    # P-0104 Wave 2.2 / Issue #459 binary canonical spec ----------------
+
+    def test_search_space_catalog_num_leaves_ratio_canonical(self) -> None:
+        """num_leaves_ratio default_range low must be 0.4 per #459 spec."""
+        schema = LizyMLAdapter().get_ui_schema()
+        catalog = {e["key"]: e for e in schema["search_space_catalog"]}
+        row = catalog["num_leaves_ratio"]
+        assert row["default_mode"] == "range"
+        assert row["default_range"] == {"low": 0.4, "high": 1.0, "log": False}
+
+    def test_search_space_catalog_bagging_freq_canonical(self) -> None:
+        """bagging_freq default_range must be {1, 10} per #459 spec.
+
+        Previous {0, 20} allowed disabling bagging entirely (low=0); the
+        new spec keeps bagging always on with a tighter cap.
+        """
+        schema = LizyMLAdapter().get_ui_schema()
+        catalog = {e["key"]: e for e in schema["search_space_catalog"]}
+        row = catalog["bagging_freq"]
+        assert row["default_mode"] == "range"
+        assert row["default_range"] == {"low": 1, "high": 10, "log": False}
+
+    def test_search_space_catalog_lambda_l1_fixed_only(self) -> None:
+        """lambda_l1 is Fixed-only at default 0 per #459 spec.
+
+        Previously offered Range mode with {1e-8, 1.0, log=True}; the new
+        spec keeps L1 disabled by default so the model relies on L2 alone.
+        """
+        schema = LizyMLAdapter().get_ui_schema()
+        catalog = {e["key"]: e for e in schema["search_space_catalog"]}
+        row = catalog["lambda_l1"]
+        assert row["modes"] == ["fixed"]
+        assert row["default"] == 0.0
+        assert "default_mode" not in row
+        assert "default_range" not in row
+
+    def test_search_space_catalog_lambda_l2_canonical(self) -> None:
+        """lambda_l2 default_range must be {1e-6, 1e-2} log per #459 spec."""
+        schema = LizyMLAdapter().get_ui_schema()
+        catalog = {e["key"]: e for e in schema["search_space_catalog"]}
+        row = catalog["lambda_l2"]
+        assert row["default_mode"] == "range"
+        assert row["default_range"] == {"low": 1e-6, "high": 1e-2, "log": True}
+
+    def test_search_space_catalog_early_stopping_rounds_canonical(self) -> None:
+        """early_stopping.rounds default_range must be {50, 200} per #459 spec.
+
+        Previous {40, 240} was wider on both ends; the new spec narrows
+        toward typical early-stopping cadence for the new n_estimators
+        range (500-2000).
+        """
+        schema = LizyMLAdapter().get_ui_schema()
+        catalog = {e["key"]: e for e in schema["search_space_catalog"]}
+        row = catalog["early_stopping.rounds"]
+        assert row["default_mode"] == "range"
+        assert row["default_range"] == {"low": 50, "high": 200, "log": False}
+
+    def test_option_sets_objective_regression_no_cross_entropy(self) -> None:
+        """option_sets.objective.regression must NOT contain cross_entropy.
+
+        P-0104 Wave 2.2 / Issue #459: cross_entropy is a binary-task
+        objective only; its presence in the regression list was a long
+        standing UX bug exposing an invalid choice.
+        """
+        schema = LizyMLAdapter().get_ui_schema()
+        regression_objectives = schema["option_sets"]["objective"]["regression"]
+        assert "cross_entropy" not in regression_objectives
 
     def test_step_map_includes_expanded_params(self) -> None:
         """step_map should include entries for newly added params."""


### PR DESCRIPTION
## Summary

Implements **P-0104 Wave 2.2 (backend portion of Issue #459)** -- aligns `lizyml_ui_schema.search_space_catalog` and the Studio default-config layer with the canonical binary-task spec recorded in Issue #459, and rewrites BLUEPRINT.md section 4.2.2 to match.

## Catalog default changes (binary canonical spec)

| Key | Mode | Before | After |
|---|---|---|---|
| `num_leaves_ratio` | Range | low=0.5 | low=0.4 |
| `n_estimators` | Range | {600, 2500} | {500, 2000} |
| `learning_rate` | Range | high=0.1 (log) | high=0.01 (log) |
| `max_depth` | Range | high=12 | high=9 |
| `max_bin` | Choice | `[15,63,127,255,511,1023]` | `[15,63,127,255,511]` |
| `bagging_freq` | Range | {0, 20} | {1, 10} |
| `lambda_l1` | Fixed | (was Range 1e-8..1.0 log) | **Fixed-only**, default=0 |
| `lambda_l2` | Range | {1e-8, 1.0, log} | {1e-6, 1e-2, log} |
| `early_stopping.rounds` | Range | {40, 240} | {50, 200} |

Also drops `cross_entropy` from `option_sets.objective.regression` (was an invalid choice -- `cross_entropy` is binary-task only).

`num_leaves_ratio` / `min_data_in_leaf_ratio` / `min_data_in_bin_ratio` gain explicit `default_mode: "range"` to surface them as Range-by-default to the frontend (Wave 2.3 consumer).

## Studio default-config layer

`ConfigMixin.get_default_config()` injects `training.seed = 1120` for all tasks before `LizyMLConfig.model_validate`. The library default of `42` is overridden so fresh Fit-tab configs match the Tune-tab catalog `seed` default already at `1120` -- keeping the Fit / Tune split reproducible without manual override.

## Spec doc

BLUEPRINT.md section 4.2.2 default-range table rewritten:

- Replaces 8 stale rows using XGBoost-mixed names (`subsample`, `colsample_bytree`, `reg_alpha`, `reg_lambda`) with the LizyML / LightGBM canonical names
- Splits into Smart / Model / Training groups matching `search_space_catalog` group ordering
- Adds rows that were missing from the prior table (Smart-params Range defaults, Training group, etc.)
- Notes that `regression` / `multiclass` defaults are deferred to a follow-up Issue (per Issue #459 scope statement)

## Test updates

- `tests/test_ui_schema.py`: update 4 existing asserts + add 6 new canonical-spec tests
- `tests/test_backends_lizyml.py`: add `test_get_default_config_training_seed_overrides_library_default` covering binary / regression / multiclass
- `tests/test_config_api.py`: update `test_config_defaults_binary` seed assertion `42 -> 1120`

## Out of scope (deferred)

- **Wave 2.3 (frontend)**: SearchSpaceRow inner_valid picker, Tune Evaluation default-populate, `@cv_recommended` sentinel resolution
- **Wave 3.1**: `option_sets.objective` / `option_sets.metric` reading from LizyML `EstimatorProvider` SSOT (full canonical for all 3 tasks); `option_sets.model_metric` retirement
- **regression / multiclass canonical defaults**: separate follow-up Issue per Issue #459 scope statement

## Test plan

- [x] `uv run pytest tests/test_ui_schema.py tests/test_backends_lizyml.py tests/contract/` -- 263 passed
- [x] `uv run pytest tests/` (unit subset, no slow / e2e / integration / regression / bench) -- 1218 passed
- [x] `pnpm test -- --run` -- 1880 passed (127 files)
- [x] `pnpm check` -- biome lint + format clean
- [x] `uv run ruff check` + `ruff format --check` -- clean
- [ ] CI green on full backend + e2e matrix
- [ ] Reviewer confirms the BLUEPRINT.md table additions match `search_space_catalog` row-by-row

## Related

- Proposal P-0104 (PR #463 merged)
- Issue #459 -- "Tune initial parameter spec (binary task) + inner_valid picker UI + Fit seed default 1120"
- Issue #458 Finding B (BLUEPRINT default-range table stale) -- closed by this PR's BLUEPRINT rewrite
- Wave 2.1 PR #467 -- merged, Re-tune Switch
- `docs/issue-cleanup-plan-2026-05-10.md` Wave 2.2 (merged in #462)
