### PR TITLE
feat(workspace): residuals plot kind selector (#457, P-0105)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -2502,16 +2502,18 @@ Workspace の `workspace_result` は完了時に自動更新される。
 
 **`plot_type` の値:**
 
-| plot_type | 条件 |
-|-----------|------|
-| `learning-curve` | 全タスク |
-| `importance` | 全タスク |
-| `oof-distribution` | 全タスク |
-| `residuals` | regression |
-| `roc-curve` | binary |
-| `calibration` | binary + calibration有効 |
-| `probability-histogram` | binary |
-| `tuning` | tune実行済み |
+| plot_type | 条件 | `?kind=` |
+|-----------|------|----------|
+| `learning-curve` | 全タスク | — (`?metrics=` で subplot フィルタ) |
+| `importance` | 全タスク | `split` / `gain` / `shap`（`?top_n=` も — P-0097） |
+| `oof-distribution` | 全タスク | — |
+| `residuals` | regression | `scatter` / `histogram` / `qq` / `all`（既定 `all` = 3-panel layout、Issue #457 / P-0105）。不正値は `400 INVALID_PARAM` |
+| `roc-curve` | binary | — |
+| `calibration` | binary + calibration有効 | — |
+| `probability-histogram` | binary | — |
+| `tuning` | tune実行済み | — |
+
+> Residuals の kind selector（`PlotSection` の `SegmentGroup`、`Scatter / Histogram / QQ / All`）は Importance の kind selector と同じ位置に描画され、狭い結果パネルでも 1 panel ずつ読めるようにする（Issue #457）。`all` は従来の 3-panel 表示と完全一致。
 
 ### 5.4 Inference API
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3720,3 +3720,72 @@ LizyML v0.15.0 の出荷（2026-05-10）により、Studio の Tune workflow を
 - 2026-05-11 **Wave 3.1b 着地（#461 残り）** — `option_sets.model_metric` 撤廃 →`option_sets.metric` を `LGBMProvider.metric_choices(task)` 由来の `{native, feval}` ネスト構造に統合（Q3）。eval-metrics registry の post-hoc 評価メトリクスは新フィールド `option_sets.eval_metric`（flat）に分離（Tune Evaluation セクション用）。`parameter_hints.metric.kind` / `special_search_space_fields.metric` を `model_metric`→`metric` にリネーム。`config_compat.py::task_params_compat_errors` の `allowed_metric` を `option_sets.metric` の `native ∪ feval` 参照に切替。frontend は `metric-options.ts` ヘルパで `option_sets` の narrowing を一元化。feval 由来 metric に "Custom (slow)" バッジ（Q2 — SearchSpaceRow metric チップ + ModelParamsSection ChipGroup）。`BoundaryDimStatus.clamped_to_bound`（lizyml v0.15）を `serialize_boundary_report` で wire に露出し Re-tune の Boundary Expansion パネルに「bounded」バッジ。残るは **#474（deferred parse_space validation）** と **#457（Residuals plot kind selector）** — いずれも P-0104 本体からは独立
 
 
+
+### P-0105: Residuals plot に kind selector を追加（3-panel layout → Importance パターン mirror、Issue #457）
+
+- **Date:** 2026-05-11 起票・即承認（Issue #457 で詳細仕様確定済 + ユーザ go-ahead）
+- **Related:** Issue #457、`src/lizystudio/backends/lizyml/evaluation_mixin.py`、`src/lizystudio/api/jobs.py`、`frontend/src/hooks/useJobResultData.ts`、`frontend/src/api/queryKeys.ts`、`frontend/src/components/workspace/PlotSection.tsx`、`frontend/src/components/shared/JobResultsBody.tsx`、BLUEPRINT.md §4.3、`docs/plot-matrix.md`、lizyml `Model.residuals_plot(*, kind="all")`（lizyml 0.9.0+ で kind dispatch 出荷済）
+
+#### Motivation
+
+regression Fit 結果の Residuals plot は現在「1 figure に 3 panel（Actual vs Predicted / Residual Distribution / QQ）」を横並びで描画する。Workspace 右パネルが狭い（laptop / Inspector docked）ときに 3 panel が潰れて読めなくなる。Importance タブは既に `SegmentGroup`（`split / gain / shap`）で 1 panel ずつ切替えられる UX を持っており、Residuals も同じパターンに揃える。lizyml 側は `residuals_plot(kind="scatter"|"histogram"|"qq"|"all")` を既にサポート済（`_VALID_KINDS = ("scatter","histogram","qq","all")`）、Studio 側の配線のみが残っている。
+
+#### Purpose
+
+- backend dispatch（`evaluation_mixin.plot()`）が `plot_type == "residuals"` のとき `kind` を `Model.residuals_plot(kind=...)` に転送する（`importance` と同じ枠で）。
+- API（`GET /api/jobs/{id}/plot/{plot_type}`）が `residuals` でも `?kind=` を受け付ける。`{"scatter","histogram","qq","all"}` 以外は `INVALID_PARAM`（400）。
+- frontend hook（`useJobResultData.ts`）に `residualsKind` state（default `"all"`）+ `setResidualsKind` を追加、residuals タブが active のとき `fetchJobPlot(jobId, "residuals", {kind})` で取得。`queryKeys.jobPlotResiduals(jobId, kind)` を追加し generic plotData query から split（importance と同じ手法）。
+- frontend UI（`PlotSection.tsx`）に residuals 用 `SegmentGroup`（`Scatter / Histogram / QQ / All`）を importance kind selector と同じ slot に追加。
+- `pnpm generate:api` で `schema.d.ts` 再生成（手書きしない）。
+
+#### Invariants
+
+- **INV-resid-1**: `kind` 未指定の `GET /api/jobs/{id}/plot/residuals` は従来通り `"all"`（3-panel）図を返す — 既存クライアントのバイト列を変えない（後方互換）。
+- **INV-resid-2**: `PlotSection` の residuals kind selector が描画する選択肢は backend `Model.residuals_plot` の `_VALID_KINDS` と一致する（`RESIDUAL_KIND_LABELS` のキー集合で固定）。
+- **INV-resid-3**: `evaluation_mixin.plot()` の `kind` 転送は `plot_type ∈ {"importance","residuals"}` に限る（`shap-summary` は `kind="shap"` 固定の別経路、他は転送しない）。
+
+#### Impact
+
+**Public API:**
+- `GET /api/jobs/{job_id}/plot/{plot_type}` が `residuals` でも `?kind=` を受理（後方互換 — 省略時 `"all"`）。invalid kind は `400 INVALID_PARAM`。docstring 更新。`schema.d.ts` 再生成。
+
+**Backend:**
+- `evaluation_mixin.py`: `plot()` の `kind` 転送条件に `residuals` を追加。`_RESIDUALS_KINDS` module-level 定数（`_PLOT_DISPATCH` style）を新設し、`available_plots` の `shap-summary` probe と同様の方針で使う。
+- `api/jobs.py`: residuals 用 `kind` バリデーション（`_RESIDUALS_KINDS` に対する membership check）。
+
+**Frontend:**
+- `useJobResultData.ts`: `residualsKind` state（default `"all"`）+ `setResidualsKind` + `residualsPlot` query（`enabled = selectedPlot === "residuals" && plots.includes("residuals")`）。generic `plotData` query の `enabled` 条件から `residuals` を除外。
+- `queryKeys.ts`: `jobPlotResiduals(jobId, kind)`。
+- `PlotSection.tsx`: `residualsKinds` / `selectedResidualsKind` / `onResidualsKindChange` / `residualsPlot` props 追加。`selectedPlot === "residuals"` のとき `SegmentGroup`（`RESIDUAL_KIND_LABELS = {scatter:"Scatter", histogram:"Histogram", qq:"QQ", all:"All"}`）を importance kind selector と同じ位置に。fullscreen dialog title は `kind !== "all"` のとき `Residuals — <Kind>`。
+- `JobResultsBody.tsx`: hook の新 state を `PlotSection` に配線。
+
+**Behavior change for users:**
+- Residuals タブに `Scatter / Histogram / QQ / All` の SegmentGroup が出る。default は `All` で従来の 3-panel と完全一致。
+
+**Compatibility:**
+- 後方互換（kind 省略 = `"all"` = 従来図）。保存形式・他 API 変更なし。
+
+**Testing:**
+- backend unit（`tests/test_backends_lizyml.py`）: `plot("residuals", kind=...)` 4 種 + invalid kind が typed error。
+- API contract（`tests/test_jobs_api.py` 相当）: `?kind=scatter` → 200、`?kind=bogus` → 400、kind 省略 → 200。
+- frontend Vitest（`PlotSection.test.tsx`）: residuals タブ active で selector 描画 / クリックで `onResidualsKindChange`。`useJobResultData.test.ts`: `residualsKind` の state 遷移。
+- e2e（軽量）: `workspace-fit.spec.ts` の regression path に `all → scatter` 切替の smoke を 1 件追加。
+
+#### Acceptance criteria
+
+- [ ] Residuals タブが `Scatter / Histogram / QQ / All` の SegmentGroup を表示、default `All`。
+- [ ] 各 kind が対応する lizyml 図を描画、`kind=all` は従来の 3-panel と一致。
+- [ ] `GET /api/jobs/{id}/plot/residuals?kind=bogus` → `400 INVALID_PARAM`。
+- [ ] `GET /api/jobs/{id}/plot/residuals`（kind 省略）→ 従来の `"all"` 図。
+- [ ] `uv run pytest` / `pnpm test` / `pnpm test:e2e --grep workspace-fit` / `pnpm check` / `pnpm build` 全 green。
+- [ ] BLUEPRINT.md の Residuals plot 記述 + `docs/plot-matrix.md` を更新。
+
+#### Alternatives considered
+
+- **(a) default を 3-panel から単一 panel に変更**: 拒否。現行ビューに依存しているユーザを無言で壊す（Issue #457 Out of scope に明記）。
+- **(b) Residuals を Importance と同様にバックエンドで kind 別キャッシュ**: 不要。`residuals_plot` は安価で、frontend query cache（`jobPlotResiduals(jobId, kind)` キー）で十分。
+- **(c) per-fold residuals breakdown / 新 kind 追加**: 拒否（Issue #457 Out of scope — lizyml がサポートする 4 kind のみ）。
+
+#### Decision
+
+- 2026-05-11 **Approved** — Issue #457 の詳細仕様（target shape 1-5）+ UI spec をそのまま採用。実装は単一 PR（Proposal commit → 実装 commit）。`shap-summary` を top-level タブに昇格する件（#373）とは独立。

--- a/docs/plot-matrix.md
+++ b/docs/plot-matrix.md
@@ -31,7 +31,7 @@ same PR.
 | `roc-curve`                | `roc_curve_plot`            | `ROC`             | binary              | |
 | `calibration`              | `calibration_plot`          | `Calibration`     | binary + cal enabled | |
 | `probability-histogram`    | `probability_histogram_plot`| `Prob Hist`       | binary + cal enabled | |
-| `residuals`                | `residuals_plot`            | `Residuals`       | regression          | |
+| `residuals`                | `residuals_plot`            | `Residuals`       | regression          | accepts `kind={scatter,histogram,qq,all}` (default `all` = 3-panel; Issue #457 / P-0105) |
 | `importance`               | `importance_plot`           | `Importance`      | all                 | accepts `kind={split,gain,shap}`; `top_n` query (P-0097) |
 | `shap-summary`             | `importance_plot`           | _(see notes)_     | all + shap installed| alias of `importance_plot(kind="shap")` (Issue #373). NOT in Workspace `PLOT_LABELS` (Issue #393): Workspace surfaces SHAP via `Importance kind=shap`; Inference renders the SHAP Summary accordion (`ResultsPredOnly` / `ResultsWithGT`) which does not consume `PlotSection`. |
 | `tuning`                   | `tuning_plot`               | _(in TuneTrialsSection)_ | tune jobs    | NOT in `PLOT_LABELS` — rendered by `TuneTrialsSection`, intentionally absent from the tab strip |
@@ -46,6 +46,8 @@ same PR.
 | API render endpoint | `src/lizystudio/api/jobs.py` | `GET /api/jobs/{id}/plot/{plot_type}` |
 | Frontend labels | `frontend/src/components/workspace/PlotSection.tsx` | `PLOT_LABELS` |
 | Importance kind labels | `frontend/src/components/workspace/PlotSection.tsx` | `KIND_LABELS` |
+| Residuals kind labels | `frontend/src/components/workspace/PlotSection.tsx` | `RESIDUAL_KINDS` / `RESIDUAL_KIND_LABELS` |
+| Residuals kind allowlist (API) | `src/lizystudio/api/jobs.py` | `_RESIDUALS_KINDS` (mirrors `EvaluationMixin.RESIDUALS_KINDS`) |
 
 ---
 

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -753,6 +753,8 @@ export interface paths {
          *
          *     For ``learning-curve``, pass ``?metrics=auc,f1`` to filter subplots.
          *     For ``importance``, pass ``?kind=split|gain|shap`` to select kind.
+         *     For ``residuals``, pass ``?kind=scatter|histogram|qq|all`` to select
+         *     which panel to render (default ``all`` — the 3-panel layout).
          */
         get: operations["get_job_plot_endpoint_api_jobs__job_id__plot__plot_type__get"];
         put?: never;

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -31,6 +31,8 @@ export const queryKeys = {
     ["job-plot", jobId, "learning-curve", metric] as const,
   jobPlotImportance: (jobId: string, kind: string) =>
     ["job-plot", jobId, "importance", kind] as const,
+  jobPlotResiduals: (jobId: string, kind: string) =>
+    ["job-plot", jobId, "residuals", kind] as const,
   jobPlotTuning: (jobId: string) => ["job-plot", jobId, "tuning"] as const,
   jobImportance: (jobId: string, kind: string, topN: number | null = null) =>
     ["job-importance", jobId, kind, topN] as const,

--- a/frontend/src/components/shared/JobResultsBody.tsx
+++ b/frontend/src/components/shared/JobResultsBody.tsx
@@ -62,6 +62,11 @@ export function JobResultsBody({
     importance,
     importancePlot,
     isImportancePlotLoading,
+    residualsKind,
+    setResidualsKind,
+    residualsPlot,
+    isResidualsPlotLoading,
+    isResidualsPlotError,
     importanceTopN,
     setImportanceTopN,
     splitSummary,
@@ -103,9 +108,17 @@ export function JobResultsBody({
           isLoading={
             selectedPlot === "importance"
               ? isImportancePlotLoading
-              : isPlotLoading
+              : selectedPlot === "residuals"
+                ? isResidualsPlotLoading
+                : isPlotLoading
           }
-          isError={selectedPlot === "learning-curve" ? isLcError : isPlotError}
+          isError={
+            selectedPlot === "learning-curve"
+              ? isLcError
+              : selectedPlot === "residuals"
+                ? isResidualsPlotError
+                : isPlotError
+          }
           lcMetric={lcMetric}
           onLcMetricChange={setLcMetric}
           availableEvalMetrics={availableEvalMetrics}
@@ -114,6 +127,9 @@ export function JobResultsBody({
           onImportanceKindChange={setImportanceKind}
           importanceData={importance}
           importancePlot={importancePlot}
+          residualsPlot={residualsPlot}
+          selectedResidualsKind={residualsKind}
+          onResidualsKindChange={setResidualsKind}
           importanceTopN={importanceTopN}
           onImportanceTopNChange={setImportanceTopN}
         />

--- a/frontend/src/components/workspace/PlotSection.test.tsx
+++ b/frontend/src/components/workspace/PlotSection.test.tsx
@@ -221,6 +221,75 @@ describe("PlotSection", () => {
     expect(onKindChange).toHaveBeenCalledWith("gain");
   });
 
+  describe("residuals kind selector (Issue #457)", () => {
+    const residualsProps = {
+      ...defaultProps,
+      plots: ["learning-curve", "residuals", "importance"],
+      selectedPlot: "residuals",
+    };
+
+    it("renders the kind selector when the residuals tab is active", () => {
+      render(
+        <PlotSection
+          {...residualsProps}
+          selectedResidualsKind="all"
+          onResidualsKindChange={vi.fn()}
+          residualsPlot={{ plotly_json: "{}" }}
+        />,
+      );
+      expect(
+        screen.getByRole("radio", { name: "Scatter" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("radio", { name: "Histogram" }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "QQ" })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "All" })).toBeInTheDocument();
+    });
+
+    it("does not render the kind selector on a non-residuals tab", () => {
+      render(
+        <PlotSection
+          {...residualsProps}
+          selectedPlot="learning-curve"
+          selectedResidualsKind="all"
+          onResidualsKindChange={vi.fn()}
+        />,
+      );
+      expect(
+        screen.queryByRole("radio", { name: "Scatter" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("calls onResidualsKindChange when a kind is clicked", () => {
+      const onChange = vi.fn();
+      render(
+        <PlotSection
+          {...residualsProps}
+          selectedResidualsKind="all"
+          onResidualsKindChange={onChange}
+          residualsPlot={{ plotly_json: "{}" }}
+        />,
+      );
+      fireEvent.click(screen.getByRole("radio", { name: "Scatter" }));
+      expect(onChange).toHaveBeenCalledWith("scatter");
+    });
+
+    it("renders residualsPlot data when the residuals tab is active", () => {
+      render(
+        <PlotSection
+          {...residualsProps}
+          selectedResidualsKind="scatter"
+          onResidualsKindChange={vi.fn()}
+          residualsPlot={{ plotly_json: '{"residuals":"scatter"}' }}
+        />,
+      );
+      expect(screen.getByTestId("plotly-chart")).toHaveTextContent(
+        '{"residuals":"scatter"}',
+      );
+    });
+  });
+
   describe("importance top-N toggle (PR-B2 / P-0097)", () => {
     it("renders the toggle when on importance tab and a callback is provided", () => {
       render(

--- a/frontend/src/components/workspace/PlotSection.tsx
+++ b/frontend/src/components/workspace/PlotSection.tsx
@@ -47,6 +47,17 @@ const KIND_LABELS: Record<string, string> = {
   shap: "SHAP",
 };
 
+// Issue #457 / P-0105: residuals plot kinds. Order is the SegmentGroup
+// display order; ``all`` last (the legacy 3-panel default). Mirrors
+// lizyml ``plot_residuals._VALID_KINDS`` / backend ``_RESIDUALS_KINDS``.
+const RESIDUAL_KINDS: string[] = ["scatter", "histogram", "qq", "all"];
+const RESIDUAL_KIND_LABELS: Record<string, string> = {
+  scatter: "Scatter",
+  histogram: "Histogram",
+  qq: "QQ",
+  all: "All",
+};
+
 interface PlotSectionProps {
   plots: string[];
   selectedPlot: string;
@@ -70,6 +81,12 @@ interface PlotSectionProps {
   importanceData?: ImportanceResponse;
   /** Importance plot data (kind-independent, always default/split). */
   importancePlot?: PlotResponse;
+  /** Issue #457 / P-0105: residuals plot data for the selected kind. */
+  residualsPlot?: PlotResponse;
+  /** Currently selected residuals kind (``"all"`` = legacy 3-panel). */
+  selectedResidualsKind?: string;
+  /** Callback for residuals kind change. */
+  onResidualsKindChange?: (kind: string) => void;
   /**
    * PR-B2 / P-0097: top-N projection for the importance table. `null`
    * means "show all" (no top_n forwarded).
@@ -94,6 +111,9 @@ export function PlotSection({
   onImportanceKindChange,
   importanceData,
   importancePlot,
+  residualsPlot,
+  selectedResidualsKind,
+  onResidualsKindChange,
   importanceTopN,
   onImportanceTopNChange,
 }: PlotSectionProps) {
@@ -109,11 +129,14 @@ export function PlotSection({
   // Resolve which data to display
   const isLearningCurve = selectedPlot === "learning-curve";
   const isImportance = selectedPlot === "importance";
+  const isResiduals = selectedPlot === "residuals";
   const activePlotData = isLearningCurve
     ? learningCurve
     : isImportance
       ? importancePlot
-      : plotData;
+      : isResiduals
+        ? residualsPlot
+        : plotData;
   const chartHeight = isLearningCurve ? 500 : 350;
 
   // Importance: show kind selector when multiple kinds available
@@ -122,6 +145,11 @@ export function PlotSection({
     importanceKinds != null &&
     importanceKinds.length > 1 &&
     onImportanceKindChange != null;
+
+  // Residuals: show the kind selector whenever the residuals tab is
+  // active and a change handler is wired (Issue #457).
+  const showResidualsKind = isResiduals && onResidualsKindChange != null;
+  const residualsKindValue = selectedResidualsKind ?? "all";
 
   // Show LC filter when: on learning curve tab + more than 1 metric available
   const showLcFilter =
@@ -175,6 +203,18 @@ export function PlotSection({
             value={selectedImportanceKind}
             onChange={onImportanceKindChange}
             labels={KIND_LABELS}
+          />
+        </div>
+      )}
+
+      {/* Residuals kind selector (Issue #457) */}
+      {showResidualsKind && (
+        <div className="mb-3">
+          <SegmentGroup
+            options={RESIDUAL_KINDS}
+            value={residualsKindValue}
+            onChange={onResidualsKindChange}
+            labels={RESIDUAL_KIND_LABELS}
           />
         </div>
       )}
@@ -264,7 +304,9 @@ export function PlotSection({
         <DialogContent className="max-h-[90vh] max-w-[90vw]">
           <DialogHeader>
             <DialogTitle>
-              {PLOT_LABELS[selectedPlot] ?? selectedPlot}
+              {isResiduals && residualsKindValue !== "all"
+                ? `Residuals — ${RESIDUAL_KIND_LABELS[residualsKindValue] ?? residualsKindValue}`
+                : (PLOT_LABELS[selectedPlot] ?? selectedPlot)}
             </DialogTitle>
           </DialogHeader>
           {activePlotData && (

--- a/frontend/src/hooks/useJobResultData.test.ts
+++ b/frontend/src/hooks/useJobResultData.test.ts
@@ -262,6 +262,72 @@ describe("useJobResultData", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Residuals (Issue #457 / P-0105)
+  // -------------------------------------------------------------------------
+  it("defaults residualsKind to 'all'", () => {
+    const job = makeJob();
+    const { result } = renderHook(
+      () => useJobResultData({ job, selectedPlot: "" }),
+      { wrapper },
+    );
+    expect(result.current.residualsKind).toBe("all");
+  });
+
+  it("does NOT fetch the residuals plot when residuals is not the active tab", async () => {
+    const job = makeJob();
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["residuals"]);
+    renderHook(() => useJobResultData({ job, selectedPlot: "importance" }), {
+      wrapper,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fetchJobPlot).not.toHaveBeenCalledWith(
+      "j1",
+      "residuals",
+      expect.anything(),
+    );
+  });
+
+  it("fetches the residuals plot with the selected kind when the tab is active", async () => {
+    const job = makeJob();
+    vi.mocked(fetchJobPlots).mockResolvedValueOnce(["residuals"]);
+    const { result } = renderHook(
+      () => useJobResultData({ job, selectedPlot: "residuals" }),
+      { wrapper },
+    );
+    await waitFor(() => {
+      expect(fetchJobPlot).toHaveBeenCalledWith("j1", "residuals", {
+        kind: "all",
+      });
+    });
+    act(() => {
+      result.current.setResidualsKind("scatter");
+    });
+    await waitFor(() => {
+      expect(fetchJobPlot).toHaveBeenCalledWith("j1", "residuals", {
+        kind: "scatter",
+      });
+    });
+  });
+
+  it("resets residualsKind to 'all' when job_id changes", async () => {
+    const job1 = makeJob({ job_id: "j1" });
+    const job2 = makeJob({ job_id: "j2" });
+    vi.mocked(fetchJobPlots).mockResolvedValue(["residuals"]);
+    const { result, rerender } = renderHook(
+      ({ job }) => useJobResultData({ job, selectedPlot: "residuals" }),
+      { wrapper, initialProps: { job: job1 } },
+    );
+    act(() => {
+      result.current.setResidualsKind("qq");
+    });
+    expect(result.current.residualsKind).toBe("qq");
+    rerender({ job: job2 });
+    await waitFor(() => {
+      expect(result.current.residualsKind).toBe("all");
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Tuning plot (H-0070 fallback)
   // -------------------------------------------------------------------------
   it("fetches tuning plot only for tune jobs", async () => {

--- a/frontend/src/hooks/useJobResultData.ts
+++ b/frontend/src/hooks/useJobResultData.ts
@@ -61,6 +61,16 @@ export interface UseJobResultData {
   importancePlot: PlotResponse | undefined;
   isImportancePlotLoading: boolean;
   /**
+   * Issue #457 / P-0105: residuals plot kind state + data. ``"all"`` (the
+   * default) renders the legacy 3-panel layout; ``scatter`` / ``histogram``
+   * / ``qq`` render a single readable panel.
+   */
+  residualsKind: string;
+  setResidualsKind: (kind: string) => void;
+  residualsPlot: PlotResponse | undefined;
+  isResidualsPlotLoading: boolean;
+  isResidualsPlotError: boolean;
+  /**
    * PR-B2 / P-0097: top-N projection state for the importance table.
    * `null` means "show all" (no top_n forwarded). The default of 30
    * keeps the wide-DataFrame UX responsive.
@@ -100,7 +110,8 @@ export function useJobResultData({
     enabled:
       !!selectedPlot &&
       selectedPlot !== "learning-curve" &&
-      selectedPlot !== "importance",
+      selectedPlot !== "importance" &&
+      selectedPlot !== "residuals",
     retry: false,
   });
 
@@ -111,6 +122,10 @@ export function useJobResultData({
   // some metrics through feval callables.)
   // --------------------------------------------------------------------
   const [lcMetric, setLcMetric] = useState<string | null>(null);
+  // Issue #457 / P-0105: residuals plot kind. Declared up here (rather
+  // than in the Residuals section below) so the job-hot-swap reset
+  // effect can call ``setResidualsKind`` without a use-before-define.
+  const [residualsKind, setResidualsKind] = useState("all");
   const lcInitialized = useRef(false);
   const lcEnabled =
     selectedPlot === "learning-curve" &&
@@ -144,6 +159,8 @@ export function useJobResultData({
       lastJobIdRef.current = job.job_id;
       setLcMetric(null);
       lcInitialized.current = false;
+      // Issue #457: a hot-swapped job starts fresh on the 3-panel view.
+      setResidualsKind("all");
     }
   }, [job.job_id]);
 
@@ -220,6 +237,27 @@ export function useJobResultData({
   );
 
   // --------------------------------------------------------------------
+  // Residuals (Issue #457 / P-0105) — split out of the generic plotData
+  // query so the kind selector can refetch per-kind without invalidating
+  // the other plots. Default ``"all"`` preserves the legacy 3-panel view.
+  // (``residualsKind`` state is declared near the top — see comment there.)
+  // --------------------------------------------------------------------
+  const residualsEnabled =
+    selectedPlot === "residuals" && (plots?.includes("residuals") ?? false);
+
+  const {
+    data: residualsPlot,
+    isLoading: isResidualsPlotLoading,
+    isError: isResidualsPlotError,
+  } = useQuery({
+    queryKey: queryKeys.jobPlotResiduals(job.job_id, residualsKind),
+    queryFn: () =>
+      fetchJobPlot(job.job_id, "residuals", { kind: residualsKind }),
+    enabled: residualsEnabled,
+    retry: false,
+  });
+
+  // --------------------------------------------------------------------
   // Split summary + tuning plot
   // --------------------------------------------------------------------
   const { data: splitSummary } = useQuery({
@@ -280,6 +318,11 @@ export function useJobResultData({
     importance,
     importancePlot,
     isImportancePlotLoading,
+    residualsKind,
+    setResidualsKind,
+    residualsPlot,
+    isResidualsPlotLoading,
+    isResidualsPlotError,
     importanceTopN,
     setImportanceTopN,
     splitSummary,

--- a/frontend/tests/e2e/workspace-fit.spec.ts
+++ b/frontend/tests/e2e/workspace-fit.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import * as fs from "node:fs";
+import { setupAndFit, waitForJobDone } from "./helpers/api";
 import {
   isMobileProject,
   openWorkspaceSectionIfMobile,
@@ -507,5 +508,51 @@ test.describe("Workspace Fit Flow", () => {
     // model.params.balanced must NOT be set — that path is silently
     // dropped by lizyml and is the wrong target.
     expect(putBody.model.params?.balanced).toBeUndefined();
+  });
+
+  /**
+   * Issue #457 / P-0105: the Residuals plot (regression jobs only) renders
+   * a kind SegmentGroup (Scatter / Histogram / QQ / All, defaulting to
+   * All). Switching to "scatter" refetches ``/plot/residuals?kind=scatter``.
+   * Set up via the API + ``?job_id=`` deep-link (the
+   * session-restore.spec.ts pattern) since this is a results-panel check,
+   * not a config-write-path check.
+   */
+  test("UI: residuals plot kind selector switches the rendered panel", async ({
+    page,
+    request,
+  }, testInfo) => {
+    test.setTimeout(120_000);
+
+    const csvPath = createTestCsv();
+    const jobId = await setupAndFit(request, csvPath, "target", "regression");
+    const finished = await waitForJobDone(request, jobId);
+    expect(finished.status).toBe("completed");
+
+    await dismissOnboarding(page);
+    await page.goto(`/?job_id=${encodeURIComponent(jobId)}`);
+    await page.waitForLoadState("networkidle");
+    await openWorkspaceSectionIfMobile(page, testInfo, "results");
+    await expect(page.getByText("Completed").first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // The Residuals tab is present for regression jobs (available_plots).
+    await page.getByRole("button", { name: "Residuals" }).click();
+
+    // Kind SegmentGroup: 4 options, "All" selected by default.
+    const scatterRadio = page.getByRole("radio", { name: "Scatter" });
+    await expect(scatterRadio).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole("radio", { name: "All" })).toBeChecked();
+
+    // Switching kind refetches the figure for that kind.
+    const kindResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes("/plot/residuals") &&
+        res.url().includes("kind=scatter"),
+      { timeout: 15_000 },
+    );
+    await scatterRadio.click();
+    expect((await kindResponse).status()).toBe(200);
   });
 });

--- a/src/lizystudio/api/jobs.py
+++ b/src/lizystudio/api/jobs.py
@@ -61,6 +61,11 @@ from lizystudio.ws.progress import ProgressBroadcaster
 
 _MAX_METRICS = 20
 _VALID_PARAM_RE = re.compile(r"^[a-zA-Z0-9_]+$")
+# Issue #457 / P-0105: valid ``?kind=`` values for the residuals plot.
+# Mirrors ``LizyMLEvaluationMixin.RESIDUALS_KINDS`` (and lizyml's
+# ``plot_residuals._VALID_KINDS``); ``tests/test_jobs_api.py`` locks the
+# match so a future lizyml change can't silently desync the API guard.
+_RESIDUALS_KINDS: tuple[str, ...] = ("scatter", "histogram", "qq", "all")
 
 # P-0097: hard cap on the JSON-serialised importance payload. When the
 # unbounded response would exceed this many bytes the route falls back
@@ -506,6 +511,8 @@ def get_job_plot_endpoint(
 
     For ``learning-curve``, pass ``?metrics=auc,f1`` to filter subplots.
     For ``importance``, pass ``?kind=split|gain|shap`` to select kind.
+    For ``residuals``, pass ``?kind=scatter|histogram|qq|all`` to select
+    which panel to render (default ``all`` — the 3-panel layout).
     """
     job = _get_job_or_404(job_id, job_store)
     _require_completed(job)
@@ -529,6 +536,17 @@ def get_job_plot_endpoint(
     if kind is not None and plot_type == "importance":
         if not _VALID_PARAM_RE.match(kind):
             raise StudioError("INVALID_PARAM", f"Invalid kind: {kind!r}", 400)
+        kwargs["kind"] = kind
+    if kind is not None and plot_type == "residuals":
+        # Issue #457: explicit allowlist so an unknown kind surfaces as
+        # 400 INVALID_PARAM rather than a deep lizyml CONFIG_INVALID
+        # (which the generic handler would map to 500).
+        if kind not in _RESIDUALS_KINDS:
+            raise StudioError(
+                "INVALID_PARAM",
+                f"Invalid residuals kind {kind!r}; valid: {list(_RESIDUALS_KINDS)}",
+                400,
+            )
         kwargs["kind"] = kind
     try:
         plot_data = get_job_plot(

--- a/src/lizystudio/backends/lizyml/evaluation_mixin.py
+++ b/src/lizystudio/backends/lizyml/evaluation_mixin.py
@@ -111,6 +111,12 @@ class EvaluationMixin:
         "shap-summary": "importance_plot",
     }
 
+    # Issue #457 / P-0105: valid ``kind`` values for ``residuals_plot``.
+    # Mirrors lizyml ``plot_residuals._VALID_KINDS``; the API layer
+    # validates ``?kind=`` against this set so an invalid value surfaces
+    # as 400 instead of a deep lizyml ``LizyMLError(CONFIG_INVALID)``.
+    RESIDUALS_KINDS: tuple[str, ...] = ("scatter", "histogram", "qq", "all")
+
     def plot(self, model: Any, plot_type: str, **kwargs: Any) -> PlotData:
         method_name = self._PLOT_DISPATCH.get(plot_type)
         if method_name is None:
@@ -121,7 +127,9 @@ class EvaluationMixin:
         call_kwargs: dict[str, Any] = {}
         if plot_type == "learning-curve" and "metrics" in kwargs:
             call_kwargs["metrics"] = kwargs["metrics"]
-        if plot_type == "importance" and "kind" in kwargs:
+        # Issue #457: ``residuals`` accepts ``kind`` in the same way as
+        # ``importance`` — INV-resid-3 limits kind forwarding to these two.
+        if plot_type in ("importance", "residuals") and "kind" in kwargs:
             call_kwargs["kind"] = kwargs["kind"]
         if plot_type == "shap-summary":
             # Force kind="shap" regardless of caller-supplied kwargs;

--- a/tests/test_backends_lizyml.py
+++ b/tests/test_backends_lizyml.py
@@ -1623,6 +1623,45 @@ def test_plot_non_learning_curve_ignores_metrics_kwarg() -> None:
     mock_model.plot_oof_distribution.assert_called_once_with()
 
 
+# --- plot("residuals", kind=...) (Issue #457 / P-0105) ---
+
+
+def test_plot_residuals_forwards_kind() -> None:
+    """plot('residuals', kind=...) forwards the kind to residuals_plot()."""
+    adapter = LizyMLAdapter()
+    for kind in ("scatter", "histogram", "qq", "all"):
+        mock_model = MagicMock()
+        mock_fig = MagicMock()
+        mock_fig.to_json.return_value = '{"data": []}'
+        mock_model.residuals_plot.return_value = mock_fig
+
+        result = adapter.plot(mock_model, "residuals", kind=kind)
+
+        mock_model.residuals_plot.assert_called_once_with(kind=kind)
+        assert isinstance(result, PlotData)
+
+
+def test_plot_residuals_without_kind_calls_no_kwargs() -> None:
+    """plot('residuals') without kind passes no kwargs (lizyml defaults to 'all')."""
+    adapter = LizyMLAdapter()
+    mock_model = MagicMock()
+    mock_fig = MagicMock()
+    mock_fig.to_json.return_value = '{"data": []}'
+    mock_model.residuals_plot.return_value = mock_fig
+
+    adapter.plot(mock_model, "residuals")
+
+    mock_model.residuals_plot.assert_called_once_with()
+
+
+def test_residuals_kinds_constant_matches_lizyml() -> None:
+    """RESIDUALS_KINDS mirrors lizyml ``plot_residuals._VALID_KINDS``."""
+    from lizyml.plots.residuals import _VALID_KINDS
+
+    assert LizyMLAdapter.RESIDUALS_KINDS == ("scatter", "histogram", "qq", "all")
+    assert tuple(LizyMLAdapter.RESIDUALS_KINDS) == tuple(_VALID_KINDS)
+
+
 # --- export_model ---
 
 

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -1137,6 +1137,83 @@ def test_get_job_plot_non_learning_curve_ignores_metrics(
     assert "metrics" not in kwargs
 
 
+# --- Residuals plot kind selector (Issue #457 / P-0105) ---
+
+
+def _mock_plot_backend() -> object:
+    """Build a mock backend whose plot() returns a fake figure."""
+    from unittest.mock import MagicMock
+
+    mock_backend = _make_mock_backend()
+    fake_plot = MagicMock()
+    fake_plot.plotly_json = '{"data":[],"layout":{}}'
+    mock_backend.plot.return_value = fake_plot  # type: ignore[union-attr]
+    return mock_backend
+
+
+def test_get_job_plot_residuals_forwards_kind(
+    client: TestClient, sample_data_ref: DataRef, tmp_path: Path
+) -> None:
+    """GET /api/jobs/{id}/plot/residuals?kind=scatter forwards kind to plot()."""
+    job_id = _create_completed_job_with_model(
+        client, sample_data_ref, str(tmp_path / "model")
+    )
+    mock_backend = _mock_plot_backend()
+    app = client.app  # type: ignore[union-attr]
+    original = app.state.workspace.backend
+    app.state.workspace.backend = mock_backend
+    try:
+        res = client.get(f"/api/jobs/{job_id}/plot/residuals?kind=scatter")
+    finally:
+        app.state.workspace.backend = original
+
+    assert res.status_code == 200
+    _, kwargs = mock_backend.plot.call_args  # type: ignore[union-attr]
+    assert kwargs == {"kind": "scatter"}
+
+
+def test_get_job_plot_residuals_default_no_kind(
+    client: TestClient, sample_data_ref: DataRef, tmp_path: Path
+) -> None:
+    """GET /api/jobs/{id}/plot/residuals (no kind) returns the default figure."""
+    job_id = _create_completed_job_with_model(
+        client, sample_data_ref, str(tmp_path / "model")
+    )
+    mock_backend = _mock_plot_backend()
+    app = client.app  # type: ignore[union-attr]
+    original = app.state.workspace.backend
+    app.state.workspace.backend = mock_backend
+    try:
+        res = client.get(f"/api/jobs/{job_id}/plot/residuals")
+    finally:
+        app.state.workspace.backend = original
+
+    assert res.status_code == 200
+    # No kind kwarg forwarded — lizyml's residuals_plot defaults to "all".
+    _, kwargs = mock_backend.plot.call_args  # type: ignore[union-attr]
+    assert "kind" not in kwargs
+
+
+def test_get_job_plot_residuals_invalid_kind_rejected(
+    client: TestClient, sample_data_ref: DataRef, tmp_path: Path
+) -> None:
+    """GET /api/jobs/{id}/plot/residuals?kind=bogus → 400 INVALID_PARAM."""
+    job_id = _create_completed_job_with_model(
+        client, sample_data_ref, str(tmp_path / "model")
+    )
+    res = client.get(f"/api/jobs/{job_id}/plot/residuals?kind=bogus")
+    assert res.status_code == 400
+    assert res.json()["error"]["code"] == "INVALID_PARAM"
+
+
+def test_residuals_kinds_api_constant_matches_backend() -> None:
+    """jobs._RESIDUALS_KINDS stays in sync with the lizyml backend mixin."""
+    from lizystudio.api.jobs import _RESIDUALS_KINDS
+    from lizystudio.backends.lizyml import LizyMLAdapter
+
+    assert tuple(LizyMLAdapter.RESIDUALS_KINDS) == _RESIDUALS_KINDS
+
+
 # --- Log with content ---
 
 


### PR DESCRIPTION
## Summary

**Wave 4 / Issue #457 / Proposal P-0105.** Mirror the Importance tab's kind-selector UX for the regression **Residuals** plot, so a narrow results panel can render one readable panel at a time instead of squeezing 3 panels horizontally. lizyml already ships `residuals_plot(kind="scatter"|"histogram"|"qq"|"all")` — this PR is the Studio wiring.

This is a public-API surface extension (`?kind=` on the residuals plot path) but **backwards compatible** (omit `kind` → default `"all"` → identical bytes), so it went through the Change Gate — Proposal **P-0105** is the first commit, Decision row marked Approved (issue carries the full spec; user go-ahead given).

### Backend
- `evaluation_mixin.plot()`: forward `kind` for `plot_type == "residuals"` (alongside `importance`). New `EvaluationMixin.RESIDUALS_KINDS` constant mirroring lizyml `plot_residuals._VALID_KINDS`.
- `api/jobs.py`: accept `?kind=` for `residuals`; reject anything outside `_RESIDUALS_KINDS` with `400 INVALID_PARAM` (otherwise a lizyml `CONFIG_INVALID` would map to 500). Endpoint docstring updated. `schema.d.ts` regenerated (description-only diff).

### Frontend
- `useJobResultData`: `residualsKind` state (default `"all"`), `residualsPlot` query split out of the generic `plotData` query (its `enabled` now excludes `residuals`), reset to `"all"` on job hot-swap.
- `queryKeys.jobPlotResiduals(jobId, kind)`.
- `PlotSection`: `RESIDUAL_KINDS` / `RESIDUAL_KIND_LABELS`, a `SegmentGroup` (`Scatter / Histogram / QQ / All`) in the same slot as the Importance kind selector when the residuals tab is active; `Residuals — <Kind>` fullscreen-dialog title for non-`all` kinds.
- `JobResultsBody` wires the new hook fields through.

Default `kind = "all"` preserves the legacy 3-panel layout exactly — existing clients that omit `kind` are unaffected.

### Out of scope
- Inference does not surface residuals (`ResultsWithGT` has no `PlotSection`) — per #457.
- Changing the default away from `"all"`, per-fold breakdown, new kinds beyond lizyml's 4 — per #457.
- `_PREFERRED_METRIC`-style ordering — N/A.

## Docs
- BLUEPRINT.md §5.3 `plot_type` table now lists `?kind=` per plot + the Residuals kind-selector note.
- `docs/plot-matrix.md` updated (residuals `kind` column + source map for `RESIDUAL_KINDS` / `_RESIDUALS_KINDS`).

## Test plan
- [x] backend: `plot("residuals", kind=...)` forwards for all 4 kinds; `RESIDUALS_KINDS` ↔ lizyml `_VALID_KINDS` drift check.
- [x] API: `?kind=scatter` → 200 (forwards kind), no-`kind` → 200 (default, no kwarg), `?kind=bogus` → `400 INVALID_PARAM`; `jobs._RESIDUALS_KINDS` ↔ backend drift check.
- [x] frontend Vitest: `PlotSection` residuals-selector rendering / click / data; `useJobResultData` residuals-kind default / enable / refetch / job-swap reset.
- [x] e2e: `workspace-fit.spec.ts` — regression fit → `?job_id=` deep-link → Residuals tab → switch `all → scatter` refetches `/plot/residuals?kind=scatter`.
- [x] `uv run pytest` (1235 passed) / `uv run ruff check .` / `uv run mypy --no-incremental src/lizystudio/` → clean
- [x] `pnpm test` → all pass (one local WSL2 worker-timeout flake on `CompletedContent.test.tsx`; re-ran it standalone → 30/30 pass; not reproducible on CI)
- [x] `tsc -b` / `biome check src/` / raw-color guard / `pnpm build` → green
- [ ] CI e2e (`workspace-fit` / others) + visual — verified by this PR's CI

## Notes for reviewers
- `EvaluationMixin.RESIDUALS_KINDS` (no underscore) is intentionally public — the API guard and the drift tests reference it.
- The e2e smoke runs a `task=regression` fit on the existing binary-shaped CSV (0/1 target is fine for regression and triggers the Residuals plot path).

Refs #457, P-0105. Closes #457 once merged (manually verified — auto-close is unreliable on this repo).
