### PR TITLE
[docs-only] post-Wave-6 handoff for next session

### DIFF
--- a/docs/handoff-2026-05-11-post-wave5.md
+++ b/docs/handoff-2026-05-11-post-wave5.md
@@ -1,5 +1,7 @@
 # Handoff — 2026-05-11 (post Wave 5, P-0104 完了 + P-0105 着地)
 
+> **⚠️ SUPERSEDED 2026-05-12 — 最新は [`docs/handoff-2026-05-12-post-wave6.md`](./handoff-2026-05-12-post-wave6.md) を参照。** 本書は履歴参照のみ（Wave 6 の #403/P-0106・#456・#452 partial はそちらに反映済）。
+
 **Status**: 🟢 P-0104（Tune workflow 全面整備）全 Wave 着地。`docs/issue-cleanup-plan-2026-05-10.md` の Wave 1〜5 完了（**PR #480 = Wave 5.2 マージ済 2026-05-12**）。残るは **Wave 6（技術負債 + reconcile）** のみ。
 **Date**: 2026-05-11（2026-05-12 更新: #480 マージ + #454/#455 クローズ反映）
 **Trigger**: 前セッション（post-Wave-3.1a）の引継ぎを受けて Wave 3.1b → Wave 4 → Wave 5（5.1/5.2/5.3）を 1 セッションで連続着地。翌日（05-12）に #480 マージ + 周辺 issue 整理。

--- a/docs/handoff-2026-05-12-post-wave6.md
+++ b/docs/handoff-2026-05-12-post-wave6.md
@@ -1,0 +1,83 @@
+# Handoff — 2026-05-12 (post Wave 6: #403/P-0106 + #456 done, #452 partial)
+
+**Status**: 🟢 `docs/issue-cleanup-plan-2026-05-10.md` の Wave 1〜6 が実質完了。Wave 6（技術負債 + reconcile）のうち **#403（→ Proposal P-0106）と #456（L1〜L4, L5 は deferred）が着地**、**#452 は 5 関数中 2 関数を分割（残り 2 は別作業に gated、1 は P-0106 で obsolete）**。残るは **#451（v0.5 R-1 後）/ #453（最終 reconcile）** のみ。
+**Date**: 2026-05-12
+**Trigger**: 前 handoff（`docs/handoff-2026-05-11-post-wave5.md` = PR #481）の「Wave 6 に着手」を受けて、1 セッションで PR #490〜#494 を連続着地。
+**Tier**: 4（アクティブな個別計画 — `docs/issue-cleanup-plan-2026-05-10.md` の派生）。**前 handoff `docs/handoff-2026-05-11-post-wave5.md` は本書が supersede。**
+
+---
+
+## TL;DR
+
+- **develop HEAD = `123f271`**（PR #493 マージ後）。CI green。オープン PR は #489（`chore(deps): ignore vite semver-major` — 別系統、未マージ）のみ。
+- このセッションで **PR #490 / #491 / #492 / #493 / #494 を merge**、**Issue #403 / #454 / #455 / #456 を close**、**docs-only PR #475 / #471 を close**、**Issue #495（#456 L5 deferred follow-up）を起票**。
+- 次に着手するなら: **#451**（`services/jobs.py` 1062 行を 5 sub-PR で分割 — 計画書では「v0.5 R-1 完全着地後」と明記）/ **#453**（BLUEPRINT / architecture-as-implemented / v0.4-business-readiness-plan を v0.5.0 state に reconcile — 全部終わった後の最終整合）。あるいは **#474**（P-0104 Wave 3.1a deferred の search-space バリデーション）/ **#495**（#456 L5）。
+- **要起票の follow-up（未起票）**: `JobDetail.handleRefit` が `navigate("/", {state:{refitJobId}})` で渡す `refitJobId` を `WorkspacePage` が読んでいない → Jobs ページの「Re-fit」ボタンは Workspace に遷移するだけで config/data を再読込しない。「`refitJobId` を配線する」or「dead state を削除する」のどちらかが要（前 handoff から引き継ぎ、本セッションでも未対応）。
+
+---
+
+## 本セッション着地サマリ（2026-05-12、すべて develop へ squash merge 済）
+
+| PR | Wave / Issue | 内容 | 状態 |
+|---|---|---|---|
+| [#480](https://github.com/nbx-liz/LizyStudio/pull/480) | Wave 5.2 / #442/#445/#446 | 前 handoff で CI 待ちだった分。`jobs-ui.spec.ts`（Export Format toggle + Pause/Resume `@ci-flaky`）+ `jobs-refit.spec.ts`（Re-fit → Workspace navigation-only） | ✅ merged。#442/#445/#446 close |
+| [#481](https://github.com/nbx-liz/LizyStudio/pull/481) | — | post-Wave-5 handoff doc（本書が supersede） | ✅ merged |
+| [#490](https://github.com/nbx-liz/LizyStudio/pull/490) | #456 **L1+L2** | `tmp/` を `.gitignore` に + CONTRIBUTING.md § Working artefacts。`scripts/check_stray.sh`（`block-stray-artifacts` pre-commit hook、`pass_filenames: false` + `always_run: true`）+ `.pre-commit-config.yaml` local hook + `tests/test_check_stray.py`（20 ケース）。root-level `*.png`/`*.csv`/`*.parquet`、`coverage.json`/`.coverage`、`dist/*.whl`/`*.tar.gz`、`*.tsbuildinfo` を staged で弾く。許可: `docs/images/*.png`, `tests/fixtures/**`, `frontend/src/__fixtures__/**`, `frontend/tests/e2e/__screenshots__/**`, `data/**` | ✅ merged |
+| [#491](https://github.com/nbx-liz/LizyStudio/pull/491) | #403 / **Proposal P-0106**（Change Gate） | `BackendCore.get_incompatible_metrics(task, target_series, metric_names) -> list[IncompatibleMetric]` 追加（Protocol 本体に `return []` のデフォルト）。`IncompatibleMetric` frozen dataclass を `backends/types.py` に新設。lizyml adapter（`ConfigMixin`）が `_REGRESSION_METRIC_WATCHLIST = {mape,rmsle,r2}` + 各 precondition（mape→zero、rmsle→negative、r2→constant variance）+ `task=regression` gate + non-numeric target gate + sMAPE/WAPE suggestion 文言を所有。`services/workspace.py::_workspace_metric_compatibility_errors` は thin envelope（109→55 行）に縮小 → **#452 sub-PR 1 を obsolete**。HISTORY P-0106 Decision=Approved、BLUEPRINT §3.3.1/§3.3.2 更新。`tests/test_backends_lizyml.py::TestGetIncompatibleMetrics`（14 ケース）。contract test（`test_validate_metric_compatibility.py` 15 + `test_fit_tune_severity_filter.py`）無改修 pass。python-reviewer Approve。#403 close | ✅ merged |
+| [#492](https://github.com/nbx-liz/LizyStudio/pull/492) | #452（workspace_reset） | `api/workspace.py::workspace_reset`（123 行）→ `_request_cancel_if_running` / `_wait_for_active_slot_release`（degraded path 1: terminal holder → `force_release_active_if`）/ `_force_release_orphan_slot`（degraded path 2: timeout → force-release + WARNING）/ `_teardown_active_job`（orchestrator、active job 無しは early-return）/ thin endpoint（6 行）。`_TERMINAL_JOB_STATUSES` 定数。**schema.d.ts 再生成**（docstring 短縮 = endpoint の OpenAPI description → api-types-drift gate）| ✅ merged |
+| [#493](https://github.com/nbx-liz/LizyStudio/pull/493) | #452（_run_job_core） | `services/_training_core.py::_run_job_core`（128 行）→ `_claim_active_or_fail`（slot 競合 → failed + JOB_CONFLICT broadcast + return False）/ `_capture_job_logs`（`@contextmanager`、per-job logger に DEBUG StreamHandler を attach/detach）/ `_apply_job_outcome`（`"running"` stamp + execute_fn + completed/paused/cancelled/failed の status マップ）/ `_persist_job_log`（OSError 握り潰し、Issue #328 append semantics）/ thin orchestrator（~25 行）。`"running"` stamp を `_apply_job_outcome` に移動（→ `_run_job_core` が `job.status` を `Literal["running"]` に narrow しなくなり mypy `!= "paused"` OK）。1 回目 CI で既知 pre-existing flake 2 件で e2e fail → 原因がバックエンドのみ refactor と無関係を確認の上 rebase + 再実行で clean | ✅ merged |
+| [#494](https://github.com/nbx-liz/LizyStudio/pull/494) | #456 **L3+L4** | L3: `scripts/check_orphan_goldens.sh`（committed golden が `frontend/tests/e2e/__screenshots__/<project>/` 配下で、どの workflow も `--project=<project>` で走らせていなければ fail）+ `ci.yml` の `frontend` job に step（pure git/shell、新規 runner なし）+ `tests/test_check_orphan_goldens.py`（6 ケース）。L4: `publish.yml` の `uv build` 前に `rm -rf dist/`（fresh checkout では dist/ 不在なので防御的だが、stale wheel co-residency 時に version-verify が誤 wheel を拾うのを防ぐ）。CONTRIBUTING.md § Quality gates 更新。**#456 close**（L1〜L4 完了、L5 は #495 へ deferred） | ✅ merged |
+
+---
+
+## Issue 整理（このセッション）
+
+- **close**: #403（P-0106 で着地）、#442 / #445 / #446（#480）、#454（ローカル掃除完了 — 全 gitignore 済、commit 不要）、#455（PR #465 で既済の stale issue）、#456（L1〜L4 完了、L5 deferred）
+- **PR close**: #475 / #471（古い handoff docs-only）
+- **新規起票**: **#495**（#456 L5 — weekly stale-doc audit cron。tier-3/low、deferred）
+- **#452 にステータスコメント**（issue は open 継続）: 5 関数中 2 件分割完了（#492 `workspace_reset` / #493 `_run_job_core`）、1 件は #491 / P-0106 で obsolete（`_workspace_metric_compatibility_errors`）、残り 2 件 gated:
+  - `services/subprocess_runner.py::run_job_in_subprocess`（181 行）— issue 曰く「v3-22 server-restart recovery 着地後」
+  - `backends/lizyml/lifecycle_mixin.py::tune`（167 行）— issue 曰く「2nd-adapter 議論（ROADMAP §3.3）後」
+
+---
+
+## 残作業
+
+### Wave 6 残（`docs/issue-cleanup-plan-2026-05-10.md` §3）
+
+| # | 作業 | 注意 |
+|---|---|---|
+| 6.4 | **#451 PR series**（`services/jobs.py` 1062 行を 5 sub-PR で分割） | 計画書で「v0.5 R-1 完全着地後、最後に」と明記。それまで着手しない |
+| 6.5 | **#453 PR**（BLUEPRINT / architecture-as-implemented / v0.4-business-readiness-plan を v0.5.0 state に reconcile） | 全部終わった後の最終整合。BLUEPRINT §3.3.2 の `BackendCore.tune` 記述が `storage`/`study_name` パラメータを欠いている等の既知ドリフトもここで直す |
+| — | **#452 の gated 2 件**（`run_job_in_subprocess` → v3-22 後 / `lifecycle_mixin.tune` → 2nd-adapter 後） | それぞれの前提作業が動いてから |
+| — | **#495**（#456 L5 — weekly stale-doc audit cron） | tier-3/low。`scripts/audit_stale_docs.py` + `.github/workflows/audit-stale-docs.yml`（cron weekly）+ tracking issue 自動更新 |
+
+### プラン外 / 棚卸し
+
+- **#474**（P-0104 Wave 3.1a deferred）— inverted-range / log+low≤0 の search-space エラーを config validate 時に早期 surface（backend `validate_config` で `parse_space()` に通す）。
+- **#488**（Vite 8 / Rolldown 移行）— vite は v6 のまま、dependabot.yml で semver-major ignore（PR #489 がそれを wire するが未マージ）。Vite 8 dev server が e2e の `/api/ws` proxy を壊す（`project_vite8_migration_held.md`）。
+- **#28**（offline tests）、**#27**（load tests）— 旧来からの open。
+- **要起票 follow-up（未対応）**: `JobDetail.handleRefit` の `refitJobId` dead state（上記 TL;DR 参照）。
+- **要起票 follow-up（任意）**: #444 deferred 分 — Inference Results の `Prediction Distribution`（calibrated binary fit のみ）/ `Score`（`metrics` に `inf/is/oos` キーがある時のみ）の e2e アサーション。
+
+---
+
+## このセッションで学んだ / 再確認した Gotchas
+
+1. **pre-push `validate-push.sh` フックが `uv run mypy`（incremental）を回す** → `@property` を変更したブランチ（例: #491 の `backends/base.py`）を pull すると `.mypy_cache` が corrupt（`KeyError: 'setter_type'` / `'module'`）し、push がブロックされる。修復: `uv run python -c "import shutil; shutil.rmtree('.mypy_cache', ignore_errors=True)"` → `uv run mypy src/lizystudio/` で cache 再構築 → push。（`rm -rf .mypy_cache` は Bash でサンドボックス拒否される。）
+2. **endpoint の docstring を変えると `schema.d.ts` が drift する** — FastAPI が docstring を OpenAPI `description` に入れるため。`api-types-drift` test（`tests/test_inference_response_model.py::test_schema_d_ts_matches_generated_output`）が落ちる。`pnpm generate:api` は localhost:8501 のサーバが要るので、サーバ無しで再生成するには test と同じ手順をスクリプト化（`TestClient(create_app())` → `/openapi.json` → 同梱の `node_modules/.bin/openapi-typescript` に通す → `frontend/src/api/generated/schema.d.ts` へ）。
+3. **`.claude/` は `.gitignore` 配下**（`AGENTS.md` / `CLAUDE.md` も）。#456 L1 のチェックリストにあった `.claude/AGENTS.md` / `visual-feedback` skill の更新は repo に乗らない（local-only）。トラッキングされる enforcement は `.gitignore` + CONTRIBUTING.md + L2 hook。
+4. **既知 e2e flake**（変更しない、再実行で pass）: `workspace-config-fields-loop` / `workspace-config-reflection` の `split.n_splits`（funnel-quiescence、`waitForRequest` timeout）、`workspace-fit.spec.ts` の「3-panel layout and Fit tab」（このテストは fit を**実行しない** — `page.goto("/")` + レイアウト assertion だけ）。
+5. **複数 PR を直列で回すとき**: 先行 PR がマージされると後続 PR が BEHIND になる（branch protection は up-to-date 必須）。force-push 禁止なので `git merge origin/develop --no-edit` で merge commit を作って push。merge 後は mypy cache を clear してから push（Gotcha 1）。
+6. **CI ベースライン（2026-05-12 / develop `123f271`）**: 各マージ PR の CI が green。ローカル `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/integration --ignore=tests/bench -k "not slow"` → 1507 passed（#491 マージ前の sweep。develop には #492/#493 の refactor も入っているが pure refactor で count 不変＋ #494 の `tests/test_check_orphan_goldens.py` 6 ケース・#490 の `tests/test_check_stray.py` 20 ケースが加わる）。mypy 55 files clean、ruff / biome / `pnpm build` clean、e2e は CI で functional 全 pass（既知 flake は上記）。
+
+---
+
+## 関連ドキュメント
+
+- [docs/issue-cleanup-plan-2026-05-10.md](./issue-cleanup-plan-2026-05-10.md) — 6 Wave 計画書（Wave 1〜5 完了、Wave 6 は #451/#453 と #452 gated 分のみ残）
+- [HISTORY.md §P-0106](../HISTORY.md) — metric-compat を `BackendCore` capability の裏へ（#403）
+- [HISTORY.md §P-0104 / §P-0105](../HISTORY.md) — 前セッションの Tune workflow 整備 / Residuals kind selector
+- BLUEPRINT.md §3.3.1（`IncompatibleMetric`）、§3.3.2（`BackendCore.get_incompatible_metrics`）
+- `scripts/check_stray.sh` / `scripts/check_orphan_goldens.sh` — #456 の L2 / L3 実装
+- 旧 handoff（supersede 済）: `docs/handoff-2026-05-11-post-wave5.md`（PR #481）、`docs/handoff-2026-05-10-post-h0079.md`


### PR DESCRIPTION
## Summary

Session handoff doc for the post-Wave-6 state. Adds `docs/handoff-2026-05-12-post-wave6.md` and marks `docs/handoff-2026-05-11-post-wave5.md` as superseded (kept in place per CLAUDE.md §1.1).

Captures: PRs #490/#491/#492/#493/#494 merged (#403/P-0106, #456 L1-L4, #452 partial); #403/#454/#455/#456 closed; #495 filed; #452 stays open for 2 gated functions; remaining Wave 6 = #451 (after v0.5 R-1) + #453 (final reconcile). Plus the mypy-cache-corrupts-on-property-change push-hook gotcha and the refitJobId dead-state follow-up.

`[docs-only]` — fast-track once green.

Closable after merge: this PR (the doc lands on develop).