### PR TITLE
chore(ops): tmp/ convention + block-stray-artifacts pre-commit hook (#456 L1+L2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ src/lizystudio/static/
 .DS_Store
 Thumbs.db
 
+# Working artefacts — spike outputs, debug dumps, audit scratch, one-off scripts
+# (convention: put all such files under tmp/ — see CONTRIBUTING.md § Working artefacts)
+tmp/
+
 # Data
 *.csv
 !tests/fixtures/**/*.csv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,10 @@ repos:
         language: system
         files: ^frontend/src/.*\.(ts|tsx)$
         pass_filenames: false
+
+      - id: block-stray-artifacts
+        name: block stray artefacts
+        entry: scripts/check_stray.sh
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,8 +94,22 @@ pnpm test:e2e                       # Playwright
 
 ## Pre-commit hooks
 
-Pre-commit hooks run Ruff and Biome automatically on every commit.
-If a hook fails, fix the issue and commit again — do **not** bypass with `--no-verify`.
+Pre-commit hooks run on every commit:
+
+- **ruff / ruff-format** — Python lint + format (auto-fix)
+- **biome check** — TypeScript lint + format (`frontend/src/**`)
+- **block-stray-artifacts** ([`scripts/check_stray.sh`](scripts/check_stray.sh)) —
+  fails the commit if the staged set contains scratch/build artefacts
+  (root-level `*.png` / `*.csv` / `*.parquet`, `coverage.json` / `.coverage`,
+  `dist/*.whl` / `dist/*.tar.gz`, `*.tsbuildinfo`). These belong under `tmp/`
+  (see [Working artefacts](#working-artefacts)). Allowed exceptions:
+  `docs/images/*.png`, `tests/fixtures/**`, `frontend/src/__fixtures__/**`,
+  `frontend/tests/e2e/__screenshots__/**`, `data/**`.
+
+If a hook fails, fix the issue and commit again — do **not** bypass with
+`--no-verify`. The one legitimate `--no-verify` case is intentionally adding a
+file `block-stray-artifacts` flags (e.g. a new doc image outside `docs/images/`);
+explain why in the commit body.
 
 ## Quality gates (CI)
 
@@ -159,6 +173,28 @@ frontend/src/
 ├── pages/        # Page-level components
 └── lib/          # Shared utilities
 ```
+
+## Working artefacts
+
+Spike outputs, debug screenshots, ad-hoc dumps, and one-off audit scripts go
+under **`tmp/`** — never the repo root and never a tracked directory. `tmp/`
+is gitignored, so anything you drop there cannot accidentally end up in a
+commit.
+
+- Visual / Playwright spikes: write screenshots to `tmp/screenshots/`
+- Throwaway scripts and CSV/JSON dumps: `tmp/`
+- Local coverage / profiling output: `tmp/` (the canonical `pytest --cov` run
+  in CI writes its own; you do not need a tracked copy)
+
+This keeps `ls` on the repo root meaningful and stops generations of build
+artefacts (`dist/*.dev401`, `dist/*.dev439`, …) from co-residing. A
+`block-stray-artifacts` pre-commit hook (see [Pre-commit hooks](#pre-commit-hooks))
+is the tripwire if you `git add` something that bypasses `.gitignore`; the
+`tmp/` convention is the habit that keeps the tripwire from ever firing.
+
+> Need the file in the repo? It is probably a fixture (`tests/fixtures/**`,
+> `frontend/src/__fixtures__/**`) or a doc image (`docs/images/*.png`) — those
+> locations are explicitly un-ignored. Everything else is scratch.
 
 ## Documentation language
 

--- a/scripts/check_stray.sh
+++ b/scripts/check_stray.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# block-stray-artifacts — pre-commit tripwire for accidentally staged scratch files.
+#
+# Most artefact patterns below are already covered by .gitignore, but `git add -f`
+# / `git add .` from an unexpected cwd / a future .gitignore edit can let one
+# through. This hook fails the commit when the *staged* set contains files that
+# look like spike output, coverage dumps, or build artefacts.
+#
+# Allowed exceptions (intentional, tracked):
+#   - docs/images/*.png            doc illustrations
+#   - tests/fixtures/**            backend production-artefact fixtures (any ext)
+#   - frontend/src/__fixtures__/** frontend fixtures
+#   - frontend/tests/e2e/__screenshots__/**  Playwright visual goldens
+#   - data/**                      analysis data dir (its own .gitignore rules)
+#
+# Override (rare, document the reason in the commit body): `git commit --no-verify`.
+#
+# Exit 0 = clean, 1 = stray file staged.
+set -euo pipefail
+
+staged="$(git diff --cached --name-only --diff-filter=AM)"
+[ -z "$staged" ] && exit 0
+
+bad=""
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  case "$f" in
+    # explicitly-allowed locations — skip
+    docs/images/*.png) continue ;;
+    tests/fixtures/*) continue ;;
+    frontend/src/__fixtures__/*) continue ;;
+    frontend/tests/e2e/__screenshots__/*) continue ;;
+    data/*) continue ;;
+  esac
+  case "$f" in
+    # root-level data/image artefacts (no slash in path => repo root)
+    *.png|*.csv|*.parquet)
+      case "$f" in */*) ;; *) bad="$bad $f" ;; esac ;;
+    # coverage dumps, anywhere
+    coverage.json|.coverage|*/coverage.json|*/.coverage) bad="$bad $f" ;;
+    # build artefacts
+    dist/*.whl|dist/*.tar.gz|*/dist/*.whl|*/dist/*.tar.gz) bad="$bad $f" ;;
+    # TypeScript incremental build info
+    *.tsbuildinfo) bad="$bad $f" ;;
+  esac
+done <<< "$staged"
+
+if [ -n "$bad" ]; then
+  echo "block-stray-artifacts: refusing to commit scratch/build artefacts:" >&2
+  for f in $bad; do echo "  - $f" >&2; done
+  echo >&2
+  echo "These belong under tmp/ (gitignored) — see CONTRIBUTING.md § Working artefacts." >&2
+  echo "If this file is genuinely intended for the repo, re-run with: git commit --no-verify" >&2
+  echo "(and explain why in the commit body)." >&2
+  exit 1
+fi
+exit 0

--- a/tests/test_check_stray.py
+++ b/tests/test_check_stray.py
@@ -1,0 +1,95 @@
+"""Tests for scripts/check_stray.sh (block-stray-artifacts pre-commit hook).
+
+The hook reads ``git diff --cached`` and exits non-zero when the staged set
+contains scratch/build artefacts. These tests build a throwaway git repo,
+stage representative files with ``git add -f`` (mirroring the bypass the hook
+exists to catch), and assert the exit code.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_stray.sh"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A minimal git repo with one committed file."""
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-q")
+    _git(r, "config", "user.email", "test@example.com")
+    _git(r, "config", "user.name", "test")
+    (r / "README.md").write_text("hello\n")
+    _git(r, "add", "README.md")
+    _git(r, "commit", "-qm", "init")
+    return r
+
+
+def _run_hook(repo: Path) -> int:
+    return subprocess.run(
+        ["bash", str(SCRIPT)], cwd=repo, capture_output=True
+    ).returncode
+
+
+def _stage(repo: Path, rel: str) -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"")
+    _git(repo, "add", "-f", rel)
+
+
+@pytest.mark.parametrize(
+    "rel",
+    [
+        "dist/lizystudio-9.9.9-py3-none-any.whl",
+        "dist/lizystudio-9.9.9.tar.gz",
+        "spike-debug.png",  # root-level PNG
+        "scratch.csv",  # root-level CSV
+        "out.parquet",  # root-level parquet
+        "coverage.json",
+        ".coverage",
+        "subpkg/coverage.json",
+        "build.tsbuildinfo",
+    ],
+)
+def test_blocks_stray_artifact(repo: Path, rel: str) -> None:
+    _stage(repo, rel)
+    assert _run_hook(repo) == 1, f"expected {rel} to be blocked"
+
+
+@pytest.mark.parametrize(
+    "rel",
+    [
+        "docs/images/diagram.png",
+        "tests/fixtures/lizyml/scenario/fit_result.json",
+        "tests/fixtures/sample.csv",
+        "frontend/src/__fixtures__/lizyml/fit.json",
+        "frontend/tests/e2e/__screenshots__/chromium/visual/x.png",
+        "data/demo/train.csv",
+        "src/lizystudio/api/new_router.py",
+        "docs/some-note.md",
+        "nested/dir/module.png",  # PNG but not at repo root → allowed by this hook
+    ],
+)
+def test_allows_legit_file(repo: Path, rel: str) -> None:
+    _stage(repo, rel)
+    assert _run_hook(repo) == 0, f"expected {rel} to be allowed"
+
+
+def test_clean_index_passes(repo: Path) -> None:
+    assert _run_hook(repo) == 0
+
+
+def test_blocks_only_offending_file_in_mixed_stage(repo: Path) -> None:
+    _stage(repo, "src/lizystudio/ok.py")
+    _stage(repo, "dist/bad-1.0.0-py3-none-any.whl")
+    assert _run_hook(repo) == 1


### PR DESCRIPTION
## Summary

Wave 6 / Issue #456 — implements layers **L1** (`tmp/` convention) and **L2** (`block-stray-artifacts` pre-commit hook). Per the issue, L1+L2 alone cover 100% of the 14 stray artefacts cleaned in the #454 / #455 audit; they are the minimum-viable set.

### L1 — `tmp/` convention
- `.gitignore`: ignore `tmp/` (spike outputs, debug dumps, audit scratch, one-off scripts)
- `CONTRIBUTING.md`: new **Working artefacts** section directing all such files under `tmp/`, with a pointer to the fixture / doc-image locations that are explicitly un-ignored

### L2 — `block-stray-artifacts` pre-commit hook
- `scripts/check_stray.sh`: reads `git diff --cached` and exits 1 when the staged set contains:
  - root-level `*.png` / `*.csv` / `*.parquet`
  - `coverage.json` / `.coverage` (any path)
  - `dist/*.whl` / `dist/*.tar.gz`
  - `*.tsbuildinfo`
  - Allowed exceptions: `docs/images/*.png`, `tests/fixtures/**`, `frontend/src/__fixtures__/**`, `frontend/tests/e2e/__screenshots__/**`, `data/**`
  - Override: `git commit --no-verify` (document why in the commit body)
- `.pre-commit-config.yaml`: registered as a `local` hook (`pass_filenames: false`, `always_run: true`)
- `CONTRIBUTING.md`: documents the hook + the one legitimate `--no-verify` case
- `tests/test_check_stray.py`: 20 cases — blocked artefacts (9), allowed fixtures/doc-images/source (9), clean index, mixed stage

## Out of scope (follow-up, tracked in #456)
- **L3** — orphan-visual-golden CI gate (`ci.yml` step). Cheap; next.
- **L4** — `rm -rf dist/` before `uv build` in `publish.yml`. One line.
- **L5** — weekly stale-doc audit cron. Issue notes this is deferrable (adds CI minutes).
- `.claude/AGENTS.md` and the `visual-feedback` skill update from the L1 checklist: `.claude/` is gitignored, so those changes are local-only and not part of this PR. The trackable enforcement that travels with the repo is `.gitignore` + `CONTRIBUTING.md` + the L2 hook.

## Test plan
- [x] `uv run pytest tests/test_check_stray.py -q` -> 20 passed
- [x] `uv run ruff check . && uv run ruff format --check .` -> clean
- [x] `uv run mypy src/lizystudio/` -> clean (55 files)
- [x] Manual: staging a dist wheel via `git add -f` -> hook blocks; staging `docs/images/x.png` -> hook passes
- [x] Pre-commit ran `block stray artefacts` on this very commit -> Passed
- [ ] CI green

Refs #456 (stays open until L3/L4 and L5-or-its-deferral land).
