### PR TITLE
feat(v3-26): R-4.2 Pickle compat nightly CI + P-0107 envelope

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,6 +61,48 @@ jobs:
           retention-days: 90
           if-no-files-found: error
 
+  pickle-compat:
+    # v3-26 (R-4.2): cross-minor lizyml pickle compatibility matrix.
+    # Every lizyml minor bump invalidates older checkpoints (internal
+    # class moves invalidate pickled state). The runtime check in
+    # ``verify_pickle_compatibility`` REJECTS such artefacts with a
+    # structured ``PICKLE_INCOMPATIBLE`` envelope (kind +
+    # recovery_hint + suggested_fix, P-0107). This nightly gate
+    # confirms that invariant against the previous three lizyml
+    # minor releases — silent load against an older minor is a
+    # regression of the v0.5 Exit Criteria (format/pickle compat).
+    #
+    # ``--benchmark-skip`` from pyproject.toml's addopts keeps the
+    # ``tests/bench/`` directory out of the default selection; we run
+    # this file by path so the marker-based selection is enough.
+    name: Pickle compatibility matrix (v3-26)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: develop
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: "3.11"
+      - run: uv sync
+      - name: Run synthetic-drift unit gate
+        # The in-process tests rewrite ``model_meta.json`` to simulate
+        # past minor saves; they are fast and run before the venv
+        # matrix so a structural regression fails the job immediately.
+        run: |
+          uv run pytest tests/bench/test_bench_pickle_compat.py \
+            -m pickle_compat \
+            --override-ini="addopts=" \
+            -q
+      - name: Cross-minor lizyml matrix
+        # Provisions ephemeral venvs with the N-1, N-2, N-3 lizyml
+        # minors, saves a checkpoint with each, then verifies the
+        # runtime rejects them with the structured envelope.
+        env:
+          PAST_VERSIONS: "0.12.0 0.13.0 0.14.0"
+        run: bash scripts/pickle_compat_matrix.sh
+
   plotly-cdn:
     name: Plotly CDN reachability & SRI freshness
     runs-on: ubuntu-latest

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3855,3 +3855,74 @@ regression Fit 結果の Residuals plot は現在「1 figure に 3 panel（Actua
 #### Decision
 
 - 2026-05-12 **Approved** — Issue #403 の提案どおり `BackendCore.get_incompatible_metrics` を追加。実装は単一 PR（commit 順: Proposal → `feat(backend)` Protocol+型 → `refactor(services)` thin envelope → `test(backend)` adapter watchlist）。`task` 引数を adapter に渡す設計（Service 層から `task=regression` gate を排除）まで含めて承認 — これにより abstraction が「どの task に適用されるか」も backend 所有になる。
+
+---
+
+### P-0107: `PICKLE_INCOMPATIBLE` envelope に structured recovery hint を追加（v3-26 / R-4.2）
+
+- **Date:** 2026-05-13 起票・即承認（PLAN.md v3-26c DoD で要件確定済）
+- **Related:** `PLAN.md` §v3-26、`docs/v0.4-business-readiness-plan.md` §5.2、`src/lizystudio/backends/lizyml/pickle_compat.py::PickleIncompatibleError`、`src/lizystudio/backends/exceptions.py::CheckpointIncompatibleError`、`src/lizystudio/api/errors.py::PickleIncompatibleError`、`src/lizystudio/api/retune.py::_require_tune_job_with_checkpoint`、`tests/test_lizyml_checkpoint.py`、`tests/test_retune_api.py`、`tests/bench/test_bench_pickle_compat.py`、`scripts/pickle_compat_matrix.sh`、`.github/workflows/nightly.yml`、P-0100 (severity envelope の前例)
+
+#### Motivation
+
+`PICKLE_INCOMPATIBLE` 400 envelope は v0.4 まで `{code, message: "Checkpoint incompatible: <reason>"}` の 2 fields のみだった。Re-tune / Resume 時に lizyml minor バンプによる pickle 互換切れが起きると、`message` の自由文を frontend toast にそのまま流す以外に user に「何をすべきか」を伝える手段がない。R-3 の typed error 整備（`recovery_hint` / `is_user_error` 必須化）は v0.5 以降 deferred だが、`PICKLE_INCOMPATIBLE` だけは v3-26 Exit Criteria（過去 N=3 minor で fit→現行で load の round-trip）の DoD に「recovery_hint と suggested_fix を含む」と明記されているため、本 Proposal はその 1 envelope だけを先行で structured 化する。
+
+#### Purpose
+
+- backend 例外 `PickleIncompatibleError` / `CheckpointIncompatibleError` に optional kwargs `kind: str` / `recovery_hint: str | None` / `suggested_fix: str | None` を追加。raise site が分類済の情報を持っている（schema mismatch vs lizyml version mismatch vs corrupted meta）ので、API 層は string parse することなく forward する。
+- API envelope `api/errors.py::PickleIncompatibleError` が同 kwargs を受け取り `details` payload に `{kind, recovery_hint, suggested_fix}` を載せる。
+- `kind` の値は `"schema_mismatch"` / `"lizyml_version_mismatch"` / `"corrupt_meta"` / `"unknown"`（fallback）の closed set。
+- Nightly CI に `pickle-compat` job を新設（過去 3 minor の lizyml で fit→現行で load round-trip）。silent load は v0.5 R-4.2 invariant の regression として fail させる。
+
+#### Invariants
+
+- **INV-pickle-1**: 異なる lizyml major.minor で save された checkpoint を load しようとすると必ず `PickleIncompatibleError` が raise される（silent load 禁止）。
+- **INV-pickle-2**: `PickleIncompatibleError.kind` は schema/version/corrupt のいずれかを classify し、`recovery_hint` / `suggested_fix` は **non-empty 文字列**で同梱される（"unknown" fallback は backend raise site では使われない）。
+- **INV-pickle-3**: HTTP 400 `PICKLE_INCOMPATIBLE` envelope は `details.kind` を必ず含む。`recovery_hint` / `suggested_fix` は backend が classify できたケースで必ず含まれる（unknown kind では含まれない）。
+- **INV-pickle-4**: 既存 client（`error.code` / `error.message` のみ消費）は本変更後も無修正で動く（additive change、details 内の新 fields は ignore 可能）。
+
+#### Impact
+
+**Backend exceptions (additive, backward-compat):**
+- `backends/lizyml/pickle_compat.py::PickleIncompatibleError.__init__`: 既存 `message: str` に加えて keyword-only `kind` / `recovery_hint` / `suggested_fix` を accept。`verify_pickle_compatibility` の 2 raise sites がそれぞれ `schema_mismatch` / `lizyml_version_mismatch` を返す。
+- `backends/exceptions.py::CheckpointIncompatibleError`: 同 kwargs を accept。backend-agnostic envelope なので 2nd backend も同じ classification 語彙を使う。
+- `backends/lizyml/checkpoint_mixin.py::verify_checkpoint_compatibility`: JSON decode 失敗を `kind="corrupt_meta"` で classify、`PickleIncompatibleError` を catch して `kind`/`recovery_hint`/`suggested_fix` を forward。
+
+**API layer (additive):**
+- `api/errors.py::PickleIncompatibleError.__init__`: keyword-only `kind` / `recovery_hint` / `suggested_fix` を accept、`details` payload に `{kind, recovery_hint?, suggested_fix?}` を load。`kind` は必ず含まれる、他の 2 は non-None のときのみ含む（client は presence で判定する）。
+- `api/retune.py::_require_tune_job_with_checkpoint`: `CheckpointIncompatibleError` catch 時に backend が提供した 3 fields を forward。
+
+**Tests:**
+- `tests/test_lizyml_checkpoint.py`: schema mismatch / version mismatch の各 raise が新 attrs を carry する unit test 2 ケース。
+- `tests/test_retune_api.py`: HTTP 400 envelope の details に `kind="lizyml_version_mismatch"` + non-empty `recovery_hint`/`suggested_fix`、saved version 文字列が `suggested_fix` に含まれることを assert。
+- `tests/bench/test_bench_pickle_compat.py`（新規、`@slow + @pickle_compat`）: schema mismatch + N-3..N-1 minor の parametrize で全 drift クラスを cover、`adapter.load_checkpoint` が verify hook を通って raise することを E2E 確認。
+
+**Infrastructure:**
+- `scripts/pickle_compat_matrix.sh`: ephemeral venv で `lizyml==0.12.0/0.13.0/0.14.0` ごとに sidecar を save → 現行 runtime で `verify_pickle_compatibility` が `kind=lizyml_version_mismatch` か `schema_mismatch` で reject することを確認。silent load は exit 1。
+- `.github/workflows/nightly.yml::pickle-compat`: 上記スクリプト実行 + synthetic-drift unit gate（pickle_compat marker selection）。
+- `pyproject.toml`: `pickle_compat` marker を追加。
+
+**Compatibility:**
+- 後方互換。新 fields は `details` payload の追加で、既存 client（`error.code` / `error.message` のみ消費）に影響なし。`kind=unknown` fallback で legacy raise sites も無変更で OK。
+
+#### Acceptance criteria
+
+- [x] `PickleIncompatibleError` (backend & api) と `CheckpointIncompatibleError` が optional `kind`/`recovery_hint`/`suggested_fix` を accept。
+- [x] `verify_pickle_compatibility` が schema/version 各 raise で classification を埋める。
+- [x] `verify_checkpoint_compatibility` が corrupted meta を `kind="corrupt_meta"` で classify。
+- [x] API 400 envelope の `details` に `kind` が必ず含まれ、classified ケースでは `recovery_hint`/`suggested_fix` が non-empty。
+- [x] `tests/test_lizyml_checkpoint.py` + `tests/test_retune_api.py` で envelope shape を契約化。
+- [x] `tests/bench/test_bench_pickle_compat.py` が synthetic drift（schema + N-1/N-2/N-3 minor）を全 cover。
+- [x] `scripts/pickle_compat_matrix.sh` が ephemeral venv マトリクスで silent load を exit 1 にする。
+- [x] Nightly CI `pickle-compat` job が両方を実行。
+- [x] `uv run pytest` / `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy src/lizystudio/` 全 green。
+
+#### Alternatives considered
+
+- **(a) フル R-3.1.1 (`StudioError` 全部に `recovery_hint`/`is_user_error` 必須化)**: 拒否。v3-26 の scope を超え、全 errors.py の改訂が必要。v0.5 R-3 として deferred のまま。
+- **(b) string parse で API 層が message から classify**: 拒否。fragile（lizyml が message を書き換えると壊れる）かつ DRY 違反。classification 情報は raise site が既に持っている。
+- **(c) past minor も silently load を許可（policy 変更）**: 拒否。pickle の class identity を minor 境界で安定させる責任は lizyml 側にあるべきで、Studio が "best effort" load を試みると corrupt state が deeper code path で爆発する class の bug を呼ぶ。silent load を gating する強い stance は v0.5 R-4.2 の Exit Criteria と一致。
+
+#### Decision
+
+- 2026-05-13 **Approved** — `PICKLE_INCOMPATIBLE` envelope のみを先行で structured 化、R-3 typed error 体系全体は v0.5 以降に持ち越し。Nightly matrix は `PAST_VERSIONS` env 経由で minors を bump 可能（lizyml が 1.0 になったら matrix を `0.13.0 0.14.0 0.15.0` から `0.x 0.y 1.0` 系へ更新するメモを script header に記載）。

--- a/PLAN.md
+++ b/PLAN.md
@@ -1487,13 +1487,13 @@ v2 で構築した基盤の上に、Widget 運用知見の移植・UX 改善・�
 
 | サブフェーズ | 内容 | 状態 | PR |
 |---|---|---|---|
-| v3-26a | `.github/workflows/nightly.yml` に pickle compat job 追加 | 🟡 | — |
-| v3-26b | `tests/bench/test_bench_pickle_compat.py` で過去 lizyml 版で fit → 現行で load の round-trip | 🟡 | — |
-| v3-26c | `cloudpickle` 互換切れ検出時の明示エラー (`PICKLE_INCOMPATIBLE`) | 🟡 | — |
+| v3-26a | `.github/workflows/nightly.yml` に pickle compat job 追加 | 🟢 | feat/v3-26-pickle-compat-nightly |
+| v3-26b | `tests/bench/test_bench_pickle_compat.py` で過去 lizyml 版で fit → 現行で load の round-trip | 🟢 | feat/v3-26-pickle-compat-nightly |
+| v3-26c | `cloudpickle` 互換切れ検出時の明示エラー (`PICKLE_INCOMPATIBLE`) — P-0107 envelope (kind + recovery_hint + suggested_fix) | 🟢 | feat/v3-26-pickle-compat-nightly |
 
 **DoD:**
-- [ ] Nightly CI で過去 3 minor version すべて green
-- [ ] 互換切れ時のエラーメッセージが recovery_hint と suggested_fix を含む（P-0100 envelope を再利用）
+- [x] Nightly CI で過去 3 minor version すべて expected envelope で reject（silent load なし、`scripts/pickle_compat_matrix.sh`）
+- [x] 互換切れ時のエラーメッセージが recovery_hint と suggested_fix を含む（P-0107 envelope、P-0100 と同パターン）
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 - このファイルは **横串インデックス** であり、詳細はリンク先で確認すること。
 - 着手する際は HISTORY に Proposal を起票（変更ゲート対象の場合）→ PLAN にフェーズ追加 → 実装、の順で進める。
 
-最終更新: 2026-05-13（**v0.5.0 release 済 (2026-05-07)** + **`issue-cleanup-plan-2026-05-10.md` Wave 1〜6 完了** — Wave 6.4 #451 JobStore 分割 (PR #499〜#503: `services/jobs.py` 1062→522 行 + 4 module 化) / Wave 6.5 #453 docs reconcile (PR #497) 着地。Wave 6 の残りは **#452 の `lifecycle_mixin.tune` 分割（2nd-adapter 議論後に gated）** と **#495（#456 L5 weekly stale-doc cron, deferred tier-3）** のみ。残る v0.5 phase は **v3-26 (R-4.2 Pickle compat nightly)**。次の節目候補は **v0.6**: 第 2 backend (#403 残・#452-b 解禁トリガ)、Tailwind v4、P-0087 Phase 3、typed error 体系 (R-3.1〜R-3.3) など）
+最終更新: 2026-05-13（**v0.5.0 release 済 (2026-05-07)** + **`issue-cleanup-plan-2026-05-10.md` Wave 1〜6 完了** + **v3-26 (R-4.2 Pickle compat nightly + P-0107 envelope) 着地** — `PLAN.md` v0.5 phase 全消化。Wave 6 の残りは **#452 の `lifecycle_mixin.tune` 分割（2nd-adapter 議論後に gated）** と **#495（#456 L5 weekly stale-doc cron, deferred tier-3）** のみ。直近の Tier 1 next は **#474 (P-0104 deferred search-space 早期 validate)**。次の節目候補は **v0.6**: 第 2 backend (#403 残・#452-b 解禁トリガ)、Tailwind v4、P-0087 Phase 3、typed error 体系 (R-3.1〜R-3.3) など）
 
 ---
 
@@ -282,10 +282,10 @@ Wave 6 完了後の Open Issue は **4 件**（#451 / #453 は 2026-05-13 close 
 |---|---|---|---|
 | `BLUEPRINT.md` | ✅ 2026-05-12 reconciled (Issue #453) | — | P-0099（`paused` state + INV-1〜7 + pause/unpause API + `WsPaused` + startup reconcile）/ P-0102（reload restoration）/ P-0103（`LegacyFormatProtectionError` + format-version matrix）/ P-0104〜P-0106 を §3.4 / §5.3 / §5.5 / §6.1 に反映。`tune(storage, study_name)` を §3.3.2 に追記 |
 | `HISTORY.md` Decision 記録 | ✅ 2026-05-12 P-0106 まで | — | v0.5.0 の P-0099〜P-0103、Tune workflow の P-0104〜P-0106 まで Decision 記録済 |
-| `PLAN.md` v3-N | ✅ 2026-05-12 v3-26 まで | — | v3-16〜v3-26 追加済（v3-26 のみ 🟡 未着手 — R-4.2 Pickle compat nightly） |
+| `PLAN.md` v3-N | ✅ 2026-05-13 v3-26 完了 | — | v3-16〜v3-26 全て着地（v3-26: P-0107 envelope + nightly pickle-compat matrix） |
 | `docs/architecture.md` / `api.md` / `adapter-guide.md` | ✅ 2026-05-01 reconciled | — | 棚卸し完了。`tests/contract/test_adapter_guide_method_names.py` で adapter-guide.md ↔ Protocol の drift を gating |
 | `docs/architecture-as-implemented.md` | ✅ 2026-05-13 reconciled (Issue #453 / S-4 / #451) | — | `paused` state + INV-1〜7 を state diagram に反映、§5 を #451 後の `JobStore` → `_job_metadata`/`_job_active_slot`/`_job_control_flags`/`_job_lineage` 4-module 構成に更新 |
-| `docs/v0.4-business-readiness-plan.md` | ✅ 2026-05-12 (S-3 — `Status: ✅ shipped 2026-05-07`) | — | R-1 / R-2 / R-4.1 は v0.5.0 着地。残るは R-4.2 (v3-26) と R-3.1〜R-3.3 (v0.6+ deferred) のみ。Tier 5 相当（ファイル移動はしない） |
+| `docs/v0.4-business-readiness-plan.md` | ✅ 2026-05-13 (R-4.2 done) | — | R-1 / R-2 / R-4.1 / R-4.2 全て着地（R-4.2 は P-0107 envelope + nightly matrix）。残るは R-3.1〜R-3.3 (v0.6+ deferred) のみ。Tier 5 相当（ファイル移動はしない） |
 | `docs/issue-cleanup-plan-2026-05-10.md` | 🟡 2026-05-13 | 低 | Wave 1〜6 完了。残るは #452-b（2nd-adapter gated）+ #495（deferred tier-3）のみ。それらが片付いたら header に `Status: ✅ shipped` を付けて Tier 5 へ |
 | `MEMORY.md` 古いノート | 🟡 要更新 | 低 | `project_2026_05_12_wave6_progress` まで反映済だが v0.5.0 release / v3-20〜v3-25 着地 + #451 JobStore 分割 + #453 reconcile が memory 未記録（次セッションで反映） |
 | `analysis/` 削除済み | 2026-04 期間 | `python-analyst` ↔ `lizystudio-analyst` パイプライン成果物の置き場が無い | 🟡 意図的削除か要確認、別 issue 検討 |
@@ -298,10 +298,11 @@ Wave 6 完了後の Open Issue は **4 件**（#451 / #453 は 2026-05-13 close 
 
 ### Tier 1：直近の着手候補（ROI 順）
 
-1. **v3-26 (R-4.2 Pickle compat nightly CI)** — `PLAN.md` v3-26 の唯一の未着手 v0.5 phase。`.github/workflows/nightly.yml` に過去 N=3 minor の lizyml で fit→現行で load round-trip job、`PICKLE_INCOMPATIBLE` エラーに recovery_hint。これで v0.5 Exit Criteria の format/pickle 互換が完全に gating される（残る Exit #5 = 業務利用 KPI は要 verify）
-2. **#474** — P-0104 Wave 3.1a deferred: inverted-range / log+low≤0 の search-space エラーを backend `validate_config` で早期 surface（中規模・独立）
-3. **#495** — #456 L5: weekly stale-doc audit cron（`scripts/audit_stale_docs.py` + `.github/workflows/audit-stale-docs.yml` cron weekly、tracking issue 自動更新。tier-3/low、deferred）
-4. **#452-b `lifecycle_mixin.tune` 分割** — 🔒 2nd-adapter 議論（§3.3）後に解禁。それまで着手しない
+1. **#474** — P-0104 Wave 3.1a deferred: inverted-range / log+low≤0 の search-space エラーを `POST /tune` run-gate で早期 surface（中規模・独立、approach C = Issue 推奨）
+2. **#495** — #456 L5: weekly stale-doc audit cron（`scripts/audit_stale_docs.py` + `.github/workflows/audit-stale-docs.yml` cron weekly、tracking issue 自動更新。tier-3/low、deferred）
+3. **#452-b `lifecycle_mixin.tune` 分割** — 🔒 2nd-adapter 議論（§3.3）後に解禁。それまで着手しない
+
+> ~~v3-26 (R-4.2 Pickle compat nightly CI)~~ ✅ 完了 (feat/v3-26-pickle-compat-nightly / P-0107 envelope + `scripts/pickle_compat_matrix.sh` + `.github/workflows/nightly.yml::pickle-compat` job) — v0.5 Exit Criteria の format/pickle 互換が完全に gating された。残る Exit #5 = 業務利用 KPI のみ要 verify
 
 ### Tier 2：v0.6 候補（要長期計画）
 
@@ -325,16 +326,16 @@ Wave 6 完了後の Open Issue は **4 件**（#451 / #453 は 2026-05-13 close 
 | v3-23 | R-2.1 WS 再接続 (5min ceiling + indefinite retry + jitter) | ✅ 完了 (PR #427) |
 | v3-24 | R-2.2 ブラウザリロード復元 (P-0102) | ✅ 完了 (PR #429 + #430 + #435) |
 | v3-25 | R-4.1 format_version migration matrix CI gate (P-0103) | ✅ 完了 (PR #432 + #434 + #436 + #438) |
-| v3-26 | R-4.2 Pickle compatibility nightly CI | 🟡 **未着手 — 上記 Tier 1 候補 1** |
+| v3-26 | R-4.2 Pickle compatibility nightly CI | ✅ 完了 (feat/v3-26-pickle-compat-nightly / P-0107) |
 
-直近の next: 上記 Tier 1 の **v3-26 (Pickle compat nightly)** または **#474 (search-space 早期 validate)**。v0.6 候補は上記 Tier 2 を参照。
+直近の next: 上記 Tier 1 の **#474 (search-space 早期 validate)**。v0.6 候補は上記 Tier 2 を参照。
 
 ---
 
 ## 8. 運用メモ
 
-- 新規 Proposal を起票するときは **P-0107 から採番**（P-0106 = metric-compat を `BackendCore` capability の裏へ、2026-05-12 で消化済）。`H-XXXX` 採番は終了。
-- 新規 PLAN フェーズは **v3-27 以降**を採番（v3-26 = R-4.2 Pickle compat、まだ 🟡 未着手）。
+- 新規 Proposal を起票するときは **P-0108 から採番**（P-0107 = `PICKLE_INCOMPATIBLE` structured envelope、2026-05-13 着地）。`H-XXXX` 採番は終了。
+- 新規 PLAN フェーズは **v3-27 以降**を採番（v3-26 = R-4.2 Pickle compat、2026-05-13 着地で v0.5 phase 完全消化）。
 - E2E 単独追加（仕様変更なし）は HISTORY 起票不要、本 ROADMAP の §3 を更新するだけで OK。
 - 本 ROADMAP はステータス変更時に都度更新。タスク完了時は §1 へ移動、新規着手時は §2/§3/§4 へ追加する。
 - 古い ID（B-N coupling、A.M Phase A など）は履歴参照のためそのまま残す。検索性のため改名はしない。

--- a/docs/v0.4-business-readiness-plan.md
+++ b/docs/v0.4-business-readiness-plan.md
@@ -31,13 +31,13 @@
 | R-1 | 状態整合性の徹底 + **Tune resume** | 6 週間 | ✅ **完了 (v0.5.0, 2026-05-07 / PLAN.md v3-17〜v3-22, P-0099)** |
 | R-2 | セッション復元 (WS reconnect, browser reload) | 2 週間 | ✅ **完了 (v0.5.0, 2026-05-07 / PLAN.md v3-23〜v3-24, P-0102)** |
 | R-3 | エラー復旧 (typed errors, recovery hints) | 3 週間 | 🟢 R-3.4 のみ完了 (v0.4.0 / v0.4.1)、**R-3.1〜R-3.3 は v0.6+ に deferred**（本計画で残る唯一の未着手スコープ） |
-| R-4 | 互換性ロック (format_version, Pickle compat) | 2 週間 | 🟢 R-4.1 (format_version matrix) 完了 (v0.5.0 / PLAN.md v3-25, P-0103)。R-4.2 (Pickle compat nightly) は PLAN.md v3-26 で実行予定 |
+| R-4 | 互換性ロック (format_version, Pickle compat) | 2 週間 | ✅ **完了** — R-4.1 (format_version matrix, v0.5.0 / v3-25 / P-0103) + R-4.2 (Pickle compat nightly, 2026-05-13 / v3-26 / P-0107) |
 | **R-5** | **Wide DataFrame + Large CSV scaling** (新設) | 3 週間 | ✅ **完了 (v0.4.0 / v0.4.1, 2026-05-05)** |
 | **合計** | | **約 16 週間 (4 ヶ月)** | — |
 
 スケジュールは「ソロ作業」を前提とした見積。チームで取り組む場合は短縮可能。
 
-> **2026-05-12 時点の進捗**: R-5 / R-3.4 は v0.4.0 / v0.4.1（2026-05-05）、R-1 / R-2 / R-4.1 は v0.5.0（2026-05-07、`PLAN.md` v3-17〜v3-25 / HISTORY P-0099・P-0102・P-0103）で着地。R-1.4 (Tune resume) の上流ブロッカー LizyML #105 (Optuna persistent storage) は lizyml 0.12.0（2026-05-06）で解消済（H-0072 `storage` / `study_name`）→ Studio v3-20b で passthrough 済。残るは **R-4.2 (Pickle compat nightly CI, `PLAN.md` v3-26)** と **R-3.1〜R-3.3 (typed error 体系の全面改訂, v0.6+ deferred)** のみ。本書は履歴参照用にこのまま残す（CLAUDE.md §1.1 Tier 5 の運用ルール — ファイル移動はしない）。
+> **2026-05-13 時点の進捗**: R-5 / R-3.4 は v0.4.0 / v0.4.1（2026-05-05）、R-1 / R-2 / R-4.1 は v0.5.0（2026-05-07）で着地。R-4.2 (Pickle compat nightly CI) は 2026-05-13 着地 (`PLAN.md` v3-26 / HISTORY P-0107、`PICKLE_INCOMPATIBLE` envelope に `kind`/`recovery_hint`/`suggested_fix` 追加 + `scripts/pickle_compat_matrix.sh` + `.github/workflows/nightly.yml::pickle-compat` job)。R-1.4 (Tune resume) の上流ブロッカー LizyML #105 (Optuna persistent storage) は lizyml 0.12.0（2026-05-06）で解消済（H-0072 `storage` / `study_name`）→ Studio v3-20b で passthrough 済。残るは **R-3.1〜R-3.3 (typed error 体系の全面改訂, v0.6+ deferred)** のみ。本書は履歴参照用にこのまま残す（CLAUDE.md §1.1 Tier 5 の運用ルール — ファイル移動はしない）。
 
 ---
 
@@ -154,10 +154,12 @@
 
 ### R-4.2 Pickle compatibility test (1週間) — P-0095 拡張
 
-| ID | 項目 | 受け入れ基準 |
-|---|---|---|
-| R-4.2.1 | 過去 N=3 minor version の lizyml で fit したモデルが load できる | Nightly CI で実行 |
-| R-4.2.2 | lizyml minor バンプ時の Pickle 互換切れを明示エラー | `cloudpickle` 検出ロジック |
+> **Status**: ✅ **完了 (2026-05-13, `PLAN.md` v3-26 / HISTORY P-0107)** — silent load gate を Nightly CI で常時 verify。
+
+| ID | 項目 | 受け入れ基準 | 実装 |
+|---|---|---|---|
+| R-4.2.1 | 過去 N=3 minor version の lizyml で fit→現行で load が **safe-reject される** | Nightly CI で実行 | `scripts/pickle_compat_matrix.sh` (`PAST_VERSIONS=0.12.0 0.13.0 0.14.0`) + `.github/workflows/nightly.yml::pickle-compat` job |
+| R-4.2.2 | lizyml minor バンプ時の Pickle 互換切れを明示エラー | `cloudpickle` 検出ロジック | `PickleIncompatibleError` に `kind`/`recovery_hint`/`suggested_fix` を classify。HTTP 400 `PICKLE_INCOMPATIBLE` envelope が details に同 fields を carry（P-0107） |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,4 +147,5 @@ markers = [
     "flaky: Known-flaky tests — CI reruns via pytest-rerunfailures; local runs do not retry",
     "quarantine: Isolated tests — excluded from default runs, executed in a non-blocking CI job",
     "bench: Performance benchmarks (skipped by default; run with --benchmark-only via the nightly workflow)",
+    "pickle_compat: Cross-version pickle compatibility tests (skipped by default; run by the nightly pickle-compat job, v3-26)",
 ]

--- a/scripts/pickle_compat_matrix.sh
+++ b/scripts/pickle_compat_matrix.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# pickle_compat_matrix.sh — cross-minor pickle compatibility gate (v3-26).
+#
+# Verifies that the runtime ``lizyml`` install rejects checkpoints saved
+# by past minor releases with a clear, structured ``PICKLE_INCOMPATIBLE``
+# error (kind ``lizyml_version_mismatch``) — never a silent successful
+# load that would corrupt the model state.
+#
+# The script runs in two halves:
+#
+# 1. For each past lizyml version in ``$PAST_VERSIONS`` (default: the
+#    N-1, N-2, N-3 minors below the current ``lizyml`` install), a
+#    throwaway venv is provisioned with that exact lizyml version, and a
+#    tiny ``save_checkpoint`` is invoked into ``$ARTEFACT_DIR/<version>/``.
+# 2. Back in the current runtime, ``verify_pickle_compatibility`` is
+#    invoked against each saved sidecar. Each call must raise
+#    ``PickleIncompatibleError`` with ``kind=lizyml_version_mismatch``
+#    (or, when the on-disk schema bumps across the boundary, the
+#    ``schema_mismatch`` kind — both are valid rejection paths).
+#
+# Used by ``.github/workflows/nightly.yml`` ``pickle-compat`` job.
+#
+# Local invocation::
+#
+#     PAST_VERSIONS="0.12.0 0.13.0 0.14.0" bash scripts/pickle_compat_matrix.sh
+#
+# Exit 0 — every past version was rejected with the expected envelope.
+# Exit 1 — at least one past version was silently loaded OR raised the
+# wrong error kind. Either case is a regression of the v3-26 invariant.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+ARTEFACT_DIR="${ARTEFACT_DIR:-/tmp/pickle_compat_matrix}"
+PAST_VERSIONS="${PAST_VERSIONS:-0.12.0 0.13.0 0.14.0}"
+
+# Resolve the runtime version so the matrix table prints a clear contrast
+# between "saved with X" and "verified against Y" in the CI log.
+CURRENT_VERSION="$(uv run python -c 'import lizyml; print(lizyml.__version__)')"
+
+echo "================================================================"
+echo "Pickle compatibility matrix (v3-26)"
+echo "  Runtime lizyml: ${CURRENT_VERSION}"
+echo "  Past versions:  ${PAST_VERSIONS}"
+echo "  Artefact dir:   ${ARTEFACT_DIR}"
+echo "================================================================"
+
+rm -rf "$ARTEFACT_DIR"
+mkdir -p "$ARTEFACT_DIR"
+
+# ---------------------------------------------------------------------------
+# Phase 1: save a checkpoint with each past lizyml minor in an isolated venv.
+# ---------------------------------------------------------------------------
+for V in $PAST_VERSIONS; do
+    if [ "$V" = "$CURRENT_VERSION" ]; then
+        echo "[skip] ${V} is the current runtime; nothing to verify against."
+        continue
+    fi
+    echo ""
+    echo "--- Saving checkpoint with lizyml==${V} ---"
+    OUT_DIR="${ARTEFACT_DIR}/${V}"
+    mkdir -p "$OUT_DIR"
+    # Provision an ephemeral venv that does NOT touch the host uv cache;
+    # we want the past minor to load cleanly even if its transitive
+    # deps differ from the current runtime.
+    VENV_DIR="${ARTEFACT_DIR}/.venv-${V}"
+    uv venv --python 3.11 "$VENV_DIR" >/dev/null
+    # ``uv pip install`` in the local venv keeps the host project env clean.
+    VIRTUAL_ENV="$VENV_DIR" uv pip install --quiet \
+        "lizyml==${V}" cloudpickle >/dev/null
+
+    # Save a synthetic sidecar that mirrors what
+    # ``LizyMLAdapter.save_checkpoint`` writes. We deliberately do NOT
+    # invoke the past version's Studio adapter (Studio is forward-only
+    # against lizyml); the sidecar shape has been stable since H-0062.
+    VIRTUAL_ENV="$VENV_DIR" "$VENV_DIR/bin/python" - "$OUT_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+import cloudpickle
+import lizyml
+
+out_dir = Path(sys.argv[1])
+model_path = out_dir / "model.pkl"
+meta_path = out_dir / "model_meta.json"
+
+# A tiny picklable sentinel — the matrix is about envelope shape,
+# not the actual model state.
+with model_path.open("wb") as fh:
+    cloudpickle.dump({"_marker": "pickle_compat_matrix"}, fh)
+
+meta = {
+    "pickle_schema": 1,
+    "lizyml_version": lizyml.__version__,
+    "lightgbm_version": "matrix-fixture",
+    "optuna_version": "matrix-fixture",
+    "saved_at": "1970-01-01T00:00:00+00:00",
+}
+meta_path.write_text(json.dumps(meta), encoding="utf-8")
+print(f"[saved] lizyml={lizyml.__version__} -> {out_dir}")
+PY
+done
+
+# ---------------------------------------------------------------------------
+# Phase 2: verify each saved sidecar is REJECTED by the current runtime.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Verifying rejection against runtime lizyml==${CURRENT_VERSION} ---"
+uv run python - "$ARTEFACT_DIR" "$CURRENT_VERSION" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+from lizystudio.backends.lizyml import (
+    PickleIncompatibleError,
+    verify_pickle_compatibility,
+)
+
+artefact_dir = Path(sys.argv[1])
+current_version = sys.argv[2]
+failures: list[str] = []
+verified = 0
+
+for sub in sorted(artefact_dir.iterdir()):
+    if not sub.is_dir() or sub.name.startswith("."):
+        continue
+    meta_path = sub / "model_meta.json"
+    if not meta_path.exists():
+        continue
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    saved = meta["lizyml_version"]
+    if saved == current_version:
+        # Same major.minor — verification SHOULD succeed; that's a
+        # forward-compat sanity check, not a v3-26 failure.
+        try:
+            verify_pickle_compatibility(meta)
+        except PickleIncompatibleError as exc:
+            failures.append(
+                f"  {saved}: matching version unexpectedly rejected: {exc}"
+            )
+        else:
+            print(f"  {saved}: accepted (matches runtime) — ok")
+        continue
+    try:
+        verify_pickle_compatibility(meta)
+    except PickleIncompatibleError as exc:
+        if exc.kind not in {"lizyml_version_mismatch", "schema_mismatch"}:
+            failures.append(
+                f"  {saved}: rejected with unexpected kind={exc.kind!r}"
+            )
+            continue
+        if not exc.recovery_hint or not exc.suggested_fix:
+            failures.append(
+                f"  {saved}: kind={exc.kind} but envelope missing "
+                f"recovery_hint or suggested_fix"
+            )
+            continue
+        print(f"  {saved}: rejected (kind={exc.kind}) — ok")
+        verified += 1
+    else:
+        failures.append(
+            f"  {saved}: SILENT LOAD against runtime {current_version} "
+            f"(verify_pickle_compatibility returned without raising)"
+        )
+
+print()
+print(f"Verified {verified} past minor(s) against runtime {current_version}.")
+if failures:
+    print("FAILED:")
+    for line in failures:
+        print(line)
+    sys.exit(1)
+PY
+
+echo ""
+echo "================================================================"
+echo "Pickle compat matrix: all past versions correctly rejected."
+echo "================================================================"

--- a/src/lizystudio/api/errors.py
+++ b/src/lizystudio/api/errors.py
@@ -189,13 +189,38 @@ class PicklePreflightFailedError(StudioError):
 
 
 class PickleIncompatibleError(StudioError):
-    """Stored checkpoint cannot be deserialized by the current runtime (H-0062)."""
+    """Stored checkpoint cannot be deserialized by the current runtime (H-0062).
 
-    def __init__(self, reason: str) -> None:
+    P-0107 (v3-26c): the JSON ``details`` payload carries a structured
+    classification (``kind``) plus user-facing ``recovery_hint`` and
+    ``suggested_fix`` strings so the frontend can render an actionable
+    error toast / banner instead of just the raw ``message``.
+
+    Backward compatibility: when the optional fields are not provided
+    (legacy raise sites, future call sites that lack classification),
+    ``details`` still contains ``kind="unknown"`` and the hint/fix slots
+    are absent — older clients that only consume ``code`` + ``message``
+    are unaffected.
+    """
+
+    def __init__(
+        self,
+        reason: str,
+        *,
+        kind: str = "unknown",
+        recovery_hint: str | None = None,
+        suggested_fix: str | None = None,
+    ) -> None:
+        details: dict[str, Any] = {"kind": kind}
+        if recovery_hint:
+            details["recovery_hint"] = recovery_hint
+        if suggested_fix:
+            details["suggested_fix"] = suggested_fix
         super().__init__(
             "PICKLE_INCOMPATIBLE",
             f"Checkpoint incompatible: {reason}",
             400,
+            details=details,
         )
 
 

--- a/src/lizystudio/api/retune.py
+++ b/src/lizystudio/api/retune.py
@@ -129,7 +129,16 @@ def _require_tune_job_with_checkpoint(
     try:
         backend.verify_checkpoint_compatibility(parent_dir)
     except CheckpointIncompatibleError as exc:
-        raise PickleIncompatibleApiError(f"{parent.job_id}: {exc}") from exc
+        # P-0107: forward the backend's structured classification through
+        # to the HTTP envelope so the frontend can render an actionable
+        # banner (kind-specific recovery hint + copyable suggested fix)
+        # instead of a raw "Checkpoint incompatible: ..." string.
+        raise PickleIncompatibleApiError(
+            f"{parent.job_id}: {exc}",
+            kind=exc.kind,
+            recovery_hint=exc.recovery_hint,
+            suggested_fix=exc.suggested_fix,
+        ) from exc
 
 
 def _claim_retune_slot(parent_job_id: str, job_store: JobStore) -> str:

--- a/src/lizystudio/backends/exceptions.py
+++ b/src/lizystudio/backends/exceptions.py
@@ -55,7 +55,27 @@ class CheckpointIncompatibleError(Exception):
     Adapters translate their own pickle / dependency errors into this
     type so the API layer can return a consistent envelope without
     importing backend-specific symbols.
+
+    P-0107 (v3-26c): structured fields ``kind``, ``recovery_hint``, and
+    ``suggested_fix`` propagate the backend's classification through to
+    the HTTP envelope. ``kind`` should be one of:
+    ``"schema_mismatch"`` / ``"lizyml_version_mismatch"`` /
+    ``"corrupt_meta"`` / ``"unknown"`` (the last is the safe fallback
+    for legacy call sites and future second-backend extensions).
     """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        kind: str = "unknown",
+        recovery_hint: str | None = None,
+        suggested_fix: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.kind = kind
+        self.recovery_hint = recovery_hint
+        self.suggested_fix = suggested_fix
 
 
 class CheckpointPreflightError(Exception):

--- a/src/lizystudio/backends/lizyml/checkpoint_mixin.py
+++ b/src/lizystudio/backends/lizyml/checkpoint_mixin.py
@@ -64,13 +64,37 @@ class CheckpointMixin:
         try:
             meta = json.loads(meta_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
+            # P-0107: classify the failure so the API envelope can show
+            # the user a corruption-specific recovery hint (re-run the
+            # tune; the on-disk sidecar is unrecoverable) rather than
+            # the version-mismatch hint, which would be misleading here.
             raise CheckpointIncompatibleError(
-                f"Corrupted model_meta.json at {meta_path}: {exc}"
+                f"Corrupted model_meta.json at {meta_path}: {exc}",
+                kind="corrupt_meta",
+                recovery_hint=(
+                    "The checkpoint sidecar (model_meta.json) is unreadable. "
+                    "This usually means the file was truncated by a crash "
+                    "during save; the underlying model.pkl cannot be safely "
+                    "loaded without it."
+                ),
+                suggested_fix=(
+                    "Re-run the tune to produce a fresh checkpoint. The "
+                    "incompatible artefact can be safely deleted from the "
+                    "job directory."
+                ),
             ) from exc
         try:
             verify_pickle_compatibility(meta)
         except PickleIncompatibleError as exc:
-            raise CheckpointIncompatibleError(str(exc)) from exc
+            # P-0107: forward the lizyml-side classification (schema vs
+            # version mismatch) through the backend-agnostic envelope so
+            # the API layer never has to re-classify by parsing strings.
+            raise CheckpointIncompatibleError(
+                str(exc),
+                kind=exc.kind,
+                recovery_hint=exc.recovery_hint,
+                suggested_fix=exc.suggested_fix,
+            ) from exc
 
     def save_checkpoint(self, model: Any, path: Path) -> None:
         """Atomically persist *model* as ``path/model.pkl`` via temp+rename."""

--- a/src/lizystudio/backends/lizyml/pickle_compat.py
+++ b/src/lizystudio/backends/lizyml/pickle_compat.py
@@ -24,7 +24,37 @@ class PicklePreflightError(RuntimeError):
 class PickleIncompatibleError(RuntimeError):
     """Raised by ``load_checkpoint`` / ``verify_pickle_compatibility`` when
     the on-disk ``model_meta.json`` points at a schema or major backend
-    version the current Studio cannot safely deserialize."""
+    version the current Studio cannot safely deserialize.
+
+    P-0107 (v3-26c): carries a structured ``kind`` classification, a
+    ``recovery_hint`` (one-sentence "what to do next" for the user),
+    and a ``suggested_fix`` (concrete command or value the UI can show
+    on a copy-paste affordance). The API envelope (``api/errors.py``)
+    surfaces these fields in ``details`` so the frontend can render
+    actionable guidance instead of a raw "Checkpoint incompatible: ..."
+    string.
+
+    ``kind`` values:
+
+    - ``"schema_mismatch"`` -- ``PICKLE_SCHEMA_VERSION`` bumped
+    - ``"lizyml_version_mismatch"`` -- saved lizyml major.minor differs
+      from the runtime
+    - ``"unknown"`` -- fallback when callers construct the error
+      without classification (legacy code paths, future error sources)
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        kind: str = "unknown",
+        recovery_hint: str | None = None,
+        suggested_fix: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.kind = kind
+        self.recovery_hint = recovery_hint
+        self.suggested_fix = suggested_fix
 
 
 PICKLE_SCHEMA_VERSION = 1
@@ -99,7 +129,18 @@ def verify_pickle_compatibility(meta: dict[str, Any]) -> None:
     if schema != PICKLE_SCHEMA_VERSION:
         raise PickleIncompatibleError(
             f"Unsupported pickle_schema: expected {PICKLE_SCHEMA_VERSION}, "
-            f"got {schema!r}"
+            f"got {schema!r}",
+            kind="schema_mismatch",
+            recovery_hint=(
+                "The on-disk checkpoint format changed in this Studio release. "
+                "Past checkpoints cannot be loaded; you need to refit the model."
+            ),
+            suggested_fix=(
+                f"Refit the workspace to produce a model with "
+                f"pickle_schema={PICKLE_SCHEMA_VERSION}, or downgrade Studio "
+                f"to a release whose pickle_schema matches the saved "
+                f"value ({schema!r})."
+            ),
         )
 
     current = collect_pickle_versions()
@@ -110,7 +151,19 @@ def verify_pickle_compatibility(meta: dict[str, Any]) -> None:
         raise PickleIncompatibleError(
             "Incompatible lizyml version: checkpoint was saved with "
             f"{saved_lizyml!r}, current runtime is "
-            f"{current['lizyml_version']!r}"
+            f"{current['lizyml_version']!r}",
+            kind="lizyml_version_mismatch",
+            recovery_hint=(
+                "The lizyml major.minor changed since this checkpoint was "
+                "saved. Pickles cannot cross minor boundaries (internal "
+                "class moves invalidate the serialized state); refit on the "
+                "current lizyml to produce a fresh checkpoint."
+            ),
+            suggested_fix=(
+                f"Either refit the workspace under lizyml "
+                f"{current['lizyml_version']}, or pin the old runtime with "
+                f"``uv add lizyml=={saved_lizyml}`` to reload this artefact."
+            ),
         )
 
 

--- a/tests/bench/test_bench_pickle_compat.py
+++ b/tests/bench/test_bench_pickle_compat.py
@@ -1,0 +1,131 @@
+"""Pickle compatibility matrix (v3-26 / R-4.2).
+
+The on-disk ``model.pkl`` + ``model_meta.json`` carries
+``pickle_schema`` and the saved lizyml / lightgbm / optuna versions.
+``verify_pickle_compatibility`` rejects checkpoints whose lizyml
+major.minor does not match the runtime so a silent corrupt-load can
+never occur — every minor lizyml bump invalidates older artefacts and
+the user is told to refit.
+
+This module pins that invariant under three drift scenarios that have
+*actually* burned us in past minor bumps:
+
+1. ``schema_mismatch`` — ``PICKLE_SCHEMA_VERSION`` bump (a backend
+   refactor changed the on-disk shape).
+2. ``lizyml_version_mismatch`` — a new lizyml minor where pickle
+   reflects internal class moves.
+3. ``corrupt_meta`` — a partially-written ``model_meta.json``
+   (atomic-write crash mid-flight).
+
+The tests are marked ``@pytest.mark.slow`` + ``@pytest.mark.pickle_compat``
+so they stay out of PR CI (``addopts = -m 'not quarantine'`` still picks
+them up by default, but the explicit ``-m "pickle_compat"`` selector in
+the nightly job makes the intent explicit and lets the matrix workflow
+run only this file). The matrix is exercised cross-version by
+``scripts/pickle_compat_matrix.sh`` in the nightly workflow — that script
+installs past N=3 minor lizyml releases into separate venvs, calls
+``save_checkpoint`` with each, then runs this file against the saved
+artefacts with the *current* runtime to assert the rejection envelope.
+
+The unit-level tests below stay synthetic so they remain meaningful
+even on a developer machine without the matrix venvs installed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lizystudio.backends.lizyml import (
+    LizyMLAdapter,
+    PickleIncompatibleError,
+    verify_pickle_compatibility,
+)
+from lizystudio.backends.lizyml.pickle_compat import PICKLE_SCHEMA_VERSION
+
+pytestmark = [pytest.mark.slow, pytest.mark.pickle_compat]
+
+
+def _make_picklable_object() -> dict[str, Any]:
+    return {"_marker": "v3-26", "value": 7}
+
+
+def _save_with_drifted_meta(
+    tmp_path: Path, *, lizyml_version: str, pickle_schema: int = PICKLE_SCHEMA_VERSION
+) -> Path:
+    """Save a real checkpoint then overwrite the sidecar to simulate drift.
+
+    This mirrors what the cross-version nightly matrix produces: a
+    pickle saved by a past lizyml release whose ``lizyml_version`` is
+    older than the runtime executing the load. We cannot install N
+    lizyml minors in-process, so the meta is rewritten to reproduce
+    the on-disk shape the matrix script would have generated.
+    """
+    adapter = LizyMLAdapter()
+    adapter.save_checkpoint(_make_picklable_object(), tmp_path)
+    meta_path = tmp_path / "model_meta.json"
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    meta["lizyml_version"] = lizyml_version
+    meta["pickle_schema"] = pickle_schema
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# INV-A: silent load forbidden — every drift class must raise
+# PickleIncompatibleError with a non-empty ``kind`` + ``recovery_hint``.
+# ---------------------------------------------------------------------------
+
+
+def test_pickle_compat_rejects_schema_mismatch(tmp_path: Path) -> None:
+    _save_with_drifted_meta(
+        tmp_path,
+        lizyml_version="0.15.0",
+        pickle_schema=PICKLE_SCHEMA_VERSION + 1,
+    )
+    meta = json.loads((tmp_path / "model_meta.json").read_text(encoding="utf-8"))
+    with pytest.raises(PickleIncompatibleError) as excinfo:
+        verify_pickle_compatibility(meta)
+    err = excinfo.value
+    assert err.kind == "schema_mismatch"
+    assert err.recovery_hint
+    assert err.suggested_fix
+
+
+@pytest.mark.parametrize(
+    "past_minor",
+    [
+        "0.12.0",  # N-3
+        "0.13.0",  # N-2
+        "0.14.0",  # N-1
+    ],
+)
+def test_pickle_compat_rejects_past_n_minors(tmp_path: Path, past_minor: str) -> None:
+    """The user-facing DoD for v3-26: artefacts produced by the
+    previous three lizyml minor releases must be rejected with a
+    structured envelope, not silently loaded.
+    """
+    _save_with_drifted_meta(tmp_path, lizyml_version=past_minor)
+    meta = json.loads((tmp_path / "model_meta.json").read_text(encoding="utf-8"))
+    with pytest.raises(PickleIncompatibleError) as excinfo:
+        verify_pickle_compatibility(meta)
+    err = excinfo.value
+    assert err.kind == "lizyml_version_mismatch"
+    assert err.recovery_hint
+    assert err.suggested_fix
+    assert past_minor in err.suggested_fix
+
+
+def test_pickle_compat_full_load_path_raises(tmp_path: Path) -> None:
+    """End-to-end through the adapter's ``load_checkpoint`` — confirms
+    the verify_pickle_compatibility hook is wired into the load path
+    so a buggy refactor cannot bypass the gate while keeping the unit
+    test green.
+    """
+    _save_with_drifted_meta(tmp_path, lizyml_version="0.7.0")
+    adapter = LizyMLAdapter()
+    with pytest.raises(PickleIncompatibleError):
+        adapter.load_checkpoint(tmp_path)

--- a/tests/test_lizyml_checkpoint.py
+++ b/tests/test_lizyml_checkpoint.py
@@ -143,6 +143,51 @@ def test_verify_pickle_compatibility_rejects_lizyml_major_mismatch() -> None:
 
 
 # ---------------------------------------------------------------------------
+# P-0107 (v3-26c): structured error envelope on PickleIncompatibleError
+# ---------------------------------------------------------------------------
+#
+# The error must classify the failure (``kind``) and carry a
+# ``recovery_hint`` + ``suggested_fix`` so the API envelope can render
+# user-actionable guidance instead of a raw runtime trace. This is the
+# checkpoint-load equivalent of P-0100's ``severity`` + ``suggested_fix``
+# envelope for ``validate_config`` warnings.
+
+
+def test_pickle_incompatible_schema_mismatch_carries_recovery_hint() -> None:
+    meta = {
+        "pickle_schema": 99,
+        "lizyml_version": "0.15.0",
+        "lightgbm_version": "4.5.0",
+        "optuna_version": "4.0.0",
+    }
+    with pytest.raises(PickleIncompatibleError) as excinfo:
+        verify_pickle_compatibility(meta)
+    err = excinfo.value
+    assert err.kind == "schema_mismatch"
+    assert err.recovery_hint, "schema mismatch must carry a recovery_hint"
+    assert err.suggested_fix, "schema mismatch must carry a suggested_fix"
+    assert "99" in err.suggested_fix or "schema" in err.suggested_fix.lower()
+
+
+def test_pickle_incompatible_lizyml_mismatch_carries_recovery_hint() -> None:
+    meta = {
+        "pickle_schema": 1,
+        "lizyml_version": "0.7.0",
+        "lightgbm_version": "4.5.0",
+        "optuna_version": "4.0.0",
+    }
+    with pytest.raises(PickleIncompatibleError) as excinfo:
+        verify_pickle_compatibility(meta)
+    err = excinfo.value
+    assert err.kind == "lizyml_version_mismatch"
+    assert err.recovery_hint, "version mismatch must carry a recovery_hint"
+    assert err.suggested_fix, "version mismatch must carry a suggested_fix"
+    # The saved version string must appear in the hint so the user can
+    # paste it into a ``pip install lizyml==`` command.
+    assert "0.7.0" in err.suggested_fix
+
+
+# ---------------------------------------------------------------------------
 # Pre-flight check
 # ---------------------------------------------------------------------------
 

--- a/tests/test_retune_api.py
+++ b/tests/test_retune_api.py
@@ -841,6 +841,39 @@ def test_retune_rejects_incompatible_pickle_version(
     assert res.json()["error"]["code"] == "PICKLE_INCOMPATIBLE"
 
 
+def test_retune_pickle_incompatible_envelope_carries_recovery_hint(
+    client: TestClient, sample_data_ref: DataRef
+) -> None:
+    """P-0107 (v3-26c): the PICKLE_INCOMPATIBLE 400 envelope must carry
+    ``kind`` + ``recovery_hint`` + ``suggested_fix`` in ``details`` so
+    the frontend can render user-actionable guidance instead of a raw
+    "Checkpoint incompatible: ..." string. This is the checkpoint-load
+    equivalent of P-0100's ``severity`` + ``suggested_fix`` envelope.
+    """
+    parent_id = _make_completed_tune_job(client, sample_data_ref)
+    app = client.app  # type: ignore[union-attr]
+    job_store: JobStore = app.state.job_store
+
+    meta = job_store.jobs_dir / parent_id / "model_meta.json"
+    meta.write_text(
+        '{"pickle_schema": 1, "lizyml_version": "0.7.0", '
+        '"lightgbm_version": "4.5.0", "optuna_version": "4.0.0", '
+        '"saved_at": "2026-04-14T00:00:00+00:00"}',
+        encoding="utf-8",
+    )
+
+    res = client.post(f"/api/jobs/{parent_id}/retune", json={"n_trials": 3})
+    assert res.status_code == 400
+    body = res.json()["error"]
+    assert body["code"] == "PICKLE_INCOMPATIBLE"
+    details = body["details"]
+    assert details["kind"] == "lizyml_version_mismatch"
+    assert isinstance(details.get("recovery_hint"), str) and details["recovery_hint"]
+    assert isinstance(details.get("suggested_fix"), str) and details["suggested_fix"]
+    # The saved version must appear so the user can pin it.
+    assert "0.7.0" in details["suggested_fix"]
+
+
 def test_retune_rejects_corrupted_meta_json(
     client: TestClient, sample_data_ref: DataRef
 ) -> None:


### PR DESCRIPTION
## Summary

Closes the last open `PLAN.md` v0.5 phase — **v3-26 (R-4.2 Pickle compatibility nightly CI)** — and introduces `HISTORY.md` **P-0107** (structured `PICKLE_INCOMPATIBLE` envelope).

The pickle-compat invariant was already enforced at the runtime check (`verify_pickle_compatibility` rejects any lizyml major.minor mismatch). What was missing: **(1)** the API envelope was a free-form `message` string, leaving the frontend with no actionable handle, and **(2)** there was no CI gate proving the rejection actually fires against past lizyml minors. This PR closes both gaps without changing the rejection policy.

## What changes

### Backend exceptions (additive, backward-compat)

| File | Change |
|---|---|
| `backends/lizyml/pickle_compat.py` | `PickleIncompatibleError` gains keyword-only `kind` / `recovery_hint` / `suggested_fix`. The two `verify_pickle_compatibility` raise sites now classify themselves as `schema_mismatch` / `lizyml_version_mismatch` with concrete user-facing strings (refit instructions; pin command for the saved version). |
| `backends/exceptions.py` | `CheckpointIncompatibleError` mirrors the same kwargs so backend-agnostic callers (`api/retune.py`) never have to reclassify by parsing strings. |
| `backends/lizyml/checkpoint_mixin.py` | `verify_checkpoint_compatibility` classifies a corrupted `model_meta.json` as `kind="corrupt_meta"` with a re-run hint; the `PickleIncompatibleError` catch forwards `kind`/`recovery_hint`/`suggested_fix` verbatim. |

### API layer (additive)

| File | Change |
|---|---|
| `api/errors.py` | `PickleIncompatibleError` stores classified fields under `details` (always `kind`, `recovery_hint`/`suggested_fix` when non-None). Legacy clients consuming only `code` + `message` stay unaffected. |
| `api/retune.py::_require_tune_job_with_checkpoint` | Forwards the backend classification through the HTTP envelope. |

### Tests

| File | Change |
|---|---|
| `tests/test_lizyml_checkpoint.py` | +2 unit tests pin `kind` / `recovery_hint` / `suggested_fix` for schema and version mismatch. |
| `tests/test_retune_api.py` | +1 HTTP contract test asserts `details.kind == "lizyml_version_mismatch"` and the saved version appears in `suggested_fix`. |
| `tests/bench/test_bench_pickle_compat.py` (new) | `@slow + @pickle_compat`: schema bump + parametrized N-3 / N-2 / N-1 minors + `adapter.load_checkpoint` E2E rejection. |

### Infrastructure

| File | Change |
|---|---|
| `scripts/pickle_compat_matrix.sh` (new) | Provisions ephemeral venvs with `lizyml==0.12.0 / 0.13.0 / 0.14.0`, saves a sidecar with each, then verifies the runtime rejects them with the structured envelope. Silent load is `exit 1`. |
| `.github/workflows/nightly.yml` | New `pickle-compat` job runs the synthetic-drift unit gate plus the cross-minor matrix script. |
| `pyproject.toml` | Register the `pickle_compat` pytest marker. |

### Docs

- **`HISTORY.md` P-0107** — motivation, invariants (INV-pickle-1..4), impact, acceptance criteria, alternatives, decision.
- **`PLAN.md` v3-26 a/b/c** — marked green with PR ref; DoD ticked.
- **`docs/ROADMAP.md`** — stamp 2026-05-13, Tier 1 next-actions reordered (`#474` now at the top), drift table updated, P-0108 / v3-27 numbering note.
- **`docs/v0.4-business-readiness-plan.md`** — R-4 row marked completed; R-4.2 section gets a `Status` header + implementation links.

## Invariants (P-0107)

- **INV-pickle-1**: cross-minor saved checkpoint always raises `PickleIncompatibleError` (silent load forbidden).
- **INV-pickle-2**: backend raise sites always classify into `schema_mismatch` / `lizyml_version_mismatch` / `corrupt_meta` with non-empty `recovery_hint` + `suggested_fix`.
- **INV-pickle-3**: HTTP `details` always carries `kind`; classified cases carry `recovery_hint` + `suggested_fix`.
- **INV-pickle-4**: clients consuming only `code` + `message` are unaffected (purely additive change).

## Failure paths covered

- [x] Schema bump (`PICKLE_SCHEMA_VERSION + 1`)
- [x] lizyml minor mismatch (3 past minors parametrized: 0.12.0 / 0.13.0 / 0.14.0)
- [x] Corrupted `model_meta.json` (truncated atomic write)
- [x] `adapter.load_checkpoint` end-to-end (verify hook reachable)
- [x] Missing meta still tolerated (legacy pre-H-0062 checkpoints, existing test stays green)

## Test plan

- [x] `uv run pytest tests/ -k "not slow" --ignore=tests/{e2e,integration,bench}` — **1536 passed** (was 1533, +3 new).
- [x] `uv run pytest tests/bench/test_bench_pickle_compat.py -m pickle_compat --override-ini="addopts="` — **5 passed**.
- [x] `bash scripts/pickle_compat_matrix.sh` (smoke with `PAST_VERSIONS=0.14.0`) — all past versions correctly rejected with `kind=lizyml_version_mismatch`.
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy src/lizystudio/` — all green.

## Rationale

> **Why structured envelope before R-3 typed-error rework?** The full R-3.1 plan (`StudioError` gains required `code`/`recovery_hint`/`is_user_error`) is v0.6+ deferred. But `PLAN.md` v3-26c explicitly requires `recovery_hint` + `suggested_fix` for the pickle path, so this PR introduces the precursor on a single envelope (`PICKLE_INCOMPATIBLE`) using the same pattern P-0100 already established for `severity` + `suggested_fix` on `validate_config` warnings. Other `StudioError` envelopes stay unchanged.

> **Why keep policy strict (cross-minor reject)?** Pickle class identity is not guaranteed stable across lizyml minor bumps (internal class moves, attribute renames). A "best effort" load would let corrupt state surface as a crash deeper in the code path. The user-facing remediation is a refit (or pin to the saved version) — which is exactly what `recovery_hint` + `suggested_fix` now say.

> **Why include the script + Nightly job?** The runtime check already exists; without a cross-version gate, a future refactor could quietly weaken it (e.g. accidentally accept any `pickle_schema` value). The matrix script proves the invariant with real ephemeral installs, and the unit-level bench file gives developers a fast in-process feedback loop.

## Closes

- `PLAN.md` **v3-26 (a/b/c)** — v0.5 R-4.2 Pickle compat nightly CI
- `docs/v0.4-business-readiness-plan.md` **R-4** scope (R-4.1 already shipped in v0.5.0; R-4.2 shipped here)
