### PR TITLE
[docs-only] reconcile BLUEPRINT / arch-as-implemented / v0.4-business-readiness with v0.5.0 state (#453)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -208,6 +208,8 @@ class BackendCore(Protocol):
         re_tune: dict[str, Any] | None = None,       # H-0061 多ラウンド再チューニング
         checkpoint_dir: Any = None,                  # H-0062 試行ごとのチェックポイント
         resume: bool = False,                        # H-0062 Phase B
+        storage: str | None = None,                  # P-0099 v3-20b: Optuna persistent storage URL（in-place resume 用）
+        study_name: str | None = None,               # P-0099 v3-20b: Optuna study 名（同 study に load_if_exists=True で re-attach）
     ) -> TuningSummary: ...
 
     def predict(
@@ -318,6 +320,8 @@ class BackendAdapter(
 - ブラウザ再アクセス時は `workspace_result = None`（右パネル空）
 - 過去のJob結果は表示しない（混乱防止）
 - **Active job lock (P-0089)**: `active_job_id` がセットされている間、`PUT /api/workspace/config` および `PATCH /api/workspace/config` は 409 `WORKSPACE_LOCKED` を返す。これは UI 上の cross-hook race（CV strategy 切り替え / target 変更等）が走行中ジョブの config を後から書き換えるのを構造的に防ぐ。INV: `meta.json` に保存される config は `claim_active` 直前の workspace config と完全一致する
+- **Startup reconciliation (P-0099 v3-22a / R-1.5b)**: `active_job_id` はインメモリだが、サーバ再起動時に `JobStore.reconcile_at_startup()` が on-disk `meta.json` をスキャンして再構築する。`running` / `pending` の orphan は `failed` 化（worker thread / subprocess は前プロセスと共に消えているため）、`paused` job は `active_job_id` に再 attach（INV-7: WS 切断は active slot を release しない / restart 越しに paused slot を保持）、terminal states は rewrite しない、idempotent。
+- **Reload restoration (P-0102 / v3-24 / R-2.2)**: `current_job_id` を `GET /api/workspace/status` で露出している。frontend は `?job_id=` 不在時にこれを fallback として 1 回だけ hydrate し（latch は `workspace_reset` までクリアされない）、長時間学習中のリロードで進捗を見失わないようにする。dirty な config form を持つ状態の `beforeunload` は browser default confirm dialog を出す（誤リロード防止）。`current_job_id` が null なら従来どおり空状態。1 名利用前提のため multi-tab 衝突制御は scope 外。
 
 #### 3.4.2 Job 状態（永続・ディスク）
 
@@ -326,7 +330,7 @@ class BackendAdapter(
 | 状態 | 型 | 説明 |
 |------|-----|------|
 | `job_id` | `str` | 一意識別子 |
-| `status` | `pending \| running \| completed \| failed \| cancelled` | ジョブの実行状態 (H-0057) |
+| `status` | `pending \| running \| paused \| completed \| failed \| cancelled` | ジョブの実行状態 (H-0057。`paused` は P-0099 v3-20a で追加 — Tune long-run resumability 用の非 terminal 状態) |
 | `backend_name` | `str` | 使用バックエンド名 |
 | `config` | `dict` | 使用Config |
 | `data_ref` | `DataRef` | データ参照（パス + フィンガープリント） |
@@ -337,6 +341,29 @@ class BackendAdapter(
 | `tune_result` | `TuningSummary \| None` | Tune 実行結果（Fit Job の場合は `None`） |
 | `model_path` | `Path \| None` | 学習済みモデルの保存パス |
 | `error` | `str \| None` | エラーメッセージ（失敗時） |
+
+**状態遷移と不変条件（P-0099 R-1）:** Job state machine の合法遷移は以下のみ。illegal transitions は `JobStore.set_status` が `AssertionError` で reject する（runtime guard）。invariant test は `tests/regression/test_inv_*.py`。
+
+```
+[*] → pending          (POST /fit / /tune)
+pending → running      (worker thread が claim_active)
+pending → cancelled    (start 前の DELETE / cancel)
+running → completed    (terminal write OK)
+running → failed       (exception / subprocess died)
+running → cancelled    (cancel signal を mid-run で観測)
+running → paused       (Tune trial 完了時に user pause、R-1.4)
+paused  → running      (POST /unpause / restart 時の再 attach)
+paused  → cancelled    (paused 中の cancel — worker 不在なので明示遷移)
+paused  → failed       (resume 時に storage corruption を検出)
+```
+
+- **INV-1**: `active_job_id` は同時に高々 1 つの running-or-paused job を保持。release は completion / cancel / exception / SIGKILL / WebSocket 切断 / browser 閉じる の 6 経路すべて（`paused` だけは例外で slot を保持し続ける — `POST /unpause` のための Optuna sqlite を所有しているため）。
+- **INV-2**: `meta.json` は atomic write（tmpfile + `fsync` + `os.replace` + parent-dir `fsync`、`storage/versions.py:write_versioned_json`）。`kill -9` mid-write でも JSON 整合性が破れない。
+- **INV-3**: 上記の合法遷移以外は assert で reject。
+- **INV-4**: `paused` job は trial-level checkpoint（Optuna sqlite `storage` + `study_name`）+ `meta.json` から完全復元可能。`load_if_exists=True` で同 study に re-attach し trial 番号が monotonic に蓄積される（`tests/integration/test_tune_resume_round_trip.py`）。
+- **INV-5**: cancel observation は monotonic — `is_cancel_requested(job_id)` が一度 True を返したら job 完了まで連続 True。
+- **INV-6**: subprocess crash recovery — 子 process が SIGKILL で死ぬと既存 reconcile path が `failed (reason="subprocess died")` で terminal write + slot release（専用 watchdog は audit の結果不要と判明）。
+- **INV-7**: WebSocket 切断は active slot を release **しない**。進行中 job は subscriber 数に依らず terminal まで走り、restart 越しに paused slot を復元する。
 
 #### 3.4.3 DataRef（データ参照）
 
@@ -378,6 +405,13 @@ class DataRef:
 - `model.pkl`: Tune 実行中に各 trial 完了毎に atomic rename で上書き保存される（クラッシュ耐性のための best-effort）。加えて `Model.tune()` が `self._study` をセットしてから `return` する前に、**確定版の最終 save を必ず 1 回実行する**。lizyml の `Model.tune()` は study を関数末尾でのみ内部フィールドに代入する契約のため、毎 trial save だけだと pickle に `_study=None` しか残らず、Re-tune / Resume で `load_checkpoint()` した Model が `lizyml: Cannot resume tuning: no previous tune() call` を発生させる（H-0062 Bugfix 2026-04-14）。再tune / resume 時はこの最終 save をソース・オブ・トゥルースとして `load_checkpoint()` でモデル状態（Optuna study 含む）を復元する。
 - `model_meta.json`: pickle schema version + saved_at + lizyml/lightgbm/optuna のバージョン記録。メジャーバージョン不一致時は `PICKLE_INCOMPATIBLE` で load を拒否する。
 - `meta.json.parent_job_id`: Re-tune / Resume の child job では parent の job_id を参照する。非 child job では `null`。
+
+**format_version と legacy 保護（P-0103 / v3-25 / R-4.1）:** ディスク上の `meta.json` 等は `storage/versions.py` 経由で読み書きし、`STUDIO_FORMAT_VERSION`（現行 `2` — P-0099 v3-20a で `1`→`2`）の値を `format_version` キーに記録する。
+
+- 旧 version の読み込みは常に許可（in-memory で自動 migration、現状 v0→v1→v2 はすべて identity migration）。
+- 旧 version（`format_version < STUDIO_FORMAT_VERSION`）の同名ファイルが既に disk に存在する場合、それを上書きする write は環境変数 `LIZYSTUDIO_ALLOW_LEGACY_WRITE=1` が無いと `LegacyFormatProtectionError` を raise する（INV-fmt-2）。将来の structural change で旧 workspace を silent に破壊するのを防ぐため。
+- 新規ファイルや同 version への上書きは常に許可（INV-fmt-3）。
+- `format-version-matrix` CI job が `tests/fixtures/legacy_workspaces/{v0,v1}/` の captured fixture を v0→v1→v2 round-trip し、migration の idempotence を gating する（INV-fmt-4 / P-0095 拡張）。
 
 #### 3.4.5 Inference 履歴（永続・ディスク）
 
@@ -1968,8 +2002,10 @@ Optimization History → Best Params → Score → Learning Curve → Plots（�
 | **Inference ▸** | Inference 画面に遷移。このジョブのモデルを自動選択 | Completed（Fit / Tune） |
 | **Export ▸** | Export ダイアログを開く | Completed（Fit / Tune） |
 | **Re-fit ▸** | Config を Workspace の Model Panel にロードし、Workspace に遷移 | Completed / Failed |
+| **Pause** | 実行中 Tune を次の trial 完了時に paused に遷移（ダイアログなし、`PauseCircle` アイコン）(P-0099 v3-20f) | Running（Tune のみ） |
+| **Resume** | paused Tune を同じ Optuna study から再開（in-place。ダイアログなし、`PlayCircle` アイコン）。failed→child job を作る既存 **Resume (X trials remaining)**（§4.3.3「Re-tune / Resume アクション」、lineage）とは責務が別 (P-0099 v3-20f) | Paused（Tune のみ） |
 | **Delete** | ジョブの削除。確認ダイアログあり | 全状態（Running 以外） |
-| **Cancel** | 実行中ジョブのキャンセル。確認ダイアログあり | Running |
+| **Cancel** | 実行中 / paused ジョブのキャンセル。確認ダイアログあり（paused 用に本文を切り替え）(P-0099 v3-20c) | Running / Paused |
 
 **Re-fit の動作:**
 1. 選択ジョブの Config（data / features / split / model / training / evaluation）を Workspace の各パネルに反映
@@ -2485,9 +2521,11 @@ Workspace の `workspace_result` は完了時に自動更新される。
 | POST | `/api/jobs/{job_id}/export` | モデル/レポートを指定パスにExport |
 | GET | `/api/jobs/{job_id}/export-code` | LizyML 非依存コードを ZIP でダウンロード（H-0027） |
 | GET | `/api/jobs/{job_id}/log` | 実行ログ取得（H-0006） |
-| POST | `/api/jobs/{job_id}/cancel` | Running ジョブのキャンセル（H-0011） |
+| POST | `/api/jobs/{job_id}/cancel` | Running / Paused ジョブのキャンセル（H-0011 / P-0099 v3-20c） |
+| POST | `/api/jobs/{job_id}/pause` | Running Tune を paused に遷移（次の trial 完了時）。Fit ジョブは `JOB_NOT_PAUSEABLE`、running 以外は `JOB_NOT_RUNNING`（P-0099 v3-20d） |
+| POST | `/api/jobs/{job_id}/unpause` | Paused Tune を同 job_id で in-place 再開（Optuna `load_if_exists=True` で trial 継続）。data 再ロード必須。paused 以外は `JOB_NOT_PAUSED`、data 未読込は `WORKSPACE_NO_DATA`（P-0099 v3-20d） |
 | POST | `/api/jobs/{job_id}/retune` | 完了 Tune を起点に再チューニング子ジョブを作成（H-0062） |
-| POST | `/api/jobs/{job_id}/resume` | 失敗/中断 Tune の再開子ジョブを作成（H-0062 Phase B） |
+| POST | `/api/jobs/{job_id}/resume` | 失敗/中断 Tune の再開子ジョブを作成（H-0062 Phase B。`unpause` とは別 — こちらは lineage child を作る） |
 | GET | `/api/jobs/{job_id}/lineage` | ジョブ系譜のサブツリー（H-0062） |
 | DELETE | `/api/jobs/{job_id}` | ジョブを削除（query: `cascade=true` で子孫も削除） |
 
@@ -2607,6 +2645,15 @@ Workspace の `workspace_result` は完了時に自動更新される。
 
 ```json
 {
+  "type": "paused",
+  "job_id": "job_042",
+  "trial_number": 7,
+  "message": "Paused."
+}
+```
+
+```json
+{
   "type": "ping",
   "job_id": "job_042"
 }
@@ -2614,7 +2661,9 @@ Workspace の `workspace_result` は完了時に自動更新される。
 
 `ping` は 30 秒間隔の keepalive メッセージ（H-0058）。クライアントは受信しても無視してよい（WebSocket 接続維持のため）。
 
-**Schema SSOT (H-0069):** 上記 4 variant は `src/lizystudio/ws/messages.py` の Pydantic discriminated union として単一定義される。サーバ側送信は `WsMessage.model_dump_json(exclude_none=True)` を通り、フロントは生成 `schema.d.ts` から `WsMessage` 型を import する。optional フィールド (`fold_results` / `trial_results`) は値が存在するときだけ wire に現れ、`null` フィールドはシリアライズしない（既存 wire format と bit-identical）。
+`paused` は Tune が user pause で中断したことを通知する（P-0099 v3-20e）。`trial_number` は最初の paused emit 時点で worker が trial に到達していなければ `null`。**terminal メッセージではない** — pause は resumable なので late-subscriber replay cache（下記 Terminal replay）には載せず、frontend は WS 接続を維持したまま `unpause` 後の live stream 継続に備える。
+
+**Schema SSOT (H-0069):** 上記 5 variant は `src/lizystudio/ws/messages.py` の Pydantic discriminated union として単一定義される。サーバ側送信は `WsMessage.model_dump_json(exclude_none=True)` を通り、フロントは生成 `schema.d.ts` から `WsMessage` 型を import する。optional フィールド (`fold_results` / `trial_results`) は値が存在するときだけ wire に現れ、`null` フィールドはシリアライズしない（既存 wire format と bit-identical）。
 
 **Terminal replay (P-0093 / Issue #327):** `completed` / `error` メッセージは `ProgressBroadcaster._last_terminal` に per-jobId でキャッシュされ、subscribe より前に送信された場合でも late subscriber に replay される。TTL は default 5 分（環境変数 `LIZYSTUDIO_WS_TERMINAL_TTL_S` で上書き可）。これにより高速 fit (< 3 秒) の subscribe-vs-send race が解消される。INV-1: terminal メッセージは subscribe タイミングに関わらず subscriber に **少なくとも一度** 届く。INV-2: live broadcast 経路と replay 経路は subscriber の登録タイミングを境に disjoint なので、同一 subscriber への重複配信は発生しない。replay 発生は `lizystudio_progress_terminal_replayed_total` Counter で観測可能。
 
@@ -2899,6 +2948,11 @@ lizystudio_active_jobs 0.0
 | `PARENT_HAS_ACTIVE_CHILDREN` | DELETE 対象 parent に active children がある（cascade=true 必須）(H-0062) | 409 |
 | `CHECKPOINT_MISSING` | Re-tune/Resume 対象 job に model.pkl が存在しない (H-0062) | 400 |
 | `JOB_NOT_FAILED` | Resume は failed tune job のみ対象 (H-0062) | 400 |
+| `JOB_NOT_RUNNING` | Cancel / Pause は running（または paused — Cancel のみ）job が対象 (P-0099 v3-20c/d) | 400 |
+| `JOB_NOT_PAUSEABLE` | Pause は tune job のみ対象（fit job は paused にできない）(P-0099 v3-20d) | 400 |
+| `JOB_NOT_PAUSED` | Unpause は paused job のみ対象 (P-0099 v3-20d) | 400 |
+
+> `LegacyFormatProtectionError`（§3.4.4 / P-0103）は専用エラーコードを持たず、`INTERNAL_ERROR` (500) として surface する。発生条件（旧 format_version の disk ファイル上書き）は通常運用では起きないため。recovery 手順は環境変数 `LIZYSTUDIO_ALLOW_LEGACY_WRITE=1`。
 
 ### 6.2 バックエンドエラーの伝播
 
@@ -3240,4 +3294,4 @@ Phase B では `{jobs_dir}/{job_id}/model.pkl` に cloudpickle で Tune Job の�
 
 ---
 
-_Last reconciled: 2026-05-01 against develop @ ad4c581. P-0086 (config body) / P-0088 (`files_root`) / P-0089 (active-job lock + `WORKSPACE_LOCKED`) / P-0093 (WS terminal-replay) / P-0094 (perf baseline) / `JOB_CONFLICT` / `preflight_checkpoint_dir` を本サイクルで反映。Tier 3 派生 doc（`docs/architecture.md` / `api.md` / `adapter-guide.md`）は #332 で同期済み。_
+_Last reconciled: 2026-05-12 against develop @ 82d4ec3 (Issue #453). 2026-05-01 (@ ad4c581): P-0086 (config body) / P-0088 (`files_root`) / P-0089 (active-job lock + `WORKSPACE_LOCKED`) / P-0093 (WS terminal-replay) / P-0094 (perf baseline) / `JOB_CONFLICT` / `preflight_checkpoint_dir`。2026-05-12 (@ 82d4ec3): P-0099 (`paused` job state + state-machine invariants INV-1〜INV-7 + startup reconciliation v3-22a + `POST /jobs/{id}/pause`・`/unpause` + `WsPaused` message + `JOB_NOT_RUNNING`・`JOB_NOT_PAUSEABLE`・`JOB_NOT_PAUSED`) / P-0102 (reload restoration) / P-0103 (`LegacyFormatProtectionError` + `format-version-matrix` CI gate) / P-0104 (Tune workflow 整備) / P-0105 (Residuals kind selector) / P-0106 (metric-compat を `BackendCore` capability の裏へ) を反映。Tier 3 派生 doc（`docs/architecture.md` / `api.md` / `adapter-guide.md`）は #332 で同期済み。_

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 - このファイルは **横串インデックス** であり、詳細はリンク先で確認すること。
 - 着手する際は HISTORY に Proposal を起票（変更ゲート対象の場合）→ PLAN にフェーズ追加 → 実装、の順で進める。
 
-最終更新: 2026-05-06（v0.5 R-1 進行中：v3-17 / v3-18 / v3-19 すべて完了 (PR #412 / #413 / #414 / #415)、v3-21 subsumed by #366、v3-20 設計レビュー Approved (`docs/v3-20-tune-resume-design.md`) → 7 sub-phase で実装開始）
+最終更新: 2026-05-12（**v0.5.0 release 済 (2026-05-07)** — R-1 (v3-17〜v3-22) / R-2 (v3-23〜v3-24) / R-4.1 (v3-25) すべて着地、HISTORY P-0099 / P-0102 / P-0103。`issue-cleanup-plan-2026-05-10.md` の Wave 1〜6 もほぼ完了（Wave 6 残は #451 JobStore 分割 / #453 docs reconcile / #452 gated 2 件 / #495）。残る v0.5 phase は **v3-26 (R-4.2 Pickle compat nightly)** のみ。次の節目候補は **v0.6**: 第 2 backend (#403)、Tailwind v4 (#125)、P-0087 Phase 3、typed error 体系 (R-3.1〜R-3.3) など）
 
 ---
 
@@ -34,7 +34,7 @@
 | ドキュメント | 役割 | 最終更新 | 関係 |
 |---|---|---|---|
 | `docs/architecture.md` | 入門レベルの architecture overview。BLUEPRINT §3 へのゲートウェイ | 2026-04-10 | 内容は BLUEPRINT 派生 |
-| `docs/architecture-as-implemented.md` | 実装の現状 snapshot（BLUEPRINT は意図、こちらは現実） | 2026-04-17 | BLUEPRINT との対比で読む |
+| `docs/architecture-as-implemented.md` | 実装の現状 snapshot（BLUEPRINT は意図、こちらは現実） | 2026-05-12 | BLUEPRINT との対比で読む |
 | `docs/api.md` | REST API リファレンス。BLUEPRINT §5 へのゲートウェイ | 2026-04-10 | 内容は BLUEPRINT 派生 |
 | `docs/adapter-guide.md` | BackendAdapter Protocol 実装手順 | 2026-04-10 | BLUEPRINT §6 (Adapter 設計) と対 |
 
@@ -46,8 +46,9 @@
 
 | ドキュメント | 役割 | ステータス | 進捗追跡 |
 |---|---|---|---|
-| `docs/gui-e2e-plan.md` | GUI E2E Phase A/B/C/D 計画 | 🟡 進行中（Phase D 残り B-1/B-2/B-4/B-5/B-6/B-8 + Phase C generator） | 本 ROADMAP §4 |
-| `docs/issue-cleanup-plan-2026-05-10.md` | Open Issue 23 件を 18 PR で消化する 6 Wave 計画（Tune workflow 中心） | 🟡 計画策定済み・未着手 | 本ドキュメント自体 |
+| `docs/gui-e2e-plan.md` | GUI E2E Phase A/B/C/D 計画 | 🟢 Phase A〜D ほぼ完了（B-1〜B-8 + Phase C generator + 22 field 着地、残課題は §4.2「カバー困難」表） | 本 ROADMAP §4 |
+| `docs/issue-cleanup-plan-2026-05-10.md` | Open Issue を 6 Wave で消化する計画（Tune workflow 中心） | 🟢 Wave 1〜6 ほぼ完了（残: #451 JobStore 分割 / #453 docs reconcile / #452 gated 2 件 / #495 — §5・§7 参照） | 本ドキュメント自体 |
+| `docs/v3-20-tune-resume-design.md` | v3-20 (R-1.4 Tune resume) 設計レビュー資料 | 🟢 shipped（v0.5.0 で v3-20a〜g 着地）— Tier 5 相当 | — |
 
 ### Tier 5: アーカイブ（完了済み・参照のみ）
 
@@ -58,6 +59,9 @@
 | `docs/coupling-analysis.md` | A-1..A-10 / B-1..B-10 / C-1..C-12 の疎結合化計画 | 2026-04-22 |
 | `docs/c6-openapi-fetch-plan.md` | C-6（openapi-fetch 導入）の実装計画 | 2026-04-22 |
 | `docs/ui-config-sync-audit-2026-04.md` | Issue #249 起点の Workspace form config-sync 監査 | 2026-04-23 |
+| `docs/v0.4-business-readiness-plan.md` | v0.4「業務利用可能」化の Phase 別計画（R-1〜R-5） — R-1/R-2/R-4.1 は v0.5.0 で着地、R-3.1〜3.3 のみ v0.6+ deferred | 2026-05-07 |
+| `docs/v3-20-tune-resume-design.md` | v3-20 (R-1.4 Tune resume) 設計レビュー資料 — v3-20a〜g で実装完了 | 2026-05-07 |
+| `docs/pre-v05-handoff-2026-05-05.md` | v0.5 着手前 MUST/SHOULD/OPTIONAL 13 件の作業内訳 — 全件消化済 | 2026-05-07 |
 
 ### Project Chrome（外部向け）
 
@@ -90,7 +94,7 @@
 | `H-00XX` | HISTORY.md の旧 Proposal 番号（H-0017..H-0085） | `H-0085` | 採番終了。引き続き参照 ID として有効 |
 | `P-00XX` | HISTORY.md の現行 Proposal 番号（P-0086 から） | `P-0092` | **進行中の正規 ID**。新規 Proposal は `P-0093` 以降 |
 | Coupling `A-N` / `B-N` / `C-N` | `docs/coupling-analysis.md` のリファクタ系列 | `B-7`, `C-9` | **完了** (2026-04-22)。歴史参照のみ |
-| GUI E2E `Phase A.1〜A.7`, `B-1..B-8`, `C`, `D-1..D-5` | `docs/gui-e2e-plan.md` の E2E 計画 | `B-4`, `D-3` | **進行中**。本文書 §3 で実装状況を追跡 |
+| GUI E2E `Phase A.1〜A.7`, `B-1..B-8`, `C`, `D-1..D-5` | `docs/gui-e2e-plan.md` の E2E 計画 | `B-4`, `D-3` | **概ね完了**（B-1〜B-8 + Phase C generator + 22 field 着地）。本文書 §4 で実装状況を追跡 |
 | `G-1..G-8`, `H-1..H-4` | 2026-04-30 develop ブランチの code-review 監査で付けた gap/highlight ID | `G-3`, `H-2` | **完了** (PR #300, #303, #306..#310)。歴史参照のみ |
 | `INV-N` | 個別 Proposal 内の invariant ID | `INV-A1` | Proposal 内ローカル ID |
 
@@ -104,6 +108,14 @@
 
 | 完了日 | ID | タイトル | 主要 PR |
 |---|---|---|---|
+| 2026-05-12 | Wave 6 (#403/#456) | metric-compat を `BackendCore` capability の裏へ (P-0106) + stray-file gate + orphan-golden gate + `workspace_reset` / `_run_job_core` の helper 分割 (#452 partial) | #490 / #491 / #492 / #493 / #494 |
+| 2026-05-12 | P-0104〜P-0106 | Tune workflow 全面整備（Re-tune UX + canonical defaults + validation guardrails + LizyML v0.15 SSOT 連動）+ Residuals kind selector + metric-compat capability | 多数（Wave 1〜5）。HISTORY §P-0104〜§P-0106 |
+| 2026-05-12 | LizyML v0.15.0 連動 | `LGBMProvider.objective_choices/metric_choices/parameter_bounds` を UiSchema 経由で SSOT 化、Studio hardcoded master 削除（D3/D7） | (Wave 3.1b) |
+| 2026-05-07 | **v0.5.0 release** | Reliability release — Tune 24h+ resumability + server restart recovery + WS reconnect + browser reload restoration + format_version CI gate + CVE patch round | #416〜#438（多数）, release merge |
+| 2026-05-07 | P-0099 (v3-17〜v3-22) | Job state machine invariants INV-1〜INV-7 + `paused` state + pause/unpause API + `WsPaused` + server restart reconciliation | #408（proposal）, #412〜#426 |
+| 2026-05-07 | P-0102 (v3-24) | ブラウザリロード後の workspace state 自動復元（`current_job_id` hydrate + beforeunload dirty guard） | #429 / #430 / #435 |
+| 2026-05-07 | P-0103 (v3-25) | 古い format_version の workspace を read-only で保護（`LegacyFormatProtectionError` + `format-version-matrix` CI gate） | #432 / #434 / #436 / #438 |
+| 2026-05-07 | R-2.1 (v3-23) | WebSocket 再接続戦略（5min ceiling + indefinite retry + ±15% jitter） | #427 |
 | 2026-05-05 | **v0.4.1 release** | Validate clarity patch — severity envelope + auto-disable uncomputable metrics + lizyml 0.11.0 (sMAPE/WAPE) | #397 / #398 / #399 / #400 / #401 / #402 (release merge) |
 | 2026-05-05 | PR-D1 (#400) | fit/tune raise sites filter on `severity="error"`; warning-only configs no longer 422 | #400 |
 | 2026-05-05 | PR-C2 (#399) | `_workspace_metric_compatibility_errors` auto-disables `mape`/`rmsle`/`r2` via severity=warning + suggested_fix | #399 |
@@ -135,13 +147,17 @@
 
 ## 3. アクティブ：仕様変更を伴う Proposal
 
-### 3.-1 v0.5 R-1 invariants Proposal（P-0099, P-0100, P-0101 — すべて Decision 確定済）
+> **状態サマリ**: 直近のアクティブ Proposal はすべて Decision 確定 + 着地済（P-0099 / P-0102 / P-0103 = v0.5.0、P-0104 / P-0105 / P-0106 = Tune workflow & metric-compat）。新規 Proposal は **P-0107 以降**を採番。
 
-- **状態**: ✅ Approved／確定済（P-0099 = 2026-05-06 Approved、P-0100 / P-0101 = 2026-05-05 確定 with #406）
-- **P-0099**: Job state machine invariants + `paused` state（R-1 全体の Change Gate）— **Approved 2026-05-06**, v3-17 着手可
-- **P-0100**: severity envelope formalization (PR-B4) — Pydantic Literal 化、`_blocking_errors` セマンティクス（PR-D1 #400 で確立、#406 で記録）
-- **P-0101**: metric-compat watchlist — `_workspace_metric_compatibility_errors` の検出ルール（PR-C2 #399 / PR-D1 #400 で確立、#406 で記録）
-- **次回採番**: P-0102 以降
+### 3.-1 v0.5 R-1 / R-2 / R-4 Proposal 群（P-0099, P-0102, P-0103 — すべて着地済）
+
+- **P-0099**: Job state machine invariants（INV-1〜INV-7）+ `paused` state（R-1 全体の Change Gate）— Approved 2026-05-06、**v3-17〜v3-22 で実装完了 (v0.5.0)**。BLUEPRINT §3.4 / §5.3 / §5.5 / §6.1 に反映済（#453）
+- **P-0102**: ブラウザリロード後の workspace state 自動復元（v3-24 / R-2.2）— Approved 2026-05-07、**v3-24 で実装完了 (v0.5.0)**
+- **P-0103**: 古い format_version の workspace を read-only で保護（`LegacyFormatProtectionError` + `format-version-matrix` CI gate、v3-25 / R-4.1）— Approved 2026-05-07、**v3-25 で実装完了 (v0.5.0)**
+- **P-0100 / P-0101**（v0.4.1 で確立、#406 で Decision 記録）: severity envelope formalization / metric-compat watchlist。`_blocking_errors` セマンティクス + auto-disable ルール
+- **P-0104**: Tune workflow 全面整備（Re-tune UX + canonical defaults + validation guardrails + LizyML v0.15 SSOT 連動）— Decision 確定、ほぼ着地（残: #474 deferred parse_space validation）
+- **P-0105**: Residuals plot に kind selector（#457）— 着地済
+- **P-0106**: metric 不適合判定を `BackendCore` capability の裏へ（Change Gate、#403）— 着地済（`BackendCore.get_incompatible_metrics`）。完全な 2nd-backend 移行は §3.3 後
 
 ### 3.0 P-0094 (済)：pytest-benchmark performance baseline（Issue #27 (a)）
 
@@ -158,7 +174,7 @@
 - **動機**: 現在 `lizystudio/backends/lizyml_ui_schema.py` で hand-coded。lizyml 側の Pydantic model から生成すれば drift が原理的に消える
 - **ブロッカー**: lizyml 側に構造化フィールドメタデータの export を頼む必要あり（リポジトリ間調整）
 - **優先度**: 中（P-0087 Phase 1+2 で contract test が drift を検出可能なので、緊急ではないが残課題）
-- **着手手順**: HISTORY に P-0095 として Proposal 起票（P-0094 は本 PR で消化）→ lizyml 側調整 → PLAN.md に `v3-17` 以降として登録 → 実装
+- **着手手順**: HISTORY に P-0107 以降として Proposal 起票 → lizyml 側に構造化フィールドメタデータ export を依頼（リポジトリ間調整）→ PLAN.md に `v3-27` 以降として登録 → 実装
 
 ### 3.3 ML Backend 抽象の 2nd 実装による検証
 
@@ -169,9 +185,9 @@
 
 ---
 
-## 4. アクティブ：GUI E2E カバレッジ強化（gui-e2e-plan.md Phase D）
+## 4. GUI E2E カバレッジ強化（gui-e2e-plan.md Phase D — 概ね完了）
 
-`docs/gui-e2e-plan.md` の段階実装プラン。**Phase A の Config field × E2E カバレッジは現状約 55%（22/40）**。Phase C generator + wave 1〜8 で大幅進捗、残りは UI 露出無し / 隠しフィールド / 複合 UI のため §4.2 末尾「カバー困難」表に分類。
+`docs/gui-e2e-plan.md` の段階実装プラン。**Phase A の Config field × E2E カバレッジは約 55%（22/40+）** — Phase B-1〜B-8 + Phase C generator + wave 1〜8 が着地済。残りは UI 露出無し / 隠しフィールド / 複合 UI で §4.2 末尾「カバー困難」表に分類（B-3b funnel state 問題 / GLOBALLY_HIDDEN フィールド / KeyValueEditor 動的 dict 等）。新規追加が必要なのは v3-22c（Playwright server-restart spec）と #444 deferred（Inference Results の Prediction Distribution / Score アサーション）程度。
 
 ### 4.1 Phase B 残：個別 spec の追加
 
@@ -247,18 +263,16 @@
 
 ## 5. アクティブ：Open Issues
 
-v0.4.1 リリース後の Open Issue は 5 件。
+v0.5.0 リリース + Wave 6 進行後の Open Issue は **6 件**（#27 / #28 / #125 は 2026-05-04 close 済、#360 / #384 / #403 / #404 / #405 も close 済）。
 
 | Issue | タイトル | priority | 推奨アクション |
 |---|---|---|---|
-| **#360** | feat(tune): long-run resumability (24h+, all termination paths) | tier-4 / high | **v0.5 core (R-1.4, 3 週間)**。✅ 上流解消（lizyml 0.12.0 / 2026-05-06 で `storage` 引数 shipped）— v3-17→v3-19 完了後に着手 |
-| **#384** | [Testing] #28 follow-up — Server Restart Recovery (blocked on #360) | tier-3 / medium | **R-1.5b (v0.5)** — #360 解消後 |
-| **#403** | refactor(backend): move metric-compat watchlist behind BackendAdapter abstraction (HIGH-2) | tier-3 / medium | **v0.6 defer 推奨** — 第 2 backend が見えてから |
-| **#404** | test: add edge-case coverage for `_workspace_metric_compatibility_errors` | tier-2 / medium | **S-1 (Day 3 着手)** — 7 cases (NaN/inf/dtype/dedup/malformed) |
-| **#405** | test(frontend): integration coverage for validate-debounce → warning banner | tier-3 / medium | **O-1 (並行可)** — frontend 単独 |
-| **#27** | [Testing] Add load and concurrency tests | medium / tier-4 | (a) `pytest-benchmark` baseline は P-0094 で完了。(b) 並行 fit stress harness は実機要件あり |
-| **#28** | [Testing] Add offline/resume resilience tests | medium / tier-4 | `current_job_id` ライフサイクル契約決定が前提。post-completion deep-link は #143 でカバー済み、during-run reload が gap |
-| **#125** | chore(frontend): migrate Tailwind CSS v3 → v4 | medium / tier-4 | Owner status: `Button` で spike → 専用 sprint。即着手は推奨しない |
+| **#451** | refactor(backend): split JobStore (`services/jobs.py` 1062 行) into focused modules | tier-4 / medium | **Wave 6.4** — v0.5 R-1 着地済で解禁。5 sub-PR（`_job_*.py`: `JobMetadataStore` / `ActiveJobSlot` / `JobControlFlags` / `JobLineage` + thin orchestrator）、§7 Tier 1 候補 2 |
+| **#452** | refactor(backend): reduce 5 over-50-line functions | tier-3 / low | **Wave 6.3** — `_workspace_metric_compatibility_errors`（P-0106 で obsolete）/ `workspace_reset`（#492）/ `_run_job_core`（#493）は完了。残り: `run_job_in_subprocess`（181 行、v3-22 着地済で解禁）/ `lifecycle_mixin.tune`（167 行、2nd-adapter 議論後 — まだ blocked） |
+| **#453** | docs: reconcile BLUEPRINT / architecture-as-implemented / v0.4-business-readiness with v0.5.0 state | tier-2 / medium | **Wave 6.5** — 本 ROADMAP 更新と同 PR で消化 |
+| **#474** | validation: surface inverted-range / log+low≤0 search-space errors early (deferred from P-0104 Wave 3.1a) | tier-3 / medium | backend `validate_config` で `parse_space()` に通して `search_space_invalid` を早期 surface |
+| **#488** | Migrate frontend to Vite 8 (Rolldown) — e2e `/api/ws` proxy regression blocks the bump | priority-low / area-frontend | vite は v6 据え置き、dependabot.yml で semver-major ignore（PR #489）。Vite 8 dev server が e2e proxy を壊す（`project_vite8_migration_held`） |
+| **#495** | chore(ops): weekly stale-doc audit cron (#456 L5, deferred follow-up) | tier-3 / low | `scripts/audit_stale_docs.py` + `.github/workflows/audit-stale-docs.yml`（cron weekly）+ tracking issue 自動更新 |
 
 ---
 
@@ -266,74 +280,62 @@ v0.4.1 リリース後の Open Issue は 5 件。
 
 | 対象 | 最終更新 | リスク | 対応 |
 |---|---|---|---|
-| `BLUEPRINT.md` | 🟡 2026-05-01 (P-0094 まで反映) | 中 | P-0095..P-0098 と v0.4.1 severity envelope（PR-B4 / PR-C2 / PR-D1）が未反映。**M-4 (Day 2) で §5 (API) に severity / suggested_fix を追記** |
-| `HISTORY.md` Decision 記録 | 🟡 2026-05-04 P-0098 まで | 中 | v0.4.1 で導入された severity envelope / metric-compat watchlist が Decision 未記録。**M-3 (Day 2) で P-0100 / P-0101 を起票** |
-| `PLAN.md` v3-N | 🟡 2026-05-01 v3-15 まで | 中 | v0.4.0 / v0.4.1 phase が未確定、v0.5 R-1〜R-2 phase が未追加。**M-5 (Day 4) で v3-16 以降を追加** |
+| `BLUEPRINT.md` | ✅ 2026-05-12 reconciled (Issue #453) | — | P-0099（`paused` state + INV-1〜7 + pause/unpause API + `WsPaused` + startup reconcile）/ P-0102（reload restoration）/ P-0103（`LegacyFormatProtectionError` + format-version matrix）/ P-0104〜P-0106 を §3.4 / §5.3 / §5.5 / §6.1 に反映。`tune(storage, study_name)` を §3.3.2 に追記 |
+| `HISTORY.md` Decision 記録 | ✅ 2026-05-12 P-0106 まで | — | v0.5.0 の P-0099〜P-0103、Tune workflow の P-0104〜P-0106 まで Decision 記録済 |
+| `PLAN.md` v3-N | ✅ 2026-05-12 v3-26 まで | — | v3-16〜v3-26 追加済（v3-26 のみ 🟡 未着手 — R-4.2 Pickle compat nightly） |
 | `docs/architecture.md` / `api.md` / `adapter-guide.md` | ✅ 2026-05-01 reconciled | — | 棚卸し完了。`tests/contract/test_adapter_guide_method_names.py` で adapter-guide.md ↔ Protocol の drift を gating |
-| `docs/architecture-as-implemented.md` | 🟡 2026-04-17 | 中 | severity filter / `_blocking_errors` の hop 図が未更新。**S-4 (Day 3) で更新** |
-| `docs/v0.4-business-readiness-plan.md` | 🟡 2026-04 | 低 | R-3.4 (Validate API) は v0.4.0 / v0.4.1 で完了。**S-3 (Day 1 午後) でレビュー → header に shipped 記載** |
-| `MEMORY.md` 古いノート | ✅ 直近セッションで更新 | — | `project_v041_shipped` / `project_pre_v05_work_plan` 反映済み |
+| `docs/architecture-as-implemented.md` | ✅ 2026-05-12 reconciled (Issue #453 / S-4) | — | `paused` state + INV-1〜7 を state diagram に反映、severity envelope hop 図（§5.4）は v0.4.1 で確立済、pause/unpause API + reconcile + format_version 保護を追記 |
+| `docs/v0.4-business-readiness-plan.md` | ✅ 2026-05-12 (S-3 — `Status: ✅ shipped 2026-05-07`) | — | R-1 / R-2 / R-4.1 は v0.5.0 着地。残るは R-4.2 (v3-26) と R-3.1〜R-3.3 (v0.6+ deferred) のみ。Tier 5 相当（ファイル移動はしない） |
+| `docs/issue-cleanup-plan-2026-05-10.md` | 🟡 2026-05-12 | 低 | Wave 1〜6 がほぼ完了。Wave 6 残: #451 (JobStore 分割) / #453 (本 reconcile) / #452 gated 2 件 / #495 (#456 L5)。すべて着地後に Tier 5 へ |
+| `MEMORY.md` 古いノート | 🟡 要更新 | 低 | `project_2026_05_12_wave6_progress` まで反映済だが v0.5.0 release / v3-20〜v3-25 着地が memory 未記録（次セッションで反映） |
 | `analysis/` 削除済み | 2026-04 期間 | `python-analyst` ↔ `lizystudio-analyst` パイプライン成果物の置き場が無い | 🟡 意図的削除か要確認、別 issue 検討 |
 
 ---
 
 ## 7. 推奨 Next Action（ROI 順 / 1 PR 単位）
 
-> v0.4.1 リリース完了 (2026-05-05)。詳細な v0.5 着手前の作業内訳は `docs/pre-v05-handoff-2026-05-05.md` 参照（MUST 6 + SHOULD 4 + OPTIONAL 3 = 13 件、計 4-7 日）。
+> v0.5.0 リリース完了 (2026-05-07)。`issue-cleanup-plan-2026-05-10.md` Wave 1〜6 もほぼ完了。残るバックログは少数。
 
-### Tier 1：v0.5 着手前必須（MUST、すべて完了）
+### Tier 1：直近の着手候補（ROI 順）
 
-1. ✅ **M-1**: LizyML 側 Optuna persistent storage — lizyml 0.12.0 (2026-05-06) で shipped (H-0072)。LizyStudio 側 `pyproject.toml` を `>=0.12.0,<0.13.0` に bump 済（本 ROADMAP 更新と同 PR）
-2. ✅ **M-2**: HISTORY.md P-0099 起票 — 2026-05-06 起票 + Approved（PR #408 + 本 PR）
-3. ✅ **M-3**: HISTORY.md P-0100 / P-0101 確定 — PR #406 で記録済
-4. ✅ **M-4**: BLUEPRINT.md §5 (API) に severity / suggested_fix を反映 — PR #406
-5. ✅ **M-5**: PLAN.md v3-17〜v3-26 (R-1 〜 R-4) phase 追加 — PR #408 + 本 PR で v3-20 entry criteria 確定
-6. ✅ **M-6**: handoff docs cleanup — `pre-v05-handoff-2026-05-05.md` は ROADMAP §0 に内容統合済、参照不要
+1. **v3-26 (R-4.2 Pickle compat nightly CI)** — `PLAN.md` v3-26 の唯一の未着手 v0.5 phase。`.github/workflows/nightly.yml` に過去 N=3 minor の lizyml で fit→現行で load round-trip job、`PICKLE_INCOMPATIBLE` エラーに recovery_hint。これで v0.5 Exit Criteria の format/pickle 互換が完全に gating される（残る Exit #5 = 業務利用 KPI は要 verify）
+2. **#451 JobStore 分割 (Wave 6.4)** — `services/jobs.py` 1062 行を `_job_*.py` 5 module（`JobMetadataStore` / `ActiveJobSlot` / `JobControlFlags` / `JobLineage` + thin orchestrator）に分割。v0.5 R-1 着地済で解禁。5 sub-PR、各 < 400 行、公開 Protocol 不変
+3. **#452 gated 2 件 (Wave 6.3)** — `subprocess_runner.run_job_in_subprocess`(181 行) は v3-22 着地済で解禁。`lifecycle_mixin.tune`(167 行) は 2nd-adapter 議論（§3.3）後（まだ blocked）
+4. **#474** — P-0104 Wave 3.1a deferred: inverted-range / log+low≤0 の search-space エラーを backend `validate_config` で早期 surface
+5. **#495** — #456 L5: weekly stale-doc audit cron（tier-3/low、deferred）
 
-### Tier 2：高 ROI 準備（SHOULD、1-2 日）
+### Tier 2：v0.6 候補（要長期計画）
 
-7. **S-1**: #404 異常系テスト 7 cases 追加（`tests/contract/test_validate_metric_compatibility.py` + `frontend/src/api/types.test.ts`）
-8. **S-2**: 本 ROADMAP の post-v0.4.1 reconciliation — 進行中（本コミット）
-9. **S-3**: `docs/v0.4-business-readiness-plan.md` レビュー + shipped 状態確定
-10. **S-4**: `docs/architecture-as-implemented.md` 更新（severity filter / `_blocking_errors` hop 図）
+- **第 2 ML backend 実装** — `BackendAdapter` 抽象の妥当性検証（候補: scikit-learn `Pipeline` / xgboost Native API / 他、未決 — §3.3）。これが見えてから #403 の `get_incompatible_metrics` 完全移行 + #452-b `lifecycle_mixin.tune` 分割が解禁される
+- **R-3.1〜R-3.3** — typed error 体系（`StudioError` に `code` / `recovery_hint` / `is_user_error` 必須化）— `docs/v0.4-business-readiness-plan.md` §4。本計画で残る唯一の未着手スコープ
+- **P-0087 Phase 3** — `cv_strategy_fields` を LizyML Pydantic から自動派生（LizyML 構造化 export 待ち）
+- **Tailwind v4 移行**（旧 #125、close 済）— `Button` で spike → 専用 sprint。即着手は推奨しない
+- **#488 Vite 8 (Rolldown) 移行** — e2e `/api/ws` proxy regression で hold（`project_vite8_migration_held`）
+- **load / stress / offline tests**（旧 #27 (b) / #28、close 済）— 並行 fit stress harness は実機要件あり。offline / during-run reload は P-0102 (v3-24) でカバー済
 
-### Tier 3：v0.5 と並行可（OPTIONAL、3-5 日）
+### v0.5 phase 進捗（`PLAN.md` v3-17〜v3-26）
 
-11. **O-1**: #405 integration test (validate-debounce → warning banner) — frontend 単独
-12. **O-2**: #403 BackendAdapter metric-compat refactor — 第 2 backend が見えるまで defer 推奨
-13. **O-3**: P-0087 Phase 3 (`cv_strategy_fields` 自動派生) — LizyML 構造化 export 待ち、defer 推奨
+| Phase | 内容 | 状態 |
+|---|---|---|
+| v3-17 | R-1.1 Slot release 6 経路 invariant (INV-1/INV-5) | ✅ 完了 (PR #412 + #413) |
+| v3-18 | R-1.2 Cancel + completion interleaving (INV-5 write-side, rescoped) | ✅ 完了 (PR #414) |
+| v3-19 | R-1.3 INV-2 fsync durability + INV-6 crash recovery (rescoped) | ✅ 完了 (PR #415) |
+| v3-20 | R-1.4 Tune resume (INV-3/INV-4 / #360) — 7 sub-phase | ✅ 完了 (PR #416〜#424) |
+| ~~v3-21~~ | ~~R-1.5 #359 job-num drift~~ | ❌ subsumed by PR #366、欠番 |
+| v3-22 | R-1.5b Server Restart Recovery (INV-7 / #384) | ✅ 完了 (PR #425 + #426)。v3-22c (Playwright server-restart spec) は 🟡 残（DoD は v3-22a/b で満了、#384 close 済） |
+| v3-23 | R-2.1 WS 再接続 (5min ceiling + indefinite retry + jitter) | ✅ 完了 (PR #427) |
+| v3-24 | R-2.2 ブラウザリロード復元 (P-0102) | ✅ 完了 (PR #429 + #430 + #435) |
+| v3-25 | R-4.1 format_version migration matrix CI gate (P-0103) | ✅ 完了 (PR #432 + #434 + #436 + #438) |
+| v3-26 | R-4.2 Pickle compatibility nightly CI | 🟡 **未着手 — 上記 Tier 1 候補 1** |
 
-### Tier 4：v0.5 core（着手可、8-12 週間）
-
-直列 R-1 → 並行 R-2 / R-4 の順で進める。各 phase の DoD は `PLAN.md` v3-17〜v3-26 を参照。
-
-| Phase | 内容 | 期間 | 並行可否 |
-|---|---|---|---|
-| ~~v3-17~~ | R-1.1 Slot release 6 経路 invariant test (INV-1/INV-5) | 1 週 | ✅ 完了 (PR #412 + #413) |
-| ~~v3-18~~ | R-1.2 Cancel + completion interleaving defense-in-depth (INV-5 write-side) | 0.5 週 (rescoped) | ✅ 完了 (PR #414) |
-| ~~v3-19~~ | R-1.3 INV-2 fsync durability + INV-6 crash recovery test coverage | 0.5 週 (rescoped — watchdog 不要と audit) | ✅ 完了 (PR #415) |
-| v3-20 | R-1.4 Tune resume (INV-3/INV-4 / #360) — `docs/v3-20-tune-resume-design.md` Approved | 3 週 (7 sub-phase: prep + a〜g) — 進行中 | — |
-| ~~v3-21~~ | ~~R-1.5 #359 job-num drift~~ | — | ❌ subsumed by PR #366 (closed 2026-05-03), 欠番 |
-| v3-22 | R-1.5b Server Restart Recovery (INV-7 / #384) | 1 週 | v3-20 後 |
-| v3-23 | R-2.1 WS 再接続 | 1 週 | v3-22 後 |
-| v3-24 | R-2.2 ブラウザリロード復元 | 1 週 | v3-23 後 |
-| v3-25 | R-4.1 format_version migration matrix | 1 週 | v3-20 完了後並行可 |
-| v3-26 | R-4.2 Pickle compatibility | 1 週 | v3-25 と並行可 |
-
-直近の next: **v3-20 (R-1.4)** — `docs/v3-20-tune-resume-design.md` (Approved 2026-05-06) に従い 7 sub-phase で実装開始。**v3-20-prep** (本 PR) で設計資料を develop に landing → **v3-20a** で format_version 1→2 migration + `Job.status` に `"paused"` 追加。
-
-### Tier 5：要長期計画（v0.6 以降）
-
-- **#27 (b)** 並行 fit stress harness — 実機マシン要件あり
-- **#125** Tailwind v4 — Button で spike → 専用 sprint
-- ML Backend 2nd 実装による Adapter 抽象検証 — 候補 backend 選定が未決
+直近の next: 上記 Tier 1 の **v3-26** または **#451 JobStore 分割**。v0.6 候補は上記 Tier 2 を参照。
 
 ---
 
 ## 8. 運用メモ
 
-- 新規 Proposal を起票するときは **P-0099 から採番**（P-0098 = `load_dataframe` chunked CSV、2026-05-04 で消化済）。`H-XXXX` 採番は終了。
-- v0.5 R-1 着手時は P-0099 (invariants + `paused` state)、v0.4.1 機能の Decision 記録は P-0100 / P-0101 を予約済み。
+- 新規 Proposal を起票するときは **P-0107 から採番**（P-0106 = metric-compat を `BackendCore` capability の裏へ、2026-05-12 で消化済）。`H-XXXX` 採番は終了。
+- 新規 PLAN フェーズは **v3-27 以降**を採番（v3-26 = R-4.2 Pickle compat、まだ 🟡 未着手）。
 - E2E 単独追加（仕様変更なし）は HISTORY 起票不要、本 ROADMAP の §3 を更新するだけで OK。
 - 本 ROADMAP はステータス変更時に都度更新。タスク完了時は §1 へ移動、新規着手時は §2/§3/§4 へ追加する。
 - 古い ID（B-N coupling、A.M Phase A など）は履歴参照のためそのまま残す。検索性のため改名はしない。

--- a/docs/architecture-as-implemented.md
+++ b/docs/architecture-as-implemented.md
@@ -1,7 +1,10 @@
 # LizyStudio Architecture (As-Implemented)
 
-2026-04-17 時点の実装から逆算した、現行アーキテクチャの可視化。
+2026-05-12 時点（develop @ 82d4ec3）の実装から逆算した、現行アーキテクチャの可視化。
 BLUEPRINT.md は設計意図、本書は**実装された姿**を示す。
+
+- 2026-04-17 baseline。
+- 2026-05-12 (Issue #453): v0.5.0 を反映 — `paused` job state（P-0099 v3-20a）、state-machine invariants INV-1〜INV-7、server restart reconciliation（v3-22a）、pause/unpause API + `WsPaused` message（v3-20d/e）、reload restoration（P-0102）、`LegacyFormatProtectionError` + `format-version-matrix` CI gate（P-0103）。severity envelope flow（§5.4）は v0.4.1 で確立済（変更なし）。
 
 ---
 
@@ -150,7 +153,7 @@ flowchart TB
 | Prefix | Router | 代表エンドポイント |
 |---|---|---|
 | `/api/workspace` | `api/workspace.py` | GET `/status`, POST `/reset`, POST `/data/path`, POST `/data/upload`, GET `/data/preview\|columns\|describe\|split-preview\|column-stats/{c}`, GET/PUT/PATCH `/config`, POST `/config/validate\|upload`, GET `/config/download`, POST `/fit`, POST `/tune` |
-| `/api/jobs` | `api/jobs.py` + `api/retune.py` | GET `/`, GET `/{id}` / `{id}/log` / `{id}/config`, DELETE `/{id}?cascade=`, POST `/{id}/cancel`, GET `/{id}/{metrics\|split-summary\|importance\|importance-kinds\|learning-curve/metrics\|plot/{type}\|plots}`, POST `/{id}/export`, GET `/{id}/export-code`, POST `/{id}/retune`, POST `/{id}/resume`, GET `/{id}/lineage` |
+| `/api/jobs` | `api/jobs.py` + `api/retune.py` | GET `/`, GET `/{id}` / `{id}/log` / `{id}/config`, DELETE `/{id}?cascade=`, POST `/{id}/cancel`, POST `/{id}/pause`, POST `/{id}/unpause` (P-0099 v3-20d), GET `/{id}/{metrics\|split-summary\|importance\|importance-kinds\|learning-curve/metrics\|plot/{type}\|plots}`, POST `/{id}/export`, GET `/{id}/export-code`, POST `/{id}/retune`, POST `/{id}/resume`, GET `/{id}/lineage` |
 | `/api/inference` | `api/inference.py` | POST `/run`, POST `/upload`, GET `/history`, GET `/{inf_id}`, GET `/{inf_id}/{predictions\|metrics\|download\|plot/{type}}`, GET `/{inf_id}/comparison/{other_inf_id}` |
 | `/api/backends` | `api/backends.py` | GET `""`, GET `/ui-schema` |
 | `/api/files` | `api/files.py` | GET `""` |
@@ -174,7 +177,7 @@ classDiagram
     +load_config_from_file(p)
     +create_model(cfg)
     +fit(model, on_progress)
-    +tune(model, on_progress, re_tune, checkpoint_dir, resume)
+    +tune(model, on_progress, re_tune, checkpoint_dir, resume, storage, study_name)
     +predict(model, df)
     +evaluate_table(model)
     +split_summary(model)
@@ -224,37 +227,56 @@ stateDiagram-v2
   pending --> running : _run_job_core starts<br/>claim_active (idempotent)
   running --> completed : terminal write + release_active
   running --> failed : exception + release_active
-  running --> canceled : is_cancel_requested==true<br/>CancelledError<br/>release_active + clear_cancel
-  pending --> canceled : DELETE or /cancel before start
+  running --> cancelled : is_cancel_requested==true<br/>CancelledError<br/>release_active + clear_cancel
+  running --> paused : is_pause_requested==true (tune)<br/>PausedError → status=paused<br/>**slot 保持** (release_active skip)
+  paused --> running : POST /unpause (same job_id)<br/>or restart reconcile re-attach
+  paused --> cancelled : POST /cancel (no worker → 明示遷移)
+  paused --> failed : storage corruption on resume
+  pending --> cancelled : DELETE or /cancel before start
   completed --> [*]
   failed --> [*]
-  canceled --> [*]
+  cancelled --> [*]
   note right of running
-    Invariants (declared):
-    INV-1: active_job_id holds at most one
-    INV-2: release_active on every exit path
-    INV-3: metrics.record_job_terminal fires once
+    Invariants (P-0099, tests/regression/test_inv_*.py):
+    INV-1: active_job_id holds at most one running-or-paused; released on
+           6 paths (completion/cancel/exc/SIGKILL/WS-disconnect/browser-close)
+    INV-2: meta.json atomic write (tmpfile + fsync + os.replace + dir fsync)
+    INV-3: illegal transitions rejected by JobStore.set_status assert
+    INV-4: paused job fully restorable from Optuna sqlite (storage,study_name)
+    INV-5: is_cancel_requested monotonic; INV-6: subprocess crash recovery
+    INV-7: WS disconnect never releases active slot
   end note
 ```
 
+サーバ再起動時は `JobStore.reconcile_at_startup()`（`server.py:lifespan` から呼ぶ）が on-disk `meta.json` をスキャンし、`running` / `pending` の orphan を `failed` 化、`paused` を `_active_job_id` に再 attach（多重 paused は newest 残し他 failed）、terminal は rewrite せず、idempotent（v3-22a / R-1.5b）。
+
 ### In-memory primitives (`services/jobs.py:JobStore`)
 - `_active_job_id: str | None` + `_active_lock: threading.Lock`
-- `_cancel_requested: set[str]` + `_cancel_lock`
+- `_cancel_requested: set[str]` + `_cancel_lock`（IPC は `<job_dir>/CANCEL` flag — subprocess child 用）
+- `_pause_requested: set[str]` + `_pause_lock`（IPC は `<job_dir>/PAUSE` flag）(P-0099 v3-20c)
 - `_parent_locks: dict[parent_id, child_id]` + `_parent_lock_mutex` （Re-tune/Resume の at-most-one 保証）
+- `set_status(job_id, new_status)` が `LEGAL_TRANSITIONS` を runtime assert（INV-3）
 
 ### Disk layout per job (`{jobs_dir}/{job_id}/`)
-- `meta.json` — status, config, data_ref, parent_job_id, error
+- `meta.json` — `format_version` (現行 2), status, config, data_ref, parent_job_id, error。`storage/versions.py:write_versioned_json` で atomic write（INV-2）。旧 version 上書きは `LIZYSTUDIO_ALLOW_LEGACY_WRITE=1` が無いと `LegacyFormatProtectionError`（P-0103 v3-25c）
 - `fit_result.json` / `tune_result.json`
 - `model/` （adapter export） / `model.pkl` + `model_meta.json` （checkpoint）
 - `tuning_plot.json` — export前にキャプチャ
 - `execution.log` — captured stdout/stderr
+- `CANCEL` / `PAUSE` — subprocess child 向け IPC flag（worker thread モードでは in-memory set のみ）
 - `inferences/{inf_id}/` — `meta.json`, `predictions.parquet`, `metrics.json`
 
 ### Thread vs Subprocess（`services/openmp_detect.py:should_use_subprocess`）
 - デフォルト: in-process thread
 - OpenMP検出 or `LIZYSTUDIO_FORCE_SUBPROCESS=1` → `subprocess.Popen` 分離
 - 子プロセス: `python -m lizystudio.services.subprocess_runner`、JSONL progress file を tail
-- 親: `_ProgressReader` が JSONL を読み `ProgressBroadcaster.send_progress` に forward
+- 親: `_ProgressReader` が JSONL を読み `ProgressBroadcaster.send_progress` に forward。子が `status="paused"` を書き込んだ場合は親の `finally` で `release_active` を skip（v3-20d、in-process 修正と対称）
+
+### Pause / Resume (Tune long-run resumability, P-0099 R-1.4)
+- `POST /api/jobs/{id}/pause` → `request_pause`。worker の trial 完了 callback が `is_pause_requested` を見て `PausedError` を raise → `_run_job_core` の `except PausedError` が `status="paused"` + `completed_at=None`、`finally` で slot を保持。`ProgressBroadcaster.send_paused`（`WsPaused` message、terminal cache には載せない）
+- `POST /api/jobs/{id}/unpause` → data 再ロード必須、`clear_pause` 後に **同 job_id** で `start_tune_async`。lizyml の Optuna `load_if_exists=True` で同 `(storage, study_name)` に re-attach、trial 番号が継続（INV-4、`tests/integration/test_tune_resume_round_trip.py`）
+- `POST /api/jobs/{id}/cancel` は paused も accept — worker 不在のため signal pass-through ではなく direct `paused → cancelled` + slot release + clear_pause
+- frontend: `usePauseJob` / `useUnpauseJob` mutation hooks、`PauseActionButton` / `UnpauseActionButton`（`ResumeActionButton` = failed→child job とは責務分離）
 
 ---
 
@@ -447,12 +469,11 @@ flowchart LR
 
 ## 8. 設計と実装の主なギャップ（参考）
 
+旧 Issue #158（BLUEPRINT §3.3.2 / §5.3 / §10 sync）と #159（Re-tune UI 配置）は close 済。残る軽微なギャップ:
+
 | 観点 | 実装 | BLUEPRINT との差分 |
 |---|---|---|
-| Re-tune/Resume/Lineage UI の配置 | Workspace 側 (ResultsCompletedView) | §4.3 は Jobs 画面配置を想定 |
-| Protocol のメソッド | save_checkpoint / load_checkpoint / learning_curve_metrics あり | §3.3.2 のコードブロックから一部抜け |
-| API `/api/jobs/:id/retune\|resume\|lineage` | 実装済 | §5.3 表に未記載 |
-| §10 ディレクトリ構成 | `metrics.py`, `security.py`, `api/health.py`, `api/metrics_api.py`, `api/retune.py`, `backends/lizyml/`（パッケージ化）, `services/subprocess_runner.py` など多数 | 旧ツリーのまま |
-| §8.2 frontend テスト | Vitest + Playwright + Storybook + MSW が運用中 | 「初期段階は未整備」のまま陳腐化 |
+| Re-tune/Resume/Lineage UI の配置 | Workspace `ResultsCompletedView` + Jobs `JobDetail` の両方が `components/retune/` の共有コンポーネントを import（挙動は厳密に一致） | §4.3.2/§4.3.3 は共有コンポーネント前提に更新済（ギャップ解消） |
+| §10 ディレクトリ構成 | `services/_job_*.py`（#451 分割後）, `services/subprocess_runner.py` の helper 群, `services/_training_core.py` の helper 群 など、CLAUDE.md「many small files」方針で随時細分化が進む | §10 の tree は代表ファイルのみで網羅的ではない（運用上 OK — 完全列挙はしない方針） |
 
-詳細は Issue #158 / #159 を参照。
+> 本書は「実装の現状 snapshot」。Tier 1 の正は BLUEPRINT。drift を見つけたら BLUEPRINT 側を真として更新し、本表に残骸を残さない。

--- a/docs/v0.4-business-readiness-plan.md
+++ b/docs/v0.4-business-readiness-plan.md
@@ -1,9 +1,9 @@
 # v0.4 Business-Readiness Plan
 
-> **Status**: PARTIAL — R-3.4 / R-5 shipped in v0.4.0 / v0.4.1 (2026-05-05). R-1 / R-2 / R-3 (残) / R-4 deferred to v0.5+.
+> **Status**: ✅ shipped 2026-05-07（実質完了 — Tier 5 相当）。R-3.4 / R-5 は v0.4.0 / v0.4.1（2026-05-05）、R-1 / R-2 / R-4 は v0.5.0（2026-05-07、`PLAN.md` v3-17〜v3-25）で着地。**R-3.1〜R-3.3（typed error 体系の全面改訂）のみ v0.6+ に明示的に deferred** — それ以外の本計画の作業項目はすべて消化済。詳細索引は [`docs/ROADMAP.md`](ROADMAP.md) §2。
 > **基底**: [`docs/business-use-definition.md`](business-use-definition.md) v0.2 CONFIRMED
 > **目的**: v0.4 を「業務利用可能」レベルにするための Phase 別実装計画。確定された定義に基づき、必要十分な作業項目を列挙する。
-> **承認**: HISTORY.md P-0096 (業務利用定義の確定、2026-05-04 merged) で Tier 4 として固定済。
+> **承認**: HISTORY.md P-0096 (業務利用定義の確定、2026-05-04 merged) で Tier 4 として固定済。v0.5.0 着地に伴い Tier 5（アーカイブ — 履歴参照のみ）相当。
 > **当初版**: DRAFT v0.1 (2026-05-03 起票) → v0.2 (2026-05-05、§10 改訂履歴参照)
 
 ---
@@ -28,16 +28,16 @@
 
 | Phase | 内容 | 工数 | ステータス |
 |---|---|---|---|
-| R-1 | 状態整合性の徹底 + **Tune resume** | 6 週間 | 🟡 v0.5 着手予定 |
-| R-2 | セッション復元 (WS reconnect, browser reload) | 2 週間 | 🟡 v0.5 着手予定 |
-| R-3 | エラー復旧 (typed errors, recovery hints) | 3 週間 | 🟢 R-3.4 のみ完了 (v0.4.0 / v0.4.1)、R-3.1〜R-3.3 は v0.6+ 送り |
-| R-4 | 互換性ロック (format_version, Pickle compat) | 2 週間 | 🟡 v0.5 着手予定 |
+| R-1 | 状態整合性の徹底 + **Tune resume** | 6 週間 | ✅ **完了 (v0.5.0, 2026-05-07 / PLAN.md v3-17〜v3-22, P-0099)** |
+| R-2 | セッション復元 (WS reconnect, browser reload) | 2 週間 | ✅ **完了 (v0.5.0, 2026-05-07 / PLAN.md v3-23〜v3-24, P-0102)** |
+| R-3 | エラー復旧 (typed errors, recovery hints) | 3 週間 | 🟢 R-3.4 のみ完了 (v0.4.0 / v0.4.1)、**R-3.1〜R-3.3 は v0.6+ に deferred**（本計画で残る唯一の未着手スコープ） |
+| R-4 | 互換性ロック (format_version, Pickle compat) | 2 週間 | 🟢 R-4.1 (format_version matrix) 完了 (v0.5.0 / PLAN.md v3-25, P-0103)。R-4.2 (Pickle compat nightly) は PLAN.md v3-26 で実行予定 |
 | **R-5** | **Wide DataFrame + Large CSV scaling** (新設) | 3 週間 | ✅ **完了 (v0.4.0 / v0.4.1, 2026-05-05)** |
 | **合計** | | **約 16 週間 (4 ヶ月)** | — |
 
 スケジュールは「ソロ作業」を前提とした見積。チームで取り組む場合は短縮可能。
 
-> **2026-05-06 時点の進捗**: R-5 (Wide DataFrame + Large CSV) と R-3.4 (Validate API + suggested_fix) は v0.4.0 / v0.4.1 リリースで完了。残り R-1 / R-2 / R-4 は **v0.5 のスコープ**として `PLAN.md` v3-17〜v3-26 / `docs/ROADMAP.md` §7 Tier 4 で実行。R-1.4 (Tune resume) の上流ブロッカー LizyML #105 (Optuna persistent storage) は **lizyml 0.12.0 (2026-05-06) で解消済** — `Tuner` / `Model.tune()` に `storage` / `study_name` 引数を追加した H-0072 (`storage="sqlite:///..."` 等) が利用可能。
+> **2026-05-12 時点の進捗**: R-5 / R-3.4 は v0.4.0 / v0.4.1（2026-05-05）、R-1 / R-2 / R-4.1 は v0.5.0（2026-05-07、`PLAN.md` v3-17〜v3-25 / HISTORY P-0099・P-0102・P-0103）で着地。R-1.4 (Tune resume) の上流ブロッカー LizyML #105 (Optuna persistent storage) は lizyml 0.12.0（2026-05-06）で解消済（H-0072 `storage` / `study_name`）→ Studio v3-20b で passthrough 済。残るは **R-4.2 (Pickle compat nightly CI, `PLAN.md` v3-26)** と **R-3.1〜R-3.3 (typed error 体系の全面改訂, v0.6+ deferred)** のみ。本書は履歴参照用にこのまま残す（CLAUDE.md §1.1 Tier 5 の運用ルール — ファイル移動はしない）。
 
 ---
 


### PR DESCRIPTION
## Summary

**[docs-only]** Wave 6.5 of `docs/issue-cleanup-plan-2026-05-10.md`. Reconciles the Tier-1 spec (`BLUEPRINT.md`) and Tier-2/3 docs with current `develop` (v0.5.0 shipped 2026-05-07 + Wave 6 + Tune-workflow Proposals P-0104..P-0106). **No new specs** — only documents already-merged behaviour, so the Change Gate does not apply (the Decisions are in HISTORY P-0099 / P-0102 / P-0103 / P-0104..P-0106 and shipped).

Per `~/.claude/rules/common/git-workflow.md` "Docs-only PR Policy": acceptable as a standalone docs PR because everything it describes is already in `develop`. Title prefixed `[docs-only]` for fast-track.

## Changes

### `BLUEPRINT.md` (`_Last reconciled` → 2026-05-12 @ 82d4ec3)
- §3.4.1 — startup reconciliation (v3-22a) + reload restoration (P-0102) notes
- §3.4.2 — `paused` added to `Job.status` enum; state-machine transitions table; INV-1..INV-7 (P-0099)
- §3.4.4 — `format_version` / `LegacyFormatProtectionError` + `format-version-matrix` CI gate (P-0103)
- §3.3.2 — `tune(storage, study_name)` params (v3-20b)
- §4.3.3 — Pause / Resume / Cancel(paused) job actions
- §5.3 — `POST /api/jobs/{id}/pause` + `/unpause`
- §5.5 — `WsPaused` WebSocket message (5 variants)
- §6.1 — `JOB_NOT_RUNNING` / `JOB_NOT_PAUSEABLE` / `JOB_NOT_PAUSED` + `LegacyFormatProtectionError` note

### `docs/architecture-as-implemented.md` (timestamp → 2026-05-12)
- §3 pause/unpause routes; §4 `tune(storage, study_name)`; §5 state diagram with `paused` + restart reconcile + INV-1..INV-7 note + `_pause_requested` primitive + CANCEL/PAUSE IPC flags + Pause/Resume section; §8 clears resolved gaps (#158 / #159 closed)

### `docs/v0.4-business-readiness-plan.md`
- `Status` header → `✅ shipped 2026-05-07`; R-1 / R-2 / R-4.1 marked done (v0.5.0); R-3.1..R-3.3 explicitly deferred to v0.6+ (the only remaining unstarted scope of this plan)

### `docs/ROADMAP.md`
- §0 doc map, §1 glossary, §2 (v0.5.0 + Wave 6 entries), §3 (P-0099/P-0102/P-0103/P-0104..P-0106 all landed), §4 (E2E mostly done), §5 (6 open issues — closed-issue rows removed: #27/#28/#125/#360/#384/#403/#404/#405), §6 (**drift table cleared** — BLUEPRINT/arch-as-impl/PLAN/HISTORY/business-readiness all reconciled; S-3 / S-4 done), §7 (next: v3-26 or #451), §8 (next Proposal P-0107 / next phase v3-27)

## Acceptance (from #453)
- [x] All three files updated in a single PR (+ ROADMAP refresh)
- [x] ROADMAP §6 drift table cleared (S-3 / S-4 marked done)
- [x] PR title prefixed `[docs-only]`
- [x] BLUEPRINT changes do **not** introduce new specs — only document shipped behaviour

## Test plan
- [ ] CI green (docs-only — no code touched; full matrix runs anyway)
- [ ] Reviewer skim of BLUEPRINT §3.4 / §5.3 / §5.5 / §6.1 against the code (`api/jobs.py` pause/unpause, `ws/messages.py` `WsPaused`, `storage/versions.py` `LegacyFormatProtectionError`, `services/jobs.py` `Job.status`)

Closes #453
