### PR TITLE
refactor(services): extract ActiveJobSlot from JobStore (#451 step 2/5)

### DIFF
--- a/src/lizystudio/services/_job_active_slot.py
+++ b/src/lizystudio/services/_job_active_slot.py
@@ -1,0 +1,201 @@
+"""Active-job slot — the at-most-one-running concurrency control (#451).
+
+Extracted from ``JobStore`` so the concurrency concern is isolated from
+disk CRUD, cancel/pause flags and lineage.
+
+INV-1: ``active_job_id`` holds **at most one** running-or-paused job at
+any time, released on every termination path (completion / cancel /
+exception / SIGKILL / WebSocket disconnect / browser close) — ``paused``
+is the deliberate exception that retains the slot so a concurrent
+``/tune`` is rejected with ``JOB_CONFLICT`` until ``/unpause`` (the
+in-place resume contract, v3-20d).
+
+The slot holds a reference to ``JobMetadataStore`` solely to read the
+current holder's status when deciding whether the slot is *stale* (held
+by a job that is actually terminal — happens after a subprocess kill
+skipped the release, or a restart re-seeded the slot), and a reference
+to the per-app ``MetricsRegistry`` solely to keep the ``active_jobs``
+gauge in sync. Everything else — the lock, the slot id, the
+claim/release/reclaim logic — is self-contained.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from typing import TYPE_CHECKING, Any, Literal
+
+from lizystudio.backends.types import DataRef
+from lizystudio.services._job_metadata import Job, JobMetadataStore
+
+if TYPE_CHECKING:
+    from lizystudio.metrics import MetricsRegistry
+
+_logger = logging.getLogger(__name__)
+
+
+class ActiveJobSlot:
+    """At-most-one running-or-paused job (INV-1). Thread-safe."""
+
+    def __init__(
+        self,
+        metadata: JobMetadataStore,
+        metrics: MetricsRegistry | None = None,
+    ) -> None:
+        self._metadata = metadata
+        # A-9: the active-slot gauge lives on the per-app MetricsRegistry.
+        # ``metrics`` is None in the subprocess child path where the
+        # child's Prometheus state is isolated from the parent (the
+        # parent's registry is the one that gets scraped), so bumping a
+        # disconnected gauge inside the child is a no-op we simply skip.
+        self._metrics = metrics
+        self._active_job_id: str | None = None
+        self._lock = threading.Lock()
+
+    # --- gauge ---
+
+    def _set_gauge(self, value: float) -> None:
+        """Update the ``active_jobs`` gauge on the bound MetricsRegistry."""
+        if self._metrics is not None:
+            self._metrics.active_jobs.set(value)
+
+    # --- staleness probe ---
+
+    def _is_holder_stale_locked(self) -> bool:
+        """Return True when the current slot holder is in a terminal state.
+
+        Caller must hold ``self._lock``. A holder whose ``meta.json`` is
+        gone or unreadable is treated as stale (definitely not running).
+        """
+        holder = self._active_job_id
+        if holder is None:
+            return False
+        try:
+            job = self._metadata.load_job(holder)
+        except (FileNotFoundError, OSError, json.JSONDecodeError, KeyError):
+            return True
+        return job.status in ("completed", "failed", "cancelled")
+
+    # --- claim / release ---
+
+    def create_and_claim(
+        self,
+        *,
+        backend_name: str,
+        config: dict[str, Any],
+        data_ref: DataRef,
+        job_type: Literal["fit", "tune"],
+        parent_job_id: str | None = None,
+    ) -> Job | None:
+        """Atomically create a pending job and claim the slot.
+
+        Returns the newly created ``Job`` when the slot was empty, or
+        ``None`` when another (non-stale) job already owns it. Unlike a
+        two-step ``create(...) + claim(...)`` this never persists an
+        orphan ``failed`` directory for the losing caller — nothing is
+        written until the slot is actually held.
+
+        ``_run_job_core`` later re-invokes :meth:`claim` with the same
+        ``job_id`` — that call is a no-op because the slot is already
+        owned by this job.
+
+        Before refusing a request the current holder is checked for
+        staleness (terminal ``completed`` / ``failed`` / ``cancelled``
+        rows have no business occupying the slot — can happen if a
+        subprocess path returned without going through
+        ``_run_job_core.finally``, the server restarted mid-job, or a
+        cancel left the runner unable to reach the release call). Rather
+        than locking the workspace out permanently, the slot is reclaimed
+        from the stale owner so the next fit/tune can proceed. The stale
+        job's on-disk state is left untouched.
+        """
+        with self._lock:
+            if self._active_job_id is not None:
+                if not self._is_holder_stale_locked():
+                    return None
+                _logger.warning(
+                    "Active slot held by stale job %s; reclaiming",
+                    self._active_job_id,
+                )
+                self._active_job_id = None
+            job = self._metadata.create(
+                backend_name=backend_name,
+                config=config,
+                data_ref=data_ref,
+                job_type=job_type,
+                parent_job_id=parent_job_id,
+            )
+            self._active_job_id = job.job_id
+            self._set_gauge(1)
+            return job
+
+    def claim(self, job_id: str) -> bool:
+        """Attempt to claim the slot.
+
+        Returns ``True`` when the slot is empty *or* already held by
+        ``job_id`` (idempotent re-claim — the runner thread re-enters
+        with the same id to keep ownership explicit). Returns ``False``
+        when a different job currently owns it.
+        """
+        with self._lock:
+            if self._active_job_id is None:
+                self._active_job_id = job_id
+                self._set_gauge(1)
+                return True
+            # H-0065: the re-claim branch intentionally skips the gauge
+            # update — the gauge was already set to 1 by the original
+            # ``create_and_claim`` / ``claim`` that acquired the slot,
+            # and bumping it again would be a no-op.
+            return self._active_job_id == job_id
+
+    def release(self, job_id: str) -> None:
+        """Release the slot iff it is held by ``job_id``."""
+        with self._lock:
+            if self._active_job_id == job_id:
+                self._active_job_id = None
+                self._set_gauge(0)
+
+    def force_release_if(self, expected_job_id: str) -> bool:
+        """Atomically release the slot iff still held by *expected_job_id*.
+
+        H-0063: ``workspace_reset`` uses this to force-release a stuck
+        orphan slot after its cancel wait times out. The naive read +
+        ``release(active_id)`` dance is racy — between the read and the
+        release another thread could claim the slot with a new id and
+        the caller would release someone else's slot. Keeping the
+        compare and release under one critical section makes this either
+        release the exact id the caller observed or be a no-op.
+
+        Returns True if the slot was released, False otherwise.
+        """
+        with self._lock:
+            if self._active_job_id == expected_job_id:
+                self._active_job_id = None
+                self._set_gauge(0)
+                return True
+            return False
+
+    def has_active(self) -> bool:
+        """True when a job currently owns the slot."""
+        with self._lock:
+            return self._active_job_id is not None
+
+    @property
+    def active_job_id(self) -> str | None:
+        """The currently active job ID, or ``None``."""
+        with self._lock:
+            return self._active_job_id
+
+    def reattach(self, job_id: str) -> None:
+        """Force the slot onto *job_id* — startup reconciliation only.
+
+        Used by ``JobStore.reconcile_at_startup`` to restore a paused
+        survivor's slot after a restart. Unlike :meth:`claim` this does
+        not consult the current holder: at fresh process start the
+        in-memory slot is always ``None``, and the disk meta drives the
+        re-attach decision (INV-restart-2).
+        """
+        with self._lock:
+            self._active_job_id = job_id
+            self._set_gauge(1)

--- a/src/lizystudio/services/jobs.py
+++ b/src/lizystudio/services/jobs.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from fastapi import Request
 
 from lizystudio.backends.types import DataRef
+from lizystudio.services._job_active_slot import ActiveJobSlot
 
 # Most of these are pure re-exports kept in ``__all__`` so existing
 # import sites (``from lizystudio.services.jobs import Job / artifact_path
@@ -64,11 +65,13 @@ class JobStore:
         metrics: MetricsRegistry | None = None,
     ) -> None:
         # #451: the disk-CRUD half (path resolution, create/get/list/update,
-        # meta.json round-trips) is delegated to ``JobMetadataStore``.
+        # meta.json round-trips) is delegated to ``JobMetadataStore``;
+        # the at-most-one-running concurrency control to ``ActiveJobSlot``.
         # ``self.jobs_dir`` is kept (and aliases the metadata store's) for
         # the many call sites that read it directly.
         self._meta = JobMetadataStore(jobs_dir)
         self.jobs_dir = self._meta.jobs_dir
+        self._slot = ActiveJobSlot(self._meta, metrics)
         self._cancel_requested: set[str] = set()
         self._cancel_lock = threading.Lock()
         # P-0099 v3-20c: pause primitives mirror cancel exactly — same
@@ -80,15 +83,9 @@ class JobStore:
         # next call).
         self._pause_requested: set[str] = set()
         self._pause_lock = threading.Lock()
-        self._active_job_id: str | None = None
-        self._active_lock = threading.Lock()
-        # A-9: the active-slot gauge lives on the per-app MetricsRegistry.
-        # ``metrics`` is None in the subprocess child path
-        # (:func:`subprocess_runner._run_job_in_subprocess`) where the
-        # child's Prometheus state is isolated from the parent and
-        # scrape output comes from the parent's registry only — bumping
-        # a disconnected gauge inside the child would be a no-op, so we
-        # simply skip it.
+        # A-9: the metrics registry is also threaded through here for the
+        # terminal-transition counters (``record_job_terminal``). The
+        # active-slot gauge lives inside ``ActiveJobSlot``.
         self._metrics = metrics
         # H-0062: per-parent exclusive lock for Re-tune / Resume children.
         # Maps parent_job_id -> child_job_id currently holding the slot.
@@ -116,11 +113,6 @@ class JobStore:
     def clear_model_cache_for(self, model_path: str) -> None:
         """Drop memoised entries for a specific model path (H-0084)."""
         self.model_cache.clear_for(model_path)
-
-    def _set_active_gauge(self, value: float) -> None:
-        """Update the active-jobs gauge on the bound MetricsRegistry."""
-        if self._metrics is not None:
-            self._metrics.active_jobs.set(value)
 
     def record_job_terminal(
         self,
@@ -659,15 +651,13 @@ class JobStore:
 
         if paused_candidates:
             survivor = paused_candidates[0]
-            with self._active_lock:
-                self._active_job_id = survivor.job_id
-                self._set_active_gauge(1)
+            self._slot.reattach(survivor.job_id)
             _logger.info(
                 "Re-attached paused job %s to active slot at startup",
                 survivor.job_id,
             )
 
-    # --- Active job tracking (concurrency control) ---
+    # --- Active job tracking — delegated to ActiveJobSlot (#451) ---
 
     def create_and_claim_active(
         self,
@@ -679,131 +669,40 @@ class JobStore:
         parent_job_id: str | None = None,
     ) -> Job | None:
         """Atomically create a pending job and claim the active slot.
-
-        Returns the newly created ``Job`` when the slot was empty, or
-        ``None`` when another job already owns it. Unlike the two-step
-        ``create(...) + claim_active(...)`` sequence this method never
-        produces an orphan ``failed`` job directory for the losing
-        caller — nothing is persisted until the slot is actually held.
-
-        The subsequent ``_run_job_core`` will re-invoke ``claim_active``
-        with the same job_id; that call is a no-op because the slot is
-        already owned by this job.
-
-        Before refusing a request, this method checks whether the
-        currently-held slot is actually still running. Terminal jobs
-        (``completed`` / ``failed`` / ``cancelled``) have no business
-        occupying the slot and can happen if:
-
-        - a subprocess path returned without going through
-          ``_run_job_core.finally`` (e.g. the subprocess was killed and
-          the release call was skipped),
-        - the server restarted mid-job and the in-memory slot was
-          re-initialised from disk state, or
-        - a cancel request left the runner thread unable to reach the
-          release call.
-
-        Rather than locking the workspace out permanently, the slot is
-        reclaimed from the stale owner so the user's next fit/tune can
-        proceed. The stale job's on-disk state is left untouched.
-        """
-        with self._active_lock:
-            if self._active_job_id is not None:
-                stale = self._is_slot_holder_stale_locked()
-                if not stale:
-                    return None
-                _logger.warning(
-                    "Active slot held by stale job %s; reclaiming",
-                    self._active_job_id,
-                )
-                self._active_job_id = None
-            job = self.create(
-                backend_name=backend_name,
-                config=config,
-                data_ref=data_ref,
-                job_type=job_type,
-                parent_job_id=parent_job_id,
-            )
-            self._active_job_id = job.job_id
-            self._set_active_gauge(1)
-            return job
-
-    def _is_slot_holder_stale_locked(self) -> bool:
-        """Return True when the current slot holder is in a terminal state.
-
-        Caller must hold ``self._active_lock``.
-        """
-        holder = self._active_job_id
-        if holder is None:
-            return False
-        try:
-            job = self._meta.load_job(holder)
-        except (FileNotFoundError, OSError, json.JSONDecodeError, KeyError):
-            # Meta gone or unreadable -> definitely stale.
-            return True
-        return job.status in ("completed", "failed", "cancelled")
+        See :meth:`ActiveJobSlot.create_and_claim`."""
+        return self._slot.create_and_claim(
+            backend_name=backend_name,
+            config=config,
+            data_ref=data_ref,
+            job_type=job_type,
+            parent_job_id=parent_job_id,
+        )
 
     def claim_active(self, job_id: str) -> bool:
-        """Attempt to claim the active slot.
-
-        Returns ``True`` when the slot is empty *or* when it is already
-        held by ``job_id`` (idempotent re-claim after
-        ``create_and_claim_active`` — the runner thread re-enters this
-        with the same id to keep the ownership explicit). Returns
-        ``False`` when a different job currently owns the slot.
-        """
-        with self._active_lock:
-            if self._active_job_id is None:
-                self._active_job_id = job_id
-                self._set_active_gauge(1)
-                return True
-            # H-0065: the `self._active_job_id == job_id` re-claim
-            # branch intentionally skips the gauge update — the
-            # gauge was already set to 1 by the original
-            # `create_and_claim_active` or `claim_active` call that
-            # acquired the slot, and bumping it again would be a
-            # no-op.
-            return self._active_job_id == job_id
+        """Attempt to claim the active slot (idempotent re-claim by the
+        same job is a no-op). See :meth:`ActiveJobSlot.claim`."""
+        return self._slot.claim(job_id)
 
     def release_active(self, job_id: str) -> None:
-        """Release the active slot."""
-        with self._active_lock:
-            if self._active_job_id == job_id:
-                self._active_job_id = None
-                self._set_active_gauge(0)
+        """Release the active slot iff held by ``job_id``. See
+        :meth:`ActiveJobSlot.release`."""
+        self._slot.release(job_id)
 
     def force_release_active_if(self, expected_job_id: str) -> bool:
-        """Atomically release the slot iff it is still held by *expected_job_id*.
-
-        H-0063: ``workspace_reset`` uses this to force-release a stuck
-        orphan slot after its cancel wait times out. The two-step
-        ``active_job_id`` read + ``release_active(active_id)`` dance is
-        racy — between the read and the release another thread could
-        claim the slot with a new job id, and the caller would end up
-        releasing someone else's slot. This helper keeps the compare
-        and the release under a single ``_active_lock`` critical
-        section so the operation either releases the exact id the
-        caller observed or is a no-op.
-
-        Returns True if the slot was released, False otherwise.
-        """
-        with self._active_lock:
-            if self._active_job_id == expected_job_id:
-                self._active_job_id = None
-                self._set_active_gauge(0)
-                return True
-            return False
+        """Atomically release the slot iff still held by *expected_job_id*.
+        See :meth:`ActiveJobSlot.force_release_if`."""
+        return self._slot.force_release_if(expected_job_id)
 
     def has_active_job(self) -> bool:
-        """Check if a job is currently active (running or pending)."""
-        with self._active_lock:
-            return self._active_job_id is not None
+        """True when a job currently owns the active slot. See
+        :meth:`ActiveJobSlot.has_active`."""
+        return self._slot.has_active()
 
     @property
     def active_job_id(self) -> str | None:
-        """Return the currently active job ID, or None."""
-        with self._active_lock:
-            return self._active_job_id
+        """The currently active job ID, or ``None``. See
+        :attr:`ActiveJobSlot.active_job_id`."""
+        return self._slot.active_job_id
 
     def get_log(self, job_id: str) -> str:
         """Read execution log for a job. Returns empty string if not found."""


### PR DESCRIPTION
## Summary

Wave 6.4 of `docs/issue-cleanup-plan-2026-05-10.md` — **step 2 of 5** in the JobStore decomposition (#451). Following step 1 (extract `JobMetadataStore`, #499), this PR pulls the **at-most-one-running concurrency control** out of `JobStore` into `services/_job_active_slot.py` so the slot lock, slot id, claim/release/reclaim logic and the `active_jobs` gauge are isolated from disk CRUD, cancel/pause flags and lineage.

**Pure refactor — no public API or behaviour change.** Change Gate not required (the slot logic is moved verbatim, not redesigned; INV-1 is unchanged).

## Changes

### New module: `src/lizystudio/services/_job_active_slot.py` (201 lines, < 400 ✓)
`ActiveJobSlot` — thread-safe, INV-1 ("at most one running-or-paused job; released on every termination path; `paused` retains the slot for `/unpause`"):
| Member | Was on `JobStore` |
|---|---|
| `create_and_claim` | `create_and_claim_active` |
| `claim` / `release` / `force_release_if` | `claim_active` / `release_active` / `force_release_active_if` |
| `has_active` / `active_job_id` | `has_active_job` / `active_job_id` |
| `_set_gauge` | `_set_active_gauge` |
| `_is_holder_stale_locked` | `_is_slot_holder_stale_locked` |
| `reattach(job_id)` | (extracted from the `with self._active_lock:` block in `reconcile_at_startup`) |

Holds a `JobMetadataStore` ref only to read the holder's status when deciding staleness, and a `MetricsRegistry` ref only for the `active_jobs` gauge.

### `src/lizystudio/services/jobs.py` (860 → 759 lines)
- `JobStore.__init__` constructs `self._slot = ActiveJobSlot(self._meta, metrics)`; drops `_active_job_id` / `_active_lock`; keeps `_metrics` for `record_job_terminal`
- `create_and_claim_active` / `claim_active` / `release_active` / `force_release_active_if` / `has_active_job` / `active_job_id` are now one-line delegations
- `reconcile_at_startup`'s paused-survivor re-attach is now `self._slot.reattach(survivor.job_id)`

## Test plan
- [x] `uv run pytest tests/ -k "not slow" --ignore=tests/e2e --ignore=tests/integration --ignore=tests/bench` — 1533 passed, 6 skipped (unchanged). INV-1 suites (`test_inv_slot_release.py`, `test_inv_state_machine.py`, `test_inv_pause_keeps_slot.py`, `test_inv_subprocess_crash_recovery.py`, `test_inv_startup_reconcile.py`, `test_reg_0027e_concurrent_job_submission.py`, `test_reg_007*`) green
- [x] `uv run ruff check src/ tests/` / `ruff format --check` — clean
- [x] `uv run mypy src/lizystudio/` — clean
- [ ] CI green

No test changes needed — every test asserts through the public `active_job_id` / `claim_active` / `release_active` / `has_active_job` surface, which keeps its signatures.

## Acceptance progress (#451)
- [x] `_job_active_slot.py` independently importable and < 400 lines (201)
- [x] No public API change — INV-1 / state-machine tests pass unchanged
- [ ] `services/jobs.py` < 200 lines (currently 759 — reached over steps 3–5)

Next steps: 3/5 `JobControlFlags` (cancel + pause), 4/5 `JobLineage`, 5/5 `JobStore` becomes a thin orchestrator.
