### PR TITLE
refactor(workspace): split workspace_reset into focused helpers (#452)

### DIFF
--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -41,55 +41,11 @@ export interface paths {
          * Workspace Reset
          * @description Reset all workspace state.
          *
-         *     H-0063 / Issue #99: if a fit / tune is still running in the
-         *     background, reset must also cancel it and release the JobStore
-         *     active slot. Otherwise the next Fit / Tune click gets a
-         *     JOB_CONFLICT 409, directly contradicting the user's expectation
-         *     that "reset" yields a clean slate.
-         *
-         *     The cancel path mirrors the existing ``POST /jobs/{id}/cancel``
-         *     endpoint: we call ``request_cancel`` and rely on the runner (either
-         *     the in-process thread via ``_run_job_core``'s cancel-aware callback
-         *     or the subprocess via ``_poll_progress``'s cancel polling) to
-         *     transition the job to ``cancelled`` and release the slot from its
-         *     finally block. We then wait briefly for the slot to become free
-         *     so the caller can immediately start a new Fit / Tune without
-         *     racing the cancel.
-         *
-         *     Degraded paths we explicitly tolerate:
-         *
-         *     1. **Terminal holder (crashed runner finally)** — if the slot is
-         *        held but the job's on-disk status is already terminal, no one
-         *        will ever call ``release_active`` for it. We short-circuit by
-         *        calling ``force_release_active_if`` directly.
-         *     2. **No live runner (orphan slot)** — the slot may have been
-         *        claimed by a previous process / test / client that died
-         *        without draining the slot. The cancel flag lands in memory but
-         *        no runner observes it, so the wait loop would time out. In
-         *        that case we **force-release the slot** from reset itself.
-         *        Rationale: the user clicked reset expressly to clear state;
-         *        returning 200 with the slot still held would reintroduce the
-         *        exact ``JOB_CONFLICT`` regression this fix is trying to remove.
-         *        The wait budget (``_RESET_WAIT_TIMEOUT``) is deliberately set
-         *        longer than ``subprocess_runner._WAIT_TIMEOUT`` so that a
-         *        legitimate subprocess runner has time to finish its
-         *        ``proc.terminate`` / ``proc.wait`` cycle and call
-         *        ``release_active`` from its own finally, before we fall
-         *        through to the force-release branch. If we still time out,
-         *        the most plausible explanation is an orphaned slot with no
-         *        runner behind it, and force-releasing is strictly better than
-         *        leaving the user with a broken reset button.
-         *
-         *     The force-release uses ``force_release_active_if`` which is
-         *     atomic under ``JobStore._active_lock``: the slot is released only
-         *     if it still holds the exact id we observed, so a racy
-         *     ``create_and_claim_active`` from another thread between the
-         *     observation and the release cannot accidentally clear the new
-         *     owner's slot.
-         *
-         *     Workspace state is cleared AFTER the cancel + slot wait so the
-         *     shutting-down runner thread still sees live ``ws.dataframe`` /
-         *     ``ws.model`` references during its finally path.
+         *     Cancels and drains any background fit / tune first (see
+         *     :func:`_teardown_active_job` for the cancel + slot-release choreography
+         *     and its degraded paths), then clears workspace state. The order matters:
+         *     workspace state is cleared *after* the slot wait so the shutting-down
+         *     runner thread still sees live ``ws.dataframe`` / ``ws.model`` references.
          */
         post: operations["workspace_reset_api_workspace_reset_post"];
         delete?: never;

--- a/src/lizystudio/api/workspace.py
+++ b/src/lizystudio/api/workspace.py
@@ -132,6 +132,91 @@ def workspace_status(
 _RESET_WAIT_TIMEOUT = 12.0
 _RESET_WAIT_INTERVAL = 0.05
 
+_TERMINAL_JOB_STATUSES = ("completed", "failed", "cancelled")
+
+
+def _request_cancel_if_running(job_store: JobStore, job_id: str) -> None:
+    """Signal cancellation for *job_id* unless it is already terminal.
+
+    Mirrors ``POST /jobs/{id}/cancel``: we set the cancel flag and rely on
+    the runner (in-process thread or subprocess poll loop) to flip the job
+    to ``cancelled`` and release the active slot from its finally block.
+    A job whose on-disk status is already terminal has no live runner to
+    observe the flag, so we skip the no-op call.
+    """
+    job = job_store.get(job_id)
+    if job is None or job.status not in _TERMINAL_JOB_STATUSES:
+        job_store.request_cancel(job_id)
+
+
+def _wait_for_active_slot_release(job_store: JobStore) -> bool:
+    """Wait up to ``_RESET_WAIT_TIMEOUT`` for the active slot to drain.
+
+    Returns ``True`` once the slot is free. Handles the degraded path where
+    the holder became terminal on disk without ``release_active`` being
+    called (crashed runner finally block) by reclaiming the slot via the
+    atomic compare-and-release ``force_release_active_if`` — so a racy
+    ``create_and_claim_active`` from a parallel request between the
+    observation and the release cannot clear the new owner's slot.
+    """
+    deadline = time.monotonic() + _RESET_WAIT_TIMEOUT
+    while time.monotonic() < deadline:
+        if not job_store.has_active_job():
+            return True
+        current = job_store.active_job_id
+        if current is not None:
+            current_job = job_store.get(current)
+            if (
+                current_job is not None
+                and current_job.status in _TERMINAL_JOB_STATUSES
+                and job_store.force_release_active_if(current)
+            ):
+                return True
+        time.sleep(_RESET_WAIT_INTERVAL)
+    return False
+
+
+def _force_release_orphan_slot(job_store: JobStore) -> None:
+    """Force-release a slot that no runner drained within the wait budget.
+
+    Returning 200 with the slot still held would reintroduce the exact
+    ``JOB_CONFLICT`` regression H-0063 / Issue #99 set out to remove (the
+    user clicked reset expressly to clear state). The wait budget is set
+    longer than ``subprocess_runner._WAIT_TIMEOUT`` so a legitimate
+    subprocess runner has time to finish its ``proc.terminate`` /
+    ``proc.wait`` cycle first; if we still time out the slot is almost
+    certainly orphaned (a previous process / test / client died without
+    draining it). ``force_release_active_if`` only clears the exact id we
+    observed, never a new claim that landed in between.
+    """
+    stuck_id = job_store.active_job_id
+    if stuck_id is not None and job_store.force_release_active_if(stuck_id):
+        _log.warning(
+            "workspace_reset: active slot %s did not release within %.2fs; "
+            "force-released so the next fit / tune does not JOB_CONFLICT",
+            stuck_id,
+            _RESET_WAIT_TIMEOUT,
+        )
+
+
+def _teardown_active_job(job_store: JobStore) -> None:
+    """Cancel and drain any background fit / tune so reset yields a clean slate.
+
+    H-0063 / Issue #99: if a fit / tune is still running, reset must cancel
+    it and release the JobStore active slot, otherwise the next Fit / Tune
+    click gets ``JOB_CONFLICT`` 409. We request cancel, wait briefly for the
+    runner to drain the slot from its own finally block, and — only if it
+    never does — force-release. Callers must invoke this *before* clearing
+    workspace state so a shutting-down runner thread still sees live
+    ``ws.dataframe`` / ``ws.model`` references during its finally path.
+    """
+    active_id = job_store.active_job_id
+    if active_id is None:
+        return
+    _request_cancel_if_running(job_store, active_id)
+    if not _wait_for_active_slot_release(job_store):
+        _force_release_orphan_slot(job_store)
+
 
 @router.post("/reset")
 def workspace_reset(
@@ -140,111 +225,13 @@ def workspace_reset(
 ) -> dict[str, str]:
     """Reset all workspace state.
 
-    H-0063 / Issue #99: if a fit / tune is still running in the
-    background, reset must also cancel it and release the JobStore
-    active slot. Otherwise the next Fit / Tune click gets a
-    JOB_CONFLICT 409, directly contradicting the user's expectation
-    that "reset" yields a clean slate.
-
-    The cancel path mirrors the existing ``POST /jobs/{id}/cancel``
-    endpoint: we call ``request_cancel`` and rely on the runner (either
-    the in-process thread via ``_run_job_core``'s cancel-aware callback
-    or the subprocess via ``_poll_progress``'s cancel polling) to
-    transition the job to ``cancelled`` and release the slot from its
-    finally block. We then wait briefly for the slot to become free
-    so the caller can immediately start a new Fit / Tune without
-    racing the cancel.
-
-    Degraded paths we explicitly tolerate:
-
-    1. **Terminal holder (crashed runner finally)** — if the slot is
-       held but the job's on-disk status is already terminal, no one
-       will ever call ``release_active`` for it. We short-circuit by
-       calling ``force_release_active_if`` directly.
-    2. **No live runner (orphan slot)** — the slot may have been
-       claimed by a previous process / test / client that died
-       without draining the slot. The cancel flag lands in memory but
-       no runner observes it, so the wait loop would time out. In
-       that case we **force-release the slot** from reset itself.
-       Rationale: the user clicked reset expressly to clear state;
-       returning 200 with the slot still held would reintroduce the
-       exact ``JOB_CONFLICT`` regression this fix is trying to remove.
-       The wait budget (``_RESET_WAIT_TIMEOUT``) is deliberately set
-       longer than ``subprocess_runner._WAIT_TIMEOUT`` so that a
-       legitimate subprocess runner has time to finish its
-       ``proc.terminate`` / ``proc.wait`` cycle and call
-       ``release_active`` from its own finally, before we fall
-       through to the force-release branch. If we still time out,
-       the most plausible explanation is an orphaned slot with no
-       runner behind it, and force-releasing is strictly better than
-       leaving the user with a broken reset button.
-
-    The force-release uses ``force_release_active_if`` which is
-    atomic under ``JobStore._active_lock``: the slot is released only
-    if it still holds the exact id we observed, so a racy
-    ``create_and_claim_active`` from another thread between the
-    observation and the release cannot accidentally clear the new
-    owner's slot.
-
-    Workspace state is cleared AFTER the cancel + slot wait so the
-    shutting-down runner thread still sees live ``ws.dataframe`` /
-    ``ws.model`` references during its finally path.
+    Cancels and drains any background fit / tune first (see
+    :func:`_teardown_active_job` for the cancel + slot-release choreography
+    and its degraded paths), then clears workspace state. The order matters:
+    workspace state is cleared *after* the slot wait so the shutting-down
+    runner thread still sees live ``ws.dataframe`` / ``ws.model`` references.
     """
-    active_id = job_store.active_job_id
-    if active_id is not None:
-        active_job = job_store.get(active_id)
-        is_terminal = active_job is not None and active_job.status in (
-            "completed",
-            "failed",
-            "cancelled",
-        )
-        if not is_terminal:
-            job_store.request_cancel(active_id)
-
-        deadline = time.monotonic() + _RESET_WAIT_TIMEOUT
-        released = False
-        while time.monotonic() < deadline:
-            if not job_store.has_active_job():
-                released = True
-                break
-            # Degraded path 1: the holder became terminal on disk
-            # without release_active being called (crashed runner
-            # finally block). Reclaim the slot atomically so we do
-            # not race a new claim from a parallel request.
-            current = job_store.active_job_id
-            if current is not None:
-                current_job = job_store.get(current)
-                if (
-                    current_job is not None
-                    and current_job.status
-                    in (
-                        "completed",
-                        "failed",
-                        "cancelled",
-                    )
-                    and job_store.force_release_active_if(current)
-                ):
-                    released = True
-                    break
-            time.sleep(_RESET_WAIT_INTERVAL)
-
-        if not released:
-            # Degraded path 2: no runner picked up the cancel within
-            # the budget. Force-release atomically to keep reset
-            # honest — the compare-and-release inside
-            # force_release_active_if guarantees we only clear the
-            # exact id we observed, never a new claim that landed in
-            # between.
-            stuck_id = job_store.active_job_id
-            if stuck_id is not None and job_store.force_release_active_if(stuck_id):
-                _log.warning(
-                    "workspace_reset: active slot %s did not release "
-                    "within %.2fs; force-released so the next fit / "
-                    "tune does not JOB_CONFLICT",
-                    stuck_id,
-                    _RESET_WAIT_TIMEOUT,
-                )
-
+    _teardown_active_job(job_store)
     ws.reset()
     return {"status": "ok"}
 


### PR DESCRIPTION
## Summary

Wave 6 / Issue #452 — splits `api/workspace.py::workspace_reset` (123 lines) into a thin orchestrator plus four focused module-level helpers. Pure refactor: no public-API change, no behaviour change, request/response shape unchanged.

> **Note:** #452's sub-PR for `_workspace_metric_compatibility_errors` is **obsoleted by PR #491** (P-0106) — that function is now a thin envelope delegating to the backend, so there is nothing left to split.

## What moved

`workspace_reset`'s body (the cancel + active-slot-release choreography for an in-flight fit / tune, H-0063 / Issue #99) is now:

- `_request_cancel_if_running(job_store, job_id)` — set the cancel flag unless the job is already terminal
- `_wait_for_active_slot_release(job_store) -> bool` — wait up to `_RESET_WAIT_TIMEOUT` for the runner to drain the slot; handles degraded path 1 (terminal holder, crashed runner finally → atomic `force_release_active_if`)
- `_force_release_orphan_slot(job_store)` — degraded path 2 (no runner drained the slot within the budget → force-release + WARNING log)
- `_teardown_active_job(job_store)` — orchestrates the three; early-returns when there is no active job
- `workspace_reset` endpoint — `_teardown_active_job(job_store); ws.reset(); return {"status": "ok"}` (6 lines + docstring)

The long degraded-path rationale moves to the relevant helper docstrings; the `("completed", "failed", "cancelled")` literal (used in 2 places) becomes `_TERMINAL_JOB_STATUSES`. The clear-state-after-wait ordering invariant is documented on `_teardown_active_job`.

## Acceptance (#452)
- [x] Each function ≤ 60 lines (largest is `_wait_for_active_slot_release` at ~22)
- [x] No public-API signature change — `POST /api/workspace/reset` request/response identical
- [x] Existing unit + regression tests pass unmodified: `tests/regression/test_reg_0075_workspace_reset_releases_slot.py`, `test_workspace_api.py::test_reset_clears_workspace`, `test_reg_0028b_browser_reload_hydration.py`, `test_reg_0028c_data_pipeline_resilience.py`, `test_config_patch.py`, `test_server.py` (86 passed)
- [x] Coverage preserved — same code paths, relocated; the endpoint tests already exercise no-active-job / terminal-holder / orphan-slot-timeout branches
- [x] No previously-implicit invariant exposed that needs an `assert` (the ordering invariant is documented; the atomicity guarantee lives in `JobStore.force_release_active_if` already)

## Test plan
- [x] `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/integration --ignore=tests/bench -k "not slow"` → all pass
- [x] `uv run ruff check . && uv run ruff format --check .` → clean
- [x] `uv run mypy --no-incremental src/lizystudio/api/workspace.py` → clean
- [ ] CI green (incl. e2e-chromium, which exercises the reset path)

Refs #452 (remaining sub-PRs: `_run_job_core` split next; `subprocess_runner.run_job_in_subprocess` and `lifecycle_mixin.tune` are gated on v3-22 / the 2nd-adapter discussion respectively, per the issue).
