### PR TITLE
test(e2e): inference Results panel + Download CSV + multi-task coverage (#443, #444, #448)

### DIFF
--- a/frontend/tests/e2e/inference-coverage.spec.ts
+++ b/frontend/tests/e2e/inference-coverage.spec.ts
@@ -93,8 +93,10 @@ test.describe("Inference coverage (#443/#444/#448)", () => {
     await expect(combo).toBeEnabled({ timeout: 15_000 });
     await combo.click();
     await page.getByRole("listbox").getByRole("option").first().click();
+    // The page auto-selects the latest inference record (#1 for a single
+    // run, #N after N runs) — wait for whichever "Inf #<n>" heading lands.
     await expect(
-      page.getByRole("heading").filter({ hasText: /Inf\s*#1/ }),
+      page.getByRole("heading").filter({ hasText: /Inf\s*#\d/ }).first(),
     ).toBeVisible({ timeout: 15_000 });
   }
 

--- a/frontend/tests/e2e/inference-coverage.spec.ts
+++ b/frontend/tests/e2e/inference-coverage.spec.ts
@@ -1,0 +1,215 @@
+/**
+ * Inference Results panel + Download CSV + multi-task coverage.
+ *
+ * Closes the E2E gaps tracked by:
+ *   - #443: Download CSV button on a completed inference.
+ *   - #444: Results-panel UI elements (Predictions table, Plots, Comparison).
+ *   - #448: non-binary tasks (multiclass / regression) drive
+ *           fit → inference → results-render without crashing.
+ *
+ * (#447 — the inference concurrent-run / cancel guard — is out of scope:
+ * ``POST /api/inference/run`` is synchronous and stateless; there is no
+ * long-running inference state, no cancel endpoint, and no running-lock
+ * window to conflict over. The Issue is closed as not-applicable.)
+ *
+ * All scenarios run against the real backend (no MSW) so a backend
+ * response-shape change surfaces here, not just in subcomponent unit tests.
+ */
+
+import { expect, test } from "@playwright/test";
+import { randomBytes } from "node:crypto";
+import * as fs from "node:fs";
+import { API, createTestCsv, setupAndFit, waitForJobDone } from "./helpers/api";
+import { dismissOnboarding } from "./helpers/onboarding";
+
+const RUN_TAG = randomBytes(4).toString("hex");
+const tmp = (label: string) => `/tmp/e2e_inf_${RUN_TAG}_${label}.csv`;
+
+/** Write a CSV with a 3-class target column (for the multiclass loop). */
+function createMulticlassCsv(rows: number, filename: string): string {
+  const lines = ["id,age,income,target"];
+  for (let i = 0; i < rows; i++) {
+    lines.push(`${i},${20 + (i % 50)},${30000 + i * 100},class${i % 3}`);
+  }
+  fs.writeFileSync(filename, lines.join("\n"));
+  return filename;
+}
+
+/** Write a CSV with a continuous target column (for the regression loop). */
+function createRegressionCsv(rows: number, filename: string): string {
+  const lines = ["id,age,income,target"];
+  for (let i = 0; i < rows; i++) {
+    const target = (i * 1.7 + (i % 7) - 3).toFixed(3);
+    lines.push(`${i},${20 + (i % 50)},${30000 + i * 100},${target}`);
+  }
+  fs.writeFileSync(filename, lines.join("\n"));
+  return filename;
+}
+
+const TASK_FIXTURES: {
+  task: "binary" | "multiclass" | "regression";
+  makeCsv: (label: string) => string;
+}[] = [
+  { task: "binary", makeCsv: (l) => createTestCsv(120, tmp(l)) },
+  { task: "multiclass", makeCsv: (l) => createMulticlassCsv(120, tmp(l)) },
+  { task: "regression", makeCsv: (l) => createRegressionCsv(120, tmp(l)) },
+];
+
+test.describe("Inference coverage (#443/#444/#448)", () => {
+  test.beforeEach(async ({ request }) => {
+    await request.post(`${API}/workspace/reset`);
+  });
+
+  async function runInference(
+    request: import("@playwright/test").APIRequestContext,
+    jobId: string,
+    csvPath: string,
+    evaluate: boolean,
+  ): Promise<string> {
+    const res = await request.post(`${API}/inference/run`, {
+      data: {
+        job_id: jobId,
+        data: { source_type: "path", path: csvPath },
+        return_shap: false,
+        evaluate,
+      },
+    });
+    expect(
+      res.status(),
+      `POST /inference/run must succeed (got ${res.status()}): ${await res.text()}`,
+    ).toBe(200);
+    return (await res.json()).inf_id as string;
+  }
+
+  /** Navigate to /inference, pick the most recent completed job → its
+   * latest inference record auto-renders in the right panel. */
+  async function openLatestInferenceResult(
+    page: import("@playwright/test").Page,
+  ): Promise<void> {
+    await dismissOnboarding(page);
+    await page.goto("/inference");
+    await page.waitForLoadState("networkidle");
+    const combo = page.getByRole("combobox", { name: "Select completed job" });
+    await expect(combo).toBeEnabled({ timeout: 15_000 });
+    await combo.click();
+    await page.getByRole("listbox").getByRole("option").first().click();
+    await expect(
+      page.getByRole("heading").filter({ hasText: /Inf\s*#1/ }),
+    ).toBeVisible({ timeout: 15_000 });
+  }
+
+  test("UI: labelled inference results panel renders Plots + Predictions table + Download CSV (#443/#444)", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(180_000);
+    const csvPath = createTestCsv(120, tmp("labelled"));
+    const jobId = await setupAndFit(request, csvPath, "target", "binary");
+    await waitForJobDone(request, jobId);
+    await runInference(request, jobId, csvPath, true);
+
+    await openLatestInferenceResult(page);
+
+    // Plots section (binary fit always exposes ≥1 plot type).
+    await expect(
+      page.getByRole("heading", { name: "Plots" }),
+    ).toBeVisible();
+
+    // Predictions accordion → table + Download CSV link.
+    await page.getByRole("button", { name: "Predictions" }).click();
+    await expect(page.getByRole("table").first()).toBeVisible({
+      timeout: 10_000,
+    });
+    const downloadLink = page.getByRole("link", { name: /Download CSV/i });
+    await expect(downloadLink).toBeVisible();
+    await expect(downloadLink).toHaveAttribute("href", /\/download\?job_id=/);
+  });
+
+  test("UI: unlabelled inference results panel renders Predictions heading + table (#444)", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(180_000);
+    const csvPath = createTestCsv(120, tmp("unlabelled"));
+    const jobId = await setupAndFit(request, csvPath, "target", "binary");
+    await waitForJobDone(request, jobId);
+    await runInference(request, jobId, csvPath, false);
+
+    await openLatestInferenceResult(page);
+
+    await expect(
+      page.getByRole("heading", { name: "Predictions" }),
+    ).toBeVisible();
+    await expect(page.getByRole("table").first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test("UI: Download CSV button on a completed inference triggers a CSV download (#443)", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(180_000);
+    const csvPath = createTestCsv(120, tmp("dl"));
+    const jobId = await setupAndFit(request, csvPath, "target", "binary");
+    await waitForJobDone(request, jobId);
+    await runInference(request, jobId, csvPath, false);
+
+    await openLatestInferenceResult(page);
+    await expect(page.getByRole("table").first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const dlPromise = page.waitForEvent("download");
+    await page.getByRole("link", { name: /Download CSV/i }).click();
+    const dl = await dlPromise;
+    expect(dl.suggestedFilename()).toMatch(/\.csv$/i);
+  });
+
+  test("UI: Comparison panel appears after a 2nd inference on the same job (#444)", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(180_000);
+    const csvPath = createTestCsv(120, tmp("cmp"));
+    const jobId = await setupAndFit(request, csvPath, "target", "binary");
+    await waitForJobDone(request, jobId);
+    await runInference(request, jobId, csvPath, false);
+    await runInference(request, jobId, csvPath, false);
+
+    await openLatestInferenceResult(page);
+
+    // The latest record (#2) is auto-selected; with a 2nd record in
+    // history, ResultsPredOnly renders the Comparison section.
+    await expect(
+      page.getByRole("heading", { name: "Comparison" }),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  // #448: every task drives fit → inference → results-render without a crash.
+  for (const fixture of TASK_FIXTURES) {
+    test(`UI: ${fixture.task} inference renders the results panel (#448)`, async ({
+      page,
+      request,
+    }) => {
+      test.setTimeout(180_000);
+      const csvPath = fixture.makeCsv(`task_${fixture.task}`);
+      const jobId = await setupAndFit(
+        request,
+        csvPath,
+        "target",
+        fixture.task,
+      );
+      await waitForJobDone(request, jobId);
+      await runInference(request, jobId, csvPath, false);
+
+      await openLatestInferenceResult(page);
+      await expect(
+        page.getByRole("heading", { name: "Predictions" }),
+      ).toBeVisible();
+      await expect(page.getByRole("table").first()).toBeVisible({
+        timeout: 10_000,
+      });
+    });
+  }
+});


### PR DESCRIPTION
Wave 5.1 — closes the inference E2E coverage gaps.

## What

New `frontend/tests/e2e/inference-coverage.spec.ts` (7 scenarios, real backend — no MSW so a response-shape change surfaces here):

| Scenario | Issue |
|---|---|
| labelled inference: Plots section + Predictions accordion -> table + Download CSV link (`/download?job_id=` href) | #443 / #444 |
| unlabelled inference: Predictions heading + Predictions table | #444 |
| Download CSV button click fires a `download` event for a `.csv` file | #443 |
| 2nd inference on the same job -> Comparison section appears | #444 |
| fixture-driven loop `task in {binary, multiclass, regression}`: fit -> inference -> results-render | #448 |

## #447 closed as not-applicable

`POST /api/inference/run` is synchronous and stateless — it loads the completed model, predicts, persists the record, and returns it in one request handler. There is no long-running inference state, no cancel endpoint, and no running-lock window for a 2nd run to conflict over. So the `409` / cancel premise of #447 doesn't apply; if a future async-inference design lands, a running-lock test follows then. Closed with that rationale.

## Out of scope / deferred

- `Prediction Distribution` section assertion: that section gates on `probability-histogram` being available, which requires a *calibrated* binary fit (not the default). Asserting it would mean a bespoke calibrated-fit setup; left for a follow-up if needed.
- `Score` section assertion: gated on the inference metrics payload having `inf/is/oos` keys; not asserted to avoid coupling to that shape. `Plots` (always present for a binary fit) is asserted instead.

## Test plan

- [x] `playwright test inference-coverage.spec.ts --list` parses (21 = 7 × 3 projects).
- [ ] CI `e2e-chromium` runs the 7 chromium scenarios green — verified by this PR's CI.

Test-only; no production code touched. Refs #443, #444, #448; closes #447 (not-applicable).