### PR TITLE
feat(513): log every StudioError at WARNING in error handler

### DIFF
--- a/src/lizystudio/api/errors.py
+++ b/src/lizystudio/api/errors.py
@@ -255,8 +255,22 @@ class ParentHasActiveChildrenError(StudioError):
 # --- FastAPI exception handlers ---
 
 
-async def studio_error_handler(_request: Request, exc: StudioError) -> JSONResponse:
-    """Convert StudioError to the standard JSON envelope."""
+async def studio_error_handler(request: Request, exc: StudioError) -> JSONResponse:
+    """Convert StudioError to the standard JSON envelope.
+
+    Also emits a WARNING-level log line (Issue #513) so 4xx domain
+    errors are visible to operators after the fact. ``details`` is
+    deliberately excluded from the WARNING channel because it can
+    carry user-supplied input (paths, validation snippets); the
+    envelope shape itself is unchanged.
+    """
+    _backend_logger.warning(
+        "StudioError %s (%d) at %s %s",
+        exc.code,
+        exc.status_code,
+        request.method,
+        request.url.path,
+    )
     return JSONResponse(
         status_code=exc.status_code,
         content={

--- a/tests/test_error_logging.py
+++ b/tests/test_error_logging.py
@@ -1,0 +1,107 @@
+"""Tests for StudioError observability logging (Issue #513).
+
+The error handler must emit a WARNING-level log line on the
+``lizystudio.errors`` logger for every ``StudioError`` so operators
+can grep server logs for user-facing 4xx incidents.
+
+Acceptance criteria from Issue #513:
+- WARNING for every StudioError
+- Log line includes code / status_code / HTTP method / URL path
+- No ``details`` payload at WARNING level (may carry user-supplied data)
+- ``BackendError`` exception-path logging is unchanged
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+ERRORS_LOGGER = "lizystudio.errors"
+
+
+def _warning_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [
+        r
+        for r in caplog.records
+        if r.name == ERRORS_LOGGER and r.levelno == logging.WARNING
+    ]
+
+
+def test_studio_error_emits_warning_log(
+    client: TestClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A 4xx StudioError emits a WARNING line on the `lizystudio.errors` logger.
+
+    The line must include the error code, status code, HTTP method, and
+    URL path so operators can grep the log after a user-reported
+    incident (Issue #513 rationale).
+    """
+    caplog.set_level(logging.WARNING, logger=ERRORS_LOGGER)
+    resp = client.get("/api/jobs/nonexistent-job-id")
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "JOB_NOT_FOUND"
+
+    records = _warning_records(caplog)
+    assert len(records) == 1, f"expected exactly one WARNING, got {records}"
+    msg = records[0].getMessage()
+    assert "JOB_NOT_FOUND" in msg
+    assert "404" in msg
+    assert "GET" in msg
+    assert "/api/jobs/nonexistent-job-id" in msg
+
+
+def test_studio_error_warning_does_not_leak_details_payload(
+    client: TestClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The WARNING-level log must NOT contain the ``details`` payload.
+
+    ``details`` can carry user-supplied input (file paths, validation
+    snippets). Issue #513's "What NOT to do" pins this to DEBUG or
+    lower; the WARNING line stays PII-free so it can be safely
+    centralized.
+    """
+    caplog.set_level(logging.WARNING, logger=ERRORS_LOGGER)
+    secret_marker = "this-secret-marker-must-not-leak"
+    resp = client.post(
+        "/api/workspace/data/path",
+        json={"path": f"/tmp/{secret_marker}.csv"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "PATH_NOT_FOUND"
+
+    records = _warning_records(caplog)
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert "PATH_NOT_FOUND" in msg
+    assert secret_marker not in msg, (
+        "WARNING-level log line leaked a user-supplied path; "
+        "details payload must stay off the WARNING channel"
+    )
+
+
+def test_backend_error_exception_path_unchanged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``BackendError.__init__`` still calls ``_backend_logger.exception(...)``.
+
+    The handler-level WARNING is additive; we must not regress the
+    existing exception-with-traceback emission for 500-class backend
+    failures (errors.py:115).
+    """
+    caplog.set_level(logging.DEBUG, logger=ERRORS_LOGGER)
+    from lizystudio.api.errors import BackendError
+
+    BackendError(RuntimeError("simulated backend failure"))
+
+    exception_records = [
+        r
+        for r in caplog.records
+        if r.name == ERRORS_LOGGER and r.levelno == logging.ERROR
+    ]
+    assert len(exception_records) >= 1, (
+        "BackendError must still log via _backend_logger.exception"
+    )


### PR DESCRIPTION
## Summary

Closes Issue **#513** (R-3.1 observability precursor). Adds a single `WARNING`-level log line on the `lizystudio.errors` logger inside `studio_error_handler`, so every 4xx `StudioError` is searchable in the server log by code after a user-reported incident.

```bash
grep "StudioError WORKSPACE_LOCKED" server.log
grep "StudioError VALIDATION_ERROR" server.log
grep "StudioError PICKLE_INCOMPATIBLE" server.log
```

Zero behavioural impact: envelope shape unchanged, `BackendError` exception-path logging untouched, no contract test churn.

## Before / After

| Scenario | Before | After |
|---|---|---|
| `GET /api/jobs/missing` (404 `JOB_NOT_FOUND`) | uvicorn access log shows `404`, no app-level trace | uvicorn `404` **+** `WARNING StudioError JOB_NOT_FOUND (404) at GET /api/jobs/missing` |
| `PUT /api/workspace/config` racing a running job (409 `WORKSPACE_LOCKED`) | No server-side trace of the rejection (v0.6.0 verification gap) | Greppable `WARNING StudioError WORKSPACE_LOCKED (409) at PUT /api/workspace/config` |
| `BackendError` 500 wrap | `_backend_logger.exception(...)` with traceback | **Unchanged** — exception-path still fires |

## What changes

| File | Change |
|---|---|
| `src/lizystudio/api/errors.py::studio_error_handler` | Add `_backend_logger.warning("StudioError %s (%d) at %s %s", code, status, method, path)` before the JSON response. Rename `_request` → `request` (we now use it). |
| `tests/test_error_logging.py` (new) | Three `caplog`-based unit tests covering the three issue acceptance lines (emit / no-leak / `BackendError` unchanged). |

`details` is intentionally **not** logged at WARNING because it can carry user-supplied input (file paths, validation snippets). The issue's "What NOT to do" pins that to DEBUG; this PR keeps the WARNING channel PII-free.

## Out of scope

The full R-3.1 typed-error rework (`StudioError` gains required `code` / `recovery_hint` / `is_user_error`, every `errors.py` raise site updated) — that's a v0.7+ refactor and stays deferred. This PR ships the small precursor: log what we already have, no type changes.

## Test plan

- [x] `uv run pytest tests/test_error_logging.py` — 3 passed (RED first, then GREEN)
- [x] `uv run pytest tests/test_error_format.py tests/test_error_paths.py tests/contract/` — 86 passed (envelope unchanged)
- [x] `uv run pytest` (full backend) — 1574 passed, 10 skipped, 0 failures
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/lizystudio/api/errors.py` — clean
