### PR TITLE
test(backend): INV-5 queue-full eviction + INV-1 multi-paused reconcile coverage (#449, #450)

### DIFF
--- a/tests/regression/test_inv_startup_reconcile.py
+++ b/tests/regression/test_inv_startup_reconcile.py
@@ -279,3 +279,75 @@ def test_reconcile_at_startup_is_idempotent(fresh_store: JobStore) -> None:
     assert reborn.active_job_id == paused.job_id
     assert reborn.get(completed.job_id) is not None
     assert reborn.get(completed.job_id).status == "completed"  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# Issue #450 — INV-1 multi-paused reconcile branch (services/jobs.py:768-789).
+# The existing ``test_reconcile_at_startup_multiple_paused_keeps_newest_only``
+# above hits the branch for two paused jobs but does not assert the failed
+# rows' error text / ``completed_at`` nor exercise non-monotonic timestamps
+# (the ``sort(key=created_at)`` vs. insertion-order distinction).
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_at_startup_two_paused_loser_carries_inv1_error(
+    fresh_store: JobStore,
+) -> None:
+    older = _create_with_status(fresh_store, "paused")
+    newer = _create_with_status(fresh_store, "paused")
+    assert newer.created_at >= older.created_at
+
+    reborn = JobStore(fresh_store.jobs_dir)
+    reborn.reconcile_at_startup()
+
+    loser = reborn.get(older.job_id)
+    assert loser is not None
+    assert loser.status == "failed"
+    assert "only the newest" in (loser.error or ""), loser.error
+    assert loser.completed_at is not None
+    # The survivor keeps a clean record (no error / completed_at written).
+    survivor = reborn.get(newer.job_id)
+    assert survivor is not None and survivor.status == "paused"
+
+
+def test_reconcile_at_startup_three_paused_picks_latest_timestamp_not_insertion_order(
+    fresh_store: JobStore,
+) -> None:
+    """Three paused jobs whose ``created_at`` order is the *reverse* of
+    their creation order — reconciliation must keep the one with the
+    newest ``created_at`` (the sort key), not the last-created one.
+    """
+    j_a = _create_with_status(fresh_store, "paused")  # created 1st
+    j_b = _create_with_status(fresh_store, "paused")  # created 2nd
+    j_c = _create_with_status(fresh_store, "paused")  # created 3rd
+    # Timestamp them in reverse: j_a newest, j_c oldest.
+    j_a.created_at = "2026-05-03T00:00:00+00:00"
+    j_b.created_at = "2026-05-02T00:00:00+00:00"
+    j_c.created_at = "2026-05-01T00:00:00+00:00"
+    for j in (j_a, j_b, j_c):
+        fresh_store.update(j)
+
+    reborn = JobStore(fresh_store.jobs_dir)
+    reborn.reconcile_at_startup()
+
+    jobs = reborn.list()
+    paused = [j for j in jobs if j.status == "paused"]
+    failed = [j for j in jobs if j.status == "failed"]
+    assert len(paused) == 1
+    assert paused[0].job_id == j_a.job_id  # newest created_at, not last-created
+    assert {j.job_id for j in failed} == {j_b.job_id, j_c.job_id}
+    for j in failed:
+        assert "only the newest" in (j.error or ""), j.error
+        assert j.completed_at is not None
+    # The surviving paused job holds the active slot (INV-1).
+    assert reborn.active_job_id == j_a.job_id
+
+    # On-disk state matches the in-memory reconciliation (a 2nd fresh
+    # JobStore re-reads meta.json from scratch).
+    reread = JobStore(fresh_store.jobs_dir)
+    survivor = reread.get(j_a.job_id)
+    loser_b = reread.get(j_b.job_id)
+    loser_c = reread.get(j_c.job_id)
+    assert survivor is not None and survivor.status == "paused"
+    assert loser_b is not None and loser_b.status == "failed"
+    assert loser_c is not None and loser_c.status == "failed"

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -703,3 +703,94 @@ class TestTerminalReplay:
         ):
             b = ProgressBroadcaster()
         assert b._terminal_ttl_s == pytest.approx(12.5)
+
+
+class TestQueueFullEviction:
+    """Issue #449 — INV-5 defense: the terminal-eviction-on-queue-full
+    path in ``ProgressBroadcaster._enqueue`` (a queued terminal message is
+    NEVER dropped to make room for another message).
+
+    ``_enqueue`` is synchronous (it runs on the event-loop thread via
+    ``call_soon_threadsafe``), so the tests call it directly against a
+    hand-built ``asyncio.Queue`` with a tiny ``maxsize`` — no running
+    loop required. ``asyncio.Queue.put_nowait`` / ``get_nowait`` work
+    purely on the internal deque.
+    """
+
+    @staticmethod
+    def _drain(q: asyncio.Queue[dict[str, Any]]) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        while not q.empty():
+            out.append(q.get_nowait())
+        return out
+
+    def test_terminal_evicts_oldest_nonterminal_when_queue_full(self) -> None:
+        metrics = MagicMock()
+        b = ProgressBroadcaster(metrics=metrics)
+        q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=2)
+        b._enqueue(q, {"type": "progress", "step": 1}, False)
+        b._enqueue(q, {"type": "progress", "step": 2}, False)
+        assert q.full()
+
+        # A terminal arriving on a full-of-non-terminals queue evicts the
+        # head non-terminal and takes its slot.
+        b._enqueue(q, {"type": "completed", "result": "ok"}, True)
+
+        drained = self._drain(q)
+        assert {"type": "completed", "result": "ok"} in drained
+        # Exactly one non-terminal survives — the newer one (step 2).
+        nonterminals = [m for m in drained if m["type"] == "progress"]
+        assert nonterminals == [{"type": "progress", "step": 2}]
+        # The drop was recorded so production back-pressure is observable.
+        metrics.progress_dropped_total.inc.assert_called_once()
+
+    def test_terminal_preserved_when_eviction_loop_passes_through_it(self) -> None:
+        """Queue head is a terminal followed by a non-terminal; the new
+        terminal must keep the existing terminal and evict the non-terminal.
+        """
+        b = ProgressBroadcaster(metrics=MagicMock())
+        q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=2)
+        b._enqueue(q, {"type": "completed", "id": 1}, True)
+        b._enqueue(q, {"type": "progress", "id": 2}, False)
+        assert q.full()
+
+        b._enqueue(q, {"type": "error", "id": 3}, True)
+
+        drained = self._drain(q)
+        # FIFO order preserved: old terminal first, new terminal second.
+        assert [m["type"] for m in drained] == ["completed", "error"]
+        # The non-terminal is gone.
+        assert all(m["type"] != "progress" for m in drained)
+
+    def test_new_terminal_dropped_when_queue_full_of_terminals(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        b = ProgressBroadcaster(metrics=MagicMock())
+        q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=2)
+        b._enqueue(q, {"type": "completed", "id": 1}, True)
+        b._enqueue(q, {"type": "completed", "id": 2}, True)
+        assert q.full()
+
+        with caplog.at_level("WARNING"):
+            b._enqueue(q, {"type": "error", "id": 3}, True)
+
+        # The two existing terminals are preserved; the new one is dropped.
+        drained = self._drain(q)
+        assert {m["id"] for m in drained} == {1, 2}
+        assert any(
+            "queue full of terminals" in r.getMessage() for r in caplog.records
+        ), caplog.text
+
+    def test_nonterminal_dropped_silently_when_queue_full(self) -> None:
+        metrics = MagicMock()
+        b = ProgressBroadcaster(metrics=metrics)
+        q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=1)
+        b._enqueue(q, {"type": "progress", "id": 1}, False)
+        assert q.full()
+
+        # Non-terminal on a full queue: dropped silently, metric bumped.
+        b._enqueue(q, {"type": "progress", "id": 2}, False)
+
+        assert q.qsize() == 1
+        assert q.get_nowait()["id"] == 1
+        metrics.progress_dropped_total.inc.assert_called_once()


### PR DESCRIPTION
Wave 5.3 — fills the backend invariant-defense coverage gaps. Test-only; no production code touched.

## #449 — `ws/progress.py` terminal-eviction-on-queue-full (INV-5)

`ProgressBroadcaster._enqueue` lines 222-276 implement INV-5 — *a terminal message already queued is NEVER dropped to make room*. The entire eviction loop / preserved-terminals re-enqueue / "queue full of terminals" warning branch were uncovered. New `TestQueueFullEviction` (4 cases) calls `_enqueue` directly against a tiny-`maxsize` `asyncio.Queue` — it is synchronous (runs on the loop thread via `call_soon_threadsafe`), so no running loop is needed:

- terminal on a full-of-non-terminals queue → head non-terminal evicted, `progress_dropped_total` bumped, terminal queued;
- queue head is a terminal followed by a non-terminal → new terminal keeps the existing terminal (FIFO: old terminal first, new terminal second) and evicts the non-terminal;
- queue full of terminals → new terminal dropped with a `WARNING` log (asserted via `caplog`);
- non-terminal on a full queue → dropped silently, metric bumped.

## #450 — `services/jobs.py:768-789` multi-paused reconcile (INV-1)

The `len(paused_candidates) > 1` branch of `reconcile_at_startup` (INV-1: at most one paused job). There is already a `test_reconcile_at_startup_multiple_paused_keeps_newest_only` covering the two-paused case, but it does not assert the loser's error text / `completed_at` nor exercise non-monotonic timestamps. Two new regression tests:

- `...two_paused_loser_carries_inv1_error`: the failed loser carries the INV-1 "only the newest" error + `completed_at`; the survivor keeps a clean record;
- `...three_paused_picks_latest_timestamp_not_insertion_order`: three paused jobs whose `created_at` order is the *reverse* of their creation order → reconciliation keeps the newest-by-`created_at` one (the sort key), not the last-created one; the surviving job holds the active slot; and the on-disk `meta.json` state matches the in-memory reconciliation (verified by a 2nd fresh `JobStore` re-reading from disk).

## Test plan

- [x] `uv run pytest tests/test_progress.py tests/regression/test_inv_startup_reconcile.py` → 45 passed
- [x] `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/integration --ignore=tests/bench -k 'not slow'` → 1493 passed
- [x] `uv run ruff check` / `ruff format --check` → clean

Refs #449, #450.