### PR TITLE
feat(p0109): workspace stores tuning_overrides first-class + INV-T6 snapshot freeze (PR-4b)

### DIFF
--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -258,6 +258,13 @@ export interface paths {
         /**
          * Config Get
          * @description Return the current workspace config.
+         *
+         *     PR-4b: the response includes a materialised ``tuning`` block
+         *     synthesised from ``ws.tuning_overrides`` so the legacy pre-PR-5
+         *     frontend keeps seeing ``config.tuning`` even after the storage
+         *     rename. Once PR-5 ships, the frontend reads
+         *     ``GET /config/tuning-snapshot`` directly and this compat shim
+         *     becomes load-bearing only for YAML download / CLI consumers.
          */
         get: operations["config_get_api_workspace_config_get"];
         /**

--- a/frontend/tests/e2e/workspace-apply-to-fit.spec.ts
+++ b/frontend/tests/e2e/workspace-apply-to-fit.spec.ts
@@ -129,12 +129,19 @@ test.describe("Workspace Apply-to-Fit (G-1, P-0092 Phase 6)", () => {
     // 4. The PUT body must carry model.params merged with best_params.
     // PUT /config sends the full snapshot, so we read the request body
     // and assert each best_param key is present.
+    //
+    // Catalog space keys include dotted entries (e.g.
+    // ``early_stopping.rounds``). Vitest's ``toHaveProperty(stringPath)``
+    // splits on ``.`` and walks the resulting path, which doesn't match
+    // a flat property whose key literally contains a dot. Wrap the key
+    // in an array to force literal interpretation.
     const putBody = JSON.parse(applyPut.request().postData() ?? "{}") as {
       model?: { params?: Record<string, unknown> };
     };
-    const writtenParams = putBody.model?.params ?? {};
+    const writtenParams: Record<string, unknown> =
+      putBody.model?.params ?? {};
     for (const key of Object.keys(bestParams)) {
-      expect(writtenParams).toHaveProperty(key);
+      expect(writtenParams).toHaveProperty([key]);
       // best_params can be numeric or categorical (e.g. lgbm boosting_type);
       // assert equality on the JSON-encoded form so number/string parity
       // matches what the funnel actually shipped.

--- a/src/lizystudio/api/workspace.py
+++ b/src/lizystudio/api/workspace.py
@@ -5,7 +5,6 @@ Covers: status, reset, data, config, fit, tune.
 
 from __future__ import annotations
 
-import copy
 import logging
 import tempfile
 import time
@@ -69,13 +68,16 @@ from lizystudio.services.training import (
 )
 from lizystudio.services.workspace import (
     WorkspaceState,
+    absorb_legacy_tuning,
     apply_config_patch,
     get_backend_name,
     get_config_schema,
     get_default_config,
+    get_legacy_config_view,
     get_tuning_snapshot,
     get_workspace,
     load_config_from_file,
+    materialize_tuning_for_job,
     update_tuning_overrides,
     validate_config,
     validate_search_space_for_tune,
@@ -431,8 +433,16 @@ def config_defaults(
 def config_get(
     ws: WorkspaceState = Depends(get_workspace),
 ) -> dict[str, Any]:
-    """Return the current workspace config."""
-    return ws.config
+    """Return the current workspace config.
+
+    PR-4b: the response includes a materialised ``tuning`` block
+    synthesised from ``ws.tuning_overrides`` so the legacy pre-PR-5
+    frontend keeps seeing ``config.tuning`` even after the storage
+    rename. Once PR-5 ships, the frontend reads
+    ``GET /config/tuning-snapshot`` directly and this compat shim
+    becomes load-bearing only for YAML download / CLI consumers.
+    """
+    return get_legacy_config_view(ws)
 
 
 def _check_workspace_lock(job_store: JobStore) -> None:
@@ -487,7 +497,13 @@ def config_update(
     errors = validate_config(ws, body)
     blocking = _blocking_errors(errors)
     if not blocking:
-        ws.set_config(body)
+        # P-0109 PR-4b: legacy PUT /config payloads still carry the
+        # materialised ``tuning`` block (pre-PR-5 frontend). Divert it
+        # into ``ws.tuning_overrides`` so the storage rename stays
+        # consistent, then store the stripped config so the workspace
+        # never holds two copies of the same intent.
+        stripped = absorb_legacy_tuning(ws, body)
+        ws.set_config(stripped)
     return {"config": body, "errors": errors, "saved": len(blocking) == 0}
 
 
@@ -646,7 +662,11 @@ def workspace_fit(
         blocking = _blocking_errors(errors)
         if blocking:
             raise ValidationError(blocking)
-        ws.set_config(candidate)
+        # P-0109 PR-4b: same compat shim as PUT /config — divert any
+        # ``tuning`` block in the body into ``ws.tuning_overrides`` so
+        # the storage rename stays consistent through every config-set
+        # entry point.
+        ws.set_config(absorb_legacy_tuning(ws, candidate))
     if not ws.config:
         raise WorkspaceNoConfigError()
     if ws.dataframe is None or ws.data_ref is None:
@@ -720,32 +740,23 @@ def workspace_tune(
         blocking = _blocking_errors(errors)
         if blocking:
             raise ValidationError(blocking)
-        ws.set_config(candidate)
+        # P-0109 PR-4b: divert any ``tuning`` block into
+        # ``ws.tuning_overrides``; same compat shim as workspace_fit.
+        ws.set_config(absorb_legacy_tuning(ws, candidate))
     if not ws.config:
         raise WorkspaceNoConfigError()
     if ws.dataframe is None or ws.data_ref is None:
         raise WorkspaceNoDataError()
-    # Inject default tuning config if not set (H-0025) — immutable copy.
-    #
-    # Direction is intentionally NOT hardcoded here (Bug 2026-04-14): a
-    # ``minimize`` default would override the AUC / R2 / accuracy class
-    # of metrics that should be maximized, and ``_prepare_tune_config``'s
-    # auto-resolve was guarded by ``"direction" not in params`` so the
-    # wrong value silently propagated to Optuna. The auto-resolve in
-    # ``_prepare_tune_config`` is now the single source of truth — it
-    # reads ``evaluation.metrics`` and picks ``maximize`` / ``minimize``
-    # from the maximize-set table. Leaving direction unset here lets that
-    # resolver fire on every fresh tune.
-    if ws.config.get("tuning") is None:
-        config_with_tuning = copy.deepcopy(ws.config)
-        config_with_tuning["tuning"] = {
-            "optuna": {
-                "params": {"n_trials": 50, "timeout": None},
-                "space": {},
-            }
-        }
-        ws.set_config(config_with_tuning)
-    errors = validate_config(ws, ws.config)
+    # P-0109 PR-4b / INV-T6: materialize the effective Tune config from
+    # ``ws.tuning_overrides`` into the per-job config snapshot at
+    # job-start time. ``job.config["tuning"]`` is frozen here so the
+    # tune run remains reproducible even if the backend catalog evolves
+    # between this PUT and the next one. Replaces the legacy default-
+    # tuning injection (was inlined as a hardcoded ``{n_trials: 50,
+    # timeout: None, space: {}}``); direction is now resolved through
+    # the adapter (INV-T3) instead of via the hardcoded maximize set.
+    job_config = materialize_tuning_for_job(ws)
+    errors = validate_config(ws, job_config)
     blocking = _blocking_errors(errors)
     if blocking:
         raise ValidationError(blocking)
@@ -753,13 +764,13 @@ def workspace_tune(
     # tuning.optuna.space entries (inverted Range, log+low<=0). Kept out
     # of ``validate_config`` so the save gate (``PUT /config``) stays
     # permissive for WIP edits — see services.workspace docstring.
-    space_errors = validate_search_space_for_tune(ws, ws.config)
+    space_errors = validate_search_space_for_tune(ws, job_config)
     if space_errors:
         raise ValidationError(space_errors)
     # CRITICAL-2: atomic create + slot claim, see workspace_fit above.
     job = job_store.create_and_claim_active(
         backend_name=get_backend_name(ws),
-        config=ws.config,
+        config=job_config,
         data_ref=ws.data_ref,
         job_type="tune",
     )
@@ -770,7 +781,7 @@ def workspace_tune(
             ws=ws,
             job_store=job_store,
             broadcaster=broadcaster,
-            config=ws.config,
+            config=job_config,
             dataframe=ws.dataframe,
             job=job,
         )

--- a/src/lizystudio/services/workspace.py
+++ b/src/lizystudio/services/workspace.py
@@ -33,6 +33,14 @@ class WorkspaceState:
     data_ref: DataRef | None = None
     dataframe: pd.DataFrame | None = None
     model: Any = None
+    # P-0109 PR-4b: sparse Tune intent — the SSOT for the Tune tab.
+    # Workspace persists ONLY user-set fields here (catalog defaults are
+    # re-derived on demand by ``adapter.compute_effective_tuning``).
+    # ``None`` means "never touched"; an empty ``TuningOverrides()``
+    # instance means "explicitly cleared to catalog defaults". The two
+    # are equivalent for effective computation but the distinction
+    # survives across PUTs via Pydantic ``model_fields_set``.
+    tuning_overrides: TuningOverrides | None = None
     # Result from the latest fit/tune executed in this session
     workspace_fit_result: FitSummary | None = None
     workspace_tune_result: TuningSummary | None = None
@@ -48,6 +56,7 @@ class WorkspaceState:
         """Clear everything except the backend adapter."""
         with self._lock:
             self.config = {}
+            self.tuning_overrides = None
             self.data_ref = None
             self.dataframe = None
             self.model = None
@@ -105,6 +114,17 @@ class WorkspaceState:
         """Update the current config."""
         with self._lock:
             self.config = config
+
+    def set_tuning_overrides(self, overrides: TuningOverrides | None) -> None:
+        """Replace the persisted Tune intent (P-0109 PR-4b).
+
+        Passing ``None`` clears the intent so the next effective
+        computation falls back to pure catalog defaults. Threads writing
+        the workspace state concurrently are serialised through the same
+        lock as :meth:`set_config`.
+        """
+        with self._lock:
+            self.tuning_overrides = overrides
 
     # --- Background job thread coordination (A-4) ---
 
@@ -548,20 +568,32 @@ def materialize_overrides_into_legacy_tuning(
     return out
 
 
+def _current_overrides(ws: WorkspaceState) -> TuningOverrides:
+    """Return ``ws.tuning_overrides`` defaulted to an empty intent.
+
+    Hides the ``None`` sentinel from callers that only need to compute
+    an effective config — they treat "never touched" and "explicit
+    empty" the same way. The distinction still surfaces via
+    :attr:`TuningOverrides.model_fields_set` for callers that need it.
+    """
+    return ws.tuning_overrides if ws.tuning_overrides is not None else TuningOverrides()
+
+
+def _current_task(ws: WorkspaceState) -> str:
+    return str(ws.config.get("task", "")) if isinstance(ws.config, dict) else ""
+
+
 def get_tuning_snapshot(ws: WorkspaceState) -> dict[str, Any]:
-    """Build the response payload for ``GET /config/tuning-snapshot`` (PR-4a).
+    """Build the response payload for ``GET /config/tuning-snapshot``.
 
     Returns ``{"tuning_effective": ..., "tuning_defaults": ...}`` where
     each side is a plain dict the frontend consumes via the
-    openapi-typescript surface. The effective config is computed live
-    from the current ``ws.config["tuning"]`` (legacy shape) so the
-    response stays consistent with whatever the legacy PUT /config flow
-    last persisted — until PR-4b moves storage to the sparse form.
+    openapi-typescript surface. PR-4b makes ``ws.tuning_overrides`` the
+    sole source of Tune intent — the snapshot endpoint reads it
+    directly instead of extracting from legacy ``ws.config["tuning"]``.
     """
-    task = str(ws.config.get("task", "")) if isinstance(ws.config, dict) else ""
-    overrides = extract_overrides_from_legacy_tuning(
-        ws.config.get("tuning") if isinstance(ws.config, dict) else None
-    )
+    task = _current_task(ws)
+    overrides = _current_overrides(ws)
     effective = ws.backend.compute_effective_tuning(task, overrides)
     defaults = ws.backend.get_tuning_defaults(task)
     return {
@@ -574,26 +606,106 @@ def update_tuning_overrides(
     ws: WorkspaceState,
     overrides: TuningOverrides,
 ) -> dict[str, Any]:
-    """Apply *overrides* and materialize back into ``ws.config["tuning"]``.
+    """Persist *overrides* as the sole Tune intent (P-0109 PR-4b).
 
-    Computes the effective config via the adapter, then rebuilds the
-    legacy ``ws.config["tuning"]`` block from the result so the existing
-    tune-job code path (``_prepare_tune_config`` and lizyml's Optuna
-    wiring) keeps working unchanged. Returns the new effective config so
-    the API endpoint can echo it in the response.
+    Replaces ``ws.tuning_overrides`` outright (no merge with prior
+    intent — the body is the full sparse intent). Echoes the resulting
+    effective config so the caller can refresh its local state in a
+    single round-trip.
 
-    INV-T2 (P-0109): the merge happens once here. Any catalog-only key
-    that the user has not overridden is re-derived from the catalog —
-    so when the catalog evolves between two PUTs, the effective config
-    automatically tracks the new defaults for unchanged keys.
+    PR-4b removes the PR-4a write-back into ``ws.config["tuning"]`` —
+    the legacy nested form is no longer the storage. ``workspace_tune``
+    materializes the effective config into ``job.config["tuning"]`` at
+    job-start time (INV-T6), and ``GET /config`` synthesizes the same
+    block for legacy callers via :func:`get_legacy_config_view`.
+
+    INV-T2 (P-0109): catalog evolution automatically propagates because
+    catalog-only space keys are not stored — they're re-derived from
+    ``adapter.get_tuning_defaults`` on every effective computation.
     """
-    task = str(ws.config.get("task", "")) if isinstance(ws.config, dict) else ""
+    task = _current_task(ws)
+    ws.set_tuning_overrides(overrides)
     effective = ws.backend.compute_effective_tuning(task, overrides)
-    current_tuning = ws.config.get("tuning") if isinstance(ws.config, dict) else None
-    materialized = materialize_overrides_into_legacy_tuning(
-        effective, current_tuning=current_tuning
-    )
-    new_config = copy.deepcopy(ws.config) if isinstance(ws.config, dict) else {}
-    new_config["tuning"] = materialized
-    ws.set_config(new_config)
     return {"tuning_effective": effective.model_dump(mode="json")}
+
+
+def get_legacy_config_view(ws: WorkspaceState) -> dict[str, Any]:
+    """Project ``ws.config`` + ``ws.tuning_overrides`` into the legacy shape.
+
+    PR-4b stores ``tuning_overrides`` as a first-class workspace field;
+    legacy callers (``GET /config`` consumers, YAML download, the
+    pre-PR-5 frontend that still reads ``config.tuning``) keep seeing a
+    materialized ``config["tuning"]`` block synthesised here on demand.
+
+    A workspace with ``tuning_overrides = None`` and no current task
+    falls back to a ``config`` view without a ``tuning`` key — same as
+    the pre-PR-4a behaviour.
+    """
+    if not isinstance(ws.config, dict):
+        return {}
+    if ws.tuning_overrides is None:
+        return dict(ws.config)
+    out = dict(ws.config)
+    effective = ws.backend.compute_effective_tuning(
+        _current_task(ws), ws.tuning_overrides
+    )
+    out["tuning"] = materialize_overrides_into_legacy_tuning(
+        effective, current_tuning=ws.config.get("tuning")
+    )
+    return out
+
+
+def absorb_legacy_tuning(ws: WorkspaceState, config: dict[str, Any]) -> dict[str, Any]:
+    """Extract ``config["tuning"]`` into ``ws.tuning_overrides`` (P-0109 PR-4b).
+
+    Compat shim for legacy PUT /config payloads. The pre-PR-5 frontend
+    still sends the materialized ``tuning`` block alongside the rest of
+    the config; this helper diverts that block into the sparse intent
+    store and returns the config WITHOUT the ``tuning`` key so the
+    storage rename stays consistent. PUT /config flows that omit
+    ``tuning`` leave ``ws.tuning_overrides`` unchanged.
+
+    Returns a fresh dict (input is not mutated).
+    """
+    if not isinstance(config, dict):
+        return {}
+    if "tuning" not in config:
+        return dict(config)
+    tuning = config["tuning"]
+    overrides = extract_overrides_from_legacy_tuning(tuning)
+    # Always store the absorbed overrides — even an empty intent is a
+    # meaningful "user cleared tune state" signal. ``None`` is reserved
+    # for "never touched" (post-reset, fresh workspace).
+    ws.set_tuning_overrides(overrides)
+    stripped = {k: v for k, v in config.items() if k != "tuning"}
+    return stripped
+
+
+def materialize_tuning_for_job(ws: WorkspaceState) -> dict[str, Any]:
+    """Build the per-job config snapshot with the effective ``tuning`` block.
+
+    Implements INV-T6 (P-0109 PR-4b): the job's persisted config must
+    remain stable even as the catalog evolves. The effective Tune
+    config is computed once here — from
+    :attr:`WorkspaceState.tuning_overrides` if the user touched any
+    Tune state, or from an empty :class:`TuningOverrides` (which the
+    adapter resolves to pure catalog defaults) otherwise — and frozen
+    into the returned dict.
+
+    Unlike :func:`get_legacy_config_view`, this helper *always*
+    materializes a ``tuning`` block: every tune job needs concrete
+    Optuna params + direction + space at run time, regardless of
+    whether the user ever opened the Tune tab. The caller hands the
+    result to ``job_store.create_and_claim_active`` so ``job.config``
+    carries the snapshot for the lifetime of the job (and on disk via
+    ``meta.json``).
+    """
+    if not isinstance(ws.config, dict):
+        return {}
+    overrides = _current_overrides(ws)
+    effective = ws.backend.compute_effective_tuning(_current_task(ws), overrides)
+    out = dict(ws.config)
+    out["tuning"] = materialize_overrides_into_legacy_tuning(
+        effective, current_tuning=ws.config.get("tuning")
+    )
+    return out

--- a/src/lizystudio/services/workspace.py
+++ b/src/lizystudio/services/workspace.py
@@ -635,23 +635,49 @@ def get_legacy_config_view(ws: WorkspaceState) -> dict[str, Any]:
     PR-4b stores ``tuning_overrides`` as a first-class workspace field;
     legacy callers (``GET /config`` consumers, YAML download, the
     pre-PR-5 frontend that still reads ``config.tuning``) keep seeing a
-    materialized ``config["tuning"]`` block synthesised here on demand.
+    ``config["tuning"]`` block synthesised here on demand.
 
-    A workspace with ``tuning_overrides = None`` and no current task
-    falls back to a ``config`` view without a ``tuning`` key — same as
-    the pre-PR-4a behaviour.
+    Sparse-emit invariant: the synthesised ``tuning`` block contains
+    ONLY the fields the user explicitly set in
+    ``ws.tuning_overrides`` (tracked via Pydantic ``model_fields_set``).
+    This preserves the pre-PR-4b semantic that ``GET /config`` returns
+    "what was PUT" — the legacy frontend treats absent fields as
+    "user has not touched" and falls back to local UI defaults
+    (e.g. N Trials SegmentedControl default = 50). The fully-materialised
+    effective view (with all catalog defaults filled in) lives at
+    ``GET /config/tuning-snapshot``, which PR-5 frontend consumes.
+
+    INV-T6 (job-time freeze) is unaffected: ``materialize_tuning_for_job``
+    *always* emits the complete effective into ``job.config["tuning"]``
+    so tune jobs run with full optuna params + space regardless of
+    sparseness here.
     """
     if not isinstance(ws.config, dict):
         return {}
-    if ws.tuning_overrides is None:
+    overrides = ws.tuning_overrides
+    if overrides is None:
         return dict(ws.config)
+    fields_set = overrides.model_fields_set
     out = dict(ws.config)
-    effective = ws.backend.compute_effective_tuning(
-        _current_task(ws), ws.tuning_overrides
-    )
-    out["tuning"] = materialize_overrides_into_legacy_tuning(
-        effective, current_tuning=ws.config.get("tuning")
-    )
+    optuna_params: dict[str, Any] = {}
+    if "n_trials" in fields_set:
+        optuna_params["n_trials"] = overrides.n_trials
+    if "timeout" in fields_set:
+        optuna_params["timeout"] = overrides.timeout
+    if "direction" in fields_set:
+        optuna_params["direction"] = overrides.direction
+    optuna: dict[str, Any] = {}
+    if optuna_params:
+        optuna["params"] = optuna_params
+    if overrides.space:
+        optuna["space"] = {k: dict(v) for k, v in overrides.space.items()}
+    tuning: dict[str, Any] = {}
+    if optuna:
+        tuning["optuna"] = optuna
+    if "evaluation_metrics" in fields_set and overrides.evaluation_metrics is not None:
+        tuning["evaluation"] = {"metrics": list(overrides.evaluation_metrics)}
+    if tuning:
+        out["tuning"] = tuning
     return out
 
 

--- a/tests/test_p0109_pr4b_storage_rename.py
+++ b/tests/test_p0109_pr4b_storage_rename.py
@@ -156,9 +156,20 @@ class TestPutConfigAbsorbsLegacyTuning:
 class TestGetConfigSynthesisesLegacyTuning:
     """``GET /config`` returns materialised ``tuning`` for legacy callers."""
 
-    def test_get_after_overrides_set_includes_materialised_tuning(
+    def test_get_after_overrides_set_includes_user_set_tuning(
         self, client: TestClient, tmp_path: Path
     ) -> None:
+        """Sparse-emit: the synthesised ``tuning`` only carries user-set fields.
+
+        Catalog defaults intentionally do NOT bleed into ``GET /config``
+        — they live at ``GET /config/tuning-snapshot`` for callers that
+        want the fully-materialised effective view. The pre-PR-4b
+        legacy frontend reads ``config.tuning.optuna.params.n_trials``
+        and treats missing fields as "untouched", falling back to its
+        local SegmentedControl default. Sparseness preserves that
+        semantic so the legacy frontend keeps working unchanged
+        between PR-4b and PR-5.
+        """
         _load_data_and_binary_config(client, tmp_path)
         r = client.put(
             "/api/workspace/config/tuning-overrides",
@@ -170,8 +181,11 @@ class TestGetConfigSynthesisesLegacyTuning:
         body = cfg.json()
         assert "tuning" in body
         assert body["tuning"]["optuna"]["params"]["n_trials"] == 250
-        # Catalog space defaults fill in the rest.
-        assert "learning_rate" in body["tuning"]["optuna"]["space"]
+        # ``timeout`` / ``direction`` / ``space`` not in ``model_fields_set``
+        # of the PUT body — sparse-emit omits them.
+        assert "timeout" not in body["tuning"]["optuna"]["params"]
+        assert "direction" not in body["tuning"]["optuna"]["params"]
+        assert "space" not in body["tuning"]["optuna"]
 
     def test_get_without_overrides_omits_tuning(
         self, client: TestClient, tmp_path: Path

--- a/tests/test_p0109_pr4b_storage_rename.py
+++ b/tests/test_p0109_pr4b_storage_rename.py
@@ -1,0 +1,340 @@
+"""Tests for P-0109 PR-4b — workspace storage rename + INV-T6 snapshot freeze.
+
+PR-4b makes :attr:`WorkspaceState.tuning_overrides` the sole source of
+Tune intent. The legacy nested ``config["tuning"]`` block is no longer
+persisted in the workspace — it's synthesised on demand by
+:func:`get_legacy_config_view` for backward-compat GET /config callers,
+and materialised once at tune-job start via
+:func:`materialize_tuning_for_job` (INV-T6).
+
+Tests cover:
+
+* The new ``WorkspaceState.tuning_overrides`` field + reset behaviour
+* PUT /config compat: legacy ``tuning`` block diverts into
+  ``ws.tuning_overrides`` and is stripped from ``ws.config``
+* GET /config compat: synthesises ``tuning`` from
+  ``ws.tuning_overrides`` so legacy callers keep seeing the materialised
+  shape
+* INV-T6 snapshot freeze: tune jobs receive a config snapshot whose
+  ``tuning`` block is materialised once at start and is independent of
+  later catalog changes
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from lizystudio.backends.types import TuningOverrides
+from lizystudio.services.workspace import (
+    absorb_legacy_tuning,
+    get_legacy_config_view,
+    materialize_tuning_for_job,
+)
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_csv(tmp_path: Path) -> str:
+    csv_path = tmp_path / "train.csv"
+    with csv_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["id", "age", "target"])
+        for i in range(50):
+            writer.writerow([i, 20 + i, i % 2])
+    return str(csv_path)
+
+
+def _load_default_binary_config(client: TestClient) -> dict[str, Any]:
+    res = client.get("/api/workspace/config/defaults?task=binary&target=target")
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def _load_data_and_binary_config(client: TestClient, tmp_path: Path) -> None:
+    r = client.post("/api/workspace/data/path", json={"path": _create_csv(tmp_path)})
+    assert r.status_code == 200, r.text
+    r = client.put("/api/workspace/config", json=_load_default_binary_config(client))
+    assert r.status_code == 200 and r.json()["saved"] is True, r.text
+
+
+# ---------------------------------------------------------------------------
+# WorkspaceState.tuning_overrides field
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceTuningOverridesField:
+    """The new sparse-intent storage field on :class:`WorkspaceState`."""
+
+    def test_fresh_workspace_has_none(self, client: TestClient) -> None:
+        ws = client.app.state.workspace  # type: ignore[attr-defined]
+        assert ws.tuning_overrides is None
+
+    def test_reset_clears_tuning_overrides(self, client: TestClient) -> None:
+        ws = client.app.state.workspace  # type: ignore[attr-defined]
+        ws.tuning_overrides = TuningOverrides(n_trials=42)
+        ws.reset()
+        assert ws.tuning_overrides is None
+
+    def test_set_tuning_overrides_locks_under_write(self, client: TestClient) -> None:
+        ws = client.app.state.workspace  # type: ignore[attr-defined]
+        ws.set_tuning_overrides(TuningOverrides(n_trials=100))
+        assert ws.tuning_overrides is not None
+        assert ws.tuning_overrides.n_trials == 100
+
+
+# ---------------------------------------------------------------------------
+# PUT /config compat — absorbs legacy tuning into tuning_overrides
+# ---------------------------------------------------------------------------
+
+
+class TestPutConfigAbsorbsLegacyTuning:
+    """``PUT /config`` diverts ``body["tuning"]`` into ``ws.tuning_overrides``."""
+
+    def test_legacy_payload_with_tuning_lands_in_overrides(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        _load_data_and_binary_config(client, tmp_path)
+        config = _load_default_binary_config(client)
+        config["tuning"] = {
+            "optuna": {
+                "params": {
+                    "n_trials": 333,
+                    "timeout": None,
+                    "direction": "maximize",
+                },
+                "space": {
+                    "learning_rate": {
+                        "type": "float",
+                        "low": 0.5,
+                        "high": 1.0,
+                        "log": False,
+                    }
+                },
+            }
+        }
+        r = client.put("/api/workspace/config", json=config)
+        assert r.status_code == 200, r.text
+        ws = client.app.state.workspace  # type: ignore[attr-defined]
+        # The intent landed in tuning_overrides.
+        assert ws.tuning_overrides is not None
+        assert ws.tuning_overrides.n_trials == 333
+        assert "learning_rate" in ws.tuning_overrides.space
+        # And was stripped from ws.config so the storage has a single SSOT.
+        assert "tuning" not in ws.config
+
+    def test_payload_without_tuning_leaves_overrides_unchanged(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        _load_data_and_binary_config(client, tmp_path)
+        ws = client.app.state.workspace  # type: ignore[attr-defined]
+        ws.tuning_overrides = TuningOverrides(n_trials=99)
+        # A pure config update (no tuning block) preserves the intent.
+        config = _load_default_binary_config(client)
+        config.pop("tuning", None)
+        r = client.put("/api/workspace/config", json=config)
+        assert r.status_code == 200, r.text
+        assert ws.tuning_overrides is not None
+        assert ws.tuning_overrides.n_trials == 99
+
+
+# ---------------------------------------------------------------------------
+# GET /config compat — synthesises tuning from tuning_overrides
+# ---------------------------------------------------------------------------
+
+
+class TestGetConfigSynthesisesLegacyTuning:
+    """``GET /config`` returns materialised ``tuning`` for legacy callers."""
+
+    def test_get_after_overrides_set_includes_materialised_tuning(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        _load_data_and_binary_config(client, tmp_path)
+        r = client.put(
+            "/api/workspace/config/tuning-overrides",
+            json={"n_trials": 250},
+        )
+        assert r.status_code == 200, r.text
+        cfg = client.get("/api/workspace/config")
+        assert cfg.status_code == 200, cfg.text
+        body = cfg.json()
+        assert "tuning" in body
+        assert body["tuning"]["optuna"]["params"]["n_trials"] == 250
+        # Catalog space defaults fill in the rest.
+        assert "learning_rate" in body["tuning"]["optuna"]["space"]
+
+    def test_get_without_overrides_omits_tuning(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        """Pre-PR-5 behaviour: no tune state → no tuning key in GET /config."""
+        _load_data_and_binary_config(client, tmp_path)
+        ws = client.app.state.workspace  # type: ignore[attr-defined]
+        ws.tuning_overrides = None
+        cfg = client.get("/api/workspace/config")
+        assert cfg.status_code == 200, cfg.text
+        assert "tuning" not in cfg.json()
+
+
+# ---------------------------------------------------------------------------
+# INV-T6 — tune-job snapshot freeze
+# ---------------------------------------------------------------------------
+
+
+class TestInvT6JobSnapshotFreeze:
+    """``materialize_tuning_for_job`` produces a frozen effective at start."""
+
+    def test_workspace_with_no_overrides_yields_catalog_defaults_in_job_config(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        _load_data_and_binary_config(client, tmp_path)
+        ws = client.app.state.workspace  # type: ignore[attr-defined]
+        ws.tuning_overrides = None
+
+        captured: dict[str, Any] = {}
+
+        def fake_start(**kwargs: object) -> str:
+            captured["job_config"] = kwargs["config"]
+            return "job_inv_t6_a"
+
+        with patch("lizystudio.api.workspace.start_tune_async", side_effect=fake_start):
+            r = client.post("/api/workspace/tune")
+        assert r.status_code == 200, r.text
+
+        snapshot = captured["job_config"]
+        assert snapshot["tuning"]["optuna"]["params"]["n_trials"] == 50
+        assert snapshot["tuning"]["optuna"]["params"]["direction"] == "maximize"
+        # Catalog space appears in the job snapshot.
+        assert "learning_rate" in snapshot["tuning"]["optuna"]["space"]
+
+    def test_workspace_with_overrides_yields_merged_effective_in_job_config(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        _load_data_and_binary_config(client, tmp_path)
+        # Set a sparse override via the dedicated endpoint.
+        r = client.put(
+            "/api/workspace/config/tuning-overrides",
+            json={"n_trials": 200},
+        )
+        assert r.status_code == 200, r.text
+
+        captured: dict[str, Any] = {}
+
+        def fake_start(**kwargs: object) -> str:
+            captured["job_config"] = kwargs["config"]
+            return "job_inv_t6_b"
+
+        with patch("lizystudio.api.workspace.start_tune_async", side_effect=fake_start):
+            r = client.post("/api/workspace/tune")
+        assert r.status_code == 200, r.text
+
+        snapshot = captured["job_config"]
+        # User intent survives.
+        assert snapshot["tuning"]["optuna"]["params"]["n_trials"] == 200
+        # Catalog direction (auc → maximize) fills the unset field.
+        assert snapshot["tuning"]["optuna"]["params"]["direction"] == "maximize"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — service helpers behave correctly when called directly
+# ---------------------------------------------------------------------------
+
+
+class TestAbsorbLegacyTuning:
+    def test_extracts_and_strips_tuning(self) -> None:
+        from lizystudio.backends.lizyml import LizyMLAdapter
+        from lizystudio.services.workspace import WorkspaceState
+
+        ws = WorkspaceState(backend=LizyMLAdapter())
+        config = {
+            "task": "binary",
+            "tuning": {"optuna": {"params": {"n_trials": 77}, "space": {}}},
+        }
+        out = absorb_legacy_tuning(ws, config)
+        assert out == {"task": "binary"}
+        assert ws.tuning_overrides is not None
+        assert ws.tuning_overrides.n_trials == 77
+
+    def test_no_tuning_in_payload_leaves_state_unchanged(self) -> None:
+        from lizystudio.backends.lizyml import LizyMLAdapter
+        from lizystudio.services.workspace import WorkspaceState
+
+        ws = WorkspaceState(backend=LizyMLAdapter())
+        ws.tuning_overrides = TuningOverrides(n_trials=99)
+        out = absorb_legacy_tuning(ws, {"task": "binary"})
+        assert out == {"task": "binary"}
+        # Overrides survive a tuning-less PUT.
+        assert ws.tuning_overrides is not None
+        assert ws.tuning_overrides.n_trials == 99
+
+    def test_does_not_mutate_input(self) -> None:
+        from lizystudio.backends.lizyml import LizyMLAdapter
+        from lizystudio.services.workspace import WorkspaceState
+
+        ws = WorkspaceState(backend=LizyMLAdapter())
+        original = {
+            "task": "binary",
+            "tuning": {"optuna": {"params": {"n_trials": 50}, "space": {}}},
+        }
+        snap = dict(original)
+        absorb_legacy_tuning(ws, original)
+        # Caller's dict survives unchanged — fresh copy returned.
+        assert original == snap
+
+
+class TestGetLegacyConfigView:
+    def test_no_overrides_returns_config_as_is(self) -> None:
+        from lizystudio.backends.lizyml import LizyMLAdapter
+        from lizystudio.services.workspace import WorkspaceState
+
+        ws = WorkspaceState(backend=LizyMLAdapter())
+        ws.config = {"task": "binary"}
+        out = get_legacy_config_view(ws)
+        assert out == {"task": "binary"}
+
+    def test_overrides_synthesise_materialised_tuning_block(self) -> None:
+        from lizystudio.backends.lizyml import LizyMLAdapter
+        from lizystudio.services.workspace import WorkspaceState
+
+        ws = WorkspaceState(backend=LizyMLAdapter())
+        ws.config = {"task": "binary"}
+        ws.tuning_overrides = TuningOverrides(n_trials=42)
+        out = get_legacy_config_view(ws)
+        assert out["tuning"]["optuna"]["params"]["n_trials"] == 42
+
+
+class TestMaterializeTuningForJob:
+    def test_always_emits_tuning_block(self) -> None:
+        """INV-T6 stronger than ``get_legacy_config_view``: always materialise."""
+        from lizystudio.backends.lizyml import LizyMLAdapter
+        from lizystudio.services.workspace import WorkspaceState
+
+        ws = WorkspaceState(backend=LizyMLAdapter())
+        ws.config = {"task": "binary"}
+        ws.tuning_overrides = None  # no user intent
+        out = materialize_tuning_for_job(ws)
+        # Pure catalog defaults materialised — INV-T6 demands a tuning
+        # block at job start regardless of the workspace's intent state.
+        assert "tuning" in out
+        assert out["tuning"]["optuna"]["params"]["n_trials"] == 50
+        assert out["tuning"]["optuna"]["params"]["direction"] == "maximize"
+
+    def test_overrides_win_per_field(self) -> None:
+        from lizystudio.backends.lizyml import LizyMLAdapter
+        from lizystudio.services.workspace import WorkspaceState
+
+        ws = WorkspaceState(backend=LizyMLAdapter())
+        ws.config = {"task": "binary"}
+        ws.tuning_overrides = TuningOverrides(n_trials=11, direction="minimize")
+        out = materialize_tuning_for_job(ws)
+        assert out["tuning"]["optuna"]["params"]["n_trials"] == 11
+        assert out["tuning"]["optuna"]["params"]["direction"] == "minimize"

--- a/tests/test_workspace_api.py
+++ b/tests/test_workspace_api.py
@@ -345,50 +345,62 @@ def test_tune_injects_default_tuning_config_when_missing(
     client: TestClient,
     tmp_path: Path,
 ) -> None:
-    """POST /tune must inject a default tuning section when config has none (H-0025)."""
+    """POST /tune materializes a tuning block at job start (P-0109 PR-4b / INV-T6).
+
+    Pre-PR-4b this injected ``tuning`` into ``ws.config``; PR-4b moved
+    the materialization to ``materialize_tuning_for_job`` so the job
+    config snapshot — not the workspace — carries the canonical
+    optuna params + space. The workspace itself keeps Tune state in
+    ``ws.tuning_overrides`` (sparse).
+    """
     _load_data_and_config(client, tmp_path)
 
-    # Ensure the stored config has no tuning key
     app = client.app  # type: ignore[attr-defined]
     ws = app.state.workspace
+    # PR-4b: ws.config never holds tuning; the workspace defaults to
+    # ``tuning_overrides=None`` (catalog defaults will materialize at start).
     ws.config.pop("tuning", None)
+    ws.tuning_overrides = None
 
-    with patch(
-        "lizystudio.api.workspace.start_tune_async", return_value="job_tune999"
-    ) as _mock_start:
+    captured: dict[str, Any] = {}
+
+    def fake_start(**kwargs: object) -> str:
+        captured["job_config"] = kwargs["config"]
+        return "job_tune999"
+
+    with patch("lizystudio.api.workspace.start_tune_async", side_effect=fake_start):
         res = client.post("/api/workspace/tune")
 
     assert res.status_code == 200
     body = res.json()
     assert body["job_id"] == "job_tune999"
 
-    # The tuning section must now be in workspace config
-    assert ws.config.get("tuning") is not None
-    tuning = ws.config["tuning"]
-    assert "optuna" in tuning
-    assert tuning["optuna"]["params"]["n_trials"] == 50
+    job_config = captured["job_config"]
+    assert "tuning" in job_config
+    assert "optuna" in job_config["tuning"]
+    assert job_config["tuning"]["optuna"]["params"]["n_trials"] == 50
 
 
 def test_tune_default_tuning_uses_auc_maximize_for_binary(
     client: TestClient,
     tmp_path: Path,
 ) -> None:
-    """Bug 2026-04-14: hardcoded ``direction: minimize`` in the inject path
-    caused AUC to be optimized as if low-is-better. The injected default
-    tuning config must end up with ``direction: maximize`` for the
-    ``binary`` + default-AUC combination after ``_prepare_tune_config``
-    runs, otherwise Optuna walks the wrong way and ``best_params`` is
-    meaningless.
+    """Bug 2026-04-14 / P-0109 PR-4b: default binary tune must run as maximize.
 
-    This is an integration test: it goes through the whole
-    ``POST /workspace/tune`` path so a future regression in either the
-    inject step OR the auto-resolve step in ``_prepare_tune_config``
-    is caught up front.
+    Hardcoded ``direction: minimize`` in the legacy inject path used to
+    flip AUC's optimization direction (low-is-better). PR-4b moves the
+    direction resolution to ``adapter.compute_effective_tuning`` inside
+    ``materialize_tuning_for_job`` — the adapter sources direction from
+    its metric registry (INV-T3). This integration test exercises the
+    whole ``POST /workspace/tune`` path so a future regression in
+    either the materialization step OR ``_prepare_tune_config``'s
+    auto-resolve is caught up front.
     """
     _load_data_and_config(client, tmp_path)
     app = client.app  # type: ignore[attr-defined]
     ws = app.state.workspace
     ws.config.pop("tuning", None)
+    ws.tuning_overrides = None
 
     captured: dict[str, dict] = {}
 
@@ -409,8 +421,8 @@ def test_tune_default_tuning_uses_auc_maximize_for_binary(
     direction = prepared["tuning"]["optuna"]["params"].get("direction")
     assert direction == "maximize", (
         f"Default binary + AUC tune must run as maximize, got {direction!r}. "
-        "Likely cause: workspace_tune injected a hardcoded direction "
-        "('minimize') and _prepare_tune_config refused to override it."
+        "Likely cause: materialize_tuning_for_job emitted the wrong direction, "
+        "or _prepare_tune_config silently flipped it."
     )
 
 
@@ -418,21 +430,36 @@ def test_tune_preserves_existing_tuning_config(
     client: TestClient,
     tmp_path: Path,
 ) -> None:
-    """POST /tune must NOT overwrite a tuning section that already exists."""
+    """POST /tune must honour user-set tuning intent (P-0109 PR-4b).
+
+    Pre-PR-4b this asserted ``ws.config["tuning"]`` survived the call.
+    PR-4b moves intent to ``ws.tuning_overrides`` (sparse), so the
+    invariant is now: a user-set ``n_trials=10`` survives the job-start
+    materialization. The materialized ``job.config["tuning"]`` carries
+    that ``n_trials`` while catalog defaults fill in the rest.
+    """
+    from lizystudio.backends.types import TuningOverrides
+
     _load_data_and_config(client, tmp_path)
 
     app = client.app  # type: ignore[attr-defined]
     ws = app.state.workspace
-    custom_tuning = {"optuna": {"params": {"n_trials": 10}}}
-    ws.config["tuning"] = custom_tuning
+    ws.tuning_overrides = TuningOverrides(n_trials=10)
 
-    with patch(
-        "lizystudio.api.workspace.start_tune_async", return_value="job_tune_custom"
-    ):
+    captured: dict[str, Any] = {}
+
+    def fake_start(**kwargs: object) -> str:
+        captured["job_config"] = kwargs["config"]
+        return "job_tune_custom"
+
+    with patch("lizystudio.api.workspace.start_tune_async", side_effect=fake_start):
         res = client.post("/api/workspace/tune")
 
     assert res.status_code == 200
-    assert ws.config["tuning"] == custom_tuning
+    assert captured["job_config"]["tuning"]["optuna"]["params"]["n_trials"] == 10
+    # The workspace state itself keeps the sparse intent unchanged.
+    assert ws.tuning_overrides is not None
+    assert ws.tuning_overrides.n_trials == 10
 
 
 def test_tune_starts_job_when_data_and_config_present(


### PR DESCRIPTION
## Summary

PR-4b completes the **storage rename** half of the original P-0109 PR-4 plan and pins **INV-T6** (per-job snapshot freeze). Builds on:

- [#517](https://github.com/nbx-liz/LizyStudio/pull/517) PR-2 — Tuning types + Protocol
- [#518](https://github.com/nbx-liz/LizyStudio/pull/518) PR-3 — LizyMLAdapter catalog-aware impl
- [#519](https://github.com/nbx-liz/LizyStudio/pull/519) PR-4a — additive `GET /config/tuning-snapshot` + `PUT /config/tuning-overrides`

## What changed

### Storage

* `WorkspaceState.tuning_overrides: TuningOverrides | None` is now the **sole source of Tune intent**. `ws.config` no longer carries the materialised `tuning` block.
* `WorkspaceState.set_tuning_overrides()` — locked write under the existing workspace mutex.
* `WorkspaceState.reset()` clears `tuning_overrides` alongside other session state.

### Compat shims (until PR-5 frontend ships)

* `absorb_legacy_tuning(ws, body)` — extracts `body["tuning"]` into `ws.tuning_overrides` and returns a stripped config. Called from `PUT /config`, `POST /fit?config=...`, and `POST /tune?config=...` so every config-set entry point routes through the same SSOT.
* `get_legacy_config_view(ws)` — synthesises `config["tuning"]` from `ws.tuning_overrides` for `GET /config` so the pre-PR-5 frontend (and YAML download / CLI consumers) still see the materialised shape.

### INV-T6 — per-job snapshot freeze

* `materialize_tuning_for_job(ws)` — *always* emits a `tuning` block (using `adapter.compute_effective_tuning(task, overrides_or_empty)`) so every tune job starts with a concrete optuna params + space + direction in `job.config["tuning"]`.
* `workspace_tune` calls this once at job start. The catalog can evolve afterwards; the running job's persisted config remains stable.
* `get_tuning_snapshot` / `update_tuning_overrides` (PR-4a) now read/write `ws.tuning_overrides` directly — no more materialise-and-write-back round-trip.

## Out of scope for PR-4b (deferred to PR-6 reconciliation)

- [ ] INV-T3 assertion in `_prepare_tune_config`
- [ ] Removal of the hardcoded `maximize_metrics = {"auc","auc_pr","r2","accuracy","f1","auc_mu"}` set in `services/training.py`

PR-3's deferral note (INV-ADAPTER-1) still applies. Closing this requires either:

- A `BackendCore` Protocol semantic change so `compute_effective_tuning` derives direction from the *effective* first metric instead of the catalog's canonical first metric, **or**
- Threading an adapter handle through `_prepare_tune_config` and updating the ~20 test call sites.

Both are real refactors with their own review cost, so they cleanly slot into PR-6 (final reconciliation + BLUEPRINT docs + Decision flip).

### Why no `STUDIO_FORMAT_VERSION` bump

The original chain spec called for a v2 → v3 bump. PR-4b's analysis shows **no on-disk artefact shape change**:

- `WorkspaceState` is in-memory only — never persisted directly.
- `job.config["tuning"]` (the only on-disk artefact that carries Tune state, via `meta.json`) still uses the same materialised nested shape because `materialize_tuning_for_job` produces it at job start.

The format-version-matrix CI gate (`tests/regression/test_format_version_migration_matrix.py`) stays green at v2; no migration entry needed.

## Invariants

- **INV-T1** — overrides are task-agnostic and explicit-None is preserved as user intent (PR-2/PR-4a contract tests cover this).
- **INV-T2** — catalog evolution propagates: catalog-only space keys are re-derived on every effective computation; the workspace never holds a stale materialised copy.
- **INV-T5** — adapter is the SSOT for its own defaults (PR-3).
- **INV-T6** — job-time snapshot freeze. New in PR-4b. The job's persisted config remains stable even as the catalog evolves between job submission and a future re-load.

## Failure paths covered

- [x] Fresh workspace (no overrides) → tune job receives catalog-default materialised tuning
- [x] Workspace with sparse override → effective merges user intent with catalog
- [x] Legacy PUT /config carrying `tuning` → diverted into `tuning_overrides`, stripped from `ws.config`
- [x] PUT /config without `tuning` → `ws.tuning_overrides` unchanged
- [x] Reset clears `tuning_overrides`
- [x] No-mutation invariant: `absorb_legacy_tuning` returns a fresh dict

## Test plan

- [x] `tests/test_p0109_pr4b_storage_rename.py` — 16 new tests
- [x] `tests/test_workspace_api.py` — 3 pre-existing tests updated for PR-4b semantics
- [x] PR-4a's 21 tests + PR-3's 18 adapter tests + PR-2's 26 contract tests stay green
- [x] Full pytest suite: 1656 passed, 10 skipped
- [x] mypy clean (`uv run mypy --no-incremental src/lizystudio/`)
- [x] ruff check + format clean, Biome check clean
- [x] `frontend/src/api/generated/schema.d.ts` regenerated (docstring update on `GET /config`)

## Files changed

| File | Change |
|---|---|
| `src/lizystudio/services/workspace.py` | +`WorkspaceState.tuning_overrides`, +`set_tuning_overrides`, +4 helpers (`absorb_legacy_tuning`, `get_legacy_config_view`, `materialize_tuning_for_job`, `_current_overrides`/`_current_task`); rewrote `get_tuning_snapshot` + `update_tuning_overrides` |
| `src/lizystudio/api/workspace.py` | GET /config uses `get_legacy_config_view`; PUT /config + POST /fit + POST /tune route through `absorb_legacy_tuning`; POST /tune passes `materialize_tuning_for_job(ws)` to the runner (INV-T6) |
| `tests/test_p0109_pr4b_storage_rename.py` | +16 tests (new file) |
| `tests/test_workspace_api.py` | 3 tests updated to PR-4b semantics |
| `frontend/src/api/generated/schema.d.ts` | regenerated |

## Next in chain

- **PR-5** — Frontend three-useEffect physical deletion + effective/overrides two-layer prop refactor → consumes PR-4a's snapshot endpoint and PR-4b's first-class overrides storage. **The PR that actually fixes the user-visible bug.**
- **PR-6** — BLUEPRINT §3.3.2/§6/§7 reconcile + docs/format-version-matrix.md + `_prepare_tune_config` final cleanup (INV-T3 assertion + hardcoded `maximize_metrics` removal) + Decision flip to "Approved & shipped".

Refs: #517 (PR-2), #518 (PR-3), #519 (PR-4a), P-0109 (HISTORY).