### PR TITLE
feat(tune): wire UiSchema metric to LizyML v0.15 SSOT, drop model_metric (#461, P-0104 Wave 3.1b)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -114,7 +114,7 @@ class TuningSummary:
     # Re-tune (Phase A) — いずれも後方互換のため optional。
     # re_tune 未指定の単一ラウンド tune では None が入る (H-0061)。
     rounds: list[dict[str, Any]] | None = None         # 各ラウンドの n_trials / best_score_before / best_score_after / expanded_dims / space_snapshot
-    boundary_report: dict[str, Any] | None = None      # 最終ラウンド後の BoundaryReport（per-dim: best_value / position_pct / edge / expanded / new bounds）
+    boundary_report: dict[str, Any] | None = None      # 最終ラウンド後の BoundaryReport（per-dim: best_value / position_pct / edge / expanded / new bounds / clamped_to_bound）
 
 @dataclass
 class PredictionSummary:
@@ -702,7 +702,7 @@ Fit タブと Tune タブは**同一の Config オブジェクト**を操作す�
 │     inner_valid [holdout    ▼]  │ ← enabled=ON時のみ
 │                                  │
 │ ▸ Evaluation           ← config.evaluation │
-│   ☑ AUC  ☑ LogLoss              │ ← ui_schema.option_sets.metric から
+│   ☑ AUC  ☑ LogLoss              │ ← ui_schema.option_sets.eval_metric から
 │   ☐ Accuracy  ☐ F1              │
 │                                  │
 │ ▸ Calibration          ← config.calibration │
@@ -752,8 +752,8 @@ JSON Schema から動的生成する LGBMConfig 固有フィールド。
 
 | 要素 | コンポーネント | Config パス | 説明 |
 |------|-------------|------------|------|
-| objective | Segment buttons（task 別） | `model.params.objective` | `ui_schema.option_sets.objective[task]` から選択肢生成 |
-| metric | Chip buttons（multi-select） | `model.params.metric` | `ui_schema.option_sets.model_metric[task]` から選択肢生成 |
+| objective | Segment buttons（task 別） | `model.params.objective` | `ui_schema.option_sets.objective[task]`（LizyML `LGBMProvider.objective_choices(task)` SSOT — P-0104 Wave 3.1a）から選択肢生成 |
+| metric | Chip buttons（multi-select） | `model.params.metric` | `ui_schema.option_sets.metric[task]`（`{native, feval}` — LizyML `LGBMProvider.metric_choices(task)` SSOT）から `native ∪ feval` を選択肢生成。`feval` 由来の項目には "Custom (slow)" バッジ（P-0104 Wave 3.1b / Q2） |
 | n_estimators | NumberInput (int, step=100) | `model.params.n_estimators` | |
 | learning_rate | NumberInput (float, step=0.001) | `model.params.learning_rate` | |
 | max_depth | NumberInput (int, step=1) | `model.params.max_depth` | |
@@ -793,11 +793,11 @@ step 値は `ui_schema.step_map` から取得。値が未設定の場合は plac
 
 **Evaluation セクション（config.evaluation）:**
 
-`evaluation.metrics` は `MetricEntry[]` 型（`MetricEntry = string | { metric_name: { param: value } }`）。選択肢は `ui_schema.option_sets.metric[task]` から動的取得する（フロントエンドにハードコードしない）。パラメータ付きメトリクス（例: `{"precision_at_k": {"k": 20}}`）は dict 形式で格納する（LizyML v0.7.0 / H-0065）。
+`evaluation.metrics` は `MetricEntry[]` 型（`MetricEntry = string | { metric_name: { param: value } }`）。選択肢は `ui_schema.option_sets.eval_metric[task]`（LizyML の eval-metrics registry — `model.params.metric` の LightGBM 生名とは別物）から動的取得する（フロントエンドにハードコードしない）。パラメータ付きメトリクス（例: `{"precision_at_k": {"k": 20}}`）は dict 形式で格納する（LizyML v0.7.0 / H-0065）。
 
 | 要素 | コンポーネント | 説明 |
 |------|-------------|------|
-| メトリクス | Chip グループ（Toggle） | `ui_schema.option_sets.metric[task]` から選択肢を生成。Task 変更時にデフォルト選択にリセット。クリックで ON/OFF |
+| メトリクス | Chip グループ（Toggle） | `ui_schema.option_sets.eval_metric[task]` から選択肢を生成。Task 変更時にデフォルト選択にリセット。クリックで ON/OFF |
 
 Data Panel で Task が変更されたとき、`evaluation.metrics` をそのタスクのデフォルト値にリセットする。空選択の場合は Backend のランタイムデフォルトが使用される。
 
@@ -878,7 +878,7 @@ Fit タブと Tune タブは**同一の Config オブジェクト**の異なる�
 
 SegmentedControl: プリセット値をボタン群で表示し、「カスタム」を選ぶと NumberInput が出現する。
 
-> 注: `direction` は廃止。Optimization Metric の選択に応じて `ui_schema.option_sets.metric_direction[task][metric]` から自動判定する（H-0031）。
+> 注: `direction` は廃止。Optimization Metric の選択に応じて `ui_schema.metric_direction[task][metric]` から自動判定する（H-0031）。
 
 **Re-tune Settings セクション（config.tuning.re_tune, H-0061 Phase A）:**
 
@@ -978,7 +978,7 @@ Range / Choice / Fixed のデフォルト初期値（P-0104 Wave 2.2 / Issue #45
 | パラメータ | default_mode | low / 値 | high | log | 備考 |
 |-----------|-------------|---------|------|-----|------|
 | `objective` | Choice | `option_sets.objective[task]` 全列挙（LizyML `LGBMProvider.objective_choices(task)` SSOT — P-0104 Wave 3.1a） | — | — | regression: `[regression, regression_l1, huber, fair, poisson, quantile, mape, gamma, tweedie]` / binary: `[binary, cross_entropy, cross_entropy_lambda]` / multiclass: `[multiclass, multiclassova]` |
-| `metric` | Choice | `option_sets.model_metric[task]` のサブセット | — | — | binary 推奨: `[auc, binary_logloss, binary_error, cross_entropy, brier]` |
+| `metric` | Choice | `option_sets.metric[task]`（`{native, feval}` — LizyML `LGBMProvider.metric_choices(task)` SSOT）の `native ∪ feval` | — | — | binary native: `[binary_logloss, binary_error, auc, average_precision, cross_entropy, cross_entropy_lambda, kullback_leibler]` / feval（"Custom (slow)" バッジ）: `[f1, brier, ece, precision_at_k, accuracy]` |
 | `first_metric_only` | Fixed | `True` | — | — | — |
 | `n_estimators` | Range | 500 | 2000 | false | step=100（`step_map`） |
 | `learning_rate` | Range | 1e-4 | 1e-2 | **true** | log-uniform |
@@ -1016,7 +1016,7 @@ Tune 時の評価メトリクスを Fit の `evaluation.metrics` とは独立し
 
 | 要素 | コンポーネント | Config パス | 説明 |
 |------|-------------|------------|------|
-| Optimization Metric | Segment buttons（single select） | `tuning.evaluation.metrics[0]` | Optuna の objective として使用されるメトリクス。`ui_schema.option_sets.metric[task]` から選択肢生成。`direction` は `metric_direction[task][metric]` から自動判定 |
+| Optimization Metric | Segment buttons（single select） | `tuning.evaluation.metrics[0]` | Optuna の objective として使用されるメトリクス。`ui_schema.option_sets.eval_metric[task]` から選択肢生成。`direction` は `metric_direction[task][metric]` から自動判定 |
 | Additional Metrics | Chip buttons（multi-select） | `tuning.evaluation.metrics[1..]` | Optuna が全メトリクスを計算するが objective は metrics[0] のみ。Optimization Metric は候補から除外 |
 
 **Tune ボタン有効条件:**
@@ -1269,7 +1269,7 @@ Model Panel 全体のコンポーネントスタイルを定義する。shadcn/u
 | セパレータ | `<Separator />` | `border-t my-3` | グループ間の視覚分離 |
 | Model Params 行 | Label + NumberInput | 前述のフォームフィールド仕様 | `parameter_hints` から生成。step は `step_map` から |
 | Objective | Segment buttons | 前述の SegmentedControl 仕様 | `option_sets.objective[task]` から選択肢 |
-| Metric | Chip buttons | 前述のメトリクスチップ仕様 | `option_sets.model_metric[task]` から選択肢 |
+| Metric | Chip buttons | 前述のメトリクスチップ仕様 | `option_sets.metric[task]` の `native ∪ feval` から選択肢（`feval` 由来は "Custom (slow)" バッジ） |
 | Additional Params 選択 | `Select` | `h-7 w-40 text-xs` | `ui_schema.additional_params` から未使用のパラメータ |
 | Additional Params 値 | NumberInput / Input | `h-7 w-24 text-xs text-right` | step は `step_map` から |
 | 削除ボタン | `Button variant="ghost" size="icon"` | `h-6 w-6` | lucide `X` (12px) |
@@ -1600,7 +1600,7 @@ Fit 完了と同じ評価項目に加え、探索結果（Best Params・収束�
 |--------|-------------|-------------|---------|
 | Round History | `RoundHistoryTable` | `rounds[*].{n_rounds, best_score_before, best_score_after, expanded_dims}` | `rounds.length >= 1` |
 | Search Space Evolution | `SearchSpaceEvolutionPanel` | `rounds[*].space_snapshot` + `boundary_report` | 少なくとも 1 ラウンドが非 null の `space_snapshot` を持つ |
-| Boundary Expansion | `BoundaryExpansionPanel` | `boundary_report.dims[*].{best_value, position_pct, edge, expanded, new_low, new_high}` | `boundary_report != null` |
+| Boundary Expansion | `BoundaryExpansionPanel` | `boundary_report.dims[*].{best_value, position_pct, edge, expanded, new_low, new_high, clamped_to_bound}` | `boundary_report != null`。`clamped_to_bound=true` の dim には「bounded」バッジ（探索範囲の拡張が LizyML `parameter_bounds` の上限で頭打ちになったことを示す — P-0104 Wave 3.1b） |
 | Convergence Signal | `ConvergenceSignalPanel` | 最終ラウンドの `expanded_dims` + `rounds[*].best_score_after` 推移 | `rounds.length >= 1` |
 
 **Convergence の判定ロジック（Studio 側の責務）:**
@@ -2645,20 +2645,20 @@ Workspace の `workspace_result` は完了時に自動更新される。
       "multiclass": ["multiclass", "multiclassova"]
     },
     "metric": {
-      "regression": ["mae", "mape", "rmse", "..."],
-      "binary": ["auc", "logloss", "auc_pr", "..."],
-      "multiclass": ["multi_logloss", "auc_mu", "..."]
+      "regression": {"native": ["rmse", "mae", "mape", "..."], "feval": ["rmsle", "r2", "smape", "wape"]},
+      "binary": {"native": ["binary_logloss", "binary_error", "auc", "..."], "feval": ["f1", "brier", "ece", "precision_at_k", "accuracy"]},
+      "multiclass": {"native": ["multi_logloss", "multi_error", "auc_mu", "multiclassova"], "feval": ["f1", "brier", "accuracy"]}
     },
-    "model_metric": {
-      "regression": ["huber", "mae", "rmse", "..."],
-      "binary": ["auc", "binary_logloss", "..."],
-      "multiclass": ["multi_logloss", "auc_mu", "..."]
-    },
-    "metric_direction": {
-      "regression": {"mae": "minimize", "r2": "maximize", "...": "..."},
-      "binary": {"auc": "maximize", "logloss": "minimize", "...": "..."},
-      "multiclass": {"multi_logloss": "minimize", "...": "..."}
+    "eval_metric": {
+      "regression": ["rmse", "mae", "mape", "huber", "r2", "..."],
+      "binary": ["auc", "logloss", "auc_pr", "brier", "..."],
+      "multiclass": ["auc", "logloss", "f1", "..."]
     }
+  },
+  "metric_direction": {
+    "regression": {"mae": "minimize", "r2": "maximize", "...": "..."},
+    "binary": {"auc": "maximize", "logloss": "minimize", "...": "..."},
+    "multiclass": {"multi_logloss": "minimize", "...": "..."}
   },
   "parameter_bounds": {
     "regression": {"learning_rate": {"min": 1e-8, "max": 1.0}, "n_estimators": {"min": 10, "max": 10000}, "...": "..."},
@@ -2668,7 +2668,7 @@ Workspace の `workspace_result` は完了時に自動更新される。
   "n_trials_presets": [10, 50, 100, 200, 500],
   "parameter_hints": [
     {"key": "objective", "label": "Objective", "kind": "objective"},
-    {"key": "metric", "label": "Metric", "kind": "model_metric"},
+    {"key": "metric", "label": "Metric", "kind": "metric"},
     {"key": "n_estimators", "label": "N Estimators", "kind": "integer", "step": 100},
     {"key": "learning_rate", "label": "Learning Rate", "kind": "number", "step": 0.001},
     "..."
@@ -2716,7 +2716,7 @@ Workspace の `workspace_result` は完了時に自動更新される。
 | フィールド | 説明 |
 |-----------|------|
 | `sections` | Fit タブの Accordion セクション定義 |
-| `option_sets` | Task 別の選択肢リスト（objective, metric, model_metric, metric_direction）。`objective` は LizyML `LGBMProvider.objective_choices(task)` の canonical 全列挙を SSOT として読込む（P-0104 Wave 3.1a）— Studio 側でハードコードしない |
+| `option_sets` | Task 別の選択肢リスト。`objective`（`{task: [...]}`）は LizyML `LGBMProvider.objective_choices(task)` の canonical 全列挙（P-0104 Wave 3.1a）、`metric`（`{task: {native, feval}}`）は `LGBMProvider.metric_choices(task)` の `model.params.metric` 選択肢で `feval` 由来は "Custom (slow)" バッジ表示（P-0104 Wave 3.1b / Q2-Q3）、`eval_metric`（`{task: [...]}`）は LizyML eval-metrics registry の post-hoc 評価メトリクス（Tune Evaluation セクション用）。いずれも Studio 側でハードコードしない。`model_metric` は Wave 3.1b で撤廃（`metric` に統合） |
 | `parameter_bounds` | Task 別の hyper-parameter 上下限（`{task: {param: {"min": ..., "max": ...}}}`）。LizyML `LGBMProvider.parameter_bounds(task)` を SSOT として読込む（P-0104 Wave 3.1a）。キーは LizyML 正規名（`early_stopping_rounds`）。フロントエンドは `search_space_catalog` のドット記法キー（`early_stopping.rounds`）をアンダースコア記法に正規化して参照し、Tune Search Space の Range Min/Max NumberInput をこの範囲にクランプする |
 | `parameter_hints` | Model Params セクションに常時表示するパラメータ定義 |
 | `search_space_catalog` | Tune Search Space に表示するパラメータ定義（`group` でグループ分け）。各エントリの詳細は下記参照 |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3688,19 +3688,19 @@ LizyML v0.15.0 の出荷（2026-05-10）により、Studio の Tune workflow を
 
 #### Acceptance criteria
 
-- [ ] `pyproject.toml` の lizyml pin が `>=0.15.0,<0.16.0`（Wave 1.2）
-- [ ] `lizyml_ui_schema.py` が `LGBMProvider()` の `objective_choices` / `metric_choices` / `parameter_bounds` を SSOT として読む（Wave 2.2 / 3.1）
-- [ ] `option_sets.model_metric` フィールド削除 + 参照 code path の `option_sets.metric` 移行（Wave 2.2 / 3.1）
-- [ ] `option_sets.objective.regression` の `cross_entropy` 除去（Wave 2.2）
-- [ ] `option_sets.metric.multiclass` の `auc` 除去 + 対応 fixture / e2e snapshot 更新（Wave 3.1）
-- [ ] `RetuneSettingsSection` の Switch 復活 + null payload 後方互換テスト（Wave 2.1）
-- [ ] `SearchSpaceRow` inner_valid picker + Range Min/Max クランプ + BoundaryDimStatus バッジ（Wave 2.3 / 3.1）
-- [ ] NumberInput integer 強制 + inline 警告（Wave 2.4）
-- [ ] feval 由来 metric 項目に "Custom (slow)" バッジ（Wave 3.1）
-- [ ] BLUEPRINT.md §4.2.2 の default-range 表を SSOT 連動後の値に更新（Wave 2.2 / 3.1 でまとめて）
-- [ ] `tests/contract/test_lizyml_objective_metric_drift.py` 新設（Wave 3.1）
-- [ ] `tests/contract/test_ui_schema_matches_pydantic.py` を新規 schema に整合（Wave 2.2 以降の各 PR で）
-- [ ] `pnpm test:e2e --grep workspace-fit|workspace-tune|workspace-retune` 全 green（Wave 2 / 3 完了時）
+- [x] `pyproject.toml` の lizyml pin が `>=0.15.0,<0.16.0`（Wave 1.2 — #464）
+- [x] `lizyml_ui_schema.py` が `LGBMProvider()` の `objective_choices` / `metric_choices` / `parameter_bounds` を SSOT として読む（Wave 3.1a #473 で objective / bounds、Wave 3.1b で metric）
+- [x] `option_sets.model_metric` フィールド削除 + 参照 code path の `option_sets.metric` 移行（Wave 3.1b）。eval-metrics registry は `option_sets.eval_metric`（新規, flat）に分離
+- [x] `option_sets.objective.regression` の `cross_entropy` 除去（Wave 2.2 #468 / 3.1a #473 — provider 由来で自動）
+- [x] `option_sets.metric.multiclass` の `auc` 除去（Wave 3.1b — provider 由来で自動。`auc_mu` のみ）
+- [x] `RetuneSettingsSection` の Switch 復活 + null payload 後方互換テスト（Wave 2.1 #467）
+- [x] `SearchSpaceRow` inner_valid picker + Range Min/Max クランプ + BoundaryDimStatus バッジ（inner_valid: Wave 2.3 #470 / クランプ: Wave 3.1a #473 / `clamped_to_bound` バッジ: Wave 3.1b）
+- [x] NumberInput integer 強制 + inline 警告（Wave 2.4 #472）
+- [x] feval 由来 metric 項目に "Custom (slow)" バッジ（Wave 3.1b — SearchSpaceRow metric チップ + ModelParamsSection ChipGroup）
+- [x] BLUEPRINT.md §4.2.2 の default-range 表 / objective・metric テーブルを SSOT 連動後の値に更新（Wave 2.2 / 3.1a / 3.1b でまとめて）
+- [x] objective / metric drift CI 新設（`tests/contract/test_lizyml_objective_drift.py` を Wave 3.1b で metric drift / `option_sets` 構造検証まで拡張）
+- [x] `tests/contract/test_ui_schema_matches_pydantic.py` を新規 schema に整合（`build_ui_schema()` 引数削除に追従）
+- [ ] `pnpm test:e2e --grep workspace-fit|workspace-tune|workspace-retune` 全 green（Wave 3.1b PR の CI で確認）
 
 #### Alternatives considered
 
@@ -3715,5 +3715,8 @@ LizyML v0.15.0 の出荷（2026-05-10）により、Studio の Tune workflow を
 #### Decision
 
 - 2026-05-11 **Approved** — Wave 2.1（#458 Re-tune Switch）→ 2.2（#459 backend canonical defaults）→ 2.3（#459 frontend inner_valid + auto-populate）→ 2.4（#460 NumberInput usability）→ 3.1（#461 UiSchema SSOT 統合 + auc 除去 + drift CI）の 5 PR 直列実装。Wave 1.2 dep bump（lizyml v0.15）は本 Proposal 採用と並行で先行 PR 化。Q1-Q3 は本セッションで確定（Q1=full canonical / Q2=feval badge / Q3=model_metric 撤廃）
+- 2026-05-11 **Wave 1.2 / 2.1 / 2.2 / 2.3 / 2.4 着地** — #464（lizyml pin）/ #467（Re-tune Switch）/ #468（canonical defaults + Fit seed=1120）/ #470（inner_valid picker + Tune Evaluation auto-populate）/ #472（NumberInput integer guard）
+- 2026-05-11 **Wave 3.1a 着地** — #473（`option_sets.objective` + `parameter_bounds` を `LGBMProvider` SSOT に配線、Range Min/Max クランプ、objective drift CI）。当初同梱予定だった `validate_config` の `parse_space()` 化は e2e regression（`validate_config` が保存ゲートも兼ねるため過渡状態の空 Choice / `low>high` を弾いてしまう）で取り下げ、Issue #474 に deferred
+- 2026-05-11 **Wave 3.1b 着地（#461 残り）** — `option_sets.model_metric` 撤廃 →`option_sets.metric` を `LGBMProvider.metric_choices(task)` 由来の `{native, feval}` ネスト構造に統合（Q3）。eval-metrics registry の post-hoc 評価メトリクスは新フィールド `option_sets.eval_metric`（flat）に分離（Tune Evaluation セクション用）。`parameter_hints.metric.kind` / `special_search_space_fields.metric` を `model_metric`→`metric` にリネーム。`config_compat.py::task_params_compat_errors` の `allowed_metric` を `option_sets.metric` の `native ∪ feval` 参照に切替。frontend は `metric-options.ts` ヘルパで `option_sets` の narrowing を一元化。feval 由来 metric に "Custom (slow)" バッジ（Q2 — SearchSpaceRow metric チップ + ModelParamsSection ChipGroup）。`BoundaryDimStatus.clamped_to_bound`（lizyml v0.15）を `serialize_boundary_report` で wire に露出し Re-tune の Boundary Expansion パネルに「bounded」バッジ。残るは **#474（deferred parse_space validation）** と **#457（Residuals plot kind selector）** — いずれも P-0104 本体からは独立
 
 

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -1963,7 +1963,9 @@ export interface components {
             /** Option Sets */
             option_sets: {
                 [key: string]: {
-                    [key: string]: string[];
+                    [key: string]: string[] | {
+                        [key: string]: string[];
+                    };
                 };
             };
             /** Metric Direction */

--- a/frontend/src/api/workspace.test.ts
+++ b/frontend/src/api/workspace.test.ts
@@ -438,8 +438,7 @@ describe("fetchUiSchema", () => {
           option_sets: {
             objective: {},
             metric: {},
-            model_metric: {},
-            metric_direction: {},
+            eval_metric: {},
           },
           parameter_hints: [],
           search_space_catalog: [],

--- a/frontend/src/components/retune/BoundaryExpansionPanel.test.tsx
+++ b/frontend/src/components/retune/BoundaryExpansionPanel.test.tsx
@@ -14,6 +14,7 @@ const baseDim: BoundaryDimStatus = {
   expanded: false,
   new_low: null,
   new_high: null,
+  clamped_to_bound: false,
 };
 
 function makeReport(dims: BoundaryDimStatus[]): BoundaryReport {
@@ -103,6 +104,19 @@ describe("BoundaryExpansionPanel", () => {
     expect(screen.getByText("\u25b2")).toBeInTheDocument();
     expect(screen.getByText("\u25bc")).toBeInTheDocument();
     expect(screen.getByText("\u2013")).toBeInTheDocument();
+  });
+
+  it("renders a 'bounded' badge for dims clamped by parameter_bounds", () => {
+    render(
+      <BoundaryExpansionPanel
+        report={makeReport([
+          { ...baseDim, name: "lr", clamped_to_bound: true, expanded: true },
+          { ...baseDim, name: "num_leaves", clamped_to_bound: false },
+        ])}
+      />,
+    );
+    const badges = screen.getAllByText(/^bounded$/i);
+    expect(badges).toHaveLength(1);
   });
 
   it("renders categorical best_value as its string representation", () => {

--- a/frontend/src/components/retune/BoundaryExpansionPanel.tsx
+++ b/frontend/src/components/retune/BoundaryExpansionPanel.tsx
@@ -79,7 +79,7 @@ export function BoundaryExpansionPanel({
                   {dim.clamped_to_bound && (
                     <Badge
                       variant="outline"
-                      className="shrink-0 border-amber-500/40 text-[8px] uppercase tracking-wide text-amber-700 dark:text-amber-400"
+                      className="shrink-0 border-warning-border text-[8px] uppercase tracking-wide text-warning-fg"
                       title="Expansion clipped by the LizyML parameter_bounds limit"
                     >
                       bounded

--- a/frontend/src/components/retune/BoundaryExpansionPanel.tsx
+++ b/frontend/src/components/retune/BoundaryExpansionPanel.tsx
@@ -74,7 +74,18 @@ export function BoundaryExpansionPanel({
                 className="font-mono text-xs max-w-[140px] truncate"
                 title={dim.name}
               >
-                {dim.name}
+                <span className="inline-flex items-center gap-1">
+                  <span className="truncate">{dim.name}</span>
+                  {dim.clamped_to_bound && (
+                    <Badge
+                      variant="outline"
+                      className="shrink-0 border-amber-500/40 text-[8px] uppercase tracking-wide text-amber-700 dark:text-amber-400"
+                      title="Expansion clipped by the LizyML parameter_bounds limit"
+                    >
+                      bounded
+                    </Badge>
+                  )}
+                </span>
               </TableCell>
               <TableCell className="text-xs tabular-nums">
                 {dim.best_value !== null

--- a/frontend/src/components/retune/RetuneDashboard.test.tsx
+++ b/frontend/src/components/retune/RetuneDashboard.test.tsx
@@ -32,6 +32,7 @@ const boundaryReport: BoundaryReport = {
       expanded: false,
       new_low: null,
       new_high: null,
+      clamped_to_bound: false,
     },
   ],
   expanded_names: [],

--- a/frontend/src/components/retune/SearchSpaceEvolutionPanel.test.tsx
+++ b/frontend/src/components/retune/SearchSpaceEvolutionPanel.test.tsx
@@ -50,6 +50,7 @@ const boundaryReport = (name: string, best: number | null): BoundaryReport => ({
       expanded: false,
       new_low: null,
       new_high: null,
+      clamped_to_bound: false,
     },
   ],
   expanded_names: [],

--- a/frontend/src/components/retune/types.ts
+++ b/frontend/src/components/retune/types.ts
@@ -18,6 +18,11 @@ export interface BoundaryDimStatus {
   expanded: boolean;
   new_low: number | null;
   new_high: number | null;
+  // P-0104 Wave 3.1b / Issue #461: lizyml v0.15 sets this when a proposed
+  // boundary expansion was clipped by ``parameter_bounds`` (the hard
+  // library limit). Older lizyml versions / single-round tunes omit it,
+  // so the serializer defaults it to ``false``.
+  clamped_to_bound: boolean;
 }
 
 export interface BoundaryReport {

--- a/frontend/src/components/workspace/ChipGroup.test.tsx
+++ b/frontend/src/components/workspace/ChipGroup.test.tsx
@@ -128,4 +128,18 @@ describe("ChipGroup", () => {
     );
     expect(container.querySelector(".lzs-chip-group")).toBeInTheDocument();
   });
+
+  it("badges options listed in customOptions as 'Custom (slow)'", () => {
+    render(
+      <ChipGroup
+        options={["auc", "f1", "brier"]}
+        selected={[]}
+        onChange={vi.fn()}
+        customOptions={["f1", "brier"]}
+      />,
+    );
+    expect(screen.getAllByText(/^Custom \(slow\)$/i)).toHaveLength(2);
+    // The native option keeps a plain accessible name.
+    expect(screen.getByRole("button", { name: "auc" })).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/workspace/ChipGroup.tsx
+++ b/frontend/src/components/workspace/ChipGroup.tsx
@@ -50,7 +50,7 @@ export function ChipGroup({
           >
             {label}
             {isCustom && (
-              <span className="ml-1 rounded-sm bg-amber-500/15 px-1 text-[8px] uppercase tracking-wide text-amber-700 dark:text-amber-400">
+              <span className="ml-1 rounded-sm bg-warning px-1 text-[8px] uppercase tracking-wide text-warning-fg">
                 Custom (slow)
               </span>
             )}

--- a/frontend/src/components/workspace/ChipGroup.tsx
+++ b/frontend/src/components/workspace/ChipGroup.tsx
@@ -4,6 +4,9 @@ interface ChipGroupProps {
   onChange: (selected: string[]) => void;
   minSelected?: number;
   labels?: Record<string, string>;
+  /** Options that should render a small "Custom (slow)" badge — used for
+   * LizyML custom feval metrics (P-0104 Wave 3.1b / Q2). */
+  customOptions?: string[];
 }
 
 export function ChipGroup({
@@ -12,7 +15,9 @@ export function ChipGroup({
   onChange,
   minSelected = 0,
   labels,
+  customOptions,
 }: ChipGroupProps) {
+  const customSet = new Set(customOptions ?? []);
   const handleClick = (option: string) => {
     const isSelected = selected.includes(option);
     if (isSelected) {
@@ -29,15 +34,26 @@ export function ChipGroup({
       {options.map((option) => {
         const isActive = selected.includes(option);
         const label = labels?.[option] ?? option;
+        const isCustom = customSet.has(option);
         return (
           <button
             key={option}
             type="button"
             className={`lzs-chip${isActive ? " lzs-chip--active" : ""}`}
             aria-pressed={isActive}
+            title={
+              isCustom
+                ? "Custom feval metric — re-evaluated in Python each round (slower)"
+                : undefined
+            }
             onClick={() => handleClick(option)}
           >
             {label}
+            {isCustom && (
+              <span className="ml-1 rounded-sm bg-amber-500/15 px-1 text-[8px] uppercase tracking-wide text-amber-700 dark:text-amber-400">
+                Custom (slow)
+              </span>
+            )}
           </button>
         );
       })}

--- a/frontend/src/components/workspace/ConfigForm.test.tsx
+++ b/frontend/src/components/workspace/ConfigForm.test.tsx
@@ -404,9 +404,9 @@ describe("ConfigForm", () => {
             binary: ["binary", "cross_entropy"],
             regression: ["huber", "regression_l1"],
           },
-          model_metric: {
-            binary: ["auc", "binary_logloss"],
-            regression: ["rmse", "huber"],
+          metric: {
+            binary: { native: ["auc", "binary_logloss"], feval: [] },
+            regression: { native: ["rmse", "huber"], feval: [] },
           },
         },
       } as unknown as UiSchema,
@@ -469,9 +469,9 @@ describe("ConfigForm", () => {
             binary: ["binary", "cross_entropy"],
             regression: ["huber", "regression_l1"],
           },
-          model_metric: {
-            binary: ["auc", "binary_logloss"],
-            regression: ["rmse", "huber"],
+          metric: {
+            binary: { native: ["auc", "binary_logloss"], feval: [] },
+            regression: { native: ["rmse", "huber"], feval: [] },
           },
         },
       } as unknown as UiSchema,
@@ -735,12 +735,12 @@ describe("ConfigForm — getOptionsForHint", () => {
   const uiSchemaWithOptionSets = {
     parameter_hints: [
       { key: "objective", kind: "objective", label: "Objective" },
-      { key: "metric", kind: "model_metric", label: "Metric" },
+      { key: "metric", kind: "metric", label: "Metric" },
       { key: "learning_rate", kind: "number", label: "LR" },
     ],
     option_sets: {
       objective: { binary: ["binary", "cross_entropy"] },
-      model_metric: { binary: ["auc", "binary_logloss"] },
+      metric: { binary: { native: ["auc", "binary_logloss"], feval: [] } },
     },
   } as unknown as UiSchema;
 
@@ -758,7 +758,7 @@ describe("ConfigForm — getOptionsForHint", () => {
     expect(objCall?.options).toEqual(["binary", "cross_entropy"]);
   });
 
-  it("passes model_metric options for task when kind is model_metric", () => {
+  it("passes metric options for task when kind is metric", () => {
     renderConfigForm({
       schema: minimalSchema,
       config: minimalConfig,
@@ -772,7 +772,7 @@ describe("ConfigForm — getOptionsForHint", () => {
     expect(metricCall?.options).toEqual(["auc", "binary_logloss"]);
   });
 
-  it("returns empty options for non-objective/model_metric kind", () => {
+  it("returns empty options for non-objective/metric kind", () => {
     renderConfigForm({
       schema: minimalSchema,
       config: minimalConfig,
@@ -823,21 +823,17 @@ describe("ConfigForm — getValueForHint", () => {
     expect(objCall?.value).toBe("binary");
   });
 
-  it("returns model.params.metric for model_metric kind", () => {
+  it("returns model.params.metric for metric kind", () => {
     renderConfigForm({
       schema: minimalSchema,
       config: { model: { name: "lgbm", params: { metric: "auc" } } },
       onChange: vi.fn(),
       uiSchema: {
-        parameter_hints: [
-          { key: "metric", kind: "model_metric", label: "Metric" },
-        ],
+        parameter_hints: [{ key: "metric", kind: "metric", label: "Metric" }],
       } as unknown as UiSchema,
     });
 
-    const metricCall = dynParamCalls.find(
-      (c) => c.hint.kind === "model_metric",
-    );
+    const metricCall = dynParamCalls.find((c) => c.hint.kind === "metric");
     expect(metricCall?.value).toBe("auc");
   });
 
@@ -889,16 +885,14 @@ describe("ConfigForm — handleHintChange (onChange propagation)", () => {
     expect(updatedConfig.model.params.objective).toBe("__changed__");
   });
 
-  it("calls onChange with updated metric when model_metric DynParam changes", () => {
+  it("calls onChange with updated metric when metric DynParam changes", () => {
     const onChange = vi.fn();
     renderConfigForm({
       schema: minimalSchema,
       config: minimalConfig,
       onChange,
       uiSchema: {
-        parameter_hints: [
-          { key: "metric", kind: "model_metric", label: "Metric" },
-        ],
+        parameter_hints: [{ key: "metric", kind: "metric", label: "Metric" }],
       } as unknown as UiSchema,
     });
 
@@ -979,7 +973,7 @@ describe("ConfigForm — auto-select useEffect", () => {
       uiSchema: {
         parameter_hints: [],
         option_sets: {
-          model_metric: { binary: ["auc", "binary_logloss"] },
+          metric: { binary: { native: ["auc", "binary_logloss"], feval: [] } },
         },
       } as unknown as UiSchema,
     });
@@ -1028,7 +1022,7 @@ describe("ConfigForm — auto-select useEffect", () => {
         parameter_hints: [],
         option_sets: {
           objective: { binary: ["binary"] },
-          model_metric: { binary: ["auc"] },
+          metric: { binary: { native: ["auc"], feval: [] } },
         },
       } as unknown as UiSchema,
     });
@@ -1117,7 +1111,7 @@ describe("ConfigForm — auto-select useEffect", () => {
         parameter_hints: [
           {
             key: "metric",
-            kind: "model_metric",
+            kind: "metric",
             default: {
               binary: ["auc", "binary_logloss"],
               multiclass: ["auc_mu", "multi_logloss"],
@@ -1125,9 +1119,9 @@ describe("ConfigForm — auto-select useEffect", () => {
           },
         ],
         option_sets: {
-          model_metric: {
-            binary: ["auc", "binary_logloss"],
-            multiclass: ["auc_mu", "multi_logloss"],
+          metric: {
+            binary: { native: ["auc", "binary_logloss"], feval: [] },
+            multiclass: { native: ["auc_mu", "multi_logloss"], feval: [] },
           },
         },
       } as unknown as UiSchema,
@@ -1171,8 +1165,8 @@ describe("ConfigForm — auto-select useEffect", () => {
           objective: {
             binary: ["binary", "cross_entropy"],
           },
-          model_metric: {
-            binary: ["auc", "binary_logloss"],
+          metric: {
+            binary: { native: ["auc", "binary_logloss"], feval: [] },
           },
         },
       } as unknown as UiSchema,
@@ -1432,7 +1426,7 @@ describe("ConfigForm — MetricsChips integration", () => {
     expect(screen.getByText("Evaluation")).toBeInTheDocument();
   });
 
-  it("passes metricsByTask from uiSchema option_sets.metric to MetricsChips", () => {
+  it("passes metricsByTask from uiSchema option_sets.eval_metric to MetricsChips", () => {
     renderConfigForm({
       schema: minimalSchema,
       config: {
@@ -1443,7 +1437,7 @@ describe("ConfigForm — MetricsChips integration", () => {
       task: "binary",
       uiSchema: {
         option_sets: {
-          metric: {
+          eval_metric: {
             binary: ["auc", "ks", "logloss"],
           },
         },

--- a/frontend/src/components/workspace/ConfigForm.tsx
+++ b/frontend/src/components/workspace/ConfigForm.tsx
@@ -30,6 +30,12 @@ import { renderField } from "./field-renderers";
 import { KeyValueEditor } from "./KeyValueEditor";
 import { MetricsChips } from "./MetricsChips";
 import { ModelParamsSection } from "./ModelParamsSection";
+import {
+  evalMetricMap,
+  metricChoicesFor,
+  metricOptionsFor,
+  objectiveOptionsFor,
+} from "./metric-options";
 import { NumberInput } from "./NumberInput";
 
 interface ConfigFormProps {
@@ -228,29 +234,35 @@ export function ConfigForm({
     }
   }, [task, calibration, enqueueAutoReset, config.config_version, config.task]);
 
-  // Resolve options for objective/model_metric kinds from option_sets
+  // Resolve options for objective/metric kinds from option_sets
   const getOptionsForHint = useCallback(
     (hint: import("@/api/types").ParameterHint): string[] => {
       if (!task) return [];
       if (hint.kind === "objective") {
-        return uiSchema?.option_sets?.objective?.[task] ?? [];
+        return objectiveOptionsFor(uiSchema, task);
       }
-      if (hint.kind === "model_metric") {
-        return uiSchema?.option_sets?.model_metric?.[task] ?? [];
+      if (hint.kind === "metric") {
+        return metricOptionsFor(uiSchema, task);
       }
       return [];
     },
     [task, uiSchema],
   );
 
+  // Feval subset of the model-metric options — badged "Custom (slow)".
+  const fevalMetrics = useMemo(
+    () => metricChoicesFor(uiSchema, task).feval,
+    [task, uiSchema],
+  );
+
   // Resolve the current value for a parameter hint
   const getValueForHint = useCallback(
     (hint: import("@/api/types").ParameterHint): unknown => {
-      // objective and metric live at model.params.objective and model.metric respectively
+      // objective and metric live at model.params.objective and model.params.metric
       if (hint.kind === "objective") {
         return modelParams.objective;
       }
-      if (hint.kind === "model_metric") {
+      if (hint.kind === "metric") {
         return modelParams.metric;
       }
       // numeric/boolean params live under model.params
@@ -267,7 +279,7 @@ export function ConfigForm({
     (hint: import("@/api/types").ParameterHint, value: unknown) => {
       if (hint.kind === "objective") {
         handleFieldChange(["model", "params", "objective"], value);
-      } else if (hint.kind === "model_metric") {
+      } else if (hint.kind === "metric") {
         handleFieldChange(["model", "params", "metric"], value);
       } else {
         handleFieldChange(["model", "params", hint.key], value);
@@ -297,13 +309,13 @@ export function ConfigForm({
     [uiSchema, modelConfig, modelParams, config],
   );
 
-  // Auto-select defaults for objective and model_metric when empty OR
-  // when the current value belongs to a different task (H-0062 Bugfix
-  // 2026-04-14 (3)). The original guard only fired for empty values,
-  // so switching task=multiclass -> task=binary left
-  // objective=multiclass / metric=[auc_mu, multi_logloss] stale and
-  // the subsequent Tune failed with "All tuning trials failed" because
-  // LGBM rejects a multiclass objective on a binary target.
+  // Auto-select defaults for objective and metric when empty OR when the
+  // current value belongs to a different task (H-0062 Bugfix 2026-04-14
+  // (3)). The original guard only fired for empty values, so switching
+  // task=multiclass -> task=binary left objective=multiclass /
+  // metric=[auc_mu, multi_logloss] stale and the subsequent Tune failed
+  // with "All tuning trials failed" because LGBM rejects a multiclass
+  // objective on a binary target.
   useEffect(() => {
     if (!task || !uiSchema?.option_sets) return;
     // Issue #107 regression guard: skip auto-select while the config is
@@ -325,7 +337,7 @@ export function ConfigForm({
 
     // Objective: single-select. Reset when empty OR when current value
     // is not in the list of objectives valid for the current task.
-    const objOpts = uiSchema.option_sets.objective?.[task] ?? [];
+    const objOpts = objectiveOptionsFor(uiSchema, task);
     if (objOpts.length > 0) {
       const currentObj = modelParams.objective;
       const objInvalid =
@@ -338,7 +350,7 @@ export function ConfigForm({
 
     // Metric: multi-select, use parameter_hints default for task.
     // Reset when empty OR when no current entry is valid for the task.
-    const metricOpts = uiSchema.option_sets.model_metric?.[task] ?? [];
+    const metricOpts = metricOptionsFor(uiSchema, task);
     if (metricOpts.length > 0) {
       const cur = modelParams.metric;
       const empty =
@@ -517,6 +529,7 @@ export function ConfigForm({
                         getValueForHint={getValueForHint}
                         handleHintChange={handleHintChange}
                         getOptionsForHint={getOptionsForHint}
+                        fevalMetrics={fevalMetrics}
                         shouldShowField={shouldShowField}
                         precisionAtKValue={
                           (modelParams._precision_at_k_k as number) ?? 10
@@ -638,7 +651,7 @@ export function ConfigForm({
                   // saved=false (silently reverting the task switch).
                   task={(config.task as string) || task}
                   selectedMetrics={selectedMetrics}
-                  metricsByTask={uiSchema?.option_sets?.metric}
+                  metricsByTask={evalMetricMap(uiSchema)}
                   onChange={(metrics) => {
                     handleFieldChange(["evaluation", "metrics"], metrics);
                   }}

--- a/frontend/src/components/workspace/DynParam.test.tsx
+++ b/frontend/src/components/workspace/DynParam.test.tsx
@@ -54,11 +54,11 @@ describe("DynParam", () => {
     });
   });
 
-  describe("kind=model_metric → ChipGroup (multi-select)", () => {
+  describe("kind=metric → ChipGroup (multi-select)", () => {
     it("renders a ChipGroup with options", () => {
       render(
         <DynParam
-          hint={hint({ kind: "model_metric", key: "metric" })}
+          hint={hint({ kind: "metric", key: "metric" })}
           value={["auc"]}
           onChange={vi.fn()}
           options={["auc", "logloss", "f1"]}
@@ -75,7 +75,7 @@ describe("DynParam", () => {
       const onChange = vi.fn();
       render(
         <DynParam
-          hint={hint({ kind: "model_metric", key: "metric" })}
+          hint={hint({ kind: "metric", key: "metric" })}
           value={["auc"]}
           onChange={onChange}
           options={["auc", "logloss"]}
@@ -88,7 +88,7 @@ describe("DynParam", () => {
     it("selected chips have aria-pressed=true", () => {
       render(
         <DynParam
-          hint={hint({ kind: "model_metric", key: "metric" })}
+          hint={hint({ kind: "metric", key: "metric" })}
           value={["auc"]}
           onChange={vi.fn()}
           options={["auc", "logloss"]}

--- a/frontend/src/components/workspace/DynParam.tsx
+++ b/frontend/src/components/workspace/DynParam.tsx
@@ -9,11 +9,13 @@ interface DynParamProps {
   hint: ParameterHint;
   value: unknown;
   onChange: (value: unknown) => void;
-  /** Options list for objective / model_metric kinds (task-filtered). */
+  /** Options list for objective / metric kinds (task-filtered). */
   options?: string[];
+  /** Feval subset of ``options`` (metric kind) — badged "Custom (slow)". */
+  customMetricOptions?: string[];
   /** Whether the field is visible (conditional_visibility). */
   visible?: boolean;
-  /** precision_at_k k-value (for model_metric kind). */
+  /** precision_at_k k-value (for metric kind). */
   precisionAtKValue?: number;
   /** Callback for precision_at_k k-value change. */
   onPrecisionAtKChange?: (k: number) => void;
@@ -23,17 +25,18 @@ interface DynParamProps {
  * Renders a single parameter based on its ParameterHint.kind.
  *
  * Maps:
- *   objective    -> SegmentGroup  (single-select)
- *   model_metric -> ChipGroup     (multi-select among task metrics)
- *   integer      -> CompactStepper
- *   number       -> CompactStepper
- *   boolean      -> CompactToggle
+ *   objective -> SegmentGroup  (single-select)
+ *   metric    -> ChipGroup     (multi-select among task metrics)
+ *   integer   -> CompactStepper
+ *   number    -> CompactStepper
+ *   boolean   -> CompactToggle
  */
 export function DynParam({
   hint,
   value,
   onChange,
   options,
+  customMetricOptions,
   visible = true,
   precisionAtKValue,
   onPrecisionAtKChange,
@@ -55,7 +58,7 @@ export function DynParam({
       );
     }
 
-    case "model_metric": {
+    case "metric": {
       const opts = options ?? [];
       if (opts.length === 0) return null;
       const selected = Array.isArray(value)
@@ -72,6 +75,7 @@ export function DynParam({
               selected={selected}
               onChange={(v) => onChange(v)}
               minSelected={1}
+              customOptions={customMetricOptions}
             />
           </FormRow>
           {showK && (

--- a/frontend/src/components/workspace/ModelParamsSection.tsx
+++ b/frontend/src/components/workspace/ModelParamsSection.tsx
@@ -15,6 +15,7 @@ export function ModelParamsSection({
   getValueForHint,
   handleHintChange,
   getOptionsForHint,
+  fevalMetrics,
   shouldShowField,
   precisionAtKValue,
   onPrecisionAtKChange,
@@ -26,6 +27,8 @@ export function ModelParamsSection({
     value: unknown,
   ) => void;
   getOptionsForHint: (hint: import("@/api/types").ParameterHint) => string[];
+  /** Feval subset of the model-metric options — badged "Custom (slow)". */
+  fevalMetrics?: string[];
   shouldShowField: (key: string) => boolean;
   precisionAtKValue?: number;
   onPrecisionAtKChange?: (k: number) => void;
@@ -35,24 +38,25 @@ export function ModelParamsSection({
   const essential = hints.filter((h) => ESSENTIAL_PARAM_KEYS.has(h.key));
   const advanced = hints.filter((h) => !ESSENTIAL_PARAM_KEYS.has(h.key));
 
+  const renderHint = (hint: import("@/api/types").ParameterHint) => (
+    <DynParam
+      key={hint.key}
+      hint={hint}
+      value={getValueForHint(hint)}
+      onChange={(v) => handleHintChange(hint, v)}
+      options={getOptionsForHint(hint)}
+      customMetricOptions={hint.kind === "metric" ? fevalMetrics : undefined}
+      visible={shouldShowField(hint.key)}
+      precisionAtKValue={hint.kind === "metric" ? precisionAtKValue : undefined}
+      onPrecisionAtKChange={
+        hint.kind === "metric" ? onPrecisionAtKChange : undefined
+      }
+    />
+  );
+
   return (
     <>
-      {essential.map((hint) => (
-        <DynParam
-          key={hint.key}
-          hint={hint}
-          value={getValueForHint(hint)}
-          onChange={(v) => handleHintChange(hint, v)}
-          options={getOptionsForHint(hint)}
-          visible={shouldShowField(hint.key)}
-          precisionAtKValue={
-            hint.kind === "model_metric" ? precisionAtKValue : undefined
-          }
-          onPrecisionAtKChange={
-            hint.kind === "model_metric" ? onPrecisionAtKChange : undefined
-          }
-        />
-      ))}
+      {essential.map(renderHint)}
       {advanced.length > 0 && (
         <>
           <button
@@ -65,25 +69,7 @@ export function ModelParamsSection({
               ? `▾ Hide advanced (${advanced.length})`
               : `▸ Show advanced (${advanced.length})`}
           </button>
-          {showAdvanced &&
-            advanced.map((hint) => (
-              <DynParam
-                key={hint.key}
-                hint={hint}
-                value={getValueForHint(hint)}
-                onChange={(v) => handleHintChange(hint, v)}
-                options={getOptionsForHint(hint)}
-                visible={shouldShowField(hint.key)}
-                precisionAtKValue={
-                  hint.kind === "model_metric" ? precisionAtKValue : undefined
-                }
-                onPrecisionAtKChange={
-                  hint.kind === "model_metric"
-                    ? onPrecisionAtKChange
-                    : undefined
-                }
-              />
-            ))}
+          {showAdvanced && advanced.map(renderHint)}
         </>
       )}
     </>

--- a/frontend/src/components/workspace/SearchSpaceRow.test.tsx
+++ b/frontend/src/components/workspace/SearchSpaceRow.test.tsx
@@ -182,10 +182,10 @@ describe("SearchSpaceRow – objective SegmentGroup", () => {
 });
 
 // ---------------------------------------------------------------------------
-// model_metric chip buttons (lines 115-145)
+// metric chip buttons (lines 115-145)
 // ---------------------------------------------------------------------------
 
-describe("SearchSpaceRow – model_metric chips", () => {
+describe("SearchSpaceRow – metric chips", () => {
   it("renders metric chips", () => {
     const onModelParamChange = vi.fn();
     renderWithQuery(
@@ -194,7 +194,7 @@ describe("SearchSpaceRow – model_metric chips", () => {
           param: { ...baseParam, key: "metrics" },
           modelParams: { metrics: ["auc"] },
           onModelParamChange,
-          specialSearchSpaceFields: { metrics: "model_metric" },
+          specialSearchSpaceFields: { metrics: "metric" },
           metricOptions: ["auc", "logloss", "accuracy"],
         })}
       />,
@@ -212,7 +212,7 @@ describe("SearchSpaceRow – model_metric chips", () => {
           param: { ...baseParam, key: "metrics" },
           modelParams: { metrics: [] },
           onModelParamChange,
-          specialSearchSpaceFields: { metrics: "model_metric" },
+          specialSearchSpaceFields: { metrics: "metric" },
           metricOptions: ["auc", "logloss"],
         })}
       />,
@@ -229,13 +229,31 @@ describe("SearchSpaceRow – model_metric chips", () => {
           param: { ...baseParam, key: "metrics" },
           modelParams: { metrics: ["auc", "logloss"] },
           onModelParamChange,
-          specialSearchSpaceFields: { metrics: "model_metric" },
+          specialSearchSpaceFields: { metrics: "metric" },
           metricOptions: ["auc", "logloss"],
         })}
       />,
     );
     fireEvent.click(screen.getByText("auc"));
     expect(onModelParamChange).toHaveBeenCalledWith("metrics", ["logloss"]);
+  });
+
+  it("badges feval metrics as 'Custom (slow)'", () => {
+    renderWithQuery(
+      <SearchSpaceRow
+        {...makeProps({
+          param: { ...baseParam, key: "metrics" },
+          modelParams: { metrics: ["auc"] },
+          onModelParamChange: vi.fn(),
+          specialSearchSpaceFields: { metrics: "metric" },
+          metricOptions: ["auc", "binary_logloss", "f1", "brier"],
+          fevalMetrics: ["f1", "brier"],
+        })}
+      />,
+    );
+    const badges = screen.getAllByText(/^Custom \(slow\)$/i);
+    // f1 + brier → two badges; native auc / binary_logloss → none.
+    expect(badges).toHaveLength(2);
   });
 });
 
@@ -539,7 +557,7 @@ describe("SearchSpaceRow – precision_at_k row", () => {
           param: { ...baseParam, key: "metrics" },
           modelParams: { metrics: ["precision_at_k"], _precision_at_k_k: 5 },
           onModelParamChange,
-          specialSearchSpaceFields: { metrics: "model_metric" },
+          specialSearchSpaceFields: { metrics: "metric" },
           metricOptions: ["precision_at_k", "auc"],
         })}
       />,
@@ -558,7 +576,7 @@ describe("SearchSpaceRow – precision_at_k row", () => {
           param: { ...baseParam, key: "metrics" },
           modelParams: { metrics: ["precision_at_k"] },
           onModelParamChange,
-          specialSearchSpaceFields: { metrics: "model_metric" },
+          specialSearchSpaceFields: { metrics: "metric" },
           metricOptions: ["precision_at_k"],
         })}
       />,
@@ -575,7 +593,7 @@ describe("SearchSpaceRow – precision_at_k row", () => {
           param: { ...baseParam, key: "metrics" },
           modelParams: { metrics: ["auc"] },
           onModelParamChange,
-          specialSearchSpaceFields: { metrics: "model_metric" },
+          specialSearchSpaceFields: { metrics: "metric" },
           metricOptions: ["precision_at_k", "auc"],
         })}
       />,
@@ -591,7 +609,7 @@ describe("SearchSpaceRow – precision_at_k row", () => {
           param: { ...baseParam, key: "metrics" },
           modelParams: { metrics: ["precision_at_k"], _precision_at_k_k: 10 },
           onModelParamChange,
-          specialSearchSpaceFields: { metrics: "model_metric" },
+          specialSearchSpaceFields: { metrics: "metric" },
           metricOptions: ["precision_at_k"],
         })}
       />,
@@ -617,7 +635,7 @@ describe("SearchSpaceRow – precision_at_k row", () => {
           space: choiceSpace,
           modelParams: { _precision_at_k_k: 3 },
           onModelParamChange,
-          specialSearchSpaceFields: { metrics: "model_metric" },
+          specialSearchSpaceFields: { metrics: "metric" },
           metricOptions: ["precision_at_k", "auc"],
         })}
       />,

--- a/frontend/src/components/workspace/SearchSpaceRow.tsx
+++ b/frontend/src/components/workspace/SearchSpaceRow.tsx
@@ -166,7 +166,7 @@ export function SearchSpaceRow({
                   >
                     {opt}
                     {isCustomFeval && (
-                      <span className="rounded-sm bg-amber-500/15 px-1 text-[8px] uppercase tracking-wide text-amber-700 dark:text-amber-400">
+                      <span className="rounded-sm bg-warning px-1 text-[8px] uppercase tracking-wide text-warning-fg">
                         Custom (slow)
                       </span>
                     )}

--- a/frontend/src/components/workspace/SearchSpaceRow.tsx
+++ b/frontend/src/components/workspace/SearchSpaceRow.tsx
@@ -34,6 +34,7 @@ export function SearchSpaceRow({
   task,
   objectiveOptions,
   metricOptions,
+  fevalMetrics,
   cvStrategy,
   innerValidOptions,
   bounds,
@@ -131,18 +132,24 @@ export function SearchSpaceRow({
               onChange={(v) => onModelParamChange(param.key, v)}
             />
           ) : onModelParamChange &&
-            specialSearchSpaceFields?.[param.key] === "model_metric" ? (
+            specialSearchSpaceFields?.[param.key] === "metric" ? (
             <div className="flex flex-wrap gap-1">
               {(metricOptions ?? []).map((opt) => {
                 const currentValue = modelParams[param.key];
                 const selected = Array.isArray(currentValue)
                   ? currentValue.includes(opt)
                   : false;
+                const isCustomFeval = (fevalMetrics ?? []).includes(opt);
                 return (
                   <button
                     key={opt}
                     type="button"
-                    className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                    title={
+                      isCustomFeval
+                        ? "Custom feval metric — re-evaluated in Python each round (slower)"
+                        : undefined
+                    }
+                    className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium transition-colors ${
                       selected
                         ? "bg-primary text-primary-foreground border-transparent"
                         : "bg-transparent text-muted-foreground border-muted-foreground/30 hover:bg-muted"
@@ -158,6 +165,11 @@ export function SearchSpaceRow({
                     }}
                   >
                     {opt}
+                    {isCustomFeval && (
+                      <span className="rounded-sm bg-amber-500/15 px-1 text-[8px] uppercase tracking-wide text-amber-700 dark:text-amber-400">
+                        Custom (slow)
+                      </span>
+                    )}
                   </button>
                 );
               })}
@@ -298,7 +310,7 @@ export function SearchSpaceRow({
       )}
 
       {/* precision_at_k k-value row — Fixed and Choice modes */}
-      {specialSearchSpaceFields?.[param.key] === "model_metric" &&
+      {specialSearchSpaceFields?.[param.key] === "metric" &&
         onModelParamChange &&
         (() => {
           // Fixed: check modelParams; Choice: check space choices

--- a/frontend/src/components/workspace/SearchSpaceTable.test.tsx
+++ b/frontend/src/components/workspace/SearchSpaceTable.test.tsx
@@ -528,7 +528,7 @@ describe("SearchSpaceTable", () => {
       },
     ];
 
-    it("renders model_metric badge buttons for metric special field", () => {
+    it("renders metric badge buttons for metric special field", () => {
       const onModelParamChange = vi.fn();
       render(
         <SearchSpaceTable
@@ -539,10 +539,10 @@ describe("SearchSpaceTable", () => {
           task="binary"
           metricOptions={["auc", "f1", "accuracy"]}
           onModelParamChange={onModelParamChange}
-          specialSearchSpaceFields={{ metric: "model_metric" }}
+          specialSearchSpaceFields={{ metric: "metric" }}
         />,
       );
-      // model_metric renders badge buttons for each option
+      // metric renders badge buttons for each option
       expect(screen.getByText("auc")).toBeInTheDocument();
       expect(screen.getByText("f1")).toBeInTheDocument();
       expect(screen.getByText("accuracy")).toBeInTheDocument();
@@ -559,7 +559,7 @@ describe("SearchSpaceTable", () => {
           task="binary"
           metricOptions={["auc", "f1"]}
           onModelParamChange={onModelParamChange}
-          specialSearchSpaceFields={{ metric: "model_metric" }}
+          specialSearchSpaceFields={{ metric: "metric" }}
         />,
       );
       // Click "f1" to add it
@@ -578,7 +578,7 @@ describe("SearchSpaceTable", () => {
           task="binary"
           metricOptions={["auc", "f1"]}
           onModelParamChange={onModelParamChange}
-          specialSearchSpaceFields={{ metric: "model_metric" }}
+          specialSearchSpaceFields={{ metric: "metric" }}
         />,
       );
       // Click "f1" to remove it (it's currently selected)
@@ -711,7 +711,7 @@ describe("SearchSpaceTable", () => {
           task="binary"
           metricOptions={["auc", "precision_at_k"]}
           onModelParamChange={onModelParamChange}
-          specialSearchSpaceFields={{ metric: "model_metric" }}
+          specialSearchSpaceFields={{ metric: "metric" }}
         />,
       );
       // The k-value row shows "precision_at_k: k" label
@@ -729,7 +729,7 @@ describe("SearchSpaceTable", () => {
           task="binary"
           metricOptions={["auc", "precision_at_k"]}
           onModelParamChange={onModelParamChange}
-          specialSearchSpaceFields={{ metric: "model_metric" }}
+          specialSearchSpaceFields={{ metric: "metric" }}
         />,
       );
       expect(screen.queryByText("precision_at_k: k")).not.toBeInTheDocument();
@@ -746,7 +746,7 @@ describe("SearchSpaceTable", () => {
           task="binary"
           metricOptions={["precision_at_k"]}
           onModelParamChange={onModelParamChange}
-          specialSearchSpaceFields={{ metric: "model_metric" }}
+          specialSearchSpaceFields={{ metric: "metric" }}
         />,
       );
       // The k-value row has a NumberInput with increment button
@@ -1328,7 +1328,7 @@ describe("SearchSpaceTable", () => {
           task="binary"
           metricOptions={["auc", "precision_at_k"]}
           onModelParamChange={onModelParamChange}
-          specialSearchSpaceFields={{ metric: "model_metric" }}
+          specialSearchSpaceFields={{ metric: "metric" }}
         />,
       );
       expect(screen.getByText("precision_at_k: k")).toBeInTheDocument();
@@ -1347,7 +1347,7 @@ describe("SearchSpaceTable", () => {
           task="binary"
           metricOptions={["auc", "precision_at_k"]}
           onModelParamChange={onModelParamChange}
-          specialSearchSpaceFields={{ metric: "model_metric" }}
+          specialSearchSpaceFields={{ metric: "metric" }}
         />,
       );
       expect(screen.queryByText("precision_at_k: k")).not.toBeInTheDocument();

--- a/frontend/src/components/workspace/SearchSpaceTable.tsx
+++ b/frontend/src/components/workspace/SearchSpaceTable.tsx
@@ -27,7 +27,11 @@ interface SearchSpaceTableProps {
   stepMap?: Record<string, number>;
   task?: string | null;
   objectiveOptions?: string[];
+  /** Flat model-metric option list (``native`` followed by ``feval``). */
   metricOptions?: string[];
+  /** Subset of ``metricOptions`` that are LizyML custom feval metrics
+   * (badged "Custom (slow)" — P-0104 Wave 3.1b / Q2). */
+  fevalMetrics?: string[];
   additionalParams?: string[];
   /** Per-parameter option sets for generic choice mode (keyed by param name). */
   paramOptionSets?: Record<string, string[]>;
@@ -35,7 +39,7 @@ interface SearchSpaceTableProps {
   onModelParamChange?: (key: string, value: unknown) => void;
   /** Conditional visibility rules: {paramKey: {depKey: requiredValue}} */
   conditionalVisibility?: Record<string, Record<string, unknown>>;
-  /** Special field rendering hints: {paramKey: "objective"|"model_metric"|...} */
+  /** Special field rendering hints: {paramKey: "objective"|"metric"|"inner_valid_picker"} */
   specialSearchSpaceFields?: Record<string, string>;
   /** Column names for feature_weights editor. */
   columns?: string[];
@@ -60,6 +64,7 @@ export function SearchSpaceTable({
   task,
   objectiveOptions,
   metricOptions,
+  fevalMetrics,
   additionalParams,
   paramOptionSets,
   onModelParamChange,
@@ -296,6 +301,7 @@ export function SearchSpaceTable({
                 task={task}
                 objectiveOptions={objectiveOptions}
                 metricOptions={metricOptions}
+                fevalMetrics={fevalMetrics}
                 cvStrategy={cvStrategy}
                 innerValidOptions={innerValidOptions}
                 bounds={

--- a/frontend/src/components/workspace/TuneTab.test.tsx
+++ b/frontend/src/components/workspace/TuneTab.test.tsx
@@ -72,7 +72,7 @@ describe("TuneTab", () => {
         uiSchema={
           {
             option_sets: {
-              metric: { binary: ["auc", "f1", "accuracy"] },
+              eval_metric: { binary: ["auc", "f1", "accuracy"] },
             },
           } as unknown as UiSchema
         }
@@ -87,7 +87,7 @@ describe("TuneTab", () => {
         config={tuneConfig}
         onChange={vi.fn()}
         task="binary"
-        uiSchema={{ option_sets: { metric: {} } } as unknown as UiSchema}
+        uiSchema={{ option_sets: { eval_metric: {} } } as unknown as UiSchema}
       />,
     );
     expect(screen.queryByText("Optimization Metric")).not.toBeInTheDocument();
@@ -112,7 +112,7 @@ describe("TuneTab", () => {
         uiSchema={
           {
             option_sets: {
-              metric: { binary: ["auc", "f1", "accuracy"] },
+              eval_metric: { binary: ["auc", "f1", "accuracy"] },
             },
           } as unknown as UiSchema
         }
@@ -140,7 +140,7 @@ describe("TuneTab", () => {
         uiSchema={
           {
             option_sets: {
-              metric: { binary: ["auc", "f1"] },
+              eval_metric: { binary: ["auc", "f1"] },
             },
             metric_direction: {
               binary: { auc: "maximize", f1: "maximize" },
@@ -189,7 +189,7 @@ describe("TuneTab", () => {
         uiSchema={
           {
             option_sets: {
-              metric: { binary: ["auc", "f1", "accuracy"] },
+              eval_metric: { binary: ["auc", "f1", "accuracy"] },
             },
           } as unknown as UiSchema
         }
@@ -222,7 +222,7 @@ describe("TuneTab", () => {
         uiSchema={
           {
             option_sets: {
-              metric: { binary: ["auc", "f1"] },
+              eval_metric: { binary: ["auc", "f1"] },
             },
             metric_direction: { binary: { auc: "maximize", f1: "maximize" } },
           } as unknown as UiSchema
@@ -250,7 +250,7 @@ describe("TuneTab", () => {
         uiSchema={
           {
             option_sets: {
-              metric: { binary: ["auc", "f1"] },
+              eval_metric: { binary: ["auc", "f1"] },
             },
             metric_direction: { binary: { auc: "maximize", f1: "maximize" } },
           } as unknown as UiSchema
@@ -288,7 +288,7 @@ describe("TuneTab", () => {
         uiSchema={
           {
             option_sets: {
-              metric: { binary: ["auc", "f1"] },
+              eval_metric: { binary: ["auc", "f1"] },
             },
             metric_direction: { binary: { auc: "maximize", f1: "maximize" } },
           } as unknown as UiSchema
@@ -317,7 +317,7 @@ describe("TuneTab", () => {
         uiSchema={
           {
             option_sets: {
-              metric: { binary: ["auc", "f1"] },
+              eval_metric: { binary: ["auc", "f1"] },
             },
             // metric_direction has no entry for "binary"
             metric_direction: {},
@@ -357,7 +357,7 @@ describe("TuneTab", () => {
         uiSchema={
           {
             option_sets: {
-              metric: { binary: ["precision_at_k", "auc"] },
+              eval_metric: { binary: ["precision_at_k", "auc"] },
             },
           } as unknown as UiSchema
         }
@@ -386,7 +386,7 @@ describe("TuneTab", () => {
         uiSchema={
           {
             option_sets: {
-              metric: { binary: ["precision_at_k", "auc"] },
+              eval_metric: { binary: ["precision_at_k", "auc"] },
             },
           } as unknown as UiSchema
         }
@@ -424,7 +424,7 @@ describe("TuneTab", () => {
         uiSchema={
           {
             option_sets: {
-              metric: { binary: ["auc", "f1", "accuracy"] },
+              eval_metric: { binary: ["auc", "f1", "accuracy"] },
             },
           } as unknown as UiSchema
         }
@@ -608,7 +608,7 @@ describe("TuneTab", () => {
         uiSchema={
           {
             option_sets: {
-              metric: { ranking: ["precision_at_k", "auc"] },
+              eval_metric: { ranking: ["precision_at_k", "auc"] },
             },
             metric_direction: {
               ranking: { precision_at_k: "maximize", auc: "maximize" },
@@ -666,7 +666,7 @@ describe("TuneTab", () => {
         uiSchema={
           {
             option_sets: {
-              metric: { ranking: ["precision_at_k", "auc"] },
+              eval_metric: { ranking: ["precision_at_k", "auc"] },
             },
           } as unknown as import("@/api/types").UiSchema
         }
@@ -717,7 +717,7 @@ describe("TuneTab", () => {
         uiSchema={
           {
             option_sets: {
-              metric: { binary: ["unknown_metric", "auc"] },
+              eval_metric: { binary: ["unknown_metric", "auc"] },
             },
             metric_direction: { binary: { auc: "maximize" } },
           } as unknown as import("@/api/types").UiSchema
@@ -780,7 +780,7 @@ describe("TuneTab", () => {
         uiSchema={
           {
             option_sets: {
-              metric: { binary: ["auc", "f1", "accuracy"] },
+              eval_metric: { binary: ["auc", "f1", "accuracy"] },
             },
             metric_direction: {
               binary: { auc: "maximize", f1: "maximize", accuracy: "maximize" },
@@ -838,7 +838,7 @@ describe("TuneTab", () => {
           uiSchema={
             {
               option_sets: {
-                metric: {
+                eval_metric: {
                   binary: ["auc", "auc_pr", "brier", "logloss", "f1"],
                 },
               },
@@ -879,7 +879,7 @@ describe("TuneTab", () => {
           uiSchema={
             {
               option_sets: {
-                metric: { binary: ["auc", "auc_pr", "brier", "logloss"] },
+                eval_metric: { binary: ["auc", "auc_pr", "brier", "logloss"] },
               },
             } as unknown as UiSchema
           }
@@ -909,7 +909,7 @@ describe("TuneTab", () => {
           uiSchema={
             {
               option_sets: {
-                metric: { regression: ["rmse", "mae", "mape"] },
+                eval_metric: { regression: ["rmse", "mae", "mape"] },
               },
             } as unknown as UiSchema
           }
@@ -945,7 +945,7 @@ describe("TuneTab", () => {
           uiSchema={
             {
               inner_valid_options: ["holdout", "group_holdout", "time_holdout"],
-              option_sets: { metric: { binary: ["auc"] } },
+              option_sets: { eval_metric: { binary: ["auc"] } },
             } as unknown as UiSchema
           }
         />,
@@ -979,7 +979,7 @@ describe("TuneTab", () => {
           uiSchema={
             {
               inner_valid_options: ["holdout", "group_holdout", "time_holdout"],
-              option_sets: { metric: { binary: ["auc"] } },
+              option_sets: { eval_metric: { binary: ["auc"] } },
             } as unknown as UiSchema
           }
         />,

--- a/frontend/src/components/workspace/TuneTab.tsx
+++ b/frontend/src/components/workspace/TuneTab.tsx
@@ -8,6 +8,12 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { filterInnerValidOptions, recommendedInnerValid } from "./cv-state";
+import {
+  evalMetricOptionsFor,
+  metricChoicesFor,
+  metricOptionsFor,
+  objectiveOptionsFor,
+} from "./metric-options";
 import { groupToCategory, SearchSpaceTable } from "./SearchSpaceTable";
 import { TuneEvaluationSection } from "./TuneEvaluationSection";
 import { TuneSettings } from "./TuneSettings";
@@ -92,13 +98,13 @@ export function TuneTab({
   const modelSection = (config.model as Record<string, unknown>) ?? {};
   const modelParams = (modelSection.params as Record<string, unknown>) ?? {};
 
-  // Metric options for the current task (used for optimization + additional metrics)
-  const metricOptions = useMemo(() => {
-    if (!task) return [];
-    const opts = uiSchema?.option_sets?.metric;
-    if (opts?.[task]) return opts[task];
-    return [];
-  }, [task, uiSchema]);
+  // Eval-metrics registry list for the current task — used by the Tune
+  // Evaluation section (Optimization Metric / Additional Metrics). These
+  // are LizyML post-hoc reporting metrics, NOT the LightGBM ``metric`` param.
+  const evalMetricOptions = useMemo(
+    () => evalMetricOptionsFor(uiSchema, task),
+    [task, uiSchema],
+  );
 
   // metric_direction map for auto direction
   const metricDirection = useMemo(() => {
@@ -106,20 +112,22 @@ export function TuneTab({
   }, [uiSchema]);
 
   // Objective options for task
-  const objectiveOptions = useMemo(() => {
-    if (!task) return [];
-    const opts = uiSchema?.option_sets?.objective;
-    if (opts?.[task]) return opts[task];
-    return [];
-  }, [task, uiSchema]);
+  const objectiveOptions = useMemo(
+    () => objectiveOptionsFor(uiSchema, task),
+    [task, uiSchema],
+  );
 
-  // Model metric options (for search space catalog metric choices)
-  const modelMetricOptions = useMemo(() => {
-    if (!task) return [];
-    const opts = uiSchema?.option_sets?.model_metric;
-    if (opts?.[task]) return opts[task];
-    return [];
-  }, [task, uiSchema]);
+  // Model-metric options (``model.params.metric``) — flat native ∪ feval
+  // list for the Search Space catalog ``metric`` row, plus the feval
+  // subset for the "Custom (slow)" badge (P-0104 Wave 3.1b / Q2/Q3).
+  const modelMetricOptions = useMemo(
+    () => metricOptionsFor(uiSchema, task),
+    [task, uiSchema],
+  );
+  const fevalMetrics = useMemo(
+    () => metricChoicesFor(uiSchema, task).feval,
+    [task, uiSchema],
+  );
 
   // P-0104 Wave 3.1a / Issue #461: hyper-parameter bounds for the current
   // task, forwarded to SearchSpaceTable so Range Min/Max NumberInputs clamp.
@@ -128,25 +136,15 @@ export function TuneTab({
     return uiSchema?.parameter_bounds?.[task] ?? undefined;
   }, [task, uiSchema]);
 
-  // Per-parameter option sets — exclude "metric" to avoid overriding
-  // SearchSpaceTable's getChoiceOptions which correctly uses model_metric.
+  // Per-parameter option sets keyed by Search Space catalog param name.
+  // Only ``objective`` has a catalog row with choices; ``metric`` is
+  // handled by SearchSpaceTable via the ``metricOptions`` prop, and
+  // ``eval_metric`` is not a catalog param.
   const paramOptionSets = useMemo((): Record<string, string[]> => {
-    if (!uiSchema?.option_sets) return {};
     const result: Record<string, string[]> = {};
-    for (const [paramKey, value] of Object.entries(uiSchema.option_sets)) {
-      // Skip "metric" — SearchSpaceTable handles it via metricOptions prop
-      if (paramKey === "metric") continue;
-      if (Array.isArray(value)) {
-        result[paramKey] = value as string[];
-      } else if (task && typeof value === "object" && value !== null) {
-        const taskMap = value as Record<string, string[]>;
-        if (taskMap[task]) {
-          result[paramKey] = taskMap[task];
-        }
-      }
-    }
+    if (objectiveOptions.length > 0) result.objective = objectiveOptions;
     return result;
-  }, [task, uiSchema]);
+  }, [objectiveOptions]);
 
   const handleParamsChange = (params: Record<string, unknown>) => {
     onChange(updateOptunaField(config, "params", params));
@@ -219,6 +217,7 @@ export function TuneTab({
               task={task}
               objectiveOptions={objectiveOptions}
               metricOptions={modelMetricOptions}
+              fevalMetrics={fevalMetrics}
               additionalParams={uiSchema?.additional_params ?? undefined}
               paramOptionSets={paramOptionSets}
               onModelParamChange={handleModelParamChange}
@@ -243,7 +242,7 @@ export function TuneTab({
             config={config}
             onChange={onChange}
             task={task}
-            metricOptions={metricOptions}
+            metricOptions={evalMetricOptions}
             metricDirection={metricDirection}
             evaluation={evaluation}
             tuningParams={tuningParams}

--- a/frontend/src/components/workspace/metric-options.test.ts
+++ b/frontend/src/components/workspace/metric-options.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { UiSchema } from "@/api/types";
+import {
+  evalMetricMap,
+  evalMetricOptionsFor,
+  isCustomFevalMetric,
+  metricChoicesFor,
+  metricOptionsFor,
+  objectiveOptionsFor,
+} from "./metric-options";
+
+const uiSchema = {
+  option_sets: {
+    objective: {
+      binary: ["binary", "cross_entropy"],
+      regression: ["huber", "regression_l1"],
+    },
+    metric: {
+      binary: {
+        native: ["auc", "binary_logloss"],
+        feval: ["f1", "brier"],
+      },
+      regression: {
+        native: ["rmse", "mae"],
+        feval: ["r2"],
+      },
+    },
+    eval_metric: {
+      binary: ["auc", "auc_pr", "logloss"],
+      regression: ["rmse", "r2"],
+    },
+  },
+} as unknown as UiSchema;
+
+describe("metric-options helpers", () => {
+  it("objectiveOptionsFor returns the task's objective list", () => {
+    expect(objectiveOptionsFor(uiSchema, "binary")).toEqual([
+      "binary",
+      "cross_entropy",
+    ]);
+    expect(objectiveOptionsFor(uiSchema, null)).toEqual([]);
+    expect(objectiveOptionsFor(uiSchema, "unknown_task")).toEqual([]);
+    expect(objectiveOptionsFor(undefined, "binary")).toEqual([]);
+  });
+
+  it("metricChoicesFor returns the native/feval split", () => {
+    expect(metricChoicesFor(uiSchema, "binary")).toEqual({
+      native: ["auc", "binary_logloss"],
+      feval: ["f1", "brier"],
+    });
+    expect(metricChoicesFor(uiSchema, null)).toEqual({
+      native: [],
+      feval: [],
+    });
+    expect(metricChoicesFor(uiSchema, "missing")).toEqual({
+      native: [],
+      feval: [],
+    });
+  });
+
+  it("metricOptionsFor flattens native then feval", () => {
+    expect(metricOptionsFor(uiSchema, "binary")).toEqual([
+      "auc",
+      "binary_logloss",
+      "f1",
+      "brier",
+    ]);
+    expect(metricOptionsFor(uiSchema, "regression")).toEqual([
+      "rmse",
+      "mae",
+      "r2",
+    ]);
+  });
+
+  it("evalMetricOptionsFor returns the eval-registry list", () => {
+    expect(evalMetricOptionsFor(uiSchema, "binary")).toEqual([
+      "auc",
+      "auc_pr",
+      "logloss",
+    ]);
+    expect(evalMetricOptionsFor(uiSchema, null)).toEqual([]);
+  });
+
+  it("evalMetricMap returns the {task: [...]} map", () => {
+    expect(evalMetricMap(uiSchema)).toEqual({
+      binary: ["auc", "auc_pr", "logloss"],
+      regression: ["rmse", "r2"],
+    });
+    expect(evalMetricMap(undefined)).toEqual({});
+  });
+
+  it("isCustomFevalMetric flags feval-only metrics", () => {
+    expect(isCustomFevalMetric(uiSchema, "binary", "f1")).toBe(true);
+    expect(isCustomFevalMetric(uiSchema, "binary", "brier")).toBe(true);
+    expect(isCustomFevalMetric(uiSchema, "binary", "auc")).toBe(false);
+    expect(isCustomFevalMetric(uiSchema, "binary", "not_a_metric")).toBe(false);
+    expect(isCustomFevalMetric(uiSchema, null, "f1")).toBe(false);
+  });
+});

--- a/frontend/src/components/workspace/metric-options.ts
+++ b/frontend/src/components/workspace/metric-options.ts
@@ -1,0 +1,95 @@
+import type { UiSchema } from "@/api/types";
+
+/**
+ * Accessors for the heterogeneous ``uiSchema.option_sets`` map (P-0104
+ * Wave 3.1b). The generated type is
+ * ``{ [key: string]: { [task: string]: string[] | { [section: string]: string[] } } }``
+ * because ``objective`` / ``eval_metric`` are ``{task: [...]}`` while
+ * ``metric`` is the nested ``{task: {native, feval}}`` shape sourced from
+ * LizyML's ``LGBMProvider.metric_choices(task)``. These helpers centralise
+ * the narrowing so call sites stay readable.
+ */
+
+type OptionSetEntry = string[] | { [section: string]: string[] };
+
+function asStringList(value: OptionSetEntry | undefined): string[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function asSections(value: OptionSetEntry | undefined): {
+  native: string[];
+  feval: string[];
+} {
+  if (value && !Array.isArray(value)) {
+    return {
+      native: Array.isArray(value.native) ? value.native : [],
+      feval: Array.isArray(value.feval) ? value.feval : [],
+    };
+  }
+  return { native: [], feval: [] };
+}
+
+/** Objective choices for the given task (``model.params.objective``). */
+export function objectiveOptionsFor(
+  uiSchema: UiSchema | undefined,
+  task: string | null | undefined,
+): string[] {
+  if (!task) return [];
+  return asStringList(uiSchema?.option_sets?.objective?.[task]);
+}
+
+export interface MetricChoices {
+  /** LightGBM built-in ``metric`` names — cheap, evaluated by the booster. */
+  native: string[];
+  /** LizyML custom feval implementations — slower (re-evaluated in Python). */
+  feval: string[];
+}
+
+/** Model-metric choices (``model.params.metric``) split into native / feval. */
+export function metricChoicesFor(
+  uiSchema: UiSchema | undefined,
+  task: string | null | undefined,
+): MetricChoices {
+  if (!task) return { native: [], feval: [] };
+  return asSections(uiSchema?.option_sets?.metric?.[task]);
+}
+
+/** Flat model-metric option list (``native`` followed by ``feval``). */
+export function metricOptionsFor(
+  uiSchema: UiSchema | undefined,
+  task: string | null | undefined,
+): string[] {
+  const { native, feval } = metricChoicesFor(uiSchema, task);
+  return [...native, ...feval];
+}
+
+/** Eval-metrics registry list — post-hoc reporting metrics, NOT the
+ *  LightGBM ``metric`` param. Used by the Tune Evaluation section. */
+export function evalMetricOptionsFor(
+  uiSchema: UiSchema | undefined,
+  task: string | null | undefined,
+): string[] {
+  if (!task) return [];
+  return asStringList(uiSchema?.option_sets?.eval_metric?.[task]);
+}
+
+/** True when ``metric`` is a LizyML custom feval metric (badged "Custom (slow)"). */
+export function isCustomFevalMetric(
+  uiSchema: UiSchema | undefined,
+  task: string | null | undefined,
+  metric: string,
+): boolean {
+  return metricChoicesFor(uiSchema, task).feval.includes(metric);
+}
+
+/** Eval-metrics registry as a ``{task: [metric, ...]}`` map (for MetricsChips). */
+export function evalMetricMap(
+  uiSchema: UiSchema | undefined,
+): Record<string, string[]> {
+  const raw = uiSchema?.option_sets?.eval_metric ?? {};
+  const out: Record<string, string[]> = {};
+  for (const [task, value] of Object.entries(raw)) {
+    if (Array.isArray(value)) out[task] = value;
+  }
+  return out;
+}

--- a/frontend/src/components/workspace/search-space-utils.ts
+++ b/frontend/src/components/workspace/search-space-utils.ts
@@ -107,7 +107,11 @@ export interface SearchSpaceRowProps {
   stepMap?: Record<string, number>;
   task?: string | null;
   objectiveOptions?: string[];
+  /** Flat model-metric option list (``native`` followed by ``feval``). */
   metricOptions?: string[];
+  /** Subset of ``metricOptions`` that are LizyML custom feval metrics —
+   * rendered with a "Custom (slow)" badge (P-0104 Wave 3.1b / Q2). */
+  fevalMetrics?: string[];
   /** Outer CV strategy from ``config.split.method`` — drives the
    * ``inner_valid_picker`` row's filtered options. */
   cvStrategy?: string;

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -20,8 +20,7 @@ export const handlers = [
       option_sets: {
         objective: {},
         metric: {},
-        model_metric: {},
-        metric_direction: {},
+        eval_metric: {},
       },
       parameter_hints: [],
       search_space_catalog: [],

--- a/frontend/tests/e2e/workspace-ui-improvements.spec.ts
+++ b/frontend/tests/e2e/workspace-ui-improvements.spec.ts
@@ -43,10 +43,17 @@ test.describe("Workspace UI Improvements", () => {
     // n_trials_presets should be [10, 50, 100, 200, 500]
     expect(data.n_trials_presets).toEqual([10, 50, 100, 200, 500]);
 
-    // model_metric should have task-keyed entries
-    expect(data.option_sets).toHaveProperty("model_metric");
-    expect(data.option_sets.model_metric).toHaveProperty("binary");
-    expect(data.option_sets.model_metric).toHaveProperty("regression");
+    // P-0104 Wave 3.1b: option_sets.metric is the nested {native, feval}
+    // shape; model_metric was removed and folded into it; eval_metric
+    // carries the post-hoc reporting metrics for the Tune Evaluation section.
+    expect(data.option_sets).not.toHaveProperty("model_metric");
+    expect(data.option_sets).toHaveProperty("metric");
+    expect(data.option_sets.metric.binary).toHaveProperty("native");
+    expect(data.option_sets.metric.binary).toHaveProperty("feval");
+    expect(data.option_sets.metric.regression).toHaveProperty("native");
+    expect(data.option_sets).toHaveProperty("eval_metric");
+    expect(data.option_sets.eval_metric).toHaveProperty("binary");
+    expect(data.option_sets.eval_metric).toHaveProperty("regression");
 
     // conditional_visibility should have num_leaves entries
     expect(data.conditional_visibility).toHaveProperty("num_leaves");

--- a/src/lizystudio/api/models.py
+++ b/src/lizystudio/api/models.py
@@ -525,7 +525,12 @@ class UiSchemaResponse(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     sections: list[UiSection]
-    option_sets: dict[str, dict[str, list[str]]]
+    # ``option_sets`` is a heterogeneous map. ``objective`` / ``eval_metric``
+    # are ``{task: [name, ...]}``; ``metric`` (P-0104 Wave 3.1b) is the
+    # nested ``{task: {"native": [...], "feval": [...]}}`` shape sourced
+    # from ``LGBMProvider.metric_choices(task)``. The ``model_metric`` key
+    # was removed in Wave 3.1b (Q3 — folded into ``metric``).
+    option_sets: dict[str, dict[str, list[str] | dict[str, list[str]]]]
     metric_direction: dict[str, dict[str, str]] | None = None
     # P-0104 Wave 3.1a / Issue #461: ``{task: {param: {"min": ..., "max": ...}}}``
     # straight from LizyML ``LGBMProvider.parameter_bounds(task)``. Keys use

--- a/src/lizystudio/backends/lizyml/config_compat.py
+++ b/src/lizystudio/backends/lizyml/config_compat.py
@@ -151,12 +151,17 @@ def task_params_compat_errors(config: dict[str, Any]) -> list[dict[str, Any]]:
     if not isinstance(params, dict):
         return []
 
-    from lizystudio.backends.lizyml_metrics import get_eval_metrics_by_task
     from lizystudio.backends.lizyml_ui_schema import build_ui_schema
 
-    option_sets = build_ui_schema(get_eval_metrics_by_task()).get("option_sets", {})
+    option_sets = build_ui_schema().get("option_sets", {})
     allowed_objective = set(option_sets.get("objective", {}).get(task, []))
-    allowed_metric = set(option_sets.get("model_metric", {}).get(task, []))
+    # P-0104 Wave 3.1b: ``option_sets.metric`` is now the nested
+    # ``{task: {native, feval}}`` shape — a model-metric is valid if it
+    # appears in either section.
+    metric_choices = option_sets.get("metric", {}).get(task, {})
+    allowed_metric = set(metric_choices.get("native", [])) | set(
+        metric_choices.get("feval", [])
+    )
 
     errors: list[dict[str, Any]] = []
 

--- a/src/lizystudio/backends/lizyml/config_mixin.py
+++ b/src/lizystudio/backends/lizyml/config_mixin.py
@@ -22,12 +22,9 @@ class ConfigMixin:
         return BackendInfo(name="lizyml", version=lizyml.__version__)
 
     def get_ui_schema(self) -> dict[str, Any]:
-        from lizystudio.backends.lizyml_ui_schema import (
-            build_ui_schema,
-            get_eval_metrics_by_task,
-        )
+        from lizystudio.backends.lizyml_ui_schema import build_ui_schema
 
-        return build_ui_schema(get_eval_metrics_by_task())
+        return build_ui_schema()
 
     def get_config_schema(self) -> ConfigSchema:
         from lizyml.config.schema import LizyMLConfig

--- a/src/lizystudio/backends/lizyml/serialization.py
+++ b/src/lizystudio/backends/lizyml/serialization.py
@@ -88,6 +88,11 @@ def serialize_boundary_report(report: Any) -> dict[str, Any] | None:
                 "expanded": bool(d.expanded),
                 "new_low": d.new_low,
                 "new_high": d.new_high,
+                # P-0104 Wave 3.1b / Issue #461: lizyml v0.15 flags dims
+                # whose proposed expansion was clipped by ``parameter_bounds``.
+                # The Re-tune UI badges these so the user knows the search
+                # range hit the hard library limit.
+                "clamped_to_bound": bool(getattr(d, "clamped_to_bound", False)),
             }
             for d in dims
         ],

--- a/src/lizystudio/backends/lizyml_ui_schema.py
+++ b/src/lizystudio/backends/lizyml_ui_schema.py
@@ -2,10 +2,13 @@
 
 Ported from LizyML-Widget's adapter_contract.py.
 Contains only static data structures — no ML logic, except for the
-``option_sets.objective`` and ``parameter_bounds`` blocks which are
-sourced from LizyML's ``LGBMProvider`` (P-0104 Wave 3.1a) so the Studio
-UI always reflects the canonical objective list / hyper-parameter bounds
-shipped with the installed LizyML version.
+``option_sets.objective`` / ``option_sets.metric`` / ``parameter_bounds``
+blocks which are sourced from LizyML's ``LGBMProvider`` (P-0104 Wave
+3.1a / 3.1b) so the Studio UI always reflects the canonical objective
+list / model-metric choices / hyper-parameter bounds shipped with the
+installed LizyML version. The ``option_sets.eval_metric`` block is the
+eval-metrics registry list (LizyML post-hoc reporting metrics, distinct
+from the LightGBM ``metric`` param) used by the Tune Evaluation section.
 """
 
 from __future__ import annotations
@@ -60,6 +63,37 @@ def _build_objective_option_sets() -> dict[str, list[str]]:
     return {task: list(provider.objective_choices(task)) for task in _TASKS}
 
 
+def _build_metric_option_sets() -> dict[str, dict[str, list[str]]]:
+    """``{task: {"native": [...], "feval": [...]}}`` from the provider.
+
+    ``native`` are LightGBM's built-in ``metric`` names; ``feval`` are
+    LizyML's custom feval implementations (slower — they re-evaluate the
+    model in Python on every boosting round). The UI shows both as
+    model-metric (``model.params.metric``) options and badges the feval
+    ones as "Custom (slow)" so the speed trade-off is visible (P-0104 Q2).
+    """
+    provider = _get_lgbm_provider()
+    out: dict[str, dict[str, list[str]]] = {}
+    for task in _TASKS:
+        choices = provider.metric_choices(task)
+        out[task] = {
+            "native": list(choices["native"]),
+            "feval": list(choices["feval"]),
+        }
+    return out
+
+
+def _build_eval_metric_option_sets() -> dict[str, list[str]]:
+    """``{task: [metric, ...]}`` from LizyML's eval-metrics registry.
+
+    These are the post-hoc reporting metrics LizyML computes after a fit
+    / tune (``auc_pr``, ``logloss``, ...), *not* the LightGBM ``metric``
+    param. Used by the Tune Evaluation section (Optimization Metric /
+    Additional Metrics).
+    """
+    return {task: list(ms) for task, ms in get_eval_metrics_by_task().items()}
+
+
 def _build_parameter_bounds() -> dict[str, dict[str, dict[str, float | int]]]:
     """``{task: {param: {"min": ..., "max": ...}}}`` from the provider.
 
@@ -74,9 +108,7 @@ def _build_parameter_bounds() -> dict[str, dict[str, dict[str, float | int]]]:
 # --- UI schema builder ---
 
 
-def build_ui_schema(
-    all_metrics_by_task: dict[str, list[str]],
-) -> dict[str, Any]:
+def build_ui_schema() -> dict[str, Any]:
     """Build the full UI schema for the LizyML backend contract."""
     metric_directions = get_metric_directions()
     return {
@@ -86,48 +118,16 @@ def build_ui_schema(
             {"key": "calibration", "title": "Calibration"},
             {"key": "evaluation", "title": "Evaluation"},
         ],
+        # P-0104 Wave 3.1b / Issue #461 (Q3): ``option_sets.model_metric``
+        # was removed and folded into ``option_sets.metric``. ``metric`` is
+        # now the nested ``{task: {native, feval}}`` shape sourced straight
+        # from ``LGBMProvider.metric_choices(task)`` — the LightGBM
+        # ``model.params.metric`` options. The eval-metrics registry list
+        # (post-hoc reporting metrics) moved to ``option_sets.eval_metric``.
         "option_sets": {
             "objective": _build_objective_option_sets(),
-            "metric": dict(all_metrics_by_task),
-            "model_metric": {
-                "regression": [
-                    "l1",
-                    "l2",
-                    "rmse",
-                    "quantile",
-                    "mape",
-                    "huber",
-                    "fair",
-                    "poisson",
-                    "gamma",
-                    "gamma_deviance",
-                    "tweedie",
-                    "r2",
-                    "rmsle",
-                ],
-                "binary": [
-                    "auc",
-                    "binary_logloss",
-                    "binary_error",
-                    "average_precision",
-                    "cross_entropy",
-                    "cross_entropy_lambda",
-                    "kullback_leibler",
-                    "f1",
-                    "accuracy",
-                    "brier",
-                    "ece",
-                    "precision_at_k",
-                ],
-                "multiclass": [
-                    "multi_logloss",
-                    "multi_error",
-                    "auc_mu",
-                    "f1",
-                    "accuracy",
-                    "brier",
-                ],
-            },
+            "metric": _build_metric_option_sets(),
+            "eval_metric": _build_eval_metric_option_sets(),
         },
         "metric_direction": metric_directions,
         # P-0104 Wave 3.1a / Issue #461: hyper-parameter bounds straight
@@ -152,7 +152,7 @@ def build_ui_schema(
             {
                 "key": "metric",
                 "label": "Metric",
-                "kind": "model_metric",
+                "kind": "metric",
                 "default": {
                     "regression": ["huber", "mae", "mape"],
                     "binary": ["auc", "binary_logloss"],
@@ -614,7 +614,7 @@ def build_ui_schema(
         "additional_params": _build_additional_params(),
         "special_search_space_fields": {
             "objective": "objective",
-            "metric": "model_metric",
+            "metric": "metric",
             "inner_valid": "inner_valid_picker",
         },
     }

--- a/src/lizystudio/backends/types.py
+++ b/src/lizystudio/backends/types.py
@@ -58,7 +58,8 @@ class TuningSummary:
     rounds: list[dict[str, Any]] | None = None
     # Final-round BoundaryReport. Keys:
     #   dims: list of per-dim status (name, best_value, low, high,
-    #         position_pct, edge, expanded, new_low, new_high),
+    #         position_pct, edge, expanded, new_low, new_high,
+    #         clamped_to_bound),
     #   expanded_names: list[str].
     boundary_report: dict[str, Any] | None = None
 

--- a/tests/contract/test_lizyml_objective_drift.py
+++ b/tests/contract/test_lizyml_objective_drift.py
@@ -1,15 +1,18 @@
-"""Contract: UI schema objective list / parameter bounds == LizyML SSOT.
+"""Contract: UI schema objective / metric lists / parameter bounds == LizyML SSOT.
 
-P-0104 Wave 3.1a / Issue #461. The Studio UI schema used to carry a
-hardcoded ``option_sets.objective`` list and (before this Wave) no
-hyper-parameter bounds at all. Both now come straight from LizyML's
-``LGBMProvider`` so the UI always reflects the canonical objective list /
-bounds shipped with the installed LizyML version.
+P-0104 Wave 3.1a / 3.1b / Issue #461. The Studio UI schema used to carry
+hardcoded ``option_sets.objective`` / ``option_sets.model_metric`` lists
+and (before Wave 3.1a) no hyper-parameter bounds at all. They now come
+straight from LizyML's ``LGBMProvider`` so the UI always reflects the
+canonical objective list / model-metric choices / bounds shipped with the
+installed LizyML version. The ``option_sets.eval_metric`` block tracks
+LizyML's eval-metrics registry instead.
 
-This test locks that invariant — if a future LizyML release adds or
-removes an objective, or tweaks a parameter bound, CI fails here unless
-the Studio schema picks the change up automatically (which it does, by
-sourcing from the provider) or a maintainer consciously diverges.
+This test locks those invariants — if a future LizyML release adds or
+removes an objective / metric, or tweaks a parameter bound, CI fails here
+unless the Studio schema picks the change up automatically (which it does,
+by sourcing from the provider / registry) or a maintainer consciously
+diverges.
 """
 
 from __future__ import annotations
@@ -26,7 +29,7 @@ pytestmark = pytest.mark.unit
 
 
 def _ui_schema() -> dict:
-    return build_ui_schema(get_eval_metrics_by_task())
+    return build_ui_schema()
 
 
 def _provider():
@@ -42,6 +45,41 @@ def test_option_sets_objective_matches_lizyml_canonical() -> None:
         assert tuple(schema["option_sets"]["objective"][task]) == tuple(
             provider.objective_choices(task)
         ), f"objective drift for task={task!r}"
+
+
+def test_option_sets_metric_matches_lizyml_provider() -> None:
+    """``option_sets.metric[task]`` is the nested ``{native, feval}`` shape
+    sourced straight from ``LGBMProvider.metric_choices(task)`` (Wave 3.1b)."""
+    schema = _ui_schema()
+    provider = _provider()
+    for task in _TASKS:
+        choices = provider.metric_choices(task)
+        actual = schema["option_sets"]["metric"][task]
+        assert set(actual.keys()) == {"native", "feval"}, (
+            f"metric option set for task={task!r} must have native/feval sections"
+        )
+        assert tuple(actual["native"]) == tuple(choices["native"]), (
+            f"native metric drift for task={task!r}"
+        )
+        assert tuple(actual["feval"]) == tuple(choices["feval"]), (
+            f"feval metric drift for task={task!r}"
+        )
+
+
+def test_option_sets_has_no_model_metric() -> None:
+    """``option_sets.model_metric`` was removed in Wave 3.1b (Q3)."""
+    schema = _ui_schema()
+    assert "model_metric" not in schema["option_sets"]
+
+
+def test_option_sets_eval_metric_matches_registry() -> None:
+    """``option_sets.eval_metric[task]`` mirrors LizyML's eval-metrics registry."""
+    schema = _ui_schema()
+    registry = get_eval_metrics_by_task()
+    for task in _TASKS:
+        assert list(schema["option_sets"]["eval_metric"][task]) == list(
+            registry[task]
+        ), f"eval_metric drift for task={task!r}"
 
 
 def test_parameter_bounds_match_lizyml_provider() -> None:
@@ -66,6 +104,21 @@ def test_parameter_hint_objective_defaults_are_valid_choices() -> None:
         )
 
 
+def test_parameter_hint_metric_defaults_are_valid_choices() -> None:
+    """Each ``parameter_hints.metric.default[task]`` entry is a valid model metric."""
+    schema = _ui_schema()
+    provider = _provider()
+    hint = next(h for h in schema["parameter_hints"] if h["key"] == "metric")
+    assert hint["kind"] == "metric"
+    for task in _TASKS:
+        choices = provider.metric_choices(task)
+        valid = set(choices["native"]) | set(choices["feval"])
+        for default in hint["default"][task]:
+            assert default in valid, (
+                f"metric hint default {default!r} not a valid {task} metric"
+            )
+
+
 def test_search_space_catalog_objective_defaults_are_valid_choices() -> None:
     """``search_space_catalog`` objective entry default must be a valid choice."""
     schema = _ui_schema()
@@ -76,3 +129,26 @@ def test_search_space_catalog_objective_defaults_are_valid_choices() -> None:
         assert default in provider.objective_choices(task), (
             f"objective catalog default {default!r} not a valid {task} objective"
         )
+
+
+def test_search_space_catalog_metric_defaults_are_valid_choices() -> None:
+    """``search_space_catalog`` metric entry default must be a valid model metric."""
+    schema = _ui_schema()
+    provider = _provider()
+    entry = next(e for e in schema["search_space_catalog"] if e["key"] == "metric")
+    for task in _TASKS:
+        choices = provider.metric_choices(task)
+        valid = set(choices["native"]) | set(choices["feval"])
+        default = entry["default"][task]
+        assert default in valid, (
+            f"metric catalog default {default!r} not a valid {task} metric"
+        )
+
+
+def test_special_search_space_fields_use_canonical_picker_tags() -> None:
+    """``special_search_space_fields.metric`` was renamed model_metric->metric."""
+    schema = _ui_schema()
+    ssf = schema["special_search_space_fields"]
+    assert ssf["objective"] == "objective"
+    assert ssf["metric"] == "metric"
+    assert ssf["inner_valid"] == "inner_valid_picker"

--- a/tests/contract/test_ui_schema_matches_pydantic.py
+++ b/tests/contract/test_ui_schema_matches_pydantic.py
@@ -19,10 +19,7 @@ from typing import Any
 
 import pytest
 
-from lizystudio.backends.lizyml_ui_schema import (
-    build_ui_schema,
-    get_eval_metrics_by_task,
-)
+from lizystudio.backends.lizyml_ui_schema import build_ui_schema
 
 pytestmark = pytest.mark.unit
 
@@ -56,7 +53,7 @@ def test_cv_strategy_fields_match_pydantic_or_data() -> None:
     """
     from lizyml.config.schema import LizyMLConfig
 
-    ui_schema = build_ui_schema(get_eval_metrics_by_task())
+    ui_schema = build_ui_schema()
     cv_strategy_fields = ui_schema["capabilities"]["cv_strategy_fields"]
 
     defs = LizyMLConfig.model_json_schema().get("$defs", {})
@@ -88,7 +85,7 @@ def test_every_ui_method_has_matching_pydantic_variant() -> None:
     """
     from lizyml.config.schema import LizyMLConfig
 
-    ui_schema = build_ui_schema(get_eval_metrics_by_task())
+    ui_schema = build_ui_schema()
     cv_strategy_fields = ui_schema["capabilities"]["cv_strategy_fields"]
 
     defs = LizyMLConfig.model_json_schema().get("$defs", {})
@@ -118,7 +115,7 @@ def test_frontend_fallback_matches_backend_cv_strategy_fields() -> None:
     import re
     from pathlib import Path
 
-    ui_schema = build_ui_schema(get_eval_metrics_by_task())
+    ui_schema = build_ui_schema()
     backend = ui_schema["capabilities"]["cv_strategy_fields"]
 
     ts_path = (
@@ -241,7 +238,7 @@ def test_parameter_hints_do_not_shadow_smart_params() -> None:
     """
     from lizyml.config.schema import LizyMLConfig
 
-    ui_schema = build_ui_schema(get_eval_metrics_by_task())
+    ui_schema = build_ui_schema()
     hint_keys = {h["key"] for h in ui_schema["parameter_hints"]}
 
     defs = LizyMLConfig.model_json_schema().get("$defs", {})

--- a/tests/test_ui_schema.py
+++ b/tests/test_ui_schema.py
@@ -71,15 +71,29 @@ class TestLizyMLAdapterUiSchema:
         option_sets = schema["option_sets"]
         assert "objective" in option_sets
         assert "metric" in option_sets
-        assert "model_metric" in option_sets
+        # P-0104 Wave 3.1b (Q3): model_metric folded into metric.
+        assert "model_metric" not in option_sets
+        assert "eval_metric" in option_sets
 
-    def test_option_sets_metric_has_all_tasks(self) -> None:
+    def test_option_sets_metric_has_all_tasks_with_native_feval(self) -> None:
         schema = LizyMLAdapter().get_ui_schema()
         metric = schema["option_sets"]["metric"]
         for task in ("binary", "regression", "multiclass"):
             assert task in metric
-            assert isinstance(metric[task], list)
-            assert len(metric[task]) > 0
+            assert set(metric[task].keys()) == {"native", "feval"}
+            assert isinstance(metric[task]["native"], list)
+            assert len(metric[task]["native"]) > 0
+            assert isinstance(metric[task]["feval"], list)
+
+    def test_option_sets_eval_metric_has_all_tasks(self) -> None:
+        schema = LizyMLAdapter().get_ui_schema()
+        eval_metric = schema["option_sets"]["eval_metric"]
+        for task in ("binary", "regression", "multiclass"):
+            assert task in eval_metric
+            assert isinstance(eval_metric[task], list)
+            assert len(eval_metric[task]) > 0
+            for m in eval_metric[task]:
+                assert isinstance(m, str)
 
     def test_option_sets_objective_has_all_tasks(self) -> None:
         schema = LizyMLAdapter().get_ui_schema()
@@ -177,16 +191,15 @@ class TestLizyMLAdapterUiSchema:
         r2 = get_metric_directions()
         assert r1 is r2  # same object reference (cached)
 
-    def test_model_metric_options_structure(self) -> None:
-        """model_metric should have task-keyed lists of metric strings."""
+    def test_metric_option_set_native_feval_are_string_lists(self) -> None:
+        """option_sets.metric[task] is the nested {native, feval} shape."""
         schema = LizyMLAdapter().get_ui_schema()
-        model_metric = schema["option_sets"]["model_metric"]
+        metric = schema["option_sets"]["metric"]
         for task in ("binary", "regression", "multiclass"):
-            assert task in model_metric
-            assert isinstance(model_metric[task], list)
-            assert len(model_metric[task]) > 0
-            for m in model_metric[task]:
-                assert isinstance(m, str)
+            for section in ("native", "feval"):
+                assert isinstance(metric[task][section], list)
+                for m in metric[task][section]:
+                    assert isinstance(m, str)
 
     def test_conditional_visibility_num_leaves(self) -> None:
         """conditional_visibility should have num_leaves/num_leaves_ratio entries."""
@@ -400,32 +413,34 @@ class TestLizyMLAdapterUiSchema:
         assert catalog["auto_num_leaves"]["default"] is True
 
     def test_eval_metrics_match_lizyml_registry(self) -> None:
-        """option_sets.metric must match the live LizyML _TASK_METRICS registry."""
+        """option_sets.eval_metric must match the live LizyML _TASK_METRICS registry."""
         from lizyml.metrics.registry import _TASK_METRICS
 
         schema = LizyMLAdapter().get_ui_schema()
         for task in ("binary", "regression", "multiclass"):
             expected = sorted(_TASK_METRICS[task])
-            actual = sorted(schema["option_sets"]["metric"][task])
+            actual = sorted(schema["option_sets"]["eval_metric"][task])
             assert actual == expected, (
-                f"metric mismatch for {task}: expected={expected}, actual={actual}"
+                f"eval_metric mismatch for {task}: expected={expected}, actual={actual}"
             )
 
-    def test_model_metric_includes_feval_metrics(self) -> None:
-        """model_metric for binary should include feval metrics from v0.6.0+."""
+    def test_metric_binary_includes_feval_metrics(self) -> None:
+        """option_sets.metric.binary.feval should include the custom feval metrics."""
         schema = LizyMLAdapter().get_ui_schema()
-        binary_mm = schema["option_sets"]["model_metric"]["binary"]
-        # These became available as training metrics via metric bridge
+        binary_feval = schema["option_sets"]["metric"]["binary"]["feval"]
         for m in ("f1", "accuracy", "brier", "ece", "precision_at_k"):
-            assert m in binary_mm, f"binary model_metric missing feval metric: {m}"
+            assert m in binary_feval, f"binary metric feval missing: {m}"
 
-    def test_model_metric_multiclass_uses_lizyml_names(self) -> None:
-        """model_metric for multiclass should use LightGBM native metric names."""
+    def test_metric_multiclass_native_uses_lizyml_names(self) -> None:
+        """option_sets.metric.multiclass.native uses LightGBM native metric names."""
         schema = LizyMLAdapter().get_ui_schema()
-        mc_mm = schema["option_sets"]["model_metric"]["multiclass"]
-        assert "multi_logloss" in mc_mm
-        assert "multi_error" in mc_mm
-        assert "auc_mu" in mc_mm
+        mc_native = schema["option_sets"]["metric"]["multiclass"]["native"]
+        assert "multi_logloss" in mc_native
+        assert "multi_error" in mc_native
+        assert "auc_mu" in mc_native
+        # multiclass `auc` is rejected by LightGBM 4.x — must not be offered
+        # as a model metric (P-0104 Scope-5).
+        assert "auc" not in mc_native
 
     # --- Phase 1: Expanded parameter coverage (Widget parity) ---
 
@@ -539,26 +554,20 @@ class TestLizyMLAdapterUiSchema:
         for key in ("min_child_weight", "min_gain_to_split", "scale_pos_weight"):
             assert key in additional, f"additional_params missing: {key}"
 
-    def test_model_metric_regression_includes_lgbm_native(self) -> None:
-        """model_metric regression should include LightGBM native metrics."""
+    def test_metric_regression_native_uses_canonical_names(self) -> None:
+        """option_sets.metric.regression.native uses LizyML canonical names."""
         schema = LizyMLAdapter().get_ui_schema()
-        reg_mm = schema["option_sets"]["model_metric"]["regression"]
-        for m in ("l1", "l2", "rmse", "huber", "mape", "quantile"):
-            assert m in reg_mm, f"regression model_metric missing LGB native: {m}"
+        reg_native = schema["option_sets"]["metric"]["regression"]["native"]
+        # Canonical names: l1 -> mae, l2 -> rmse (LizyML v0.15 SSOT).
+        for m in ("mae", "rmse", "huber", "mape", "quantile"):
+            assert m in reg_native, f"regression metric native missing: {m}"
 
-    def test_model_metric_binary_includes_lgbm_native(self) -> None:
-        """model_metric binary should include LightGBM native metrics."""
+    def test_metric_binary_native_includes_lgbm_native(self) -> None:
+        """option_sets.metric.binary.native includes LightGBM native metrics."""
         schema = LizyMLAdapter().get_ui_schema()
-        binary_mm = schema["option_sets"]["model_metric"]["binary"]
+        binary_native = schema["option_sets"]["metric"]["binary"]["native"]
         for m in ("binary_logloss", "binary_error", "average_precision", "auc"):
-            assert m in binary_mm, f"binary model_metric missing LGB native: {m}"
-
-    def test_model_metric_multiclass_includes_lgbm_native(self) -> None:
-        """model_metric multiclass should include LightGBM native metrics."""
-        schema = LizyMLAdapter().get_ui_schema()
-        mc_mm = schema["option_sets"]["model_metric"]["multiclass"]
-        for m in ("multi_logloss", "multi_error", "auc_mu"):
-            assert m in mc_mm, f"multiclass model_metric missing LGB native: {m}"
+            assert m in binary_native, f"binary metric native missing: {m}"
 
     def test_capabilities_cv_strategy_fields(self) -> None:
         """capabilities must include cv_strategy_fields mapping."""
@@ -673,7 +682,8 @@ class TestLizyMLAdapterUiSchema:
         assert "special_search_space_fields" in schema
         ssf = schema["special_search_space_fields"]
         assert ssf["objective"] == "objective"
-        assert ssf["metric"] == "model_metric"
+        # P-0104 Wave 3.1b: renamed model_metric -> metric (Q3).
+        assert ssf["metric"] == "metric"
 
     def test_search_space_catalog_learning_rate_default_mode_range(self) -> None:
         """learning_rate must have default_mode='range' and default_range.
@@ -836,9 +846,10 @@ class TestLizyMLAdapterUiSchema:
         """Eval metrics must place preferred metric first (Widget conformance).
 
         binary: auc first, regression: rmse first, multiclass: auc first.
+        Applies to option_sets.eval_metric (the post-hoc reporting list).
         """
         schema = LizyMLAdapter().get_ui_schema()
-        metrics = schema["option_sets"]["metric"]
+        metrics = schema["option_sets"]["eval_metric"]
         assert metrics["binary"][0] == "auc", f"binary first: {metrics['binary'][0]}"
         assert metrics["regression"][0] == "rmse", (
             f"regression first: {metrics['regression'][0]}"


### PR DESCRIPTION
## Summary

P-0104 **Wave 3.1b** — completes the remaining #461 work (UiSchema ⇄ LizyML v0.15 SSOT integration). Single PR per the agreed plan.

### Backend
- **`option_sets.model_metric` removed** (Q3). `option_sets.metric` is now the nested `{task: {native, feval}}` shape sourced straight from `LGBMProvider.metric_choices(task)` — the `model.params.metric` options.
- **New `option_sets.eval_metric`** (flat `{task: [...]}`) carries LizyML's eval-metrics registry (post-hoc reporting metrics) for the Tune Evaluation section, which previously read `option_sets.metric`. *(This field is an implementation detail not spelled out in the P-0104 Decision, but necessary so the Tune Evaluation / Fit-tab metric chips keep working after `metric` was repurposed — see HISTORY P-0104 Decision log.)*
- `parameter_hints.metric.kind` and `special_search_space_fields.metric` renamed `model_metric` → `metric`.
- `build_ui_schema()` no longer takes an `all_metrics_by_task` argument.
- `config_compat.py::task_params_compat_errors` `allowed_metric` now reads `option_sets.metric[task]` (`native ∪ feval`).
- `serialize_boundary_report` exposes lizyml v0.15's `BoundaryDimStatus.clamped_to_bound` on the wire.
- `UiSchemaResponse.option_sets` typed `dict[str, dict[str, list[str] | dict[str, list[str]]]]`; `schema.d.ts` regenerated.

### Frontend
- New `metric-options.ts` helper module centralises the `option_sets` narrowing (`objectiveOptionsFor` / `metricChoicesFor` / `metricOptionsFor` / `evalMetricOptionsFor` / `evalMetricMap` / `isCustomFevalMetric`).
- TuneTab / SearchSpaceTable / SearchSpaceRow / ConfigForm / ModelParamsSection / DynParam migrated off `option_sets.model_metric`. Tune Evaluation and the Fit-tab MetricsChips now read `option_sets.eval_metric`.
- feval metrics get a **"Custom (slow)" badge** (Q2): Search Space metric chips (SearchSpaceRow) and the Fit-tab metric ChipGroup (new `customOptions` prop on `ChipGroup`).
- Re-tune Boundary Expansion panel badges `clamped_to_bound` dims as **"bounded"** (`BoundaryDimStatus.clamped_to_bound` added to retune types).

### Scope notes
- multiclass `auc` removal (Scope-5) falls out automatically — `metric_choices("multiclass").native` already excludes it.
- `_PREFERRED_METRIC["multiclass"]` is intentionally **not** changed: it only orders the eval-registry list, and `auc_mu` is not a registry metric, so the change would be a no-op. (See plan discussion.)
- Out of scope: deferred `validate_config` → `parse_space()` rewire (Issue #474), Residuals plot kind selector (Issue #457).

## Docs
- BLUEPRINT.md §4.2.2 + the UI-schema example/glossary updated for the new `option_sets` shape, the "Custom (slow)" badge, and `clamped_to_bound`. (Also moved `metric_direction` to top level in the example JSON — it was incorrectly nested under `option_sets`.)
- HISTORY.md P-0104 Decision log + acceptance-criteria checklist updated.

## Test plan
- [x] `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/integration --ignore=tests/regression --ignore=tests/bench -k "not slow"` → 1228 passed
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy --no-incremental src/lizystudio/` → clean
- [x] `pnpm test -- --run` → 1914 passed (incl. new `metric-options.test.ts`, ChipGroup / SearchSpaceRow / BoundaryExpansionPanel badge tests)
- [x] `tsc -b` / `biome check src/ tests/` / `pnpm build` → green
- [ ] CI e2e (`workspace-fit` / `workspace-tune` / `workspace-retune`) green — verified by this PR's CI

## Notes for reviewers
- The drift CI was extended in-place (`tests/contract/test_lizyml_objective_drift.py`) rather than creating a new `test_lizyml_objective_metric_drift.py` file.
- `tests/test_backends_lizyml.py` needed no change — its metric-mismatch tests use concrete canonical names that remain valid under the provider-sourced lists.

Refs #461, P-0104 Wave 3.1b. Follow-ups: #474 (deferred parse_space validation), #457 (Residuals plot).
