### PR TITLE
feat(474): run-gate parse_space validation + P-0108 envelope

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3926,3 +3926,86 @@ regression Fit 結果の Residuals plot は現在「1 figure に 3 panel（Actua
 #### Decision
 
 - 2026-05-13 **Approved** — `PICKLE_INCOMPATIBLE` envelope のみを先行で structured 化、R-3 typed error 体系全体は v0.5 以降に持ち越し。Nightly matrix は `PAST_VERSIONS` env 経由で minors を bump 可能（lizyml が 1.0 になったら matrix を `0.13.0 0.14.0 0.15.0` から `0.x 0.y 1.0` 系へ更新するメモを script header に記載）。
+
+---
+
+### P-0108: 構造的に壊れた search space を `POST /tune` run-gate で 422 する（Issue #474, Change Gate）
+
+- **Date:** 2026-05-13 起票・即承認（Issue #474 で詳細仕様確定済 + アプローチ C 推奨済）
+- **Related:** Issue #474（P-0104 Wave 3.1a deferred）、P-0104 Scope-4 (HISTORY)、PR #473（Wave 3.1a — `parse_space` を `validate_config` に組み込もうとして失敗した記録）、`src/lizystudio/backends/base.py::BackendCore.validate_search_space`、`src/lizystudio/backends/lizyml/config_mixin.py::ConfigMixin.validate_search_space`、`src/lizystudio/services/workspace.py::validate_search_space_for_tune`、`src/lizystudio/api/workspace.py::workspace_tune`、`tests/test_backends_lizyml.py::TestValidateSearchSpace`、`tests/test_workspace_api.py`、`frontend/tests/e2e/workspace-tune.spec.ts:459`、P-0100（severity envelope の前例）、P-0089（save gate immutability）
+
+#### Motivation
+
+`tuning.optuna.space` に structurally-broken な entry（inverted Range = `low >= high`、log distribution + `low <= 0`）が混入すると、`validate_config` を通過して Tune ジョブが起動し、Optuna のループで N 試行繰り返した後に「All tuning trials failed」という deep error が出る。ユーザは「自分の指定のどこがダメだったか」を直接知る術が無い。Issue #474（P-0104 Wave 3.1a deferred、Scope-4）が要求する **「Fix validation errors first」バナーで早期に surface する** は v0.5.0 では未着手のまま develop に残った。
+
+PR #473（Wave 3.1a）でこれを `validate_config` に組み込もうとしたが、`validate_config` は `PUT /config`（save gate）と `POST /fit`/`POST /tune`（run gate）の **両方** から呼ばれるため、save gate に厳格化を被せた結果 `workspace-tune.spec.ts:459` を破壊した（empty-choice categorical の transient 状態と inverted Range の編集中状態が両方とも `saved: false` を返してフォーム revert された）。この経緯から **save gate は permissive のまま、run-gate のみで結束的に reject する** という分離が要件として確定している。
+
+#### Purpose
+
+- `BackendCore` Protocol に `validate_search_space(space: dict[str, Any]) -> list[dict[str, Any]]` を追加。Protocol 本体は `return []`（実装しない backend = 不適合 space ゼロ）を既定とする。
+- lizyml adapter は `parse_space(space)` を per-entry で呼び、`LizyMLError(CONFIG_INVALID)` を `{path: "tuning.optuna.space.<param>", message, severity: "error", suggested_fix}` envelope に map。
+- **categorical `choices: []` は backend 側で完全に filter out** する（frontend の `empty-choice-banner` が UX owner、PR #473 post-mortem で確立した不変条件）。
+- Service 層に `validate_search_space_for_tune(ws, config)` を新設（type narrowing + adapter dispatch のみの thin envelope）。
+- API `POST /api/workspace/tune` で `validate_config` の直後、`create_and_claim_active` の直前に上記 helper を呼び、空でない結果を `ValidationError` に投げる。
+
+#### Invariants
+
+- **INV-search-1 (save gate permissive)**: `PUT /api/workspace/config` は inverted-range / log+low<=0 / empty-choices いずれの WIP も `saved: true` で persist する（Issue #474 + PR #473 post-mortem で確立した制約）。
+- **INV-search-2 (run gate strict)**: `POST /api/workspace/tune` は inverted-range / log+low<=0 の space を 422 `VALIDATION_ERROR` で reject し、`start_tune_async` を絶対に呼ばない。
+- **INV-search-3 (empty-choices is frontend territory)**: `POST /api/workspace/tune` は categorical `choices: []` を **run-gate では追加で flag しない**。既存の経路（schema layer の reject、frontend の empty-choice-banner）に委ねる。
+- **INV-search-4 (envelope shape)**: 各 error は `{path: "tuning.optuna.space.<param>", message, severity: "error", suggested_fix}` の 4 キーを必ず含む（P-0100 envelope と byte-identical）。
+- **INV-search-5 (per-entry isolation)**: 単一 broken row が他の row の drift を mask しない（multiple-violation のとき全 row が returned）。
+
+#### Impact
+
+**共通型 / Protocol (← Change Gate 対象):**
+- `backends/base.py::BackendCore.validate_search_space`: 新メソッド追加。Protocol 本体に `return []` のデフォルト。`BackendAdapter` alias は `BackendCore` を継承しているので自動的に新メソッドを含む。
+
+**Backend (lizyml adapter):**
+- `backends/lizyml/config_mixin.py::ConfigMixin.validate_search_space`: 実装。`lizyml.tuning.parse_space` を per-entry で呼び、`LizyMLError` の `code.value == "CONFIG_INVALID"` のみを user-facing envelope に変換。empty-choices categorical は事前 filter で除外。
+- `backends/lizyml/config_mixin.py::_suggested_fix_for_space_error`: module-level helper。log/low/high の値を読んで「Swap Min and Max」「raise Min above zero」など具体的な remediation 文言を作る。
+
+**Service:**
+- `services/workspace.py::validate_search_space_for_tune`: 新規 thin envelope。`tuning.optuna.space` の type narrowing と adapter dispatch のみ。`validate_config` は **意図的に無改変** (save gate permissive 保持)。
+
+**API:**
+- `api/workspace.py::workspace_tune`: `validate_config` の直後に `validate_search_space_for_tune(ws, ws.config)` を呼び、空でない結果を既存の `ValidationError` envelope に flow。
+
+**Tests:**
+- `tests/test_backends_lizyml.py::TestValidateSearchSpace` (新規 9 ケース): 空 space / non-dict / valid / inverted range / log+low=0 / log+low<0 / empty-choices drop / multiple-violation / non-dict entry。
+- `tests/test_workspace_api.py` (新規 4 ケース): POST /tune inverted-range 422 + start_tune_async 未呼び出し、log+low=0 422、empty-choices accept-or-other-validator (run-gate は flag しない)、PUT /config inverted-range save 200.
+
+**Behavior change for users:**
+- 反転 Range と log+low<=0 の space で Tune を起動しようとすると **422 になり「Fix validation errors first」バナー** に具体的な suggested_fix が出る（旧: Optuna ループの後で「All tuning trials failed」）。
+- 編集中の状態（部分入力）で PUT /config しても従来どおり保存される（INV-search-1）。
+- categorical empty-choices の挙動は不変（frontend の empty-choice-banner が disable する）。
+
+**Compatibility:**
+- 後方互換。新 Protocol method は本体に default `return []` を持つので 2nd backend（既存 + 将来）に非破壊。lizyml の挙動拡張は run-gate のみ。
+- HTTP envelope shape は P-0100 と同じ（既存 frontend 表示 path で render される）。
+
+#### Acceptance criteria
+
+- [x] `BackendCore.validate_search_space` Protocol method 追加、デフォルト `return []`、`BackendAdapter` alias へ伝播。
+- [x] lizyml adapter が inverted-range / log+low<=0 を classify、empty-choices categorical は filter out。
+- [x] Service `validate_search_space_for_tune` が thin envelope として実装。
+- [x] `POST /tune` が validate_config 後 + create_and_claim_active 前で gate。422 envelope。`start_tune_async` 未呼び出し（テストで明示）。
+- [x] `PUT /config` が引き続き inverted-range / log+low<=0 / empty-choices を `saved: true` で persist（INV-search-1）。
+- [x] `tests/test_backends_lizyml.py::TestValidateSearchSpace` の 9 ケース + `tests/test_workspace_api.py` の 4 ケース pass。
+- [x] `frontend/tests/e2e/workspace-tune.spec.ts:459`（Choice mode seeds + gates Tune when emptied）regression 無し（local backend pytest level で empty-choices invariant 確認、CI で e2e 走行）。
+- [x] `uv run pytest` / `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy src/lizystudio/` 全 green。
+- [ ] BLUEPRINT.md §3.3.2 の adapter capability 一覧に `validate_search_space` を追記（次の reconcile タイミング、本 PR では HISTORY 起票 + 実装で十分）。
+
+#### Alternatives considered
+
+- **(a, rejected): `parse_space` を `validate_config` 内で unconditionally 呼ぶ** — PR #473 で試行 → save gate を破壊（empty-choices と transient inverted-range で `saved: false` 連発、frontend が revert）。
+- **(b, considered)**: `search_space_invalid` を `severity: "warning"` で `validate_config` から出し、frontend で Tune button を disable する。
+    - Pros: 既存 validate envelope を再利用、frontend で gating 完結
+    - Cons: 「警告だが run-gate でもブロック」という挙動分裂、severity の semantics が崩れる、PR #473 の empty-choices 問題が再発（transient 状態でも warning が出続ける）
+- **(c, ADOPTED — Issue #474 推奨)**: `validate_config` は無改変、`POST /tune` 直前で run-gate 専用 helper を呼ぶ。
+    - Pros: save / run の責務が明確に分離、empty-choices は frontend 所有のまま、既存 envelope を再利用、e2e regression なし
+    - Cons: validate helper が 2 つになる（`validate_config` + `validate_search_space_for_tune`）が、責務が分かれているので drift しにくい
+
+#### Decision
+
+- 2026-05-13 **Approved** — Issue #474 の Approach C（run-gate only）で実装。実装は単一 PR（commit 順: Proposal + 全実装一括 + test）。`task` / `target` 等の文脈情報は本 method には渡さない（純粋な structural check）。将来 2nd backend が同じ Protocol を実装するとき、その backend の search-space DSL に固有な検証はその adapter 内に閉じる（lizyml の `parse_space` への coupling は backend 内に留まる）。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -298,11 +298,12 @@ Wave 6 完了後の Open Issue は **4 件**（#451 / #453 は 2026-05-13 close 
 
 ### Tier 1：直近の着手候補（ROI 順）
 
-1. **#474** — P-0104 Wave 3.1a deferred: inverted-range / log+low≤0 の search-space エラーを `POST /tune` run-gate で早期 surface（中規模・独立、approach C = Issue 推奨）
-2. **#495** — #456 L5: weekly stale-doc audit cron（`scripts/audit_stale_docs.py` + `.github/workflows/audit-stale-docs.yml` cron weekly、tracking issue 自動更新。tier-3/low、deferred）
-3. **#452-b `lifecycle_mixin.tune` 分割** — 🔒 2nd-adapter 議論（§3.3）後に解禁。それまで着手しない
+1. **#495** — #456 L5: weekly stale-doc audit cron（`scripts/audit_stale_docs.py` + `.github/workflows/audit-stale-docs.yml` cron weekly、tracking issue 自動更新。tier-3/low、deferred）
+2. **#452-b `lifecycle_mixin.tune` 分割** — 🔒 2nd-adapter 議論（§3.3）後に解禁。それまで着手しない
 
-> ~~v3-26 (R-4.2 Pickle compat nightly CI)~~ ✅ 完了 (feat/v3-26-pickle-compat-nightly / P-0107 envelope + `scripts/pickle_compat_matrix.sh` + `.github/workflows/nightly.yml::pickle-compat` job) — v0.5 Exit Criteria の format/pickle 互換が完全に gating された。残る Exit #5 = 業務利用 KPI のみ要 verify
+> ~~v3-26 (R-4.2 Pickle compat nightly CI)~~ ✅ 完了 (PR #506 / P-0107 envelope + `scripts/pickle_compat_matrix.sh` + `.github/workflows/nightly.yml::pickle-compat` job) — v0.5 Exit Criteria の format/pickle 互換が完全に gating された。残る Exit #5 = 業務利用 KPI のみ要 verify
+>
+> ~~#474 (P-0104 deferred — search-space 早期 validate)~~ ✅ 着地 (PR #507 / P-0108) — `BackendCore.validate_search_space` 追加 + `POST /tune` run-gate で 422、`PUT /config` は引き続き permissive。
 
 ### Tier 2：v0.6 候補（要長期計画）
 
@@ -334,7 +335,7 @@ Wave 6 完了後の Open Issue は **4 件**（#451 / #453 は 2026-05-13 close 
 
 ## 8. 運用メモ
 
-- 新規 Proposal を起票するときは **P-0108 から採番**（P-0107 = `PICKLE_INCOMPATIBLE` structured envelope、2026-05-13 着地）。`H-XXXX` 採番は終了。
+- 新規 Proposal を起票するときは **P-0109 から採番**（P-0107 = `PICKLE_INCOMPATIBLE` structured envelope / v3-26、P-0108 = search-space run-gate / #474、いずれも 2026-05-13 着地）。`H-XXXX` 採番は終了。
 - 新規 PLAN フェーズは **v3-27 以降**を採番（v3-26 = R-4.2 Pickle compat、2026-05-13 着地で v0.5 phase 完全消化）。
 - E2E 単独追加（仕様変更なし）は HISTORY 起票不要、本 ROADMAP の §3 を更新するだけで OK。
 - 本 ROADMAP はステータス変更時に都度更新。タスク完了時は §1 へ移動、新規着手時は §2/§3/§4 へ追加する。

--- a/src/lizystudio/api/workspace.py
+++ b/src/lizystudio/api/workspace.py
@@ -73,6 +73,7 @@ from lizystudio.services.workspace import (
     get_workspace,
     load_config_from_file,
     validate_config,
+    validate_search_space_for_tune,
 )
 from lizystudio.ws.progress import ProgressBroadcaster
 
@@ -701,6 +702,13 @@ def workspace_tune(
     blocking = _blocking_errors(errors)
     if blocking:
         raise ValidationError(blocking)
+    # P-0108 / Issue #474: run-gate-only check for structurally-broken
+    # tuning.optuna.space entries (inverted Range, log+low<=0). Kept out
+    # of ``validate_config`` so the save gate (``PUT /config``) stays
+    # permissive for WIP edits — see services.workspace docstring.
+    space_errors = validate_search_space_for_tune(ws, ws.config)
+    if space_errors:
+        raise ValidationError(space_errors)
     # CRITICAL-2: atomic create + slot claim, see workspace_fit above.
     job = job_store.create_and_claim_active(
         backend_name=get_backend_name(ws),

--- a/src/lizystudio/backends/base.py
+++ b/src/lizystudio/backends/base.py
@@ -85,6 +85,40 @@ class BackendCore(Protocol):
         """
         return []
 
+    def validate_search_space(self, space: dict[str, Any]) -> list[dict[str, Any]]:
+        """Structural validation of an Optuna ``tuning.optuna.space`` dict.
+
+        Called by ``Service.validate_search_space_for_tune`` from the
+        ``POST /tune`` run-gate (P-0108, Issue #474). The role is to
+        reject search-space entries that the backend cannot evaluate
+        even in principle — e.g. lizyml's ``parse_space()`` rejects an
+        inverted Range (``low >= high``) or a log distribution with
+        non-positive lower bound. Without this gate the bad space slips
+        past ``validate_config`` and only blows up deep inside the
+        tuning loop as "All tuning trials failed".
+
+        Returns ``[{path, message, severity, suggested_fix}]`` entries
+        mirroring the ``validate_config`` envelope (P-0100), with one
+        important shape constraint:
+
+        - ``path`` always starts with ``"tuning.optuna.space.<param>"``
+          so the frontend can surface the message next to the offending
+          row.
+        - ``severity`` is ``"error"`` (run-gate is blocking, unlike the
+          metric-compat warnings).
+
+        **Out of scope.** Empty-choices categoricals are NOT a backend
+        responsibility: the frontend's ``empty-choice-banner`` already
+        owns that UX (transient editing state, Tune button disabled).
+        The backend MUST filter that case out of the returned list so a
+        legitimately-empty WIP categorical does not produce a 400 on the
+        run-gate. See PR #473 (Wave 3.1a) post-mortem.
+
+        A minimal backend (or one that does not use Optuna-style search
+        spaces) returns ``[]`` (the default below).
+        """
+        return []
+
     def get_default_config(self, task: str, target: str) -> dict[str, Any]:
         """Return a complete valid config with all defaults."""
         ...

--- a/src/lizystudio/backends/lizyml/config_mixin.py
+++ b/src/lizystudio/backends/lizyml/config_mixin.py
@@ -148,6 +148,65 @@ class ConfigMixin:
                 )
         return out
 
+    def validate_search_space(self, space: dict[str, Any]) -> list[dict[str, Any]]:
+        """Structural validation of ``tuning.optuna.space`` for lizyml.
+
+        Implements :meth:`BackendCore.validate_search_space` (P-0108,
+        Issue #474). The two structurally-broken cases that
+        ``parse_space()`` rejects are exposed here at the run-gate so
+        the user sees "Fix validation errors first" with a concrete
+        suggested_fix instead of "All tuning trials failed" deep in the
+        Optuna loop.
+
+        Out of scope (mirrored from the Protocol docstring): empty
+        categorical ``choices``. The frontend's ``empty-choice-banner``
+        already owns that UX, so we tolerate / drop the
+        empty-categorical entries before calling ``parse_space()``
+        (which itself rejects them with a CONFIG_INVALID error). This
+        keeps ``PUT /config`` permissive for in-progress edits — the
+        save gate (P-0089) is permissive; only the run-gate is strict.
+
+        The function evaluates each entry independently so a single
+        broken row does not mask drift in the rest of the space.
+        """
+        from lizyml.core.exceptions import LizyMLError
+        from lizyml.tuning import parse_space
+
+        if not isinstance(space, dict) or not space:
+            return []
+
+        out: list[dict[str, Any]] = []
+        for name, raw in space.items():
+            if not isinstance(raw, dict):
+                continue
+            # Filter out the frontend-owned empty-choices state. lizyml's
+            # parse_space() would reject this, but the Studio gate must
+            # not — see the docstring + PR #473 post-mortem.
+            if (
+                raw.get("type") == "categorical"
+                and isinstance(raw.get("choices"), list)
+                and len(raw["choices"]) == 0
+            ):
+                continue
+            try:
+                parse_space({name: raw})
+            except LizyMLError as exc:
+                # Only structural CONFIG_INVALID rejections belong on the
+                # run-gate envelope. Anything else propagates so the API
+                # layer wraps it as 500 (a lizyml-internal bug must not
+                # be misreported as a user input error).
+                if getattr(exc.code, "value", None) != "CONFIG_INVALID":
+                    raise
+                out.append(
+                    {
+                        "path": f"tuning.optuna.space.{name}",
+                        "message": exc.user_message,
+                        "severity": "error",
+                        "suggested_fix": _suggested_fix_for_space_error(name, raw),
+                    }
+                )
+        return out
+
     @staticmethod
     def _strip_internal_keys(config: dict[str, Any]) -> dict[str, Any]:
         """Thin shim around :func:`strip_internal_keys` kept for backward
@@ -170,3 +229,40 @@ class ConfigMixin:
             msg = f"Expected a mapping, got {type(data).__name__}"
             raise ValueError(msg)
         return data
+
+
+def _suggested_fix_for_space_error(name: str, raw: dict[str, Any]) -> str:
+    """Concrete remediation text for the two structural errors we surface.
+
+    Lives at module scope so the prose stays out of ``ConfigMixin`` and
+    a second backend (or a future helper) can reuse the strings.
+    """
+    log = bool(raw.get("log"))
+    low = raw.get("low")
+    high = raw.get("high")
+    if (
+        log
+        and isinstance(low, int | float)
+        and not isinstance(low, bool)
+        and float(low) <= 0
+    ):
+        return (
+            f"Either disable log distribution on '{name}', or raise Min above "
+            f"zero (Min={low}). Log distributions require a strictly positive "
+            f"lower bound."
+        )
+    if (
+        isinstance(low, int | float)
+        and isinstance(high, int | float)
+        and not isinstance(low, bool)
+        and not isinstance(high, bool)
+        and float(low) >= float(high)
+    ):
+        return (
+            f"Swap Min and Max for '{name}' (current Min={low}, Max={high}). "
+            f"The lower bound must be strictly less than the upper bound."
+        )
+    return (
+        f"Review the '{name}' search space entry — Min must be < Max, and "
+        f"log distributions require Min > 0."
+    )

--- a/src/lizystudio/services/workspace.py
+++ b/src/lizystudio/services/workspace.py
@@ -203,6 +203,39 @@ def validate_config(ws: WorkspaceState, config: dict[str, Any]) -> list[dict[str
     return normalized
 
 
+def validate_search_space_for_tune(
+    ws: WorkspaceState, config: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Run-gate check for ``tuning.optuna.space`` (P-0108, Issue #474).
+
+    Called from ``POST /api/workspace/tune`` (and retune) AFTER
+    ``validate_config`` so structurally-broken search spaces are
+    rejected with a clear 422 *before* the tune job launches.
+
+    Deliberately NOT folded into ``validate_config``: that function is
+    shared by the save gate (``PUT /config``), which must remain
+    permissive so users can ``PUT`` work-in-progress configs (inverted
+    Range mid-keystroke, log+low=0 while raising Min, etc.) without
+    losing their edits. See Issue #474 + PR #473 post-mortem.
+
+    Returns the same ``{path, message, severity, suggested_fix}``
+    envelope as ``validate_config`` so the same frontend renderer can
+    surface either source.
+    """
+    if not isinstance(config, dict):
+        return []
+    tuning = config.get("tuning")
+    if not isinstance(tuning, dict):
+        return []
+    optuna = tuning.get("optuna")
+    if not isinstance(optuna, dict):
+        return []
+    space = optuna.get("space")
+    if not isinstance(space, dict) or not space:
+        return []
+    return ws.backend.validate_search_space(space)
+
+
 def _workspace_split_errors(
     ws: WorkspaceState, config: dict[str, Any]
 ) -> list[dict[str, Any]]:

--- a/tests/test_backends_lizyml.py
+++ b/tests/test_backends_lizyml.py
@@ -2042,3 +2042,103 @@ class TestGetIncompatibleMetrics:
             {"mape", "rmsle", "r2"},
         )
         assert sorted(m.metric for m in out) == ["r2", "rmsle"]
+
+
+class TestValidateSearchSpace:
+    """LizyMLAdapter.validate_search_space — P-0108 / Issue #474.
+
+    The run-gate must reject the two structurally-broken cases lizyml's
+    ``parse_space()`` cannot evaluate even in principle (inverted Range,
+    log + low<=0) while leaving the empty-choices categorical case to
+    the frontend's ``empty-choice-banner``.
+    """
+
+    @pytest.fixture
+    def adapter(self) -> LizyMLAdapter:
+        return LizyMLAdapter()
+
+    def test_empty_space_returns_empty(self, adapter: LizyMLAdapter) -> None:
+        assert adapter.validate_search_space({}) == []
+
+    def test_non_dict_space_returns_empty(self, adapter: LizyMLAdapter) -> None:
+        # Defensive: malformed configs can arrive here mid-edit.
+        assert adapter.validate_search_space([1, 2, 3]) == []  # type: ignore[arg-type]
+        assert adapter.validate_search_space(None) == []  # type: ignore[arg-type]
+
+    def test_valid_space_returns_empty(self, adapter: LizyMLAdapter) -> None:
+        out = adapter.validate_search_space(
+            {
+                "lr": {"type": "float", "low": 0.01, "high": 0.3, "log": True},
+                "num_leaves": {"type": "int", "low": 16, "high": 256},
+                "subsample": {"type": "categorical", "choices": [0.6, 1.0]},
+            }
+        )
+        assert out == []
+
+    def test_inverted_range_is_flagged(self, adapter: LizyMLAdapter) -> None:
+        out = adapter.validate_search_space(
+            {"lr": {"type": "float", "low": 0.5, "high": 0.01}}
+        )
+        assert len(out) == 1
+        err = out[0]
+        assert err["path"] == "tuning.optuna.space.lr"
+        assert err["severity"] == "error"
+        assert "low" in err["message"].lower() and "high" in err["message"].lower()
+        assert "lr" in err["suggested_fix"]
+        # Suggested fix mentions the actual offending values so the user
+        # can paste them directly into the form.
+        assert "0.5" in err["suggested_fix"]
+
+    def test_log_with_zero_low_is_flagged(self, adapter: LizyMLAdapter) -> None:
+        out = adapter.validate_search_space(
+            {"lr": {"type": "float", "low": 0.0, "high": 0.3, "log": True}}
+        )
+        assert len(out) == 1
+        err = out[0]
+        assert err["path"] == "tuning.optuna.space.lr"
+        assert "log" in err["message"].lower()
+        assert "log" in err["suggested_fix"].lower()
+
+    def test_log_with_negative_low_is_flagged(self, adapter: LizyMLAdapter) -> None:
+        out = adapter.validate_search_space(
+            {"lr": {"type": "float", "low": -1.0, "high": 0.3, "log": True}}
+        )
+        assert len(out) == 1
+        assert out[0]["path"] == "tuning.optuna.space.lr"
+
+    def test_empty_categorical_choices_is_silently_dropped(
+        self, adapter: LizyMLAdapter
+    ) -> None:
+        # INV-E (P-0108): the frontend's empty-choice-banner owns the UX
+        # for this case; the run-gate must not return an entry for it.
+        out = adapter.validate_search_space(
+            {"objective": {"type": "categorical", "choices": []}}
+        )
+        assert out == []
+
+    def test_multiple_broken_entries_are_each_flagged(
+        self, adapter: LizyMLAdapter
+    ) -> None:
+        # A single broken row must not mask the rest of the space.
+        out = adapter.validate_search_space(
+            {
+                "lr": {"type": "float", "low": 0.5, "high": 0.01},
+                "max_depth": {"type": "int", "low": 0.0, "high": 1.0, "log": True},
+                "fine": {"type": "float", "low": 0.01, "high": 0.3},
+            }
+        )
+        paths = {err["path"] for err in out}
+        assert paths == {
+            "tuning.optuna.space.lr",
+            "tuning.optuna.space.max_depth",
+        }
+
+    def test_non_dict_entry_is_skipped(self, adapter: LizyMLAdapter) -> None:
+        # Defensive: tolerates a partially-typed config without crashing.
+        out = adapter.validate_search_space(
+            {
+                "lr": "not_a_dict",  # type: ignore[dict-item]
+                "ok": {"type": "float", "low": 0.01, "high": 0.3},
+            }
+        )
+        assert out == []

--- a/tests/test_workspace_api.py
+++ b/tests/test_workspace_api.py
@@ -453,6 +453,154 @@ def test_tune_starts_job_when_data_and_config_present(
 
 
 # ---------------------------------------------------------------------------
+# Issue #474 / P-0108: POST /tune run-gate for structurally-broken search space
+#
+# ``parse_space()`` in lizyml rejects three classes of structurally-broken
+# entries with ``LizyMLError(CONFIG_INVALID)``: inverted Range (low >= high),
+# log + low <= 0, and empty-choices categorical. The first two surface here
+# as a 400 *before* the job launches (run-gate, approach C in the issue).
+#
+# The empty-choices categorical case is intentionally NOT a 400: the
+# frontend's ``empty-choice-banner`` already owns that UX (the Tune button
+# is disabled, and a transient empty state is legitimate while the user is
+# wiring up Choice rows). ``PUT /config`` must keep saving in that state so
+# the frontend doesn't revert the user's deselection.
+# ---------------------------------------------------------------------------
+
+
+def _config_with_space(client: TestClient, space: dict[str, Any]) -> dict[str, Any]:
+    config = _load_valid_config(client)
+    config["tuning"] = {
+        "optuna": {
+            "params": {"n_trials": 3, "timeout": None},
+            "space": space,
+        }
+    }
+    return config
+
+
+def test_tune_rejects_inverted_range_search_space(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """POST /tune must 422 a search space whose Range has low >= high."""
+    _load_data_and_config(client, tmp_path)
+    bad_config = _config_with_space(
+        client, {"learning_rate": {"type": "float", "low": 0.5, "high": 0.01}}
+    )
+
+    with patch("lizystudio.api.workspace.start_tune_async") as _mock_start:
+        res = client.post("/api/workspace/tune", json={"config": bad_config})
+
+    assert res.status_code == 422, res.text
+    body = res.json()
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+    errors = body["error"]["details"]["errors"]
+    paths = {err["path"] for err in errors}
+    assert "tuning.optuna.space.learning_rate" in paths
+    msg = next(
+        err["message"]
+        for err in errors
+        if err["path"] == "tuning.optuna.space.learning_rate"
+    )
+    assert "low" in msg.lower() and "high" in msg.lower()
+    # Run-gate semantics: the job must NOT have been launched.
+    _mock_start.assert_not_called()
+
+
+def test_tune_rejects_log_with_nonpositive_low(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """POST /tune must 422 a search space using log distribution with low <= 0."""
+    _load_data_and_config(client, tmp_path)
+    bad_config = _config_with_space(
+        client,
+        {"learning_rate": {"type": "float", "low": 0.0, "high": 0.3, "log": True}},
+    )
+
+    with patch("lizystudio.api.workspace.start_tune_async") as _mock_start:
+        res = client.post("/api/workspace/tune", json={"config": bad_config})
+
+    assert res.status_code == 422, res.text
+    body = res.json()
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+    errors = body["error"]["details"]["errors"]
+    paths = {err["path"] for err in errors}
+    assert "tuning.optuna.space.learning_rate" in paths
+    msg = next(
+        err["message"]
+        for err in errors
+        if err["path"] == "tuning.optuna.space.learning_rate"
+    )
+    assert "log" in msg.lower()
+    _mock_start.assert_not_called()
+
+
+def test_tune_ignores_empty_categorical_choices_at_run_gate(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """INV-E: empty-choices categorical must NOT block POST /tune at the
+    new run-gate. The frontend's ``empty-choice-banner`` is the canonical
+    owner of that UX; the backend's job is only to reject the two
+    structurally-broken cases (inverted Range, log + low<=0).
+
+    Note that the underlying lizyml ``parse_space()`` *does* reject empty
+    choices, so this test pins the explicit filter in the Studio gate.
+    """
+    _load_data_and_config(client, tmp_path)
+    config = _config_with_space(
+        client, {"objective": {"type": "categorical", "choices": []}}
+    )
+
+    with patch(
+        "lizystudio.api.workspace.start_tune_async", return_value="job_run_gate"
+    ) as _mock_start:
+        res = client.post("/api/workspace/tune", json={"config": config})
+
+    # Either the job runs (gate passed) or some OTHER pre-existing
+    # validator (Pydantic schema, metric-compat) rejects it. The
+    # invariant we are pinning is that the *new* search-space gate does
+    # NOT contribute an error. We accept both 200 (start_tune_async
+    # called) and 422 (rejected by an existing validator that already
+    # tolerated empty choices in v0.5.0) — but if it is 422, the errors
+    # list must not contain an empty-choices complaint at the
+    # search-space path, and start_tune_async must not have been called.
+    assert res.status_code in (200, 422), res.text
+    if res.status_code == 200:
+        assert res.json()["job_id"] == "job_run_gate"
+        _mock_start.assert_called_once()
+    else:
+        body = res.json()
+        errors = body["error"]["details"]["errors"]
+        for err in errors:
+            assert (
+                "objective" not in err["path"]
+                or "choices" not in err["message"].lower()
+            ), f"run-gate must not flag empty-choices categorical: {err}"
+
+
+def test_put_config_persists_inverted_range_for_wip_editing(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """INV-C (save gate permissive): the user is allowed to ``PUT /config``
+    with a transiently-inverted Range while editing (NumberInput fires
+    onChange per keystroke). The save gate must NOT borrow the new
+    run-gate's structural check — see PR #473 (Wave 3.1a) post-mortem
+    where that change broke ``workspace-tune.spec.ts:459``.
+    """
+    _load_data_and_config(client, tmp_path)
+    bad_config = _config_with_space(
+        client, {"learning_rate": {"type": "float", "low": 0.5, "high": 0.01}}
+    )
+
+    res = client.put("/api/workspace/config", json=bad_config)
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["saved"] is True, (
+        f"PUT /config must persist WIP with inverted Range; got {body!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # POST /workspace/config/upload — valid YAML file
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes Issue **#474** (P-0104 Wave 3.1a deferred) by surfacing structurally-broken Optuna search spaces at the `POST /api/workspace/tune` gate with a clear **422 VALIDATION_ERROR**, before the tune job launches. The change deliberately leaves `PUT /api/workspace/config` (save gate) permissive so users can persist work-in-progress configs — see **PR #473 post-mortem** for the gating split rationale.

> **Approach C (run-gate only)** — per the issue's explicit recommendation. We add a new `BackendCore.validate_search_space` Protocol method (Change Gate), implement it in the lizyml adapter via `lizyml.tuning.parse_space()` with empty-choices categoricals filtered out, plumb a thin Service helper, then call it in `workspace_tune` after the existing `validate_config` call.

## Before / After

| Scenario | Before | After |
|---|---|---|
| `tuning.optuna.space = {lr: {type:"float", low:0.5, high:0.01}}` | Tune launches → Optuna runs N trials → "**All tuning trials failed**" | **422 at POST /tune** — "Swap Min and Max for 'lr' (current Min=0.5, Max=0.01)..." |
| `{lr: {type:"float", low:0, high:0.3, log:true}}` | Tune launches → Optuna error mid-loop | **422 at POST /tune** — "Either disable log distribution on 'lr', or raise Min above zero..." |
| `{objective: {type:"categorical", choices:[]}}` | Frontend disables Tune button + shows `empty-choice-banner` | **Unchanged** — the new gate does NOT flag empty-choices (frontend owns that UX) |
| `PUT /config` with any of the above mid-keystroke | 200 saved | **200 saved** — INV-search-1 |

## What changes

### Protocol (Change Gate)

| File | Change |
|---|---|
| `backends/base.py::BackendCore.validate_search_space` | New method. Default body returns `[]`; minimal backends or non-Optuna backends keep working unchanged. Mirrors the `P-0100` envelope shape (`path / message / severity / suggested_fix`). |

### Backend implementation

| File | Change |
|---|---|
| `backends/lizyml/config_mixin.py::ConfigMixin.validate_search_space` | Calls `parse_space()` per-entry. Only `LizyMLError(CONFIG_INVALID)` is mapped to the envelope; anything else propagates. **Empty-choices categoricals are filtered out** (frontend banner owns that UX, per PR #473 post-mortem). |
| `backends/lizyml/config_mixin.py::_suggested_fix_for_space_error` (module scope) | Generates copy-paste-grade remediation text for the two structural failures ("Swap Min and Max" / "raise Min above zero"), reading the actual offending `low`/`high` values. |

### Service plumbing

| File | Change |
|---|---|
| `services/workspace.py::validate_search_space_for_tune` | Thin envelope around the backend method: type narrowing on `tuning.optuna.space` + adapter dispatch. `validate_config` is **left untouched** so the save gate stays permissive. |

### API gate

| File | Change |
|---|---|
| `api/workspace.py::workspace_tune` | Calls the helper **between** `validate_config` and `create_and_claim_active`. A non-empty result raises `ValidationError(422)` **before** `start_tune_async` is invoked. |

### Tests

| File | Change |
|---|---|
| `tests/test_backends_lizyml.py::TestValidateSearchSpace` (new, 9 cases) | empty / non-dict / valid / inverted-range / log+low=0 / log+low<0 / empty-choices-dropped / multiple-violation / non-dict-entry. |
| `tests/test_workspace_api.py` (new, 4 cases) | POST /tune inverted-range 422 + `start_tune_async` **not called**; POST /tune log+low=0 422; POST /tune empty-choices is **NOT** flagged at this gate; PUT /config inverted-range still saves (INV-search-1). |

### Docs

- **`HISTORY.md` P-0108** — motivation / Purpose / Invariants (INV-search-1..5) / Impact / Acceptance criteria / Alternatives / Decision.
- **`docs/ROADMAP.md`** — `#474` removed from Tier 1 with a struck-through pointer to this PR; numbering note bumped to P-0109.

## Invariants (P-0108)

- **INV-search-1 (save gate permissive)**: `PUT /config` persists inverted-range / log+low<=0 / empty-choices configs unchanged.
- **INV-search-2 (run gate strict)**: `POST /tune` 422s the two structurally-broken cases and never calls `start_tune_async`.
- **INV-search-3 (empty-choices is frontend territory)**: the new gate filters that case out so the existing `empty-choice-banner` UX is unaffected.
- **INV-search-4 (envelope shape)**: each error carries `path / message / severity="error" / suggested_fix` (P-0100 envelope).
- **INV-search-5 (per-entry isolation)**: a single broken row does not mask drift in the rest of the space.

## Failure paths covered

- [x] Inverted Range (`low >= high`)
- [x] Log + `low == 0` / `low < 0`
- [x] Multiple-violation in one config (per-entry isolation)
- [x] Empty-choices categorical (silently dropped at this gate)
- [x] Non-dict space / non-dict entry (defensive)
- [x] `PUT /config` with an inverted Range mid-keystroke (still saves)

## Test plan

- [x] `uv run pytest tests/ -k "not slow" --ignore=tests/{e2e,integration,bench}` — **1546 passed** (was 1533, **+13 new** across adapter + API tests).
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy src/lizystudio/` — all green.
- [ ] CI `e2e-chromium`: `frontend/tests/e2e/workspace-tune.spec.ts:459` (Choice mode seeds + gates Tune when emptied) — must stay green to confirm INV-search-3 + save-gate permissiveness end-to-end.

## Rationale

> **Why not fold into `validate_config`?** That function is shared between the save gate (`PUT /config`) and the run gate (`POST /tune`). PR #473 tried that — it broke `workspace-tune.spec.ts:459` because the empty-choice categorical transient state and the in-flight inverted-Range edit state both became blocking errors, so `PUT /config` returned `saved: false` and the frontend reverted user input.

> **Why not warn instead of reject?** A `severity="warning"` from `validate_config` would still leak into the save gate (same call site), and the run-gate semantics ("block this from launching") collapse into a different concern from the save-gate semantics ("don't lose my draft"). The current design keeps both clean.

> **Why a Protocol method and not a free function?** A second backend may have a different search-space DSL (sklearn `Pipeline` param_grid, xgboost native, …) with different structural failure modes. Putting the check behind the Protocol lets that backend declare its own vocabulary without Studio's run-gate caring. lizyml's coupling to `parse_space()` stays inside `backends/lizyml/`.

## Closes

- Issue **#474** — validation(workspace/tune): surface inverted-range / log+low<=0 search-space errors early (deferred from P-0104 Wave 3.1a)
