### PR TITLE
refactor(backend): move metric-compat watchlist behind BackendCore (#403, P-0106)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -96,6 +96,15 @@ class ConfigSchema:
     """Config の JSON Schema。フォーム生成用。"""
     json_schema: dict[str, Any]        # JSON Schema形式
 
+@dataclass(frozen=True)
+class IncompatibleMetric:
+    """設定済みメトリクスのうち、ロード済み target 列が前提条件を満たさないものの advisory（P-0106）。
+    suggested_fix はバックエンド固有の代替を指してよい（lizyml: MAPE→sMAPE/WAPE 等）。
+    Service 層が severity="warning" envelope に包む（Fit は止めない）。"""
+    metric: str                        # メトリクス名 ("mape" 等)
+    message: str                       # 警告文（target 列名を含む）
+    suggested_fix: str                 # 修正案
+
 @dataclass
 class FitSummary:
     """学習結果のサマリー。"""
@@ -172,6 +181,11 @@ class BackendCore(Protocol):
     # --- Config ---
     def get_config_schema(self) -> ConfigSchema: ...
     def validate_config(self, config: dict[str, Any]) -> list[dict[str, Any]]: ...  # エラー一覧 (空=valid)
+    def get_incompatible_metrics(                                                    # P-0106 (#403)
+        self, task: str, target_series: pd.Series, metric_names: set[str]
+    ) -> list[IncompatibleMetric]: ...
+        # task/target 前提条件に反する設定済みメトリクスの advisory（watchlist と suggested_fix prose は backend 所有）。
+        # デフォルトは [] — 実装しない backend は不適合メトリクスを宣言しない。Service が severity="warning" に包む。
     def get_default_config(self, task: str, target: str) -> dict[str, Any]: ...  # H-0025
     def load_config_from_file(self, content: bytes, filename: str) -> dict[str, Any]: ...
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3789,3 +3789,69 @@ regression Fit 結果の Residuals plot は現在「1 figure に 3 panel（Actua
 #### Decision
 
 - 2026-05-11 **Approved** — Issue #457 の詳細仕様（target shape 1-5）+ UI spec をそのまま採用。実装は単一 PR（Proposal commit → 実装 commit）。`shap-summary` を top-level タブに昇格する件（#373）とは独立。
+
+### P-0106: metric 不適合判定を `BackendCore` capability の裏へ移す（Change Gate、Issue #403）
+
+- **Date:** 2026-05-12 起票・即承認（Issue #403 で詳細仕様確定済 + ユーザ go-ahead）
+- **Related:** Issue #403（v0.4.1 pre-release code review HIGH-2 follow-up）、`src/lizystudio/backends/base.py::BackendCore`、`src/lizystudio/backends/types.py::IncompatibleMetric`、`src/lizystudio/backends/lizyml/config_mixin.py::ConfigMixin.get_incompatible_metrics`、`src/lizystudio/services/workspace.py::_workspace_metric_compatibility_errors`、`tests/test_backends_lizyml.py::TestGetIncompatibleMetrics`、`tests/contract/test_validate_metric_compatibility.py`、`tests/contract/test_fit_tune_severity_filter.py`、BLUEPRINT.md §3（backend abstraction）、`docs/coupling-analysis.md`、PR #399（validator 導入 = PR-C2 / Issue #394）/ PR #400（severity gating = PR-D1）
+
+#### Motivation
+
+`Service.validate_config` が呼ぶ `_workspace_metric_compatibility_errors`（PR #399 で導入）は lizyml 固有の regression metric 名（`mape` / `rmsle` / `r2`）の前提条件チェックと、lizyml 0.11.0 の sMAPE / WAPE を指す `suggested_fix` prose を **Service 層に直書き**していた。さらに「`task=regression` のときだけチェックする」という gate も Service 層にあり、これも lizyml の metric 語彙への暗黙の coupling。BLUEPRINT §3 の「Service 層は backend-agnostic、per-backend ロジックは `BackendAdapter` に委譲」に反するドリフトで、2nd backend（sklearn Pipeline / XGBoost native 等）が別 metric 名を使うと Service 層ガードはその backend の不適合 metric を silent に見逃す。
+
+#### Purpose
+
+- `BackendCore` Protocol に `get_incompatible_metrics(task: str, target_series: pd.Series, metric_names: set[str]) -> list[IncompatibleMetric]` を追加。Protocol 本体は `return []`（実装しない backend = 不適合 metric ゼロ）を既定とする。
+- 共通型 `IncompatibleMetric`（`@dataclass(frozen=True)`、フィールド `metric` / `message` / `suggested_fix`）を `backends/types.py` に新設。
+- lizyml adapter（`ConfigMixin`）が `get_incompatible_metrics` を実装し、watchlist（`_REGRESSION_METRIC_WATCHLIST = {"mape","rmsle","r2"}`）・各前提条件・`task=regression` gate・non-numeric target gate・sMAPE/WAPE suggestion 文言の所有を adapter 側に持つ。
+- `_workspace_metric_compatibility_errors` を thin envelope（≤ 60 行）に縮小: dataframe / target / `evaluation.metrics` の存在チェック + metric 名パース → `ws.backend.get_incompatible_metrics(...)` 呼び出し → 戻り値を既存の `{path:"evaluation.metrics", message, severity:"warning", suggested_fix}` envelope に map。
+
+#### Invariants
+
+- **INV-metric-1**: `validate_config` が返す metric-compat 警告の envelope（`path` / `message` / `severity="warning"` / `suggested_fix`）は本変更前後で byte-identical（frontend 変更ゼロ・既存 contract test 無改修 pass）。
+- **INV-metric-2**: `task != "regression"` のとき lizyml adapter は不適合 metric を一切返さない（constant 0/1 の binary target が misleading な R² 警告を出さない — PR-D1 / #394 HIGH-1 で確立した挙動を adapter 側で維持）。
+- **INV-metric-3**: metric watchlist と precondition ロジックは backend が所有する（Service 層は metric 名を一切知らない）。
+
+#### Impact
+
+**共通型 / Protocol（← Change Gate 対象）:**
+- `backends/types.py`: `IncompatibleMetric` 追加。
+- `backends/base.py`: `BackendCore.get_incompatible_metrics` 追加（Config セクション、`validate_config` の直後）。Protocol 本体に `return []` のデフォルト。`BackendAdapter` alias は `BackendCore` を継承しているので自動的に新メソッドを含む。
+
+**Backend（lizyml adapter）:**
+- `backends/lizyml/config_mixin.py`: `import pandas as pd` 追加。module-level `_REGRESSION_METRIC_WATCHLIST` 定数。`ConfigMixin.get_incompatible_metrics` 実装（旧 Service 層ロジックの完全移植 — mape→zero、rmsle→negative、r2→constant variance / <2 non-null、`task != "regression"` / non-numeric target は `[]`）。
+
+**Service:**
+- `services/workspace.py`: `_workspace_metric_compatibility_errors` を thin envelope に縮小（109 行 → 約 55 行）。`pd.api.types.is_numeric_dtype` チェックは adapter 側へ移動（`pd` は `WorkspaceState.dataframe` の型注釈で引き続き使用）。`validate_config` の呼び出し箇所（`normalized.extend(_workspace_metric_compatibility_errors(ws, config))`）は不変。
+- これにより Issue #452 の sub-PR 1（`_workspace_metric_compatibility_errors` を 3 helper に分割）は obsolete（thin envelope なので分割不要）。
+
+**Behavior change for users:**
+- なし（INV-metric-1）。
+
+**Compatibility:**
+- 後方互換。API レスポンス不変、保存形式変更なし、frontend 変更なし。新メソッドは Protocol デフォルト `[]` を持つので、構造的に satisfy するだけの将来の backend にも非破壊（呼び出し時に `AttributeError` を避けたい場合は、その backend が `BackendCore` を base class として継承すればデフォルトが効く）。
+
+**Testing:**
+- `tests/test_backends_lizyml.py::TestGetIncompatibleMetrics`（新規 14 ケース）: mape/rmsle/r2 の発火・非発火、複数同時、単一観測（std NaN）、未登録 metric 無視、non-regression task / 空 task は空、non-numeric target は空、空 metric set、all-NaN target、inf 含み target。
+- `tests/contract/test_validate_metric_compatibility.py`（既存 15 ケース）・`tests/contract/test_fit_tune_severity_filter.py`: 無改修 pass を確認（INV-metric-1）。
+- `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/integration --ignore=tests/bench -k "not slow"` 全 pass / `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy src/lizystudio/` 全 green。
+
+#### Acceptance criteria
+
+- [x] `BackendCore` に `get_incompatible_metrics` 追加、Protocol 本体デフォルト `return []`、`IncompatibleMetric` TypedDict（frozen dataclass）定義。
+- [x] lizyml adapter が現ロジックを完全移植して実装。watchlist と sMAPE/WAPE 文言の所有が adapter 側に移る。
+- [x] `_workspace_metric_compatibility_errors` は thin envelope（≤ 60 行）。#452 sub-PR 1 obsolete。
+- [x] `tests/contract/test_validate_metric_compatibility.py` 全ケース無改修 pass。`tests/contract/test_fit_tune_severity_filter.py` 無 regression。
+- [x] 新規 adapter ユニットテストで lizyml の不適合 metric リストを直接検証。
+- [x] `uv run pytest` / `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy src/lizystudio/` 全 green。
+- [x] BLUEPRINT.md §3 の adapter capability 一覧に `get_incompatible_metrics` を追記。HISTORY.md Decision row 記入。
+
+#### Alternatives considered
+
+- **(a) 現状維持（drift 放置）**: 拒否。2nd backend 導入時に silent miss のリスク。Issue #403 / `docs/coupling-analysis.md` が明示的に flagging 済。
+- **(b) `backends/lizyml_metrics.py` にモジュール関数として置くだけ**: 拒否。Protocol を経由しないので「backend が自分の metric 語彙を所有する」abstraction にならず、Service 層が `lizyml_metrics` を import する coupling が残る。
+- **(c) `_workspace_split_errors`（行数チェック）も同じパターンに移す**: scope 外。n_rows は universal precondition で Service 層に居てよい（Issue #403 も out-of-scope と明記）。
+
+#### Decision
+
+- 2026-05-12 **Approved** — Issue #403 の提案どおり `BackendCore.get_incompatible_metrics` を追加。実装は単一 PR（commit 順: Proposal → `feat(backend)` Protocol+型 → `refactor(services)` thin envelope → `test(backend)` adapter watchlist）。`task` 引数を adapter に渡す設計（Service 層から `task=regression` gate を排除）まで含めて承認 — これにより abstraction が「どの task に適用されるか」も backend 所有になる。

--- a/src/lizystudio/backends/base.py
+++ b/src/lizystudio/backends/base.py
@@ -16,6 +16,7 @@ from lizystudio.backends.types import (
     BackendInfo,
     ConfigSchema,
     FitSummary,
+    IncompatibleMetric,
     PlotData,
     PredictionSummary,
     TuningSummary,
@@ -60,6 +61,29 @@ class BackendCore(Protocol):
     def validate_config(self, config: dict[str, Any]) -> list[dict[str, Any]]:
         """Return a list of validation errors (empty == valid)."""
         ...
+
+    def get_incompatible_metrics(
+        self,
+        task: str,
+        target_series: pd.Series,
+        metric_names: set[str],
+    ) -> list[IncompatibleMetric]:
+        """Advisory: configured metrics whose preconditions the target violates.
+
+        Called by ``Service.validate_config`` once it has confirmed a target
+        column is loaded — *task* is the configured task (``"regression"`` /
+        ``"binary"`` / ``"multiclass"`` / ``""`` if absent), *target_series*
+        the loaded column, *metric_names* the set of metric names parsed from
+        ``evaluation.metrics``. The backend owns which of those names have
+        target preconditions (e.g. lizyml: MAPE undefined on zeros, RMSLE on
+        negatives, R² on a constant target) and the ``suggested_fix`` text,
+        which may reference backend-specific replacements.
+
+        The Service wraps each entry in a ``severity="warning"`` envelope; it
+        does not block Fit. A minimal backend declares no incompatibilities
+        (default below).
+        """
+        return []
 
     def get_default_config(self, task: str, target: str) -> dict[str, Any]:
         """Return a complete valid config with all defaults."""

--- a/src/lizystudio/backends/lizyml/config_mixin.py
+++ b/src/lizystudio/backends/lizyml/config_mixin.py
@@ -5,11 +5,18 @@ from __future__ import annotations
 import json
 from typing import Any
 
+import pandas as pd
 import yaml
 
-from lizystudio.backends.types import BackendInfo, ConfigSchema
+from lizystudio.backends.types import BackendInfo, ConfigSchema, IncompatibleMetric
 
 from .config_compat import strip_internal_keys, task_params_compat_errors
+
+# Regression metrics whose value is undefined / degenerate for certain target
+# distributions. The Service layer used to hardcode this watchlist (Issue #394);
+# P-0106 (#403) moved it here so the metric vocabulary stays owned by the
+# backend — a second backend declares its own watchlist (or none).
+_REGRESSION_METRIC_WATCHLIST = frozenset({"mape", "rmsle", "r2"})
 
 
 class ConfigMixin:
@@ -65,6 +72,81 @@ class ConfigMixin:
 
         errors.extend(task_params_compat_errors(clean))
         return errors
+
+    def get_incompatible_metrics(
+        self,
+        task: str,
+        target_series: pd.Series,
+        metric_names: set[str],
+    ) -> list[IncompatibleMetric]:
+        """Regression metrics whose preconditions ``target_series`` violates.
+
+        Implements :meth:`BackendCore.get_incompatible_metrics` for lizyml.
+        The watchlist is regression-specific (lizyml/metrics/regression.py
+        raises mid-fit for these), so non-regression tasks and non-numeric
+        targets short-circuit to ``[]``:
+
+        * ``mape``  — undefined when ``y_true`` contains zeros
+        * ``rmsle`` — undefined when ``y_true`` contains negative values
+        * ``r2``    — degenerate (NaN / +/-inf) when the target is constant
+                      (variance == 0, or < 2 non-null observations)
+
+        Each entry's ``suggested_fix`` names the metric to drop and, for
+        ``mape``, points at lizyml >= 0.11.0's zero-tolerant ``smape`` /
+        ``wape`` as alternatives.
+        """
+        if task != "regression":
+            return []
+        if not pd.api.types.is_numeric_dtype(target_series):
+            return []
+        watched = metric_names & _REGRESSION_METRIC_WATCHLIST
+        if not watched:
+            return []
+
+        col = str(target_series.name)
+        out: list[IncompatibleMetric] = []
+        if "mape" in watched and bool((target_series == 0).any()):
+            out.append(
+                IncompatibleMetric(
+                    metric="mape",
+                    message=(
+                        f"MAPE is undefined when target column '{col}' contains zeros."
+                    ),
+                    suggested_fix=(
+                        "Remove 'mape' from evaluation.metrics — or replace it "
+                        "with 'smape' / 'wape' which tolerate zero targets "
+                        "(lizyml >= 0.11.0)."
+                    ),
+                )
+            )
+        if "rmsle" in watched and bool((target_series < 0).any()):
+            out.append(
+                IncompatibleMetric(
+                    metric="rmsle",
+                    message=(
+                        f"RMSLE is undefined when target column '{col}' "
+                        f"contains negative values."
+                    ),
+                    suggested_fix="Remove 'rmsle' from evaluation.metrics.",
+                )
+            )
+        if "r2" in watched:
+            # Constant target → variance == 0. ``std(skipna=True)`` returns
+            # NaN for < 2 non-null observations, which we also treat as
+            # "cannot compute R²".
+            std = target_series.std(skipna=True)
+            if pd.isna(std) or float(std) == 0.0:
+                out.append(
+                    IncompatibleMetric(
+                        metric="r2",
+                        message=(
+                            f"R² is undefined when target column '{col}' is "
+                            f"constant (variance == 0)."
+                        ),
+                        suggested_fix="Remove 'r2' from evaluation.metrics.",
+                    )
+                )
+        return out
 
     @staticmethod
     def _strip_internal_keys(config: dict[str, Any]) -> dict[str, Any]:

--- a/src/lizystudio/backends/types.py
+++ b/src/lizystudio/backends/types.py
@@ -28,6 +28,23 @@ class ConfigSchema:
     json_schema: dict[str, Any]
 
 
+@dataclass(frozen=True)
+class IncompatibleMetric:
+    """Advisory entry for a configured metric whose preconditions the
+    loaded target column violates (e.g. MAPE on a target containing zeros).
+
+    Returned by :meth:`BackendCore.get_incompatible_metrics`. The
+    ``suggested_fix`` string may reference backend-specific replacements
+    (e.g. lizyml's sMAPE / WAPE for MAPE). The Service layer wraps each
+    entry in its ``severity="warning"`` validation envelope; it does not
+    block Fit.
+    """
+
+    metric: str
+    message: str
+    suggested_fix: str
+
+
 @dataclass
 class FitSummary:
     """Training result summary."""

--- a/src/lizystudio/services/workspace.py
+++ b/src/lizystudio/services/workspace.py
@@ -260,43 +260,25 @@ def _metric_entry_name(metric: Any) -> str | None:
 def _workspace_metric_compatibility_errors(
     ws: WorkspaceState, config: dict[str, Any]
 ) -> list[dict[str, Any]]:
-    """Issue #394: warn before Fit when a configured regression metric
+    """Issue #394 / #403 (P-0106): warn before Fit when a configured metric
     is incompatible with the loaded dataset's target column.
 
-    Each entry returns ``severity="warning"`` (not ``"error"``) so the
-    banner advises but does not gate Fit — the underlying lizyml fit
-    path may either skip the metric or surface a clearer mid-fold
-    error, but no data is destroyed by attempting it. The
-    ``suggested_fix`` names the metric to remove and, where applicable,
-    points at upstream lizyml 0.11.0's sMAPE / WAPE as zero-tolerant
-    alternatives.
+    A thin envelope: it extracts the generic inputs from *config* and the
+    loaded dataframe (task, target column, the parsed set of metric names),
+    delegates the "which of these metrics has a target precondition" decision
+    to the backend (``ws.backend.get_incompatible_metrics`` — the watchlist
+    and ``suggested_fix`` prose are owned there, not here, so a second backend
+    declares its own vocabulary), and wraps each returned advisory in the
+    ``severity="warning"`` envelope. ``warning`` (not ``error``) so the banner
+    advises but does not gate Fit — the underlying fit path may skip the metric
+    or surface a clearer mid-fold error, but no data is destroyed by trying.
 
-    Currently detected (regression task only):
-
-    * ``mape``  — undefined when ``y_true`` contains zeros
-                  (lizyml/metrics/regression.py raises mid-fit)
-    * ``rmsle`` — undefined when ``y_true`` contains negative values
-    * ``r2``    — degenerate (NaN / +∞) when the target is constant
-                  (variance == 0)
-
-    Short-circuits to an empty list when no data is loaded, when the
-    target column is missing or non-numeric, or when ``evaluation`` is
-    not a dict. Defensive on every layer because ``validate_config``
-    runs against arbitrary user input that the schema layer may also
-    have rejected.
+    Short-circuits to an empty list when no data is loaded, when the target
+    column is missing, or when ``evaluation.metrics`` is empty / unparsable.
+    Defensive on every layer because ``validate_config`` runs against
+    arbitrary user input that the schema layer may also have rejected.
     """
-    if ws.dataframe is None:
-        return []
-    if not isinstance(config, dict):
-        return []
-    # PR-D1 / Issue #394 follow-up (code-review HIGH-1): the watchlist
-    # (mape / rmsle / r2) is regression-specific. A binary or multiclass
-    # config with a numeric target whose distribution happens to satisfy
-    # one of the triggers (e.g. constant 0/1 target) would otherwise
-    # surface a misleading R² warning. ``task`` lives at the top level
-    # of LizyMLConfig (see backends/lizyml/config_mixin.py:44); restrict
-    # to ``task=regression``.
-    if config.get("task") != "regression":
+    if ws.dataframe is None or not isinstance(config, dict):
         return []
     data = config.get("data")
     if not isinstance(data, dict):
@@ -308,62 +290,27 @@ def _workspace_metric_compatibility_errors(
     metrics = evaluation.get("metrics") if isinstance(evaluation, dict) else None
     if not isinstance(metrics, list) or not metrics:
         return []
-    target_series = ws.dataframe[target]
-    if not pd.api.types.is_numeric_dtype(target_series):
+    metric_names = {
+        name for entry in metrics if (name := _metric_entry_name(entry)) is not None
+    }
+    if not metric_names:
         return []
 
-    metric_names: set[str] = set()
-    for entry in metrics:
-        name = _metric_entry_name(entry)
-        if name is not None:
-            metric_names.add(name)
-
-    errors: list[dict[str, Any]] = []
-    if "mape" in metric_names and bool((target_series == 0).any()):
-        errors.append(
-            {
-                "path": "evaluation.metrics",
-                "message": (
-                    f"MAPE is undefined when target column '{target}' contains zeros."
-                ),
-                "severity": "warning",
-                "suggested_fix": (
-                    "Remove 'mape' from evaluation.metrics — or replace it "
-                    "with 'smape' / 'wape' which tolerate zero targets "
-                    "(lizyml >= 0.11.0)."
-                ),
-            }
-        )
-    if "rmsle" in metric_names and bool((target_series < 0).any()):
-        errors.append(
-            {
-                "path": "evaluation.metrics",
-                "message": (
-                    f"RMSLE is undefined when target column '{target}' "
-                    f"contains negative values."
-                ),
-                "severity": "warning",
-                "suggested_fix": "Remove 'rmsle' from evaluation.metrics.",
-            }
-        )
-    if "r2" in metric_names:
-        # Constant target → variance == 0. Use std() to skip NaNs; pandas
-        # returns NaN when there is < 2 non-null observations, which we
-        # also treat as "cannot compute R²".
-        std = target_series.std(skipna=True)
-        if pd.isna(std) or float(std) == 0.0:
-            errors.append(
-                {
-                    "path": "evaluation.metrics",
-                    "message": (
-                        f"R² is undefined when target column '{target}' is "
-                        f"constant (variance == 0)."
-                    ),
-                    "severity": "warning",
-                    "suggested_fix": "Remove 'r2' from evaluation.metrics.",
-                }
-            )
-    return errors
+    task = config.get("task")
+    incompatible = ws.backend.get_incompatible_metrics(
+        task if isinstance(task, str) else "",
+        ws.dataframe[target],
+        metric_names,
+    )
+    return [
+        {
+            "path": "evaluation.metrics",
+            "message": entry.message,
+            "severity": "warning",
+            "suggested_fix": entry.suggested_fix,
+        }
+        for entry in incompatible
+    ]
 
 
 def load_config_from_file(

--- a/tests/test_backends_lizyml.py
+++ b/tests/test_backends_lizyml.py
@@ -16,6 +16,7 @@ from lizystudio.backends.registry import get_adapter
 from lizystudio.backends.types import (
     BackendInfo,
     ConfigSchema,
+    IncompatibleMetric,
     PlotData,
     PredictionSummary,
 )
@@ -1898,3 +1899,146 @@ def test_tune_real_tuning_result_empty_rounds_yields_none() -> None:
     assert summary.rounds is None
     assert summary.boundary_report is None
     assert summary.best_params == {"lr": 0.01}
+
+
+class TestGetIncompatibleMetrics:
+    """LizyMLAdapter.get_incompatible_metrics — the regression-metric watchlist
+    (mape / rmsle / r2 + the sMAPE/WAPE suggestion text) that P-0106 (#403)
+    moved off the Service layer and behind the BackendCore Protocol.
+    """
+
+    @pytest.fixture
+    def adapter(self) -> LizyMLAdapter:
+        return LizyMLAdapter()
+
+    def test_mape_with_zero_target(self, adapter: LizyMLAdapter) -> None:
+        out = adapter.get_incompatible_metrics(
+            "regression", pd.Series([0.0, 1.0, 2.0], name="y"), {"mape", "mae"}
+        )
+        assert all(isinstance(m, IncompatibleMetric) for m in out)
+        assert [m.metric for m in out] == ["mape"]
+        assert "zero" in out[0].message.lower()
+        assert "'y'" in out[0].message
+        assert "smape" in out[0].suggested_fix.lower()
+        assert "wape" in out[0].suggested_fix.lower()
+
+    def test_mape_clean_when_no_zero(self, adapter: LizyMLAdapter) -> None:
+        assert (
+            adapter.get_incompatible_metrics(
+                "regression", pd.Series([1.0, 2.0, 3.0], name="y"), {"mape"}
+            )
+            == []
+        )
+
+    def test_rmsle_with_negative_target(self, adapter: LizyMLAdapter) -> None:
+        out = adapter.get_incompatible_metrics(
+            "regression", pd.Series([-1.0, 1.0, 2.0], name="y"), {"rmsle"}
+        )
+        assert [m.metric for m in out] == ["rmsle"]
+        assert "negative" in out[0].message.lower()
+
+    def test_rmsle_clean_when_nonnegative(self, adapter: LizyMLAdapter) -> None:
+        # exact zero is allowed for RMSLE (log1p(0) == 0), only negatives fail
+        assert (
+            adapter.get_incompatible_metrics(
+                "regression", pd.Series([0.0, 1.0, 2.0], name="y"), {"rmsle"}
+            )
+            == []
+        )
+
+    def test_r2_with_constant_target(self, adapter: LizyMLAdapter) -> None:
+        out = adapter.get_incompatible_metrics(
+            "regression", pd.Series([5.0, 5.0, 5.0], name="y"), {"r2"}
+        )
+        assert [m.metric for m in out] == ["r2"]
+        assert "constant" in out[0].message.lower()
+
+    def test_r2_clean_when_target_varies(self, adapter: LizyMLAdapter) -> None:
+        assert (
+            adapter.get_incompatible_metrics(
+                "regression", pd.Series([1.0, 2.0, 3.0], name="y"), {"r2"}
+            )
+            == []
+        )
+
+    def test_r2_single_observation_flagged(self, adapter: LizyMLAdapter) -> None:
+        # std() of <2 non-null observations is NaN → "cannot compute R²"
+        out = adapter.get_incompatible_metrics(
+            "regression", pd.Series([5.0], name="y"), {"r2"}
+        )
+        assert [m.metric for m in out] == ["r2"]
+
+    def test_multiple_issues_one_entry_each(self, adapter: LizyMLAdapter) -> None:
+        # all-zero target: mape (zeros) + r2 (constant) fire; rmsle needs negatives
+        out = adapter.get_incompatible_metrics(
+            "regression",
+            pd.Series([0.0, 0.0, 0.0], name="y"),
+            {"mape", "rmsle", "r2"},
+        )
+        assert sorted(m.metric for m in out) == ["mape", "r2"]
+
+    def test_unwatched_metrics_ignored(self, adapter: LizyMLAdapter) -> None:
+        assert (
+            adapter.get_incompatible_metrics(
+                "regression", pd.Series([0.0, 1.0], name="y"), {"mae", "rmse", "auc"}
+            )
+            == []
+        )
+
+    def test_non_regression_task_returns_empty(self, adapter: LizyMLAdapter) -> None:
+        # a constant 0/1 binary target must NOT surface a misleading R² warning
+        assert (
+            adapter.get_incompatible_metrics(
+                "binary", pd.Series([0, 0, 0], name="label"), {"r2", "mape"}
+            )
+            == []
+        )
+        assert (
+            adapter.get_incompatible_metrics(
+                "multiclass", pd.Series([1.0], name="y"), {"r2"}
+            )
+            == []
+        )
+        # absent task ("") is treated as non-regression
+        assert (
+            adapter.get_incompatible_metrics("", pd.Series([0.0], name="y"), {"r2"})
+            == []
+        )
+
+    def test_non_numeric_target_returns_empty(self, adapter: LizyMLAdapter) -> None:
+        assert (
+            adapter.get_incompatible_metrics(
+                "regression",
+                pd.Series(["a", "b", "c"], name="y"),
+                {"mape", "rmsle", "r2"},
+            )
+            == []
+        )
+
+    def test_empty_metric_set_returns_empty(self, adapter: LizyMLAdapter) -> None:
+        assert (
+            adapter.get_incompatible_metrics(
+                "regression", pd.Series([0.0, 1.0], name="y"), set()
+            )
+            == []
+        )
+
+    def test_all_nan_target_flags_only_r2(self, adapter: LizyMLAdapter) -> None:
+        # NaN comparisons are False, so mape/rmsle stay quiet; std() is NaN → r2
+        out = adapter.get_incompatible_metrics(
+            "regression",
+            pd.Series([float("nan")] * 5, name="y"),
+            {"mape", "rmsle", "r2"},
+        )
+        assert [m.metric for m in out] == ["r2"]
+
+    @pytest.mark.filterwarnings("ignore:invalid value encountered:RuntimeWarning")
+    def test_inf_in_target_does_not_crash(self, adapter: LizyMLAdapter) -> None:
+        # +inf is not 0 and not < 0; -inf qualifies as negative → rmsle.
+        # std with non-finite values is NaN → r2. mape stays quiet (no exact 0).
+        out = adapter.get_incompatible_metrics(
+            "regression",
+            pd.Series([float("inf"), float("-inf"), 1.0, 2.0, 3.0], name="y"),
+            {"mape", "rmsle", "r2"},
+        )
+        assert sorted(m.metric for m in out) == ["r2", "rmsle"]


### PR DESCRIPTION
## Summary

Wave 6 / Issue #403 (v0.4.1 pre-release code-review HIGH-2 follow-up) — implements **Proposal P-0106** (HISTORY.md, approved this session).

`Service.validate_config`'s `_workspace_metric_compatibility_errors` hardcoded the lizyml-specific regression-metric watchlist (`mape` / `rmsle` / `r2`), the `task=regression` gate, and the sMAPE/WAPE suggestion prose at the **Service layer** — an architectural drift from the `BackendAdapter` abstraction (BLUEPRINT §3): a second backend with a different metric vocabulary would be silently skipped. This PR moves all of that behind a new `BackendCore` capability.

## Changes

| Commit | What |
|---|---|
| `docs(history)` | Proposal P-0106 + Decision (Approved) |
| `feat(backend)` | `IncompatibleMetric` frozen dataclass (`backends/types.py`); `BackendCore.get_incompatible_metrics(task, target_series, metric_names) -> list[IncompatibleMetric]` with `return []` default (`backends/base.py`, inherited by the `BackendAdapter` alias); lizyml impl in `ConfigMixin` with module-level `_REGRESSION_METRIC_WATCHLIST` (`backends/lizyml/config_mixin.py`); BLUEPRINT §3.3.1 / §3.3.2 updated |
| `refactor(services)` | `_workspace_metric_compatibility_errors` → thin envelope (109 → ~55 lines): extracts target column / parsed metric-name set / task from config + dataframe, delegates to `ws.backend.get_incompatible_metrics(...)`, wraps results in the existing `{path, message, severity="warning", suggested_fix}` envelope. Also obsoletes #452 sub-PR 1 |
| `test(backend)` | `TestGetIncompatibleMetrics` — 14 cases exercising the moved logic directly on the adapter |

## Invariants
- **INV-metric-1**: the `validate_config` warning envelope (`path` / `message` / `severity="warning"` / `suggested_fix`) is byte-identical before/after — `tests/contract/test_validate_metric_compatibility.py` (15 cases) and `tests/contract/test_fit_tune_severity_filter.py` pass **unchanged**; frontend untouched.
- **INV-metric-2**: `task != "regression"` → the lizyml adapter returns no incompatibilities (a constant 0/1 binary target never surfaces a misleading R² warning — preserves the PR-D1 / #394 HIGH-1 behaviour, now owned by the adapter).
- **INV-metric-3**: the metric watchlist + precondition logic is owned by the backend; the Service layer knows no metric names.

## Failure paths covered
- Non-regression / absent (`""`) task → `[]`
- Non-numeric target → `[]`
- Empty / unparsable `evaluation.metrics` → `[]` (Service-side guard, unchanged)
- Target missing from the loaded dataframe → `[]` (Service-side guard, unchanged)
- Edge target distributions: all-NaN, `±inf`, constant, `<2` non-null observations — all exercised in `TestGetIncompatibleMetrics`

## Compatibility
Backward-compatible. API responses unchanged, save format unchanged, no frontend change. The new Protocol method has a `return []` default body so a future structurally-conforming backend is non-breaking (a backend that inherits `BackendCore` as a base class gets the default; one that only structurally satisfies it must implement the method like every other `BackendCore` method).

## Test plan
- [x] `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/integration --ignore=tests/bench -k "not slow"` → 1507 passed (was 1493 + 14 new)
- [x] `uv run pytest tests/contract/test_validate_metric_compatibility.py tests/contract/test_fit_tune_severity_filter.py` → unchanged, passing
- [x] `uv run ruff check . && uv run ruff format --check .` → clean
- [x] `uv run mypy --no-incremental src/lizystudio/` → clean (55 files)
- [x] `python-reviewer` agent → Approve (one MEDIUM addressed: multi-entry assertions normalised with `sorted()`)
- [ ] CI green

Closes #403.
