### PR TITLE
feat(p0109): PR-2 — TuningDefaults / TuningOverrides / TuningConfig + Protocol contracts

### DIFF
--- a/src/lizystudio/backends/base.py
+++ b/src/lizystudio/backends/base.py
@@ -8,7 +8,7 @@ runtime-checkable alias that inherits from all of them, so existing
 
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Literal, Protocol, runtime_checkable
 
 import pandas as pd
 
@@ -19,6 +19,9 @@ from lizystudio.backends.types import (
     IncompatibleMetric,
     PlotData,
     PredictionSummary,
+    TuningConfig,
+    TuningDefaults,
+    TuningOverrides,
     TuningSummary,
 )
 
@@ -118,6 +121,108 @@ class BackendCore(Protocol):
         spaces) returns ``[]`` (the default below).
         """
         return []
+
+    def get_tuning_defaults(self, task: str) -> TuningDefaults:
+        """Return canonical Tune defaults for *task* (P-0109).
+
+        The backend reads its own catalog (e.g. lizyml's
+        ``search_space_catalog``, ``metric_direction``, canonical
+        ``TASK_DEFAULT_METRICS``) and produces a
+        :class:`~lizystudio.backends.types.TuningDefaults` describing
+        the search space, evaluation metric list, and optimisation
+        direction that the Tune tab should fall back to when the user
+        has set no overrides.
+
+        Used by the service layer in two places:
+
+        1. ``GET /workspace/config`` response assembly — together with
+           ``compute_effective_tuning(task, overrides)`` to project the
+           workspace's persisted ``TuningOverrides`` into an effective
+           ``TuningConfig`` the frontend can render directly.
+        2. ``POST /workspace/tune`` — same projection, plus the
+           resulting effective is snapshot-frozen into
+           ``job.config.tuning`` (INV-T6: a job's config remains stable
+           even as the catalog later evolves).
+
+        A minimal backend (no Optuna catalog, no per-task metric set)
+        returns ``TuningDefaults()`` — the empty defaults the trivial
+        impl below provides. The effective Tune config for such a
+        backend therefore equals the user's overrides verbatim.
+
+        INV-T3 (P-0109): ``direction`` here is the single source of
+        truth. ``services/training.py::_prepare_tune_config`` MUST NOT
+        carry a duplicated maximize-metric set; instead it asserts the
+        in-flight effective config's direction agrees with this method
+        and fails fast on drift.
+
+        INV-T5 (P-0109): each backend adapter is the SSOT for its own
+        defaults. Frontend has no adapter-specific branches.
+        """
+        return TuningDefaults()
+
+    def compute_effective_tuning(
+        self, task: str, overrides: TuningOverrides
+    ) -> TuningConfig:
+        """Merge ``TuningDefaults(task)`` with *overrides* (P-0109).
+
+        Pure function: same ``(task, overrides)`` always produces the
+        same effective ``TuningConfig``. Side-effect free, no IO. The
+        merge rule is per-field:
+
+        - ``n_trials`` / ``timeout`` / ``direction``: override wins when
+          present in ``overrides.model_fields_set``; otherwise fall back
+          to the corresponding ``TuningDefaults`` field (or a sane
+          backend-specific fallback like ``n_trials = 50`` when both
+          override and default are absent).
+        - ``space``: per-key dict merge — ``overrides.space[k]`` wins
+          outright over ``defaults.space[k]``; keys present only in
+          defaults survive; keys present only in overrides (e.g. user
+          added a catalog-outside parameter via raw YAML import) also
+          survive (INV-T2: catalog evolution never silently drops user
+          customisations).
+        - ``evaluation_metrics``: list-level — when
+          ``overrides.evaluation_metrics`` is non-None, replace the
+          list; otherwise use ``defaults.evaluation_metrics``.
+        - ``user_set_paths``: derived from
+          ``overrides.model_fields_set`` plus per-key entries for
+          ``space`` overrides, formatted as dot-paths (``"n_trials"``,
+          ``"space.learning_rate"``, etc.).
+
+        The trivial impl below covers a minimal backend with no catalog
+        and no metric registry — it constructs the effective config
+        from overrides alone with hardcoded fallbacks (``n_trials=50``
+        / ``direction="minimize"``). Real adapters override this to
+        consult their catalog and registry.
+        """
+        defaults = self.get_tuning_defaults(task)
+        fields_set = overrides.model_fields_set
+        user_set: list[str] = []
+        for name in ("n_trials", "timeout", "direction", "evaluation_metrics"):
+            if name in fields_set:
+                user_set.append(name)
+        for key in overrides.space:
+            user_set.append(f"space.{key}")
+        merged_space = {**defaults.space, **overrides.space}
+        merged_metrics = (
+            overrides.evaluation_metrics
+            if overrides.evaluation_metrics is not None
+            else defaults.evaluation_metrics
+        )
+        direction: Literal["maximize", "minimize"]
+        if overrides.direction is not None:
+            direction = overrides.direction
+        elif defaults.direction is not None:
+            direction = defaults.direction
+        else:
+            direction = "minimize"
+        return TuningConfig(
+            n_trials=overrides.n_trials if overrides.n_trials is not None else 50,
+            timeout=overrides.timeout if "timeout" in fields_set else None,
+            direction=direction,
+            space=merged_space,
+            evaluation_metrics=merged_metrics,
+            user_set_paths=user_set,
+        )
 
     def get_default_config(self, task: str, target: str) -> dict[str, Any]:
         """Return a complete valid config with all defaults."""

--- a/src/lizystudio/backends/lizyml/config_mixin.py
+++ b/src/lizystudio/backends/lizyml/config_mixin.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, Literal
 
 import pandas as pd
 import yaml
 
-from lizystudio.backends.types import BackendInfo, ConfigSchema, IncompatibleMetric
+from lizystudio.backends.types import (
+    BackendInfo,
+    ConfigSchema,
+    IncompatibleMetric,
+    TuningConfig,
+    TuningDefaults,
+    TuningOverrides,
+)
 
 from .config_compat import strip_internal_keys, task_params_compat_errors
 
@@ -27,6 +34,61 @@ class ConfigMixin:
         import lizyml
 
         return BackendInfo(name="lizyml", version=lizyml.__version__)
+
+    def get_tuning_defaults(self, task: str) -> TuningDefaults:
+        """P-0109 PR-2 stub — empty catalog defaults.
+
+        Real catalog-aware impl arrives in PR-3
+        (`search_space_catalog` + `TASK_DEFAULT_METRICS` + `metric_direction`
+        wired in). For now this matches the ``BackendCore`` safe default so
+        ``LizyMLAdapter`` satisfies the Protocol unchanged and downstream
+        callers see no behaviour change (the legacy on-the-fly defaults in
+        ``workspace_tune`` / ``_prepare_tune_config`` remain authoritative
+        until PR-4 swaps them out).
+        """
+        return TuningDefaults()
+
+    def compute_effective_tuning(
+        self, task: str, overrides: TuningOverrides
+    ) -> TuningConfig:
+        """P-0109 PR-2 stub — inline mirror of ``BackendCore``'s safe-default.
+
+        ``ConfigMixin`` does not inherit from ``BackendCore`` (the
+        adapter satisfies the Protocol via duck typing) so we cannot
+        ``super().compute_effective_tuning`` here. PR-3 replaces this
+        with a catalog-aware impl (search_space_catalog + metric_direction
+        + TASK_DEFAULT_METRICS); PR-4 wires the result through the
+        service layer at PUT /config response time and at tune job start.
+        """
+        defaults = self.get_tuning_defaults(task)
+        fields_set = overrides.model_fields_set
+        user_set: list[str] = [
+            name
+            for name in ("n_trials", "timeout", "direction", "evaluation_metrics")
+            if name in fields_set
+        ]
+        user_set.extend(f"space.{key}" for key in overrides.space)
+        merged_space = {**defaults.space, **overrides.space}
+        merged_metrics = (
+            overrides.evaluation_metrics
+            if overrides.evaluation_metrics is not None
+            else defaults.evaluation_metrics
+        )
+        direction: Literal["maximize", "minimize"]
+        if overrides.direction is not None:
+            direction = overrides.direction
+        elif defaults.direction is not None:
+            direction = defaults.direction
+        else:
+            direction = "minimize"
+        return TuningConfig(
+            n_trials=overrides.n_trials if overrides.n_trials is not None else 50,
+            timeout=overrides.timeout if "timeout" in fields_set else None,
+            direction=direction,
+            space=merged_space,
+            evaluation_metrics=merged_metrics,
+            user_set_paths=user_set,
+        )
 
     def get_ui_schema(self) -> dict[str, Any]:
         from lizystudio.backends.lizyml_ui_schema import build_ui_schema

--- a/src/lizystudio/backends/types.py
+++ b/src/lizystudio/backends/types.py
@@ -1,8 +1,15 @@
 """Common types shared between Service and API layers.
 
 Backend-specific types (e.g. lizyml.FitResult) must NOT leak beyond
-the Adapter boundary. These dataclasses are the only result types that
+the Adapter boundary. These types are the only result types that
 Service / Router code may reference.
+
+Most entries are ``@dataclass`` (frozen where immutability matters).
+The Tune-defaults trio (``TuningDefaults`` / ``TuningOverrides`` /
+``TuningConfig``) uses Pydantic ``BaseModel`` so the Pydantic-specific
+``model_fields_set`` introspection can distinguish "user-set field"
+from "default-derived field" at runtime — see P-0109 INV-T1 for the
+intent/effective split.
 """
 
 from __future__ import annotations
@@ -11,6 +18,114 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 import pandas as pd
+from pydantic import BaseModel, ConfigDict, Field
+
+# ---------------------------------------------------------------------------
+# Tune defaults trio (P-0109 PR-2) — kept at top of module so subsequent
+# dataclasses can reference them via forward declaration if needed.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TuningDefaults:
+    """Canonical Tune defaults derived from a backend's catalog (P-0109).
+
+    Returned by :meth:`BackendCore.get_tuning_defaults`. Represents what
+    the catalog would propose if the user customised nothing — *not*
+    the effective tune config a job runs with (that's
+    :class:`TuningConfig`, the merge of these defaults with
+    :class:`TuningOverrides`).
+
+    Pure, immutable, task-keyed: ``adapter.get_tuning_defaults("binary")``
+    and ``adapter.get_tuning_defaults("regression")`` may differ. A
+    minimal backend (no Optuna catalog) returns ``TuningDefaults()``.
+
+    INV-T5 (P-0109): each backend adapter is the single source of truth
+    for its own defaults. Frontend has no adapter-specific branches.
+    """
+
+    space: dict[str, dict[str, Any]] = field(default_factory=dict)
+    """Catalog-derived search-space entries keyed by parameter name.
+    Each entry is the SpaceEntry dict shape
+    ``{"type": ..., "low": ..., "high": ..., "log": ..., ...}`` that
+    the backend's parser accepts. Empty when the backend declares no
+    catalog ranges."""
+
+    evaluation_metrics: list[Any] = field(default_factory=list)
+    """Canonical evaluation metrics for the task, e.g.
+    ``["auc", "auc_pr", "brier", "logloss"]`` for lizyml binary.
+    Empty when the backend has no canonical default set."""
+
+    direction: Literal["maximize", "minimize"] | None = None
+    """Optimisation direction implied by ``evaluation_metrics[0]`` under
+    the backend's metric registry. ``None`` when ``evaluation_metrics``
+    is empty or no canonical direction exists for the task."""
+
+
+class TuningOverrides(BaseModel):
+    """User-set Tune customisations — sparse intent (P-0109).
+
+    Persisted in the LizyStudio workspace config as the sole record of
+    "what the user changed". All fields are optional so the absence of a
+    value means "use the catalog default" rather than "set this to
+    ``None``". Use :meth:`pydantic.BaseModel.model_fields_set` to
+    distinguish ``user explicitly set timeout=None`` (no-timeout intent)
+    from ``user has not touched timeout`` (the field is omitted from
+    ``model_fields_set``).
+
+    INV-T1 / INV-T2 (P-0109): overrides are task-agnostic. Task
+    transitions never mutate overrides; the *effective* config is
+    re-computed from new catalog + same overrides.
+
+    ``frozen=True``: an overrides instance is immutable post-construction
+    so callers receive defensive snapshots when reading from the
+    workspace state.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    n_trials: int | None = None
+    timeout: int | None = None
+    direction: Literal["maximize", "minimize"] | None = None
+    space: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    """Per-key overrides. A key absent from this dict falls back to the
+    matching ``TuningDefaults.space[key]`` (or is simply absent in
+    effective if the catalog also has nothing). A key present here wins
+    outright over any catalog default for the same key."""
+
+    evaluation_metrics: list[Any] | None = None
+
+
+class TuningConfig(BaseModel):
+    """Effective Tune configuration — catalog defaults merged with overrides
+    (P-0109).
+
+    Computed on demand by
+    :meth:`BackendCore.compute_effective_tuning`. Never persisted in
+    the workspace; captured into ``job.config.tuning`` when a tune job
+    starts (INV-T6 P-0109: reproducibility — a job's effective config
+    must remain stable even as the catalog evolves).
+
+    All fields are required: effective state is complete by
+    construction. ``user_set_paths`` carries provenance so the UI can
+    render a "modified" badge per row / field.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    n_trials: int
+    timeout: int | None
+    direction: Literal["maximize", "minimize"]
+    space: dict[str, dict[str, Any]]
+    evaluation_metrics: list[Any]
+    user_set_paths: list[str] = Field(default_factory=list)
+    """Dot-path identifiers of fields whose value came from
+    ``TuningOverrides`` (not from ``TuningDefaults``). Examples:
+    ``"n_trials"``, ``"timeout"``, ``"direction"``,
+    ``"space.learning_rate"``, ``"evaluation_metrics"``. Per-key
+    granularity for ``space`` (catalog vs override at the row level);
+    list-level for ``evaluation_metrics`` (overrides replace the whole
+    list when present)."""
 
 
 @dataclass

--- a/tests/test_p0109_tuning_types_protocol.py
+++ b/tests/test_p0109_tuning_types_protocol.py
@@ -1,0 +1,362 @@
+"""Tests for P-0109 PR-2: ``TuningDefaults`` / ``TuningOverrides`` /
+``TuningConfig`` common types and the safe-default Protocol methods
+``BackendCore.get_tuning_defaults`` and
+``BackendCore.compute_effective_tuning``.
+
+PR-2 is the contract-only step in the P-0109 chain: no concrete adapter
+implementation, no service / API rewiring, no frontend changes. The
+safe-default bodies in ``BackendCore`` give a future 2nd backend a
+zero-effort starting point — these tests pin that contract so the
+forward-compatibility guarantee does not regress silently.
+
+See HISTORY P-0109 (Decision section) for the chain shape and how
+PR-3 / PR-4 / PR-5 build on the surface fixed here.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from lizystudio.backends.base import BackendCore
+from lizystudio.backends.types import (
+    TuningConfig,
+    TuningDefaults,
+    TuningOverrides,
+)
+
+_FROZEN_DC_ERROR = dataclasses.FrozenInstanceError
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Type-level contract: TuningDefaults
+# ---------------------------------------------------------------------------
+
+
+class TestTuningDefaults:
+    def test_empty_construction_for_backend_without_catalog(self) -> None:
+        """A backend with no Optuna catalog returns empty defaults."""
+        d = TuningDefaults()
+        assert d.space == {}
+        assert d.evaluation_metrics == []
+        assert d.direction is None
+
+    def test_full_construction(self) -> None:
+        d = TuningDefaults(
+            space={"learning_rate": {"type": "float", "low": 0.01, "high": 0.3}},
+            evaluation_metrics=["auc", "auc_pr"],
+            direction="maximize",
+        )
+        assert d.direction == "maximize"
+        assert "learning_rate" in d.space
+        assert d.evaluation_metrics == ["auc", "auc_pr"]
+
+    def test_is_frozen(self) -> None:
+        """``frozen=True`` so a workspace can hold a defensive snapshot."""
+        d = TuningDefaults()
+        with pytest.raises(_FROZEN_DC_ERROR):
+            d.direction = "maximize"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Type-level contract: TuningOverrides — the sparse intent persisted in
+# the workspace. The key invariant is "explicit None is not the same as
+# unset" (P-0109 INV-T1, Q4 resolution).
+# ---------------------------------------------------------------------------
+
+
+class TestTuningOverrides:
+    def test_default_construction_is_empty_intent(self) -> None:
+        """A workspace never customised has every field unset."""
+        o = TuningOverrides()
+        assert o.n_trials is None
+        assert o.timeout is None
+        assert o.direction is None
+        assert o.space == {}
+        assert o.evaluation_metrics is None
+        assert o.model_fields_set == set()
+
+    def test_partial_override(self) -> None:
+        o = TuningOverrides(n_trials=100)
+        assert o.n_trials == 100
+        assert o.model_fields_set == {"n_trials"}
+
+    def test_explicit_timeout_none_is_user_set_intent(self) -> None:
+        """User picking 'no timeout' is distinguishable from 'not touched'.
+
+        Both ``TuningOverrides()`` and ``TuningOverrides(timeout=None)``
+        carry ``.timeout is None``, but Pydantic's ``model_fields_set``
+        reveals which one represents an explicit user choice — the
+        signal the merge logic uses to fall through to catalog defaults
+        only when the user hasn't expressed an opinion.
+        """
+        o_default = TuningOverrides()
+        o_explicit = TuningOverrides(timeout=None)
+        assert o_default.timeout is None
+        assert o_explicit.timeout is None
+        assert "timeout" not in o_default.model_fields_set
+        assert "timeout" in o_explicit.model_fields_set
+
+    def test_extra_field_is_rejected(self) -> None:
+        """``extra='forbid'`` catches typos and stale field names."""
+        with pytest.raises(ValidationError):
+            TuningOverrides(unknown_field=42)  # type: ignore[call-arg]
+
+    def test_is_frozen(self) -> None:
+        o = TuningOverrides(n_trials=100)
+        with pytest.raises(ValidationError):
+            o.n_trials = 200  # type: ignore[misc]
+
+    def test_space_override_is_per_key(self) -> None:
+        o = TuningOverrides(
+            space={
+                "learning_rate": {"type": "float", "low": 0.001, "high": 0.5},
+            },
+        )
+        assert o.space == {
+            "learning_rate": {"type": "float", "low": 0.001, "high": 0.5},
+        }
+        assert "space" in o.model_fields_set
+
+    def test_validates_from_dict_payload(self) -> None:
+        """``model_validate`` (PUT /config path) preserves ``fields_set``."""
+        o = TuningOverrides.model_validate({"n_trials": 100, "timeout": None})
+        assert o.n_trials == 100
+        assert o.timeout is None
+        assert o.model_fields_set == {"n_trials", "timeout"}
+
+
+# ---------------------------------------------------------------------------
+# Type-level contract: TuningConfig — the effective state, always complete.
+# ---------------------------------------------------------------------------
+
+
+class TestTuningConfig:
+    def test_requires_all_required_fields(self) -> None:
+        """Effective state must be complete — partial construction fails."""
+        with pytest.raises(ValidationError):
+            TuningConfig()  # type: ignore[call-arg]
+
+    def test_full_construction(self) -> None:
+        c = TuningConfig(
+            n_trials=100,
+            timeout=300,
+            direction="maximize",
+            space={"lr": {"type": "float", "low": 0.01, "high": 0.1}},
+            evaluation_metrics=["auc"],
+            user_set_paths=["n_trials", "space.lr"],
+        )
+        assert c.n_trials == 100
+        assert c.direction == "maximize"
+        assert c.user_set_paths == ["n_trials", "space.lr"]
+
+    def test_default_user_set_paths_is_empty(self) -> None:
+        """``user_set_paths`` defaults to empty for effectives without intent."""
+        c = TuningConfig(
+            n_trials=50,
+            timeout=None,
+            direction="minimize",
+            space={},
+            evaluation_metrics=[],
+        )
+        assert c.user_set_paths == []
+
+    def test_is_frozen(self) -> None:
+        c = TuningConfig(
+            n_trials=50,
+            timeout=None,
+            direction="minimize",
+            space={},
+            evaluation_metrics=[],
+        )
+        with pytest.raises(ValidationError):
+            c.n_trials = 100  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# BackendCore.get_tuning_defaults safe default — minimal backend gets
+# empty defaults for free (forward compat for 2nd adapter).
+# ---------------------------------------------------------------------------
+
+
+class _MinimalBackend(BackendCore):
+    """Stub backend exercising only the inherited safe-default methods.
+
+    Real adapters (e.g. ``LizyMLAdapter``) do **not** inherit from
+    ``BackendCore``; they satisfy it via duck typing. Here we
+    deliberately inherit so the Protocol's safe-default method bodies
+    actually run — that is the contract PR-2 fixes for forward compat.
+    """
+
+
+class TestSafeDefaultGetTuningDefaults:
+    def test_returns_empty_for_any_task(self) -> None:
+        backend = _MinimalBackend()
+        assert backend.get_tuning_defaults("binary") == TuningDefaults()
+        assert backend.get_tuning_defaults("regression") == TuningDefaults()
+        assert backend.get_tuning_defaults("multiclass") == TuningDefaults()
+        assert backend.get_tuning_defaults("") == TuningDefaults()
+
+
+# ---------------------------------------------------------------------------
+# BackendCore.compute_effective_tuning safe default — merge semantics
+# (P-0109 INV-T1/T2: catalog evolution propagates, user intent preserved).
+# ---------------------------------------------------------------------------
+
+
+class TestSafeDefaultComputeEffectiveTuning:
+    def test_empty_overrides_and_no_catalog_yields_minimal_defaults(self) -> None:
+        backend = _MinimalBackend()
+        eff = backend.compute_effective_tuning("binary", TuningOverrides())
+        assert eff.n_trials == 50
+        assert eff.timeout is None
+        assert eff.direction == "minimize"
+        assert eff.space == {}
+        assert eff.evaluation_metrics == []
+        assert eff.user_set_paths == []
+
+    def test_partial_override_only_marks_set_fields(self) -> None:
+        """``user_set_paths`` reflects the actual sparse intent."""
+        backend = _MinimalBackend()
+        eff = backend.compute_effective_tuning("binary", TuningOverrides(n_trials=10))
+        assert eff.n_trials == 10
+        assert eff.direction == "minimize"  # fall-through default
+        assert eff.user_set_paths == ["n_trials"]
+
+    def test_explicit_timeout_none_is_tracked_in_user_set_paths(self) -> None:
+        """Explicit no-timeout intent does NOT silently fall through to default."""
+        backend = _MinimalBackend()
+        eff = backend.compute_effective_tuning("binary", TuningOverrides(timeout=None))
+        assert eff.timeout is None
+        assert "timeout" in eff.user_set_paths
+
+    def test_full_overrides_are_carried_into_effective(self) -> None:
+        backend = _MinimalBackend()
+        o = TuningOverrides(
+            n_trials=200,
+            timeout=600,
+            direction="maximize",
+            space={"learning_rate": {"type": "float", "low": 0.005, "high": 0.2}},
+            evaluation_metrics=["auc", "auc_pr"],
+        )
+        eff = backend.compute_effective_tuning("regression", o)
+        assert eff.n_trials == 200
+        assert eff.timeout == 600
+        assert eff.direction == "maximize"
+        assert eff.space == {
+            "learning_rate": {"type": "float", "low": 0.005, "high": 0.2},
+        }
+        assert eff.evaluation_metrics == ["auc", "auc_pr"]
+        assert set(eff.user_set_paths) == {
+            "n_trials",
+            "timeout",
+            "direction",
+            "evaluation_metrics",
+            "space.learning_rate",
+        }
+
+    def test_catalog_outside_custom_space_keys_are_preserved(self) -> None:
+        """Q4 resolution: catalog-outside user params persist across task changes.
+
+        Here the minimal backend has no catalog at all; the safe-default
+        merge must still surface user-added params in ``effective.space``.
+        """
+        backend = _MinimalBackend()
+        o = TuningOverrides(
+            space={"custom_param": {"type": "categorical", "choices": ["a", "b"]}},
+        )
+        eff = backend.compute_effective_tuning("binary", o)
+        assert "custom_param" in eff.space
+        assert eff.space["custom_param"]["choices"] == ["a", "b"]
+        assert "space.custom_param" in eff.user_set_paths
+
+
+class _BackendWithCatalog(BackendCore):
+    """Stub backend that overrides ``get_tuning_defaults`` to exercise the
+    inherited-merge code path against a non-empty catalog (INV-T2 test).
+    """
+
+    def get_tuning_defaults(self, task: str) -> TuningDefaults:
+        return TuningDefaults(
+            space={
+                "learning_rate": {"type": "float", "low": 0.01, "high": 0.1},
+                "num_leaves": {"type": "int", "low": 20, "high": 200},
+            },
+            evaluation_metrics=["auc"],
+            direction="maximize",
+        )
+
+
+class TestComputeEffectiveTuningMergeAgainstCatalog:
+    def test_user_override_wins_per_space_key(self) -> None:
+        """Override of one catalog key leaves the other catalog key intact."""
+        backend = _BackendWithCatalog()
+        o = TuningOverrides(
+            space={"learning_rate": {"type": "float", "low": 0.001, "high": 0.5}},
+        )
+        eff = backend.compute_effective_tuning("binary", o)
+        assert eff.space == {
+            "learning_rate": {"type": "float", "low": 0.001, "high": 0.5},
+            "num_leaves": {"type": "int", "low": 20, "high": 200},
+        }
+        assert "space.learning_rate" in eff.user_set_paths
+        assert "space.num_leaves" not in eff.user_set_paths
+
+    def test_empty_overrides_yields_pure_catalog_defaults(self) -> None:
+        """INV-T2 happy path: zero intent → effective equals catalog (almost)."""
+        backend = _BackendWithCatalog()
+        eff = backend.compute_effective_tuning("binary", TuningOverrides())
+        assert eff.space == {
+            "learning_rate": {"type": "float", "low": 0.01, "high": 0.1},
+            "num_leaves": {"type": "int", "low": 20, "high": 200},
+        }
+        assert eff.direction == "maximize"  # from catalog
+        assert eff.evaluation_metrics == ["auc"]  # from catalog
+        assert eff.user_set_paths == []
+
+    def test_override_evaluation_metrics_replaces_catalog_list(self) -> None:
+        """List-level replacement (not per-element merge)."""
+        backend = _BackendWithCatalog()
+        o = TuningOverrides(evaluation_metrics=["logloss", "brier"])
+        eff = backend.compute_effective_tuning("binary", o)
+        assert eff.evaluation_metrics == ["logloss", "brier"]
+        assert "evaluation_metrics" in eff.user_set_paths
+
+    def test_override_direction_overrides_catalog_direction(self) -> None:
+        backend = _BackendWithCatalog()
+        o = TuningOverrides(direction="minimize")
+        eff = backend.compute_effective_tuning("binary", o)
+        assert eff.direction == "minimize"
+        assert "direction" in eff.user_set_paths
+
+
+# ---------------------------------------------------------------------------
+# Pure-function semantics: ``compute_effective_tuning`` is referentially
+# transparent (P-0109: same (task, overrides) ⇒ same effective).
+# ---------------------------------------------------------------------------
+
+
+class TestComputeEffectiveTuningIsPure:
+    def test_same_inputs_yield_same_output(self) -> None:
+        backend = _BackendWithCatalog()
+        o = TuningOverrides(n_trials=42, space={"x": {"type": "float"}})
+        a = backend.compute_effective_tuning("binary", o)
+        b = backend.compute_effective_tuning("binary", o)
+        assert a == b
+
+    def test_overrides_not_mutated(self) -> None:
+        """The merge must not mutate the user's TuningOverrides snapshot."""
+        backend = _BackendWithCatalog()
+        original_space: dict[str, dict[str, Any]] = {
+            "learning_rate": {"type": "float", "low": 0.001, "high": 0.5}
+        }
+        o = TuningOverrides(space=original_space)
+        _ = backend.compute_effective_tuning("binary", o)
+        assert o.space == {
+            "learning_rate": {"type": "float", "low": 0.001, "high": 0.5}
+        }


### PR DESCRIPTION
## Summary

**PR-2 in the P-0109 chain** (HISTORY [§P-0109](HISTORY.md), Decision approved 2026-05-14). Contract-only step: add the type system and Protocol methods that PR-3 / PR-4 / PR-5 build on.

No concrete adapter logic, no service / API rewiring, no frontend changes — those are PR-3 (LizyMLAdapter impl), PR-4 (service + format_version 2 → 3 + API extension), PR-5 (frontend three-useEffect deletion).

## What's added

### `backends/types.py`

- **`TuningDefaults`** — frozen dataclass. Catalog-derived defaults a backend declares for a given task: `space`, `evaluation_metrics`, `direction`. Empty default for backends with no catalog.
- **`TuningOverrides`** — Pydantic model (`extra="forbid"`, `frozen=True`). The sparse user-intent record persisted in the workspace. All fields are optional / `None`-defaulted; `model_fields_set` distinguishes "explicit `None`" from "field omitted" so the merge falls through to catalog defaults only when no intent exists.
- **`TuningConfig`** — Pydantic model (`extra="forbid"`, `frozen=True`). The fully-required effective state computed from defaults + overrides. Carries `user_set_paths` so the UI can render a "modified" badge per row / field.

### `backends/base.py`

- **`BackendCore.get_tuning_defaults(task) -> TuningDefaults`** — Protocol method with a safe-default body returning empty defaults.
- **`BackendCore.compute_effective_tuning(task, overrides) -> TuningConfig`** — Protocol method with a safe-default merge body (per-key space merge, list-level metrics replace, override-wins-when-fields-set semantics, `user_set_paths` derivation).

### `backends/lizyml/config_mixin.py`

- Stubs returning the safe-default behaviour so `LizyMLAdapter` continues to satisfy the now-extended `BackendAdapter` / `BackendCore` Protocols. `LizyMLAdapter` doesn't inherit from `BackendCore` (it satisfies via duck typing), so the Protocol's default bodies don't apply transitively — the stub provides the same behaviour explicitly. **PR-3 replaces these stubs with a catalog-aware impl**.

### `tests/test_p0109_tuning_types_protocol.py` (new, 26 tests)

Pins the contract before adapter logic lands:

- Empty-default construction for backends with no catalog
- `model_fields_set` semantics: "explicit `None`" vs "field omitted"
- `frozen=True` immutability on all three types
- `extra="forbid"` rejection on `TuningOverrides`
- Complete-state requirement on `TuningConfig`
- Safe-default Protocol method behaviours (empty defaults + minimal merge)
- Per-key merge invariants against a non-empty catalog stub (override-wins, catalog-survives-untouched, catalog-outside-keys preserved)
- Pure-function semantics (idempotency, no mutation of input overrides)

## Invariant coverage

INV-T1 (intent / effective separation), INV-T2 (intent task-agnostic), INV-T4 (frontend-as-renderer surface), INV-T5 (per-adapter SSOT) all land as type-level constraints plus test-level pins here.

INV-T3 (direction SSOT) becomes an actual assertion in PR-3 once the catalog-aware `LizyMLAdapter` impl ships. INV-T6 (job snapshot freeze) and INV-T7 (format_version migration) arrive in PR-4.

## Behavior change for users

**None.** This PR is pure surface area. Existing callers see no change because:
- The stub on `LizyMLAdapter` returns empty `TuningDefaults` (≡ the inherited safe default ≡ current behaviour where Studio has no centralised tune-defaults notion).
- The legacy on-the-fly defaults in `workspace_tune` (`space: {}` inject) and `_prepare_tune_config` (direction force-resolve) remain authoritative until PR-4 swaps them out.

## Test plan

- [x] `uv run pytest tests/test_p0109_tuning_types_protocol.py` — 26 passed
- [x] `uv run pytest` (full backend) — 1600 passed, 10 skipped, 0 failed
- [x] `uv run mypy src/lizystudio/` — clean across 59 files
- [x] `uv run ruff check . && uv run ruff format --check .` — clean

## Related

- HISTORY [§P-0109](HISTORY.md) — Proposal (PR #516 merged)
- ROADMAP §3 Active Proposals — P-0109 entry
- Bug 2026-05-14 reproduction — original session that surfaced the Tune-tab race that motivates this chain
