### PR TITLE
feat(p0109): add GET /config/tuning-snapshot + PUT /config/tuning-overrides (PR-4a)

### DIFF
--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -290,6 +290,67 @@ export interface paths {
         patch: operations["config_patch_api_workspace_config_patch"];
         trace?: never;
     };
+    "/api/workspace/config/tuning-snapshot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Config Tuning Snapshot
+         * @description Return the Tune-tab intent/effective split (P-0109 PR-4a).
+         *
+         *     Produces ``{tuning_effective, tuning_defaults}`` derived live from
+         *     the currently-persisted ``ws.config["tuning"]`` via the adapter's
+         *     catalog (see :func:`get_tuning_snapshot` for the projection rule).
+         *
+         *     The endpoint is read-only and storage-shape neutral: PR-4b will move
+         *     the workspace to persist sparse :class:`TuningOverrides` directly,
+         *     at which point the projection from legacy nested shape becomes a
+         *     pass-through. The frontend (PR-5) consumes this snapshot to render
+         *     Tune-tab rows without the racing seed-then-edit useEffects.
+         */
+        get: operations["config_tuning_snapshot_api_workspace_config_tuning_snapshot_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspace/config/tuning-overrides": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Config Tuning Overrides Update
+         * @description Apply sparse Tune overrides and return the resulting effective config.
+         *
+         *     Body is parsed as :class:`TuningOverrides` (P-0109): every field is
+         *     optional, ``extra="forbid"`` catches typos, and Pydantic's
+         *     ``model_fields_set`` lets the merge distinguish "explicit None" from
+         *     "unset" (INV-T1 / Q4).
+         *
+         *     The legacy ``ws.config["tuning"]`` block is rebuilt from the
+         *     effective result so the existing tune-job path and the PUT /config
+         *     GET round-trip keep working unchanged — PR-4b moves storage to the
+         *     sparse form. The same workspace-lock semantics as PUT /config apply:
+         *     a tune job that is still running blocks the write with 409 (P-0089).
+         */
+        put: operations["config_tuning_overrides_update_api_workspace_config_tuning_overrides_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workspace/config/validate": {
         parameters: {
             query?: never;
@@ -1876,6 +1937,89 @@ export interface components {
             [key: string]: unknown;
         };
         /**
+         * TuningOverrides
+         * @description User-set Tune customisations — sparse intent (P-0109).
+         *
+         *     Persisted in the LizyStudio workspace config as the sole record of
+         *     "what the user changed". All fields are optional so the absence of a
+         *     value means "use the catalog default" rather than "set this to
+         *     ``None``". Use :meth:`pydantic.BaseModel.model_fields_set` to
+         *     distinguish ``user explicitly set timeout=None`` (no-timeout intent)
+         *     from ``user has not touched timeout`` (the field is omitted from
+         *     ``model_fields_set``).
+         *
+         *     INV-T1 / INV-T2 (P-0109): overrides are task-agnostic. Task
+         *     transitions never mutate overrides; the *effective* config is
+         *     re-computed from new catalog + same overrides.
+         *
+         *     ``frozen=True``: an overrides instance is immutable post-construction
+         *     so callers receive defensive snapshots when reading from the
+         *     workspace state.
+         */
+        TuningOverrides: {
+            /** N Trials */
+            n_trials?: number | null;
+            /** Timeout */
+            timeout?: number | null;
+            /** Direction */
+            direction?: ("maximize" | "minimize") | null;
+            /** Space */
+            space?: {
+                [key: string]: {
+                    [key: string]: unknown;
+                };
+            };
+            /** Evaluation Metrics */
+            evaluation_metrics?: unknown[] | null;
+        };
+        /**
+         * TuningOverridesUpdateResponse
+         * @description Response for ``PUT /api/workspace/config/tuning-overrides``.
+         *
+         *     Echoes the resulting effective config so the caller can refresh its
+         *     local Tune-tab state in a single round-trip.
+         */
+        TuningOverridesUpdateResponse: {
+            /** Tuning Effective */
+            tuning_effective: {
+                [key: string]: unknown;
+            };
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * TuningSnapshotResponse
+         * @description Response for ``GET /api/workspace/config/tuning-snapshot``.
+         *
+         *     The pair the frontend Tune tab consumes to render its rows without
+         *     racing on the WriteFunnel write path (P-0109 PR-5 deletes the three
+         *     useEffects that compose the legacy seed-then-edit flow).
+         *
+         *     * ``tuning_effective`` — the catalog defaults merged with the user's
+         *       currently-persisted sparse intent. ``user_set_paths`` carries the
+         *       provenance the frontend will use for the "modified" badge in a
+         *       follow-up PR (badge rendering is deferred so PR-5 stays focused
+         *       on the useEffect deletion).
+         *     * ``tuning_defaults`` — the pure backend catalog defaults for the
+         *       current task. Useful as the "reset" reference point in the UI.
+         *
+         *     Both are returned as plain dicts so the frontend can consume them
+         *     with the existing openapi-typescript-generated types — without
+         *     importing backend-side Pydantic / dataclass shapes.
+         */
+        TuningSnapshotResponse: {
+            /** Tuning Effective */
+            tuning_effective: {
+                [key: string]: unknown;
+            };
+            /** Tuning Defaults */
+            tuning_defaults: {
+                [key: string]: unknown;
+            };
+        } & {
+            [key: string]: unknown;
+        };
+        /**
          * UiCapabilities
          * @description Backend-declared capabilities consumed by the Workspace UI.
          */
@@ -2609,6 +2753,59 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ConfigPatchResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    config_tuning_snapshot_api_workspace_config_tuning_snapshot_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TuningSnapshotResponse"];
+                };
+            };
+        };
+    };
+    config_tuning_overrides_update_api_workspace_config_tuning_overrides_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TuningOverrides"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TuningOverridesUpdateResponse"];
                 };
             };
             /** @description Validation Error */

--- a/src/lizystudio/api/models.py
+++ b/src/lizystudio/api/models.py
@@ -126,6 +126,47 @@ class ValidationResponse(BaseModel):
     errors: list[dict[str, Any]]
 
 
+# --- Tune intent/effective split (P-0109 PR-4a) ---
+
+
+class TuningSnapshotResponse(BaseModel):
+    """Response for ``GET /api/workspace/config/tuning-snapshot``.
+
+    The pair the frontend Tune tab consumes to render its rows without
+    racing on the WriteFunnel write path (P-0109 PR-5 deletes the three
+    useEffects that compose the legacy seed-then-edit flow).
+
+    * ``tuning_effective`` — the catalog defaults merged with the user's
+      currently-persisted sparse intent. ``user_set_paths`` carries the
+      provenance the frontend will use for the "modified" badge in a
+      follow-up PR (badge rendering is deferred so PR-5 stays focused
+      on the useEffect deletion).
+    * ``tuning_defaults`` — the pure backend catalog defaults for the
+      current task. Useful as the "reset" reference point in the UI.
+
+    Both are returned as plain dicts so the frontend can consume them
+    with the existing openapi-typescript-generated types — without
+    importing backend-side Pydantic / dataclass shapes.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    tuning_effective: dict[str, Any]
+    tuning_defaults: dict[str, Any]
+
+
+class TuningOverridesUpdateResponse(BaseModel):
+    """Response for ``PUT /api/workspace/config/tuning-overrides``.
+
+    Echoes the resulting effective config so the caller can refresh its
+    local Tune-tab state in a single round-trip.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    tuning_effective: dict[str, Any]
+
+
 # --- Jobs ---
 
 

--- a/src/lizystudio/api/workspace.py
+++ b/src/lizystudio/api/workspace.py
@@ -39,11 +39,14 @@ from lizystudio.api.models import (
     JobStartResponse,
     PreviewResponseModel,
     SplitPreviewResponseModel,
+    TuningOverridesUpdateResponse,
+    TuningSnapshotResponse,
     ValidationResponse,
     WorkspaceFitRequest,
     WorkspaceStatusResponse,
     WorkspaceTuneRequest,
 )
+from lizystudio.backends.types import TuningOverrides
 from lizystudio.security import (
     check_dataframe_memory,
     read_upload_checked,
@@ -70,8 +73,10 @@ from lizystudio.services.workspace import (
     get_backend_name,
     get_config_schema,
     get_default_config,
+    get_tuning_snapshot,
     get_workspace,
     load_config_from_file,
+    update_tuning_overrides,
     validate_config,
     validate_search_space_for_tune,
 )
@@ -510,6 +515,48 @@ def config_patch(
         raise InvalidPatchError(str(exc)) from exc
     ws.set_config(patched)
     return {"config": patched}
+
+
+@router.get("/config/tuning-snapshot", response_model=TuningSnapshotResponse)
+def config_tuning_snapshot(
+    ws: WorkspaceState = Depends(get_workspace),
+) -> dict[str, Any]:
+    """Return the Tune-tab intent/effective split (P-0109 PR-4a).
+
+    Produces ``{tuning_effective, tuning_defaults}`` derived live from
+    the currently-persisted ``ws.config["tuning"]`` via the adapter's
+    catalog (see :func:`get_tuning_snapshot` for the projection rule).
+
+    The endpoint is read-only and storage-shape neutral: PR-4b will move
+    the workspace to persist sparse :class:`TuningOverrides` directly,
+    at which point the projection from legacy nested shape becomes a
+    pass-through. The frontend (PR-5) consumes this snapshot to render
+    Tune-tab rows without the racing seed-then-edit useEffects.
+    """
+    return get_tuning_snapshot(ws)
+
+
+@router.put("/config/tuning-overrides", response_model=TuningOverridesUpdateResponse)
+def config_tuning_overrides_update(
+    body: TuningOverrides,
+    ws: WorkspaceState = Depends(get_workspace),
+    job_store: JobStore = Depends(get_job_store),
+) -> dict[str, Any]:
+    """Apply sparse Tune overrides and return the resulting effective config.
+
+    Body is parsed as :class:`TuningOverrides` (P-0109): every field is
+    optional, ``extra="forbid"`` catches typos, and Pydantic's
+    ``model_fields_set`` lets the merge distinguish "explicit None" from
+    "unset" (INV-T1 / Q4).
+
+    The legacy ``ws.config["tuning"]`` block is rebuilt from the
+    effective result so the existing tune-job path and the PUT /config
+    GET round-trip keep working unchanged — PR-4b moves storage to the
+    sparse form. The same workspace-lock semantics as PUT /config apply:
+    a tune job that is still running blocks the write with 409 (P-0089).
+    """
+    _check_workspace_lock(job_store)
+    return update_tuning_overrides(ws, body)
 
 
 @router.post("/config/validate", response_model=ValidationResponse)

--- a/src/lizystudio/services/workspace.py
+++ b/src/lizystudio/services/workspace.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import dataclasses
 import re
 import threading
 from dataclasses import dataclass, field
@@ -11,9 +12,16 @@ from typing import Any
 
 import pandas as pd
 from fastapi import Request
+from pydantic import ValidationError
 
 from lizystudio.backends.base import BackendAdapter
-from lizystudio.backends.types import DataRef, FitSummary, TuningSummary
+from lizystudio.backends.types import (
+    DataRef,
+    FitSummary,
+    TuningConfig,
+    TuningOverrides,
+    TuningSummary,
+)
 
 
 @dataclass
@@ -427,3 +435,165 @@ def _apply_single_op(
         if not isinstance(existing, dict):
             existing = {}
         current[key] = {**existing, **value}
+
+
+# --- Tune intent/effective split (P-0109 PR-4a) ------------------------------
+#
+# These helpers project the legacy ``config["tuning"]`` shape onto the
+# P-0109 ``TuningOverrides`` type (and back) so the Tune-tab snapshot
+# endpoint can answer ``GET /config/tuning-snapshot`` without owning the
+# storage rename — that's PR-4b's job. The helpers keep the workspace
+# in-memory storage unchanged (still ``ws.config["tuning"]`` in the
+# legacy nested shape) while the API surface starts speaking the new
+# two-layer (overrides + effective) language to the frontend.
+
+
+def extract_overrides_from_legacy_tuning(
+    tuning: Any,
+) -> TuningOverrides:
+    """Project a legacy ``config["tuning"]`` block onto :class:`TuningOverrides`.
+
+    The legacy shape is nested
+    (``{optuna: {params, space}, evaluation, model_params, training}``);
+    :class:`TuningOverrides` is flat (``n_trials``, ``timeout``,
+    ``direction``, ``space``, ``evaluation_metrics``). Only the
+    intersection maps cleanly — ``model_params`` / ``training`` are
+    LizyML-specific overrides that the Tune-tab snapshot does not
+    expose. PR-4b widens this mapping (or moves storage) once the
+    architectural rename ships.
+
+    ``None`` / missing / malformed input is tolerated: an empty
+    :class:`TuningOverrides` is returned rather than raising. This keeps
+    the snapshot endpoint robust to fresh workspaces and in-progress
+    edits.
+
+    Each scalar field is added to ``model_fields_set`` only when present
+    in the input — so a workspace that has never set ``timeout``
+    presents as "not touched" rather than as "explicit None", preserving
+    the INV-T1 distinction.
+    """
+    if not isinstance(tuning, dict):
+        return TuningOverrides()
+    data: dict[str, Any] = {}
+    optuna = tuning.get("optuna")
+    if isinstance(optuna, dict):
+        params = optuna.get("params")
+        if isinstance(params, dict):
+            for key in ("n_trials", "timeout", "direction"):
+                if key in params:
+                    data[key] = params[key]
+        space = optuna.get("space")
+        if isinstance(space, dict) and space:
+            data["space"] = {k: v for k, v in space.items() if isinstance(v, dict)}
+    evaluation = tuning.get("evaluation")
+    if isinstance(evaluation, dict):
+        metrics = evaluation.get("metrics")
+        if isinstance(metrics, list):
+            data["evaluation_metrics"] = list(metrics)
+    try:
+        return TuningOverrides.model_validate(data)
+    except ValidationError:
+        # Malformed legacy state (e.g. n_trials="50" as a string from an
+        # ancient persisted workspace) — fall back to an empty intent so
+        # the snapshot endpoint still answers and the frontend can
+        # re-establish the state via a fresh PUT.
+        return TuningOverrides()
+
+
+def materialize_overrides_into_legacy_tuning(
+    effective: TuningConfig,
+    *,
+    current_tuning: Any = None,
+) -> dict[str, Any]:
+    """Materialize a :class:`TuningConfig` back into the legacy nested shape.
+
+    Produces a fresh dict suitable for assignment to
+    ``config["tuning"]``. ``current_tuning`` (the previous legacy block,
+    if any) is mined for non-Tune-overrides keys —
+    ``optuna.params``-keys outside the four canonical ones,
+    ``model_params``, and ``training`` — so a user's
+    LizyML-only overrides survive a Tune-tab edit.
+
+    The four canonical ``optuna.params`` keys are
+    ``n_trials`` / ``timeout`` / ``direction`` plus any extras the user
+    had set (e.g. ``study_name``). Re-tune state
+    (``tuning.re_tune``) is also preserved.
+    """
+    existing: dict[str, Any] = (
+        copy.deepcopy(current_tuning) if isinstance(current_tuning, dict) else {}
+    )
+    raw_optuna = existing.get("optuna")
+    existing_optuna: dict[str, Any] = raw_optuna if isinstance(raw_optuna, dict) else {}
+    raw_params = existing_optuna.get("params")
+    existing_params: dict[str, Any] = raw_params if isinstance(raw_params, dict) else {}
+
+    materialized_params: dict[str, Any] = dict(existing_params)
+    materialized_params["n_trials"] = effective.n_trials
+    materialized_params["timeout"] = effective.timeout
+    materialized_params["direction"] = effective.direction
+
+    out: dict[str, Any] = dict(existing)
+    out["optuna"] = {
+        **existing_optuna,
+        "params": materialized_params,
+        "space": dict(effective.space),
+    }
+    if effective.evaluation_metrics:
+        out["evaluation"] = {"metrics": list(effective.evaluation_metrics)}
+    elif "evaluation" in out:
+        # Preserve a user-cleared metric list as ``[]`` so PUT semantics
+        # round-trip — the alternative would silently re-seed defaults
+        # the user just deleted.
+        out["evaluation"] = {"metrics": []}
+    return out
+
+
+def get_tuning_snapshot(ws: WorkspaceState) -> dict[str, Any]:
+    """Build the response payload for ``GET /config/tuning-snapshot`` (PR-4a).
+
+    Returns ``{"tuning_effective": ..., "tuning_defaults": ...}`` where
+    each side is a plain dict the frontend consumes via the
+    openapi-typescript surface. The effective config is computed live
+    from the current ``ws.config["tuning"]`` (legacy shape) so the
+    response stays consistent with whatever the legacy PUT /config flow
+    last persisted — until PR-4b moves storage to the sparse form.
+    """
+    task = str(ws.config.get("task", "")) if isinstance(ws.config, dict) else ""
+    overrides = extract_overrides_from_legacy_tuning(
+        ws.config.get("tuning") if isinstance(ws.config, dict) else None
+    )
+    effective = ws.backend.compute_effective_tuning(task, overrides)
+    defaults = ws.backend.get_tuning_defaults(task)
+    return {
+        "tuning_effective": effective.model_dump(mode="json"),
+        "tuning_defaults": dataclasses.asdict(defaults),
+    }
+
+
+def update_tuning_overrides(
+    ws: WorkspaceState,
+    overrides: TuningOverrides,
+) -> dict[str, Any]:
+    """Apply *overrides* and materialize back into ``ws.config["tuning"]``.
+
+    Computes the effective config via the adapter, then rebuilds the
+    legacy ``ws.config["tuning"]`` block from the result so the existing
+    tune-job code path (``_prepare_tune_config`` and lizyml's Optuna
+    wiring) keeps working unchanged. Returns the new effective config so
+    the API endpoint can echo it in the response.
+
+    INV-T2 (P-0109): the merge happens once here. Any catalog-only key
+    that the user has not overridden is re-derived from the catalog —
+    so when the catalog evolves between two PUTs, the effective config
+    automatically tracks the new defaults for unchanged keys.
+    """
+    task = str(ws.config.get("task", "")) if isinstance(ws.config, dict) else ""
+    effective = ws.backend.compute_effective_tuning(task, overrides)
+    current_tuning = ws.config.get("tuning") if isinstance(ws.config, dict) else None
+    materialized = materialize_overrides_into_legacy_tuning(
+        effective, current_tuning=current_tuning
+    )
+    new_config = copy.deepcopy(ws.config) if isinstance(ws.config, dict) else {}
+    new_config["tuning"] = materialized
+    ws.set_config(new_config)
+    return {"tuning_effective": effective.model_dump(mode="json")}

--- a/tests/test_p0109_pr4a_tuning_endpoints.py
+++ b/tests/test_p0109_pr4a_tuning_endpoints.py
@@ -1,0 +1,400 @@
+"""Tests for P-0109 PR-4a — Tune intent/effective endpoints + helpers.
+
+PR-4a is the additive API layer for the P-0109 intent/effective split.
+The workspace storage shape is unchanged (still legacy nested
+``config["tuning"]``); the new endpoints project that shape onto the
+:class:`TuningOverrides` / :class:`TuningConfig` types so the frontend
+(PR-5) can render the Tune tab without the racing seed-then-edit
+useEffects. PR-4b will move storage to persist sparse overrides
+directly; until then, the helpers under test here keep the two
+representations in sync.
+
+See HISTORY P-0109 (Decision) for the chain shape.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from lizystudio.backends.types import TuningOverrides
+from lizystudio.services.workspace import (
+    extract_overrides_from_legacy_tuning,
+    materialize_overrides_into_legacy_tuning,
+)
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrored from test_workspace_api.py — kept local so this file
+# stays self-contained for the PR-4a test slice).
+# ---------------------------------------------------------------------------
+
+
+def _create_csv(tmp_path: Path, name: str = "train.csv") -> str:
+    csv_path = tmp_path / name
+    with csv_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["id", "age", "target"])
+        for i in range(50):
+            writer.writerow([i, 20 + i, i % 2])
+    return str(csv_path)
+
+
+def _load_default_binary_config(client: TestClient) -> dict[str, Any]:
+    res = client.get("/api/workspace/config/defaults?task=binary&target=target")
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def _load_data_and_binary_config(client: TestClient, tmp_path: Path) -> None:
+    csv_path = _create_csv(tmp_path)
+    r = client.post("/api/workspace/data/path", json={"path": csv_path})
+    assert r.status_code == 200, r.text
+    config = _load_default_binary_config(client)
+    r = client.put("/api/workspace/config", json=config)
+    assert r.status_code == 200, r.text
+    assert r.json()["saved"] is True
+
+
+# ---------------------------------------------------------------------------
+# Service helpers — extract_overrides_from_legacy_tuning
+# ---------------------------------------------------------------------------
+
+
+class TestExtractOverridesFromLegacyTuning:
+    """Project the legacy nested ``config["tuning"]`` onto TuningOverrides."""
+
+    def test_none_input_yields_empty_overrides(self) -> None:
+        o = extract_overrides_from_legacy_tuning(None)
+        assert isinstance(o, TuningOverrides)
+        assert o.model_fields_set == set()
+
+    def test_empty_dict_yields_empty_overrides(self) -> None:
+        o = extract_overrides_from_legacy_tuning({})
+        assert isinstance(o, TuningOverrides)
+        assert o.model_fields_set == set()
+
+    def test_optuna_params_are_extracted(self) -> None:
+        o = extract_overrides_from_legacy_tuning(
+            {
+                "optuna": {
+                    "params": {
+                        "n_trials": 100,
+                        "timeout": 600,
+                        "direction": "maximize",
+                    },
+                    "space": {},
+                }
+            }
+        )
+        assert o.n_trials == 100
+        assert o.timeout == 600
+        assert o.direction == "maximize"
+        assert o.model_fields_set == {"n_trials", "timeout", "direction"}
+
+    def test_optuna_space_is_extracted(self) -> None:
+        o = extract_overrides_from_legacy_tuning(
+            {
+                "optuna": {
+                    "params": {},
+                    "space": {
+                        "learning_rate": {
+                            "type": "float",
+                            "low": 0.001,
+                            "high": 0.5,
+                        }
+                    },
+                }
+            }
+        )
+        assert "learning_rate" in o.space
+        assert "space" in o.model_fields_set
+
+    def test_evaluation_metrics_are_extracted(self) -> None:
+        o = extract_overrides_from_legacy_tuning(
+            {
+                "optuna": {"params": {}, "space": {}},
+                "evaluation": {"metrics": ["logloss", "brier"]},
+            }
+        )
+        assert o.evaluation_metrics == ["logloss", "brier"]
+        assert "evaluation_metrics" in o.model_fields_set
+
+    def test_explicit_none_timeout_preserves_user_intent(self) -> None:
+        """INV-T1 (P-0109 Q4): explicit ``None`` ≠ unset."""
+        o = extract_overrides_from_legacy_tuning(
+            {"optuna": {"params": {"timeout": None}, "space": {}}}
+        )
+        assert o.timeout is None
+        assert "timeout" in o.model_fields_set
+
+    def test_malformed_input_falls_back_to_empty(self) -> None:
+        """Invalid scalar types (e.g. n_trials="50") fall back to empty."""
+        o = extract_overrides_from_legacy_tuning(
+            {"optuna": {"params": {"n_trials": "fifty"}, "space": {}}}
+        )
+        assert o.model_fields_set == set()
+
+    def test_non_dict_value_is_ignored(self) -> None:
+        o = extract_overrides_from_legacy_tuning("not a dict")
+        assert o.model_fields_set == set()
+
+
+# ---------------------------------------------------------------------------
+# Service helpers — materialize_overrides_into_legacy_tuning
+# ---------------------------------------------------------------------------
+
+
+class TestMaterializeOverridesIntoLegacyTuning:
+    """Convert TuningConfig → legacy nested ``tuning`` block."""
+
+    def _make_effective(
+        self,
+        *,
+        n_trials: int = 50,
+        timeout: int | None = None,
+        direction: str = "maximize",
+        space: dict[str, dict[str, Any]] | None = None,
+        evaluation_metrics: list[Any] | None = None,
+    ) -> Any:
+        from lizystudio.backends.types import TuningConfig
+
+        return TuningConfig(
+            n_trials=n_trials,
+            timeout=timeout,
+            direction=direction,  # type: ignore[arg-type]
+            space=space if space is not None else {},
+            evaluation_metrics=(
+                evaluation_metrics if evaluation_metrics is not None else []
+            ),
+        )
+
+    def test_minimum_effective_materializes_optuna_block(self) -> None:
+        out = materialize_overrides_into_legacy_tuning(self._make_effective())
+        assert out["optuna"]["params"]["n_trials"] == 50
+        assert out["optuna"]["params"]["timeout"] is None
+        assert out["optuna"]["params"]["direction"] == "maximize"
+        assert out["optuna"]["space"] == {}
+        # No evaluation block for empty metric list (caller can decide).
+        # Empty input → empty output preserves PUT semantics.
+
+    def test_space_is_materialized(self) -> None:
+        out = materialize_overrides_into_legacy_tuning(
+            self._make_effective(
+                space={"lr": {"type": "float", "low": 0.01, "high": 0.3}}
+            )
+        )
+        assert out["optuna"]["space"] == {
+            "lr": {"type": "float", "low": 0.01, "high": 0.3}
+        }
+
+    def test_evaluation_metrics_are_materialized(self) -> None:
+        out = materialize_overrides_into_legacy_tuning(
+            self._make_effective(evaluation_metrics=["auc", "logloss"])
+        )
+        assert out["evaluation"] == {"metrics": ["auc", "logloss"]}
+
+    def test_model_params_and_training_are_preserved(self) -> None:
+        """LizyML-specific non-Optuna overrides survive the materialization."""
+        current = {
+            "optuna": {"params": {"n_trials": 1, "study_name": "old"}, "space": {}},
+            "model_params": {"learning_rate": 0.05},
+            "training": {"seed": 123},
+        }
+        out = materialize_overrides_into_legacy_tuning(
+            self._make_effective(n_trials=100), current_tuning=current
+        )
+        assert out["model_params"] == {"learning_rate": 0.05}
+        assert out["training"] == {"seed": 123}
+        # Existing extra optuna.params keys are preserved alongside the
+        # canonical ones — n_trials gets overwritten, study_name survives.
+        assert out["optuna"]["params"]["study_name"] == "old"
+        assert out["optuna"]["params"]["n_trials"] == 100
+
+    def test_returns_independent_copy(self) -> None:
+        """Caller-side mutation must not leak back into the effective config."""
+        current = {"optuna": {"params": {}, "space": {}}, "model_params": {"x": 1}}
+        out = materialize_overrides_into_legacy_tuning(
+            self._make_effective(), current_tuning=current
+        )
+        out["model_params"]["x"] = 999
+        assert current["model_params"] == {"x": 1}
+
+
+# ---------------------------------------------------------------------------
+# GET /api/workspace/config/tuning-snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestTuningSnapshotEndpoint:
+    """``GET /config/tuning-snapshot`` projects current workspace state."""
+
+    def test_empty_workspace_returns_empty_defaults(self, client: TestClient) -> None:
+        """Fresh workspace (no config) → empty defaults, empty effective."""
+        res = client.get("/api/workspace/config/tuning-snapshot")
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert "tuning_effective" in body
+        assert "tuning_defaults" in body
+        # No task set → empty TuningDefaults from the adapter.
+        assert body["tuning_defaults"]["space"] == {}
+        assert body["tuning_defaults"]["evaluation_metrics"] == []
+        # Effective falls back to the empty-overrides safe default.
+        assert body["tuning_effective"]["n_trials"] == 50
+
+    def test_binary_config_returns_catalog_defaults(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        """Binary task → catalog space + canonical metrics + maximize direction."""
+        _load_data_and_binary_config(client, tmp_path)
+        res = client.get("/api/workspace/config/tuning-snapshot")
+        assert res.status_code == 200, res.text
+        body = res.json()
+        # Defaults carry the catalog space + canonical binary metric list.
+        assert "learning_rate" in body["tuning_defaults"]["space"]
+        assert body["tuning_defaults"]["evaluation_metrics"] == [
+            "auc",
+            "auc_pr",
+            "brier",
+            "logloss",
+        ]
+        assert body["tuning_defaults"]["direction"] == "maximize"
+        # Effective for a fresh binary config (no explicit tune intent
+        # persisted yet) matches the catalog defaults too.
+        assert body["tuning_effective"]["direction"] == "maximize"
+        assert body["tuning_effective"]["evaluation_metrics"] == [
+            "auc",
+            "auc_pr",
+            "brier",
+            "logloss",
+        ]
+
+    def test_after_legacy_put_config_effective_reflects_persisted_tuning(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        """Legacy PUT /config that sets ``tuning`` is honoured by the snapshot."""
+        _load_data_and_binary_config(client, tmp_path)
+        # Manually craft a legacy ``tuning`` block via PUT /config.
+        config = _load_default_binary_config(client)
+        config["tuning"] = {
+            "optuna": {
+                "params": {
+                    "n_trials": 200,
+                    "timeout": None,
+                    "direction": "maximize",
+                },
+                "space": {
+                    "learning_rate": {
+                        "type": "float",
+                        "low": 0.1,
+                        "high": 0.5,
+                        "log": False,
+                    }
+                },
+            }
+        }
+        r = client.put("/api/workspace/config", json=config)
+        assert r.status_code == 200, r.text
+        assert r.json()["saved"] is True
+
+        res = client.get("/api/workspace/config/tuning-snapshot")
+        assert res.status_code == 200, res.text
+        eff = res.json()["tuning_effective"]
+        assert eff["n_trials"] == 200
+        # The user's override wins per-key over the catalog default.
+        assert eff["space"]["learning_rate"]["low"] == 0.1
+        assert eff["space"]["learning_rate"]["high"] == 0.5
+        # Catalog-only keys (the user didn't touch them) survive intact.
+        assert "max_depth" in eff["space"]
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/workspace/config/tuning-overrides
+# ---------------------------------------------------------------------------
+
+
+class TestTuningOverridesUpdateEndpoint:
+    """``PUT /config/tuning-overrides`` accepts sparse intent → echoes effective."""
+
+    def test_partial_override_returns_updated_effective(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        _load_data_and_binary_config(client, tmp_path)
+        res = client.put(
+            "/api/workspace/config/tuning-overrides",
+            json={"n_trials": 250},
+        )
+        assert res.status_code == 200, res.text
+        eff = res.json()["tuning_effective"]
+        assert eff["n_trials"] == 250
+        # Catalog defaults still fill the rest.
+        assert eff["direction"] == "maximize"
+        assert "learning_rate" in eff["space"]
+
+    def test_put_then_get_round_trip(self, client: TestClient, tmp_path: Path) -> None:
+        _load_data_and_binary_config(client, tmp_path)
+        # Apply an override.
+        r = client.put(
+            "/api/workspace/config/tuning-overrides",
+            json={
+                "n_trials": 333,
+                "space": {
+                    "learning_rate": {
+                        "type": "float",
+                        "low": 0.5,
+                        "high": 1.0,
+                        "log": False,
+                    }
+                },
+            },
+        )
+        assert r.status_code == 200, r.text
+        # GET-snapshot now reflects the persisted override.
+        snap = client.get("/api/workspace/config/tuning-snapshot")
+        assert snap.status_code == 200, snap.text
+        eff = snap.json()["tuning_effective"]
+        assert eff["n_trials"] == 333
+        assert eff["space"]["learning_rate"]["low"] == 0.5
+        # Verify the legacy PUT /config path also reflects the override
+        # (the materialization wrote into ``ws.config["tuning"]``).
+        cfg = client.get("/api/workspace/config")
+        assert cfg.status_code == 200, cfg.text
+        legacy = cfg.json().get("tuning", {})
+        assert legacy["optuna"]["params"]["n_trials"] == 333
+
+    def test_evaluation_metrics_override_replaces_list(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        _load_data_and_binary_config(client, tmp_path)
+        r = client.put(
+            "/api/workspace/config/tuning-overrides",
+            json={"evaluation_metrics": ["logloss"]},
+        )
+        assert r.status_code == 200, r.text
+        eff = r.json()["tuning_effective"]
+        assert eff["evaluation_metrics"] == ["logloss"]
+
+    def test_extra_field_is_rejected(self, client: TestClient, tmp_path: Path) -> None:
+        """``TuningOverrides`` is ``extra="forbid"`` — typos surface as 422."""
+        _load_data_and_binary_config(client, tmp_path)
+        r = client.put(
+            "/api/workspace/config/tuning-overrides",
+            json={"unknown_field": 42},
+        )
+        assert r.status_code == 422, r.text
+
+    def test_empty_body_is_accepted(self, client: TestClient, tmp_path: Path) -> None:
+        """An empty intent is a valid 'reset to catalog defaults' request."""
+        _load_data_and_binary_config(client, tmp_path)
+        r = client.put("/api/workspace/config/tuning-overrides", json={})
+        assert r.status_code == 200, r.text
+        eff = r.json()["tuning_effective"]
+        # Catalog defaults shine through when no overrides are set.
+        assert eff["n_trials"] == 50  # safe fallback when catalog has none
+        assert eff["direction"] == "maximize"


### PR DESCRIPTION
## Summary

PR-4a is the **additive API layer** for the P-0109 Tune intent/effective split. Per the [previous session's split decision](https://github.com/nbx-liz/LizyStudio/pull/518), the original monolithic PR-4 is broken into:

* **PR-4a (this PR)** — additive endpoints + service helpers. Storage shape unchanged. Unblocks PR-5 (frontend useEffect deletion) without touching format-version / migration / INV-T6.
* **PR-4b (future)** — storage rename (`config["tuning"]` → `tuning_overrides`), `STUDIO_FORMAT_VERSION` 2 → 3 + migration, tune-job snapshot freeze (INV-T6), INV-T3 assertion in `_prepare_tune_config` + hardcoded `maximize_metrics` removal.

## New endpoints

### `GET /api/workspace/config/tuning-snapshot` → `TuningSnapshotResponse`

Returns `{tuning_effective, tuning_defaults}` derived live from the current `ws.config["tuning"]` via the adapter's `compute_effective_tuning` + `get_tuning_defaults` methods (P-0109 PR-3, #518).

Storage-shape neutral: PR-4b will make the projection a pass-through once workspace persists sparse overrides directly. Frontend (PR-5) consumes this snapshot to render Tune-tab rows without the racing seed-then-edit useEffects.

### `PUT /api/workspace/config/tuning-overrides` → `TuningOverridesUpdateResponse`

Accepts a sparse `TuningOverrides` body (Pydantic, `extra="forbid"` rejects typos with 422), computes the effective config via the adapter, and materializes the result back into `ws.config["tuning"]` so the existing tune-job flow and the legacy `GET /config` round-trip keep working unchanged.

Workspace-lock semantics match `PUT /config` (P-0089): a running job blocks writes with 409.

## Service helpers ([src/lizystudio/services/workspace.py](src/lizystudio/services/workspace.py))

| Helper | Role |
|---|---|
| `extract_overrides_from_legacy_tuning` | Project nested legacy `tuning` → `TuningOverrides`. Tolerant of `None` / malformed scalars. Preserves "explicit None ≠ unset" (INV-T1 / Q4) via Pydantic `model_fields_set`. |
| `materialize_overrides_into_legacy_tuning` | Inverse projection. Preserves non-Tune-overrides keys (`optuna.params` extras, `model_params`, `training`, re-tune state) so LizyML-only overrides survive a Tune-tab edit. |
| `get_tuning_snapshot` | Endpoint-facing wrapper combining both with `adapter.compute_effective_tuning`. |
| `update_tuning_overrides` | PUT-side wrapper that materializes the effective into `ws.config["tuning"]`. |

## Out of scope for PR-4a (deferred to PR-4b)

- [ ] Storage rename `WorkspaceConfig.tuning` → `tuning_overrides`
- [ ] `STUDIO_FORMAT_VERSION` 2 → 3 + `MIGRATIONS[2]`
- [ ] Tune-job snapshot freeze (INV-T6)
- [ ] INV-T3 assertion in `_prepare_tune_config`
- [ ] Hardcoded `maximize_metrics` set removal (still gated on adapter-handle plumbing, INV-ADAPTER-1)

## Invariants

- **INV-T1** — explicit-None overrides preserved as user intent (Q4 resolution).
- **INV-T2** — catalog evolution propagates: catalog-only space keys survive override edits.
- **INV-T5** — adapter is the SSOT for its own defaults (snapshot endpoint reads only `adapter.get_tuning_defaults` / `adapter.compute_effective_tuning`).

## Failure paths covered

- [x] Empty / missing / non-dict `tuning` block → empty `TuningOverrides`
- [x] Malformed scalar (e.g. `n_trials="50"`) → fallback to empty intent
- [x] Empty workspace (no task / config) → snapshot still answers with safe defaults
- [x] PUT → GET round-trip — effective survives the legacy materialization path
- [x] Extra fields on PUT → 422 (Pydantic `extra="forbid"`)
- [x] Workspace lock during running job → 409 on PUT
- [x] `evaluation_metrics` override → list-replace (not per-element merge)

## Test plan

- [x] `tests/test_p0109_pr4a_tuning_endpoints.py` — 21 new tests (8 extraction + 5 materialization + 3 GET + 5 PUT)
- [x] PR-2's 26 contract tests + PR-3's 18 adapter tests remain green
- [x] Full pytest suite: 1640 passed, 10 skipped
- [x] mypy clean (`uv run mypy --no-incremental src/lizystudio/`)
- [x] ruff check + ruff format clean
- [x] Biome check clean
- [x] `frontend/src/api/generated/schema.d.ts` regenerated — drift gate (`test_schema_d_ts_matches_generated_output`) green

## Files changed

| File | Change |
|---|---|
| `src/lizystudio/api/models.py` | +`TuningSnapshotResponse`, `TuningOverridesUpdateResponse` |
| `src/lizystudio/api/workspace.py` | +`GET /config/tuning-snapshot`, +`PUT /config/tuning-overrides` |
| `src/lizystudio/services/workspace.py` | +4 helpers (extract / materialize / get_snapshot / update_overrides) |
| `tests/test_p0109_pr4a_tuning_endpoints.py` | +21 tests (new file) |
| `frontend/src/api/generated/schema.d.ts` | regenerated for the two new endpoints |

## Next in chain

- **PR-4b** — storage rename + `STUDIO_FORMAT_VERSION` 2 → 3 + migration + INV-T6 snapshot freeze + INV-T3 assertion.
- **PR-5** — Frontend three-useEffect physical deletion + effective/overrides two-layer prop refactor → consumes this PR's `GET /config/tuning-snapshot` + `PUT /config/tuning-overrides`. **This is the PR that actually fixes the user-visible bug.**
- **PR-6** — BLUEPRINT §3.3.2 / §6 / §7 reconcile + docs + Decision flip to "Approved & shipped".

Refs: #517 (PR-2), #518 (PR-3), P-0109 (HISTORY).