### PR TITLE
feat(workspace): inner_valid picker plus auto-defaults

### DIFF
--- a/frontend/src/components/workspace/SearchSpaceRow.tsx
+++ b/frontend/src/components/workspace/SearchSpaceRow.tsx
@@ -8,6 +8,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ChoiceInput } from "./ChoiceInput";
+import { filterInnerValidOptions, recommendedInnerValid } from "./cv-state";
 import { FeatureWeightsEditor } from "./FeatureWeightsEditor";
 import { FixedValueEditor } from "./FixedValueEditor";
 import { NumberInput } from "./NumberInput";
@@ -33,6 +34,8 @@ export function SearchSpaceRow({
   task,
   objectiveOptions,
   metricOptions,
+  cvStrategy,
+  innerValidOptions,
   onModelParamChange,
   specialSearchSpaceFields,
   columns,
@@ -158,6 +161,37 @@ export function SearchSpaceRow({
                 );
               })}
             </div>
+          ) : onModelParamChange &&
+            specialSearchSpaceFields?.[param.key] === "inner_valid_picker" ? (
+            // P-0104 Wave 2.3 / Issue #459: inner_valid renders as a
+            // SegmentGroup whose options depend on the outer CV strategy
+            // (kfold -> [holdout]; group_* -> [holdout, group_holdout];
+            // time_series_* -> [holdout, time_holdout]). The displayed
+            // value falls back to ``recommendedInnerValid(strategy)`` when
+            // the persisted value is not in the filtered list, so a CV
+            // strategy switch from kfold -> time_series automatically
+            // promotes "holdout" to "time_holdout" in the UI even before
+            // the TuneTab auto-reset effect persists the change.
+            (() => {
+              const filtered = filterInnerValidOptions(
+                innerValidOptions ?? [],
+                cvStrategy ?? "",
+              );
+              const persisted = modelParams[param.key];
+              const persistedStr =
+                typeof persisted === "string" ? persisted : undefined;
+              const display =
+                persistedStr && filtered.includes(persistedStr)
+                  ? persistedStr
+                  : recommendedInnerValid(cvStrategy ?? "");
+              return (
+                <SegmentGroup
+                  options={filtered}
+                  value={display}
+                  onChange={(v) => onModelParamChange(param.key, v)}
+                />
+              );
+            })()
           ) : onModelParamChange && param.paramType === "object" ? (
             <FeatureWeightsEditor
               weights={

--- a/frontend/src/components/workspace/SearchSpaceTable.test.tsx
+++ b/frontend/src/components/workspace/SearchSpaceTable.test.tsx
@@ -585,6 +585,107 @@ describe("SearchSpaceTable", () => {
       fireEvent.click(screen.getByText("f1"));
       expect(onModelParamChange).toHaveBeenCalledWith("metric", ["auc"]);
     });
+
+    // P-0104 Wave 2.3 / Issue #459 — inner_valid_picker special field
+    const innerValidCatalog: SearchSpaceCatalogEntry[] = [
+      {
+        key: "inner_valid",
+        title: "Inner Validation",
+        paramType: "string",
+        modes: ["fixed"],
+        group: "training",
+        default: "holdout",
+      },
+    ];
+
+    it("renders inner_valid_picker filtered to [holdout] under kfold strategy", () => {
+      const onModelParamChange = vi.fn();
+      render(
+        <SearchSpaceTable
+          space={{}}
+          modelParams={{ inner_valid: "holdout" }}
+          onChange={vi.fn()}
+          catalog={innerValidCatalog}
+          task="binary"
+          onModelParamChange={onModelParamChange}
+          specialSearchSpaceFields={{ inner_valid: "inner_valid_picker" }}
+          cvStrategy="kfold"
+          innerValidOptions={["holdout", "group_holdout", "time_holdout"]}
+        />,
+      );
+      const radios = screen.getAllByRole("radio");
+      const radioNames = radios.map((r) => r.textContent?.trim());
+      expect(radioNames).toContain("holdout");
+      expect(radioNames).not.toContain("group_holdout");
+      expect(radioNames).not.toContain("time_holdout");
+    });
+
+    it("renders inner_valid_picker with time_holdout under time_series strategy", () => {
+      const onModelParamChange = vi.fn();
+      render(
+        <SearchSpaceTable
+          space={{}}
+          modelParams={{ inner_valid: "time_holdout" }}
+          onChange={vi.fn()}
+          catalog={innerValidCatalog}
+          task="binary"
+          onModelParamChange={onModelParamChange}
+          specialSearchSpaceFields={{ inner_valid: "inner_valid_picker" }}
+          cvStrategy="time_series"
+          innerValidOptions={["holdout", "group_holdout", "time_holdout"]}
+        />,
+      );
+      const radios = screen.getAllByRole("radio");
+      const radioNames = radios.map((r) => r.textContent?.trim());
+      expect(radioNames).toContain("holdout");
+      expect(radioNames).toContain("time_holdout");
+      expect(radioNames).not.toContain("group_holdout");
+    });
+
+    it("renders inner_valid_picker with group_holdout under group_kfold strategy", () => {
+      const onModelParamChange = vi.fn();
+      render(
+        <SearchSpaceTable
+          space={{}}
+          modelParams={{ inner_valid: "group_holdout" }}
+          onChange={vi.fn()}
+          catalog={innerValidCatalog}
+          task="binary"
+          onModelParamChange={onModelParamChange}
+          specialSearchSpaceFields={{ inner_valid: "inner_valid_picker" }}
+          cvStrategy="group_kfold"
+          innerValidOptions={["holdout", "group_holdout", "time_holdout"]}
+        />,
+      );
+      const radios = screen.getAllByRole("radio");
+      const radioNames = radios.map((r) => r.textContent?.trim());
+      expect(radioNames).toContain("holdout");
+      expect(radioNames).toContain("group_holdout");
+      expect(radioNames).not.toContain("time_holdout");
+    });
+
+    it("calls onModelParamChange when inner_valid segment is clicked", () => {
+      const onModelParamChange = vi.fn();
+      render(
+        <SearchSpaceTable
+          space={{}}
+          modelParams={{ inner_valid: "holdout" }}
+          onChange={vi.fn()}
+          catalog={innerValidCatalog}
+          task="binary"
+          onModelParamChange={onModelParamChange}
+          specialSearchSpaceFields={{ inner_valid: "inner_valid_picker" }}
+          cvStrategy="time_series"
+          innerValidOptions={["holdout", "group_holdout", "time_holdout"]}
+        />,
+      );
+      const timeHoldout = screen.getByRole("radio", { name: /time_holdout/i });
+      fireEvent.click(timeHoldout);
+      expect(onModelParamChange).toHaveBeenCalledWith(
+        "inner_valid",
+        "time_holdout",
+      );
+    });
   });
 
   describe("precision_at_k k-value row", () => {

--- a/frontend/src/components/workspace/SearchSpaceTable.tsx
+++ b/frontend/src/components/workspace/SearchSpaceTable.tsx
@@ -39,6 +39,12 @@ interface SearchSpaceTableProps {
   specialSearchSpaceFields?: Record<string, string>;
   /** Column names for feature_weights editor. */
   columns?: string[];
+  /** Outer CV strategy from ``config.split.method`` — forwarded to the
+   * ``inner_valid_picker`` row in SearchSpaceRow. */
+  cvStrategy?: string;
+  /** Full inner_valid options from ``uiSchema.inner_valid_options``;
+   * filtered per ``cvStrategy`` inside SearchSpaceRow. */
+  innerValidOptions?: string[];
 }
 
 export function SearchSpaceTable({
@@ -56,6 +62,8 @@ export function SearchSpaceTable({
   conditionalVisibility,
   specialSearchSpaceFields,
   columns,
+  cvStrategy,
+  innerValidOptions,
 }: SearchSpaceTableProps) {
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
   // Initialize addedParams from space keys that exist in additionalParams
@@ -283,6 +291,8 @@ export function SearchSpaceTable({
                 task={task}
                 objectiveOptions={objectiveOptions}
                 metricOptions={metricOptions}
+                cvStrategy={cvStrategy}
+                innerValidOptions={innerValidOptions}
                 onModelParamChange={onModelParamChange}
                 specialSearchSpaceFields={specialSearchSpaceFields}
                 columns={columns}

--- a/frontend/src/components/workspace/TuneEvaluationSection.tsx
+++ b/frontend/src/components/workspace/TuneEvaluationSection.tsx
@@ -25,6 +25,14 @@ function buildEntry(name: string, k?: number): MetricEntry {
   return name;
 }
 
+// P-0104 Wave 2.3 / Issue #459 — auto-populate defaults for fresh
+// configs. Binary is the only task with a confirmed canonical set;
+// regression / multiclass defaults are deferred to a follow-up issue
+// per #459's scope statement.
+const TASK_DEFAULT_METRICS: Record<string, string[]> = {
+  binary: ["auc", "auc_pr", "brier", "logloss"],
+};
+
 export function TuneEvaluationSection({
   config,
   onChange,
@@ -87,6 +95,46 @@ export function TuneEvaluationSection({
       },
     });
   }, [autoDirection]);
+
+  // P-0104 Wave 2.3 / Issue #459 — auto-populate the canonical default
+  // metric set for fresh configs. Fires at most once per workspace; if
+  // the user later clears the list explicitly we honor that and do not
+  // re-seed (only an absent ``tuning.evaluation.metrics`` is treated as
+  // "fresh"). Regression and multiclass are deferred until their
+  // canonical defaults are confirmed in a follow-up.
+  const defaultsSeededRef = useRef(false);
+  useEffect(() => {
+    if (defaultsSeededRef.current) return;
+    if (!task) return;
+    if (metricOptions.length === 0) return;
+    // tuning.evaluation.metrics already set (even to []) -> user-owned,
+    // don't re-seed.
+    const currentCfg = configRef.current;
+    const tuning = (currentCfg.tuning as Record<string, unknown>) ?? {};
+    const ev = (tuning.evaluation as Record<string, unknown>) ?? {};
+    if (Array.isArray(ev.metrics)) {
+      defaultsSeededRef.current = true;
+      return;
+    }
+    const defaults = TASK_DEFAULT_METRICS[task];
+    if (!defaults) {
+      defaultsSeededRef.current = true;
+      return;
+    }
+    const available = defaults.filter((m) => metricOptions.includes(m));
+    if (available.length === 0) {
+      defaultsSeededRef.current = true;
+      return;
+    }
+    const newMetrics: MetricEntry[] = available.map((m) => buildEntry(m));
+    onChangeRef.current(
+      updateTuningField(currentCfg, "evaluation", {
+        ...ev,
+        metrics: newMetrics,
+      }),
+    );
+    defaultsSeededRef.current = true;
+  }, [task, metricOptions]);
 
   // Get precision_at_k k-value from current tune evaluation metrics
   const tuneKValue = useMemo(() => {

--- a/frontend/src/components/workspace/TuneTab.test.tsx
+++ b/frontend/src/components/workspace/TuneTab.test.tsx
@@ -819,4 +819,185 @@ describe("TuneTab", () => {
       .map((e) => (typeof e === "string" ? e : ""));
     expect(additionalNames).not.toContain("f1");
   });
+
+  // P-0104 Wave 2.3 / Issue #459 — Tune Evaluation defaults & inner_valid
+  // auto-reset
+
+  describe("P-0104 Wave 2.3", () => {
+    it("auto-populates tuning.evaluation.metrics with canonical defaults on fresh binary config", () => {
+      const onChange = vi.fn();
+      const config = {
+        model: { name: "lgbm", params: {} },
+        tuning: { optuna: { params: { n_trials: 50 }, space: {} } },
+      };
+      render(
+        <TuneTab
+          config={config}
+          onChange={onChange}
+          task="binary"
+          uiSchema={
+            {
+              option_sets: {
+                metric: {
+                  binary: ["auc", "auc_pr", "brier", "logloss", "f1"],
+                },
+              },
+            } as unknown as UiSchema
+          }
+        />,
+      );
+      // The seeding effect fires synchronously inside useEffect on mount.
+      const seedingCalls = onChange.mock.calls.filter((c) => {
+        const t = (c[0] as Record<string, unknown>).tuning as
+          | Record<string, unknown>
+          | undefined;
+        const ev = t?.evaluation as { metrics?: unknown[] } | undefined;
+        return Array.isArray(ev?.metrics);
+      });
+      expect(seedingCalls.length).toBeGreaterThan(0);
+      const seeded = seedingCalls[0][0] as Record<string, unknown>;
+      const ev = (seeded.tuning as Record<string, unknown>).evaluation as {
+        metrics: string[];
+      };
+      expect(ev.metrics).toEqual(["auc", "auc_pr", "brier", "logloss"]);
+    });
+
+    it("does not seed defaults when tuning.evaluation.metrics is already set (even to [])", () => {
+      const onChange = vi.fn();
+      const config = {
+        model: { name: "lgbm", params: {} },
+        tuning: {
+          evaluation: { metrics: [] },
+          optuna: { params: { n_trials: 50 }, space: {} },
+        },
+      };
+      render(
+        <TuneTab
+          config={config}
+          onChange={onChange}
+          task="binary"
+          uiSchema={
+            {
+              option_sets: {
+                metric: { binary: ["auc", "auc_pr", "brier", "logloss"] },
+              },
+            } as unknown as UiSchema
+          }
+        />,
+      );
+      const seedingCalls = onChange.mock.calls.filter((c) => {
+        const t = (c[0] as Record<string, unknown>).tuning as
+          | Record<string, unknown>
+          | undefined;
+        const ev = t?.evaluation as { metrics?: unknown[] } | undefined;
+        return Array.isArray(ev?.metrics) && (ev?.metrics?.length ?? 0) > 0;
+      });
+      expect(seedingCalls).toHaveLength(0);
+    });
+
+    it("does not seed defaults for non-binary task (regression / multiclass deferred)", () => {
+      const onChange = vi.fn();
+      const config = {
+        model: { name: "lgbm", params: {} },
+        tuning: { optuna: { params: { n_trials: 50 }, space: {} } },
+      };
+      render(
+        <TuneTab
+          config={config}
+          onChange={onChange}
+          task="regression"
+          uiSchema={
+            {
+              option_sets: {
+                metric: { regression: ["rmse", "mae", "mape"] },
+              },
+            } as unknown as UiSchema
+          }
+        />,
+      );
+      const seedingCalls = onChange.mock.calls.filter((c) => {
+        const t = (c[0] as Record<string, unknown>).tuning as
+          | Record<string, unknown>
+          | undefined;
+        const ev = t?.evaluation as { metrics?: unknown[] } | undefined;
+        return Array.isArray(ev?.metrics);
+      });
+      expect(seedingCalls).toHaveLength(0);
+    });
+
+    it("auto-resets inner_valid when persisted value is not allowed under the current CV strategy", () => {
+      const onChange = vi.fn();
+      // group_holdout is only allowed under group_* / blocked_group_kfold;
+      // under plain kfold it must collapse back to "holdout".
+      const config = {
+        model: {
+          name: "lgbm",
+          params: { inner_valid: "group_holdout" },
+        },
+        split: { method: "kfold" },
+        tuning: { optuna: { params: { n_trials: 50 }, space: {} } },
+      };
+      render(
+        <TuneTab
+          config={config}
+          onChange={onChange}
+          task="binary"
+          uiSchema={
+            {
+              inner_valid_options: ["holdout", "group_holdout", "time_holdout"],
+              option_sets: { metric: { binary: ["auc"] } },
+            } as unknown as UiSchema
+          }
+        />,
+      );
+      const innerValidCalls = onChange.mock.calls.filter((c) => {
+        const m = (c[0] as Record<string, unknown>).model as
+          | Record<string, unknown>
+          | undefined;
+        const p = m?.params as Record<string, unknown> | undefined;
+        return p && "inner_valid" in p;
+      });
+      expect(innerValidCalls.length).toBeGreaterThan(0);
+      const last = innerValidCalls[innerValidCalls.length - 1][0] as {
+        model: { params: { inner_valid: string } };
+      };
+      expect(last.model.params.inner_valid).toBe("holdout");
+    });
+
+    it("preserves inner_valid when value is allowed under current CV strategy", () => {
+      const onChange = vi.fn();
+      const config = {
+        model: { name: "lgbm", params: { inner_valid: "holdout" } },
+        split: { method: "kfold" },
+        tuning: { optuna: { params: { n_trials: 50 }, space: {} } },
+      };
+      render(
+        <TuneTab
+          config={config}
+          onChange={onChange}
+          task="binary"
+          uiSchema={
+            {
+              inner_valid_options: ["holdout", "group_holdout", "time_holdout"],
+              option_sets: { metric: { binary: ["auc"] } },
+            } as unknown as UiSchema
+          }
+        />,
+      );
+      // The seed-defaults effect may produce onChange calls for the
+      // ``tuning.evaluation`` section; the inner_valid invariant we
+      // assert is that no call SETS inner_valid to a value other than
+      // the persisted "holdout".
+      const mutatedInnerValid = onChange.mock.calls
+        .map((c) => {
+          const m = (c[0] as Record<string, unknown>).model as
+            | Record<string, unknown>
+            | undefined;
+          const p = m?.params as Record<string, unknown> | undefined;
+          return p?.inner_valid;
+        })
+        .filter((v) => v !== undefined && v !== "holdout");
+      expect(mutatedInnerValid).toHaveLength(0);
+    });
+  });
 });

--- a/frontend/src/components/workspace/TuneTab.tsx
+++ b/frontend/src/components/workspace/TuneTab.tsx
@@ -7,6 +7,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { filterInnerValidOptions, recommendedInnerValid } from "./cv-state";
 import { groupToCategory, SearchSpaceTable } from "./SearchSpaceTable";
 import { TuneEvaluationSection } from "./TuneEvaluationSection";
 import { TuneSettings } from "./TuneSettings";
@@ -157,6 +158,35 @@ export function TuneTab({
     [config, modelParams, onChange],
   );
 
+  // P-0104 Wave 2.3 / Issue #459 — inner_valid auto-reset on CV strategy
+  // change.
+  //
+  // When the outer CV strategy switches between time / group / standard
+  // families, the persisted ``model.params.inner_valid`` may no longer be
+  // a member of the strategy's allowed set (e.g. ``time_holdout`` is only
+  // valid under ``time_series_*`` strategies). This effect reconciles the
+  // persisted value to the strategy-recommended default so the UI and the
+  // wire payload converge before the user runs a tune.
+  const cvStrategy = useMemo(() => {
+    const split = (config.split as Record<string, unknown>) ?? {};
+    return typeof split.method === "string" ? split.method : "";
+  }, [config.split]);
+
+  const innerValidOptions = useMemo(
+    () => uiSchema?.inner_valid_options ?? [],
+    [uiSchema],
+  );
+
+  useEffect(() => {
+    if (!cvStrategy || innerValidOptions.length === 0) return;
+    const filtered = filterInnerValidOptions(innerValidOptions, cvStrategy);
+    const current = modelParams.inner_valid;
+    if (typeof current === "string" && filtered.includes(current)) return;
+    const recommended = recommendedInnerValid(cvStrategy);
+    if (current === recommended) return;
+    handleModelParamChange("inner_valid", recommended);
+  }, [cvStrategy, innerValidOptions, modelParams, handleModelParamChange]);
+
   return (
     <Accordion
       type="multiple"
@@ -190,6 +220,8 @@ export function TuneTab({
                 uiSchema?.special_search_space_fields ?? undefined
               }
               columns={columns}
+              cvStrategy={cvStrategy}
+              innerValidOptions={innerValidOptions}
             />
           </div>
         </AccordionContent>

--- a/frontend/src/components/workspace/search-space-utils.ts
+++ b/frontend/src/components/workspace/search-space-utils.ts
@@ -108,6 +108,12 @@ export interface SearchSpaceRowProps {
   task?: string | null;
   objectiveOptions?: string[];
   metricOptions?: string[];
+  /** Outer CV strategy from ``config.split.method`` — drives the
+   * ``inner_valid_picker`` row's filtered options. */
+  cvStrategy?: string;
+  /** Full list of inner_valid options from ``uiSchema.inner_valid_options``;
+   * filtered per ``cvStrategy`` at render time. */
+  innerValidOptions?: string[];
   onModelParamChange?: (key: string, value: unknown) => void;
   specialSearchSpaceFields?: Record<string, string>;
   columns?: string[];


### PR DESCRIPTION
## Summary

Implements **P-0104 Wave 2.3** (Issue #459 frontend portion). Pairs with the Wave 2.2 backend canonical defaults (PR #468 merged) to complete the binary task Tune-tab UX.

## inner_valid picker

`SearchSpaceRow.tsx` adds an `inner_valid_picker` branch that mirrors the existing `objective` SegmentGroup pattern. Options are filtered by the outer CV strategy via `cv-state.ts::filterInnerValidOptions`:

| Outer CV strategy | Allowed inner_valid options |
|---|---|
| `kfold` or `stratified_kfold` | `[holdout]` |
| `group_kfold` or `stratified_group_kfold` or `blocked_group_kfold` | `[holdout, group_holdout]` |
| `time_series` or `purged_time_series` or `group_time_series` | `[holdout, time_holdout]` |

Displayed value falls back to `recommendedInnerValid(strategy)` when the persisted value is not in the filtered list. A CV strategy switch (kfold to time_series) auto-reflects in the UI even before the TuneTab auto-reset effect persists the change.

## TuneTab auto-reset effect

`TuneTab.tsx` runs an effect when the outer CV strategy changes. If `model.params.inner_valid` is no longer a member of the strategy's allowed set, it resets to `recommendedInnerValid(strategy)`. Persists the strategy switch through to the next `PUT` config call without manual click.

## Tune Evaluation defaults auto-populate

`TuneEvaluationSection.tsx` auto-populates `tuning.evaluation.metrics` for fresh binary configs with the canonical default set `[auc, auc_pr, brier, logloss]`.

**Fresh = `tuning.evaluation.metrics` absent (undefined).** Once seeded (or once the user explicitly sets it to `[]`), the effect is no-op for the rest of the workspace's life. Regression and multiclass tasks are intentionally deferred per Issue #459 scope. `TASK_DEFAULT_METRICS` is the single mutation point.

## Props plumbing

- `SearchSpaceRowProps` gains `cvStrategy?` and `innerValidOptions?` (forwarded by SearchSpaceTable)
- `SearchSpaceTableProps` gains the same; TuneTab feeds them from `config.split.method` and `uiSchema.inner_valid_options`

## Scope discipline (out of scope for this PR)

- **`@cv_recommended` sentinel** — not introduced. The Issue's Option B is taken (catalog ships `default: "holdout"`, frontend resolves CV-recommended value at render time). Simpler backend, same UX outcome.
- **Regression and multiclass canonical defaults** — deferred to a follow-up Issue per #459 scope statement.
- **`option_sets.objective` and `option_sets.metric` SSOT integration** — Wave 3.1.

## Test changes

- `SearchSpaceTable.test.tsx`: **4 new tests** covering `inner_valid_picker` rendering under kfold, time_series, group_kfold + click handler
- `TuneTab.test.tsx`: **5 new tests** covering Tune Evaluation auto-seed for binary, no-op for non-binary, no-op when metrics already set, inner_valid auto-reset, inner_valid preservation

## Test plan

- [x] `pnpm test -- --run` — 1889 passed (127 files; 9 new tests added)
- [x] `pnpm check` — biome lint + format clean
- [x] `pnpm build` — 2085 modules, no TS errors
- [x] `uv run pytest tests/test_ui_schema.py tests/test_backends_lizyml.py tests/contract/` — 263 passed
- [ ] CI green on full backend + e2e matrix
- [ ] Reviewer confirms inner_valid picker rendering on the actual UI

## Related

- Proposal P-0104 (PR #463 merged)
- Wave 2.1 (PR #467 merged) — Re-tune Switch
- Wave 2.2 (PR #468 merged) — backend canonical defaults
- Issue #459

## Issue #459 acceptance criteria status

| Criterion | Status |
|---|---|
| BLUEPRINT.md S4.2.2 rewritten | Wave 2.2 done |
| 18 catalog rows match canonical spec | Wave 2.2 done |
| `option_sets.objective.regression` drops `cross_entropy` | Wave 2.2 done |
| Fit-tab seed default = 1120 | Wave 2.2 done |
| inner_valid renders as SegmentGroup | **this PR** |
| Options filtered by CV strategy | **this PR** |
| Initial value = `recommendedInnerValid(strategy)` | **this PR** |
| Outer CV switch auto-updates Tune inner_valid | **this PR** |
| Fresh binary tune populates `metrics=[auc, auc_pr, brier, logloss]` | **this PR** |
| `optuna.params.direction = "maximize"` for auc | pre-existing |
