### PR TITLE
feat(workspace): NumberInput integer guard + inline warning (#460, P-0104 Wave 2.4)

### DIFF
--- a/frontend/src/components/workspace/FixedValueEditor.tsx
+++ b/frontend/src/components/workspace/FixedValueEditor.tsx
@@ -50,6 +50,7 @@ export function FixedValueEditor({
         value={Number.isNaN(numericValue) ? undefined : numericValue}
         onChange={(v) => onChange(v)}
         step={effectiveStep}
+        paramType={paramType === "integer" ? "integer" : "number"}
       />
     );
   }

--- a/frontend/src/components/workspace/NumberInput.test.tsx
+++ b/frontend/src/components/workspace/NumberInput.test.tsx
@@ -177,4 +177,121 @@ describe("NumberInput", () => {
     fireEvent.click(screen.getByRole("button", { name: /decrement/i }));
     expect(onChange).toHaveBeenCalledWith(-5);
   });
+
+  // P-0104 Wave 2.4 / Issue #460 — integer paramType usability guard.
+  describe("paramType=integer", () => {
+    it('advertises inputMode="numeric" to mobile keyboards', () => {
+      render(<NumberInput value={10} onChange={vi.fn()} paramType="integer" />);
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("inputmode", "numeric");
+    });
+
+    it("typing an integer string still drives onChange", () => {
+      const onChange = vi.fn();
+      render(
+        <NumberInput
+          value={undefined}
+          onChange={onChange}
+          paramType="integer"
+        />,
+      );
+      const input = screen.getByRole("textbox");
+      fireEvent.change(input, { target: { value: "42" } });
+      expect(onChange).toHaveBeenCalledWith(42);
+    });
+
+    it("rejects decimal characters during typing and surfaces inline warning", () => {
+      const onChange = vi.fn();
+      render(<NumberInput value={1} onChange={onChange} paramType="integer" />);
+      const input = screen.getByRole("textbox");
+      onChange.mockClear();
+      fireEvent.change(input, { target: { value: "1.5" } });
+      // Raw text is preserved so the user can correct it
+      expect(input).toHaveValue("1.5");
+      // But onChange does NOT fire with the decimal value
+      expect(onChange).not.toHaveBeenCalled();
+      // Inline warning + aria-invalid are surfaced
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Integer values only",
+      );
+      expect(input).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("clears the violation when the user deletes the decimal point", () => {
+      const onChange = vi.fn();
+      render(<NumberInput value={1} onChange={onChange} paramType="integer" />);
+      const input = screen.getByRole("textbox");
+      fireEvent.change(input, { target: { value: "1.5" } });
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      onChange.mockClear();
+      fireEvent.change(input, { target: { value: "15" } });
+      expect(screen.queryByRole("alert")).toBeNull();
+      expect(input).not.toHaveAttribute("aria-invalid", "true");
+      expect(onChange).toHaveBeenCalledWith(15);
+    });
+
+    it("blur on a decimal value rounds to nearest integer via Math.round", () => {
+      const onChange = vi.fn();
+      render(<NumberInput value={1} onChange={onChange} paramType="integer" />);
+      const input = screen.getByRole("textbox");
+      fireEvent.change(input, { target: { value: "1.5" } });
+      onChange.mockClear();
+      fireEvent.blur(input);
+      expect(onChange).toHaveBeenCalledWith(2);
+      expect(input).toHaveValue("2");
+      // Violation cleared on blur
+      expect(screen.queryByRole("alert")).toBeNull();
+    });
+
+    it("blur rounds 1.4 down to 1 (Math.round half-away-from-zero)", () => {
+      const onChange = vi.fn();
+      render(<NumberInput value={1} onChange={onChange} paramType="integer" />);
+      const input = screen.getByRole("textbox");
+      fireEvent.change(input, { target: { value: "1.4" } });
+      onChange.mockClear();
+      fireEvent.blur(input);
+      expect(onChange).toHaveBeenCalledWith(1);
+    });
+
+    it("stepper buttons still work in integer mode", () => {
+      const onChange = vi.fn();
+      render(
+        <NumberInput
+          value={10}
+          onChange={onChange}
+          paramType="integer"
+          step={1}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: /increment/i }));
+      expect(onChange).toHaveBeenCalledWith(11);
+    });
+
+    it("paramType=number preserves existing decimal-typing behaviour", () => {
+      const onChange = vi.fn();
+      render(<NumberInput value={0} onChange={onChange} paramType="number" />);
+      const input = screen.getByRole("textbox");
+      fireEvent.change(input, { target: { value: "0.5" } });
+      expect(onChange).toHaveBeenCalledWith(0.5);
+      expect(screen.queryByRole("alert")).toBeNull();
+    });
+
+    it("clamps integer value to min/max on blur", () => {
+      const onChange = vi.fn();
+      render(
+        <NumberInput
+          value={5}
+          onChange={onChange}
+          paramType="integer"
+          min={0}
+          max={10}
+        />,
+      );
+      const input = screen.getByRole("textbox");
+      fireEvent.change(input, { target: { value: "20" } });
+      onChange.mockClear();
+      fireEvent.blur(input);
+      expect(onChange).toHaveBeenCalledWith(10);
+    });
+  });
 });

--- a/frontend/src/components/workspace/NumberInput.tsx
+++ b/frontend/src/components/workspace/NumberInput.tsx
@@ -2,6 +2,7 @@ import { Minus, Plus } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 
 interface NumberInputProps {
   value: number | undefined;
@@ -21,6 +22,15 @@ interface NumberInputProps {
    * via `getByRole("textbox", { name: ... })`.
    */
   ariaLabel?: string;
+  /**
+   * P-0104 Wave 2.4 / Issue #460: when "integer", the input rejects
+   * decimal characters during typing, rounds parsed values on blur via
+   * `Math.round`, advertises `inputMode="numeric"` to mobile keyboards,
+   * and surfaces an inline warning when a decimal value is detected
+   * (e.g. via paste). Defaults to "number" to preserve historical
+   * behaviour for unspecified call sites.
+   */
+  paramType?: "number" | "integer";
 }
 
 export function NumberInput({
@@ -34,9 +44,15 @@ export function NumberInput({
   className,
   id,
   ariaLabel,
+  paramType = "number",
 }: NumberInputProps) {
+  const isInteger = paramType === "integer";
+
   // Track raw text to allow intermediate input like "0." or "1.0"
   const [raw, setRaw] = useState(value == null ? "" : String(value));
+  // Surface a decimal attempt without dropping the typed text so the
+  // user can see and correct it themselves.
+  const [hasIntegerViolation, setHasIntegerViolation] = useState(false);
 
   // Sync raw text when external value changes (e.g. stepper buttons)
   useEffect(() => {
@@ -74,9 +90,27 @@ export function NumberInput({
     setRaw(text);
     if (text === "" || text === "-") {
       onChange(undefined);
+      setHasIntegerViolation(false);
       return;
     }
-    // Allow intermediate states: "0.", "1.", ".5", "-0."
+    if (isInteger) {
+      // Decimal characters are not legal here; keep the raw text so the
+      // user can correct it and flag the violation. onChange only fires
+      // for valid integer strings.
+      if (text.includes(".")) {
+        setHasIntegerViolation(true);
+        return;
+      }
+      setHasIntegerViolation(false);
+      if (/^-?\d+$/.test(text)) {
+        const parsed = Number(text);
+        if (!Number.isNaN(parsed)) {
+          onChange(clamp(parsed));
+        }
+      }
+      return;
+    }
+    // number mode: allow intermediate states "0.", "1.", ".5", "-0."
     if (/^-?\d*\.?\d*$/.test(text)) {
       const parsed = Number(text);
       if (!Number.isNaN(parsed)) {
@@ -90,54 +124,70 @@ export function NumberInput({
     if (raw === "" || raw === "-" || raw === ".") {
       setRaw("");
       onChange(undefined);
+      setHasIntegerViolation(false);
       return;
     }
     const parsed = Number(raw);
     if (!Number.isNaN(parsed)) {
-      const clamped = clamp(parsed);
+      const coerced = isInteger ? Math.round(parsed) : parsed;
+      const clamped = clamp(coerced);
       onChange(clamped);
       setRaw(String(clamped));
+      setHasIntegerViolation(false);
     } else {
       setRaw(value == null ? "" : String(value));
+      setHasIntegerViolation(false);
     }
   };
 
   return (
-    <div className={`flex items-center gap-1 ${className ?? ""}`}>
-      <Button
-        variant="outline"
-        size="icon"
-        className="h-7 w-7"
-        onClick={handleDecrement}
-        disabled={disabled}
-        type="button"
-        aria-label="Decrement"
-      >
-        <Minus className="h-3 w-3" />
-      </Button>
-      <Input
-        id={id}
-        type="text"
-        inputMode="decimal"
-        value={raw}
-        onChange={handleChange}
-        onBlur={handleBlur}
-        placeholder={placeholder}
-        disabled={disabled}
-        aria-label={ariaLabel}
-        className="h-7 w-20 text-center text-xs tabular-nums [appearance:textfield]"
-      />
-      <Button
-        variant="outline"
-        size="icon"
-        className="h-7 w-7"
-        onClick={handleIncrement}
-        disabled={disabled}
-        type="button"
-        aria-label="Increment"
-      >
-        <Plus className="h-3 w-3" />
-      </Button>
+    <div className={cn("flex flex-col gap-0.5", className)}>
+      <div className="flex items-center gap-1">
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-7 w-7"
+          onClick={handleDecrement}
+          disabled={disabled}
+          type="button"
+          aria-label="Decrement"
+        >
+          <Minus className="h-3 w-3" />
+        </Button>
+        <Input
+          id={id}
+          type="text"
+          inputMode={isInteger ? "numeric" : "decimal"}
+          value={raw}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          placeholder={placeholder}
+          disabled={disabled}
+          aria-label={ariaLabel}
+          aria-invalid={hasIntegerViolation || undefined}
+          className={cn(
+            "h-7 w-20 text-center text-xs tabular-nums [appearance:textfield]",
+            hasIntegerViolation &&
+              "border-destructive focus-visible:ring-destructive",
+          )}
+        />
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-7 w-7"
+          onClick={handleIncrement}
+          disabled={disabled}
+          type="button"
+          aria-label="Increment"
+        >
+          <Plus className="h-3 w-3" />
+        </Button>
+      </div>
+      {hasIntegerViolation && (
+        <p className="text-[10px] leading-tight text-destructive" role="alert">
+          Integer values only
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/workspace/SearchSpaceRow.test.tsx
+++ b/frontend/src/components/workspace/SearchSpaceRow.test.tsx
@@ -319,6 +319,71 @@ describe("SearchSpaceRow – range mode expanded", () => {
     expect(screen.getByText("Step")).toBeInTheDocument();
   });
 
+  // P-0104 Wave 2.4 / Issue #460 — integer paramType on Range Min/Max
+  // surfaces an inline warning when the user attempts a decimal value
+  // and does NOT propagate the decimal upward via onUpdateEntry.
+  it("Range Min for integer paramType rejects decimals and shows inline warning", () => {
+    const intSpace = {
+      n_estimators: { type: "int", low: 10, high: 500, log: false },
+    };
+    const onUpdateEntry = vi.fn();
+    renderWithQuery(
+      <SearchSpaceRow
+        {...makeProps({
+          param: { ...baseParam, key: "n_estimators", type: "integer" },
+          space: intSpace,
+          isExpanded: true,
+          onUpdateEntry,
+        })}
+      />,
+    );
+    const minInput = screen.getByRole("textbox", { name: /n_estimators min/i });
+    fireEvent.change(minInput, { target: { value: "10.5" } });
+    expect(screen.getByRole("alert")).toHaveTextContent("Integer values only");
+    expect(onUpdateEntry).not.toHaveBeenCalled();
+  });
+
+  it("Range Max for integer paramType rounds to int on blur", () => {
+    const intSpace = {
+      n_estimators: { type: "int", low: 10, high: 500, log: false },
+    };
+    const onUpdateEntry = vi.fn();
+    renderWithQuery(
+      <SearchSpaceRow
+        {...makeProps({
+          param: { ...baseParam, key: "n_estimators", type: "integer" },
+          space: intSpace,
+          isExpanded: true,
+          onUpdateEntry,
+        })}
+      />,
+    );
+    const maxInput = screen.getByRole("textbox", { name: /n_estimators max/i });
+    fireEvent.change(maxInput, { target: { value: "500.6" } });
+    onUpdateEntry.mockClear();
+    fireEvent.blur(maxInput);
+    expect(onUpdateEntry).toHaveBeenCalledWith(
+      "n_estimators",
+      expect.objectContaining({ high: 501 }),
+    );
+  });
+
+  it("Range Min for float paramType keeps decimal-typing behaviour", () => {
+    const onUpdateEntry = vi.fn();
+    renderWithQuery(
+      <SearchSpaceRow
+        {...makeProps({ space: rangeSpace, isExpanded: true, onUpdateEntry })}
+      />,
+    );
+    const inputs = screen.getAllByRole("textbox");
+    fireEvent.change(inputs[0], { target: { value: "0.0001" } });
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(onUpdateEntry).toHaveBeenCalledWith(
+      "learning_rate",
+      expect.objectContaining({ low: 0.0001 }),
+    );
+  });
+
   it("calls onToggleExpand when summary button clicked in range mode", () => {
     const onToggleExpand = vi.fn();
     renderWithQuery(

--- a/frontend/src/components/workspace/SearchSpaceRow.tsx
+++ b/frontend/src/components/workspace/SearchSpaceRow.tsx
@@ -231,6 +231,8 @@ export function SearchSpaceRow({
               value={entry.low}
               onChange={(v) => onUpdateEntry(param.key, { low: v ?? 0 })}
               step={isInteger ? 1 : (stepMap?.[param.key] ?? 0.001)}
+              paramType={isInteger ? "integer" : "number"}
+              ariaLabel={`${param.key} min`}
             />
           </div>
           <div className="flex items-center gap-2">
@@ -239,6 +241,8 @@ export function SearchSpaceRow({
               value={entry.high}
               onChange={(v) => onUpdateEntry(param.key, { high: v ?? 0 })}
               step={isInteger ? 1 : (stepMap?.[param.key] ?? 0.001)}
+              paramType={isInteger ? "integer" : "number"}
+              ariaLabel={`${param.key} max`}
             />
           </div>
           <div className="flex items-center gap-2">
@@ -269,6 +273,8 @@ export function SearchSpaceRow({
                 onChange={(v) => onUpdateEntry(param.key, { step: v })}
                 min={1}
                 step={1}
+                paramType="integer"
+                ariaLabel={`${param.key} step`}
               />
             </div>
           )}

--- a/frontend/src/components/workspace/field-renderers.tsx
+++ b/frontend/src/components/workspace/field-renderers.tsx
@@ -134,6 +134,7 @@ export function renderNumberField(
   onChange: OnChange,
 ): ReactNode {
   const hasRange = prop.minimum != null && prop.maximum != null;
+  const numericParamType = prop.type === "integer" ? "integer" : "number";
 
   if (hasRange) {
     const min = prop.minimum as number;
@@ -149,6 +150,7 @@ export function renderNumberField(
             step={step}
             min={min}
             max={max}
+            paramType={numericParamType}
             placeholder={
               prop.default != null ? String(prop.default) : undefined
             }
@@ -168,6 +170,7 @@ export function renderNumberField(
         value={value != null ? Number(value) : undefined}
         onChange={(v) => onChange(path, v)}
         step={step}
+        paramType={numericParamType}
         placeholder={prop.default != null ? String(prop.default) : undefined}
       />
     </FormField>


### PR DESCRIPTION
## Summary

P-0104 Wave 2.4 — implement the usability-only NumberInput integer guard scoped in [HISTORY §Scope-3 (D6 = Option C)](../blob/develop/HISTORY.md#p-0104-tune-workflow-全面整備).

- Adds `paramType?: "integer" | "number"` to `NumberInput`. Default stays `"number"` so existing call sites are unaffected.
- Integer mode keeps the typed raw text visible so users can self-correct, but `onChange` only fires for valid integer strings. On blur the value is rounded via `Math.round`.
- An inline `<p role="alert">Integer values only</p>` plus red border surfaces when a decimal value sneaks in (typed, pasted, or programmatically supplied). `aria-invalid="true"` flips for assistive tech.
- `inputMode="numeric"` tells mobile keyboards to drop the decimal key.
- Wired into Range Min / Max / Step (`SearchSpaceRow`), Fixed-mode editor (`FixedValueEditor`), and JSON-Schema-driven Fit-tab fields (`field-renderers`) — so `n_estimators`, `max_depth`, `max_bin`, `bagging_freq`, `early_stopping.rounds`, `seed`, etc. all get the same guard.

Explicitly out of scope (deferred to Wave 3.1 / #461):
- Hardcoded `parameter-bounds.ts` map — Wave 3.1 consumes `LGBMProvider().parameter_bounds(task)` from UiSchema instead.
- Range-invariant warnings (`low >= high`, log `+ low <= 0`) and Tune-button block — these depend on bounds and ship together in Wave 3.1.

## Test plan

- [x] `pnpm vitest run NumberInput.test.tsx SearchSpaceRow.test.tsx FixedValueEditor.test.tsx` — 89/89 pass (12 new cases added)
- [x] `pnpm test -- --run` — full suite green (1869 / 1869 cases, 124 / 124 files; 3 unrelated worker timeouts are the known local-only flake in `PredictionsTable.test.tsx`, `RetuneDashboard.test.tsx`, `queries.phase2.test.ts`)
- [x] `pnpm check` — Biome clean (291 files)
- [x] `pnpm build` — `tsc -b` + `vite build` green
- [ ] CI green on develop

## Manual QA checklist

When CI is green:

- Workspace → Tune tab → expand an integer Range row (e.g. `n_estimators`) and try typing `100.5` into Min. The decimal stays visible, no upstream onUpdate, red border + warning appear. Delete the `.` → warning clears, value persists. Blur with `100.5` → input snaps to `101` (Math.round).
- Workspace → Tune tab → expand a float Range row (e.g. `learning_rate`) and confirm `.0001` still types as expected — no warning.
- Workspace → Fit tab → integer fields (`seed`, `n_estimators`, etc.) show the same guard.

Refs #460, P-0104 Wave 2.4
