### PR TITLE
docs(p0109): reconcile spec docs to intent/effective split + Decision flip (PR-6a)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -186,6 +186,15 @@ class BackendCore(Protocol):
     ) -> list[IncompatibleMetric]: ...
         # task/target 前提条件に反する設定済みメトリクスの advisory（watchlist と suggested_fix prose は backend 所有）。
         # デフォルトは [] — 実装しない backend は不適合メトリクスを宣言しない。Service が severity="warning" に包む。
+    def get_tuning_defaults(self, task: str) -> TuningDefaults: ...                  # P-0109
+        # backend 自身の catalog (lizyml: search_space_catalog / metric_direction / TASK_DEFAULT_METRICS) から
+        # Tune タブの canonical defaults を生成。frontend には adapter-specific 分岐を持たせない (INV-T5)
+    def compute_effective_tuning(                                                    # P-0109
+        self, task: str, overrides: TuningOverrides
+    ) -> TuningConfig: ...
+        # (task, overrides) → effective TuningConfig の純関数 merge。GET /workspace/config 応答組み立てと
+        # POST /workspace/tune 起動時の effective snapshot 凍結 (INV-T6) で呼ばれる。
+        # direction は本メソッドが SSOT (INV-T3) — services 層に hardcoded maximize-metric set を置かない
     def get_default_config(self, task: str, target: str) -> dict[str, Any]: ...  # H-0025
     def load_config_from_file(self, content: bytes, filename: str) -> dict[str, Any]: ...
 
@@ -312,6 +321,7 @@ class BackendAdapter(
 |------|-----|--------------|
 | `backend` | `BackendAdapter` | サーバー起動時に決定 |
 | `workspace_config` | `dict \| None` | Config設定時に生成 |
+| `tuning_overrides` | `TuningOverrides \| None` | Tune タブの SSOT (P-0109)。sparse user intent のみ保持。`None` = 未触手 / 空 `TuningOverrides()` = catalog defaults へ明示 clear。effective state は `adapter.compute_effective_tuning(task, overrides)` で都度 compute |
 | `workspace_data` | `DataRef \| None` | データ指定時に生成 |
 | `workspace_result` | `Job \| None` | 現セッション中の直近fit結果のみ |
 | `active_job_id` | `str \| None` | 実行中ジョブのスロット。`JobStore.active_job_id` が単一所有者として保持（P-0089 / Issue #279） |
@@ -877,6 +887,12 @@ Data Panel で Task が変更されたとき、`evaluation.metrics` をそのタ
 ハイパーパラメータの探索空間を定義し、最適なパラメータを自動探索するワークフロー。全操作がマウスで完結するよう設計する。
 
 Fit タブと Tune タブは**同一の Config オブジェクト**の異なるセクションを編集する。Tune タブは `tuning` セクションを担当し、`model` / `training` は Fit タブの値を共有する。
+
+**intent / effective 分離（P-0109、2026-05-15 着地）:** Tune タブの SSOT は backend adapter が持つ catalog（lizyml の `search_space_catalog` / `metric_direction` / `TASK_DEFAULT_METRICS`）。workspace に persist されるのは `ws.tuning_overrides: TuningOverrides | None` — ユーザーが明示的に設定したフィールドのみ含む sparse な intent。**effective state**（catalog defaults + overrides を merge した完全な `TuningConfig`）は `adapter.compute_effective_tuning(task, overrides)` で都度 compute され、永続化しない。これにより (a) Tune タブ初回マウントで catalog defaults が UI に必ず反映される、(b) catalog 進化が既存 workspace に自動伝播する、(c) tune job 起動時に effective を `job.config.tuning` に snapshot 凍結することで catalog の将来変更によって過去 job の再現性が破れない（INV-T6）、という 3 つの性質が構造的に成立する。frontend には adapter-specific 分岐を一切持たせない（INV-T5）。API surface:
+
+- `GET /api/workspace/config/tuning-snapshot` → `{tuning_effective: dict, tuning_defaults: dict}`（PR-4a #519）
+- `PUT /api/workspace/config/tuning-overrides` body は sparse `TuningOverrides`、`ws.tuning_overrides` を outright replace、新 effective を echo（PR-4a #519）
+- 既存 `GET/PUT /api/workspace/config` は legacy compat shim 経由でそのまま動作（PR-4b #520）— on-disk persist シェイプは v2 のまま、`STUDIO_FORMAT_VERSION` は 2 据え置き
 
 ```
 ┌──────────────────────────────────┐
@@ -2403,12 +2419,14 @@ Workspace の揮発状態を管理する。
 |---------|------|------|
 | GET | `/api/workspace/config/schema` | Config の JSON Schema を返す |
 | GET | `/api/workspace/config/defaults` | 完全なデフォルト Config を返す（query: `task`, `target`）(H-0025) |
-| GET | `/api/workspace/config` | 現在の Config を返す |
-| PUT | `/api/workspace/config` | Config を更新（バリデーション付き） |
+| GET | `/api/workspace/config` | 現在の Config を返す（legacy compat — `tuning` block は `ws.tuning_overrides` から sparse 投影） |
+| PUT | `/api/workspace/config` | Config を更新（バリデーション付き）。body 内の `tuning` block は `absorb_legacy_tuning` 経由で `ws.tuning_overrides` に吸収される (P-0109 PR-4b 互換 shim) |
 | PATCH | `/api/workspace/config` | Config を部分更新（指定キーのみマージ）（H-0037） |
 | POST | `/api/workspace/config/validate` | Config dict をバリデーションのみ行う |
 | POST | `/api/workspace/config/upload` | YAML/JSON ファイルから読み込み |
 | GET | `/api/workspace/config/download` | 現在の Config を YAML でダウンロード |
+| GET | `/api/workspace/config/tuning-snapshot` | Tune タブ用の effective + defaults 同梱応答 `{tuning_effective, tuning_defaults}`（P-0109 PR-4a / SSOT 読み path） |
+| PUT | `/api/workspace/config/tuning-overrides` | sparse `TuningOverrides` を `ws.tuning_overrides` に outright replace。新 effective を echo（P-0109 PR-4a / SSOT 書き path） |
 
 #### Data
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4201,12 +4201,18 @@ T=4116ms  re-render: searchSpaceKeys=0 (space lost in coalesce)
 #### Decision
 
 - 2026-05-14 **Approved (Option B)** — Q1〜Q4 解決済。PR-2 以降の実装に着手可。単一 PR ではなく **複数 PR 連鎖** で進める。理由: Protocol 拡張 + Pydantic schema rename + storage migration (`format_version` bump) + adapter 実装 + service 層 + API 拡張 + frontend refactor + e2e 確認の各レイヤで blast radius が大きく、レビュー単位を分けたほうが review quality が保てる。
-  - **PR-1**: Proposal-only (本 PR、`[docs-only]`)
-  - **PR-2**: 共通型 `TuningDefaults` / `TuningOverrides` / `TuningConfig` (Pydantic models) + `BackendCore.get_tuning_defaults` / `compute_effective_tuning` Protocol 追加（safe default）
-  - **PR-3**: `LizyMLAdapter.get_tuning_defaults` + `compute_effective_tuning` 実装 + 重複 `maximize_metrics` hardcoded set 削除 + INV-T3 assertion 追加 + unit tests
-  - **PR-4**: `WorkspaceConfig.tuning` → `tuning_overrides` rename + `STUDIO_FORMAT_VERSION` 2 → 3 bump + `storage/migrations.py::MIGRATIONS[2]` 実装 + `service.set_config` リファクタ + GET/PUT API response 拡張 + `_prepare_tune_config` から direction force-resolve 削除 + tune job 起動時の effective snapshot + integration tests + format-version-matrix CI gate 更新
-  - **PR-5**: frontend の 3 useEffect 削除 + `effective` / `overrides` 二層 prop に refactor + "modified" badge UI + 既存 frontend test の整理 + 新規 e2e `workspace-tune-init.spec.ts`
-  - **PR-6**: BLUEPRINT.md §3.3.2 / §6 / §7 reconcile + docs/format-version-matrix.md / architecture-as-implemented.md 更新 + Decision を **"Approved & shipped"** に更新
+- 2026-05-15 **Approved & shipped (Option B, partially)** — PR-1〜PR-5 を develop に着地。**Tune タブ初回マウントで Fixed 行が表示されるバグはここで構造的に解消**（PR-5 #521）。当初計画から外したのは以下:
+  - `STUDIO_FORMAT_VERSION` 2 → 3 bump および `MIGRATIONS[2]` は **未実施**。`ws.tuning_overrides` は in-memory storage の一級フィールド化に留め、on-disk persistence（`WorkspaceConfig.tuning` block）は v2 schema のまま据え置き。`absorb_legacy_tuning` / `get_legacy_config_view` の双方向シムが v2 シェイプを保持しているため、ユーザーが既存 workspace を読み込んでも `LegacyFormatProtectionError` は出ない。INV-T7 は migration 不在で trivially 成立。format-version-matrix への追記は行わない（on-disk シェイプに変更がないため）
+  - **PR-6 を 3 サブ PR に分割**して継続 (`PR-6a` docs reconcile + `TASK_DEFAULT_METRICS` 削除 / `PR-6b` INV-T3 assertion + `_prepare_tune_config` hardcoded `maximize_metrics` set 削除 / `PR-6c` Tune タブを `GET /config/tuning-snapshot` 読みに切替 + accurate "modified" badge)
+  - **PR-1**: Proposal-only (本 PR、`[docs-only]`) — ✅ shipped (#516)
+  - **PR-2**: 共通型 `TuningDefaults` / `TuningOverrides` / `TuningConfig` (Pydantic models) + `BackendCore.get_tuning_defaults` / `compute_effective_tuning` Protocol 追加（safe default）— ✅ shipped (#517)
+  - **PR-3**: `LizyMLAdapter.get_tuning_defaults` + `compute_effective_tuning` 実装 + unit tests — ✅ shipped (#518)。重複 `maximize_metrics` hardcoded set 削除 + INV-T3 assertion 追加は **PR-6b に再スコープ**（INV-ADAPTER-1 により `services/` から `backends.lizyml_*` 直 import 不可、Protocol 経由の semantic refinement が必要なため）
+  - **PR-4a**: 新規 `GET /config/tuning-snapshot` / `PUT /config/tuning-overrides` エンドポイント追加（既存 `GET/PUT /config` は legacy compat shim 経由でそのまま動く、additive） — ✅ shipped (#519)
+  - **PR-4b**: `WorkspaceState.tuning_overrides` first-class storage 化 + `absorb_legacy_tuning` / `get_legacy_config_view` 双方向 shim + tune job 起動時の effective snapshot 凍結 (INV-T6) + integration tests — ✅ shipped (#520)。`format_version` bump および `storage/migrations.py::MIGRATIONS[2]` は未実施（on-disk シェイプは v2 のまま）
+  - **PR-5**: frontend の 3 useEffect 物理削除 + render-time fallbacks + 新規 e2e `workspace-tune-firstmount.spec.ts` — ✅ shipped (#521)
+  - **PR-6a**: HISTORY.md / docs/ROADMAP.md / BLUEPRINT.md / docs/architecture-as-implemented.md 更新 + `TASK_DEFAULT_METRICS` frontend 定数削除 (bundle code touch)
+  - **PR-6b**: `services/training.py::_prepare_tune_config` の hardcoded `maximize_metrics` set 削除 + INV-T3 assertion 追加 (Protocol semantic refinement、approach (a))
+  - **PR-6c**: TuneTab / TuneEvaluationSection / SearchSpaceTable を `GET /config/tuning-snapshot` 読みに refactor + `PUT /config/tuning-overrides` sparse mutation 経路 + accurate "modified" badge (`tuning_effective.user_set_paths` 参照) + 既存 PR-5 e2e spec の整合性確認
 
 - Open questions resolved (2026-05-14):
   - **Q1 (RESOLVED)**: `_prepare_tune_config` の direction 強制再解決 → **削除 + INV-T3 assertion 化**。silent な corrected write は drift を隠す（重複 hardcoded `maximize_metrics` set と `metric_direction` の registry が drift する未来を防ぐためにも）。INV-T3 違反は `assert effective.direction == expected, ...` で fail-fast し、raw YAML import / curl 直叩きで invariant 違反が来た場合にテストや CI で surface する。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -160,7 +160,7 @@
 - **P-0104**: Tune workflow 全面整備（Re-tune UX + canonical defaults + validation guardrails + LizyML v0.15 SSOT 連動）— Decision 確定、ほぼ着地（残: #474 deferred parse_space validation）
 - **P-0105**: Residuals plot に kind selector（#457）— 着地済
 - **P-0106**: metric 不適合判定を `BackendCore` capability の裏へ（Change Gate、#403）— 着地済（`BackendCore.get_incompatible_metrics`）。完全な 2nd-backend 移行は §3.3 後
-- **P-0109**: Tune 派生デフォルトの backend SSOT 化 + intent/effective 分離（Change Gate, `format_version` 2 → 3）— 起票 2026-05-14、**Proposed (Option B, awaiting alignment)**。Tune タブ初回マウントで catalog defaults が Fixed 表示になるバグの根本治療。「persist するのは user intent (`tuning_overrides`) のみ。effective は backend が compute、job 起動時に snapshot 凍結」という構造変更により、Q2 (nullability overload) と Q4 (merge ambiguity) を構造的解消、catalog 進化が既存 workspace に自動伝播。`BackendCore.get_tuning_defaults` + `compute_effective_tuning` を Protocol に追加、`WorkspaceConfig.tuning` を `tuning_overrides` に rename、`STUDIO_FORMAT_VERSION` 2 → 3 bump + migration、frontend 3 useEffect 物理削除。複数 PR (PR-1 Proposal-only / PR-2 Protocol+共通型 / PR-3 LizyML 実装 / PR-4 schema rename + migration + service + API / PR-5 frontend refactor / PR-6 BLUEPRINT reconcile)
+- **P-0109**: Tune 派生デフォルトの backend SSOT 化 + intent/effective 分離（Change Gate）— Approved & shipped (Option B, 2026-05-15)。Tune タブ初回マウントで catalog defaults が Fixed 表示になるバグ（[2026-05-14 確認](HISTORY.md)）の根本治療が **PR-5 (#521) で構造的に解消**。`BackendCore.get_tuning_defaults` + `compute_effective_tuning` を Protocol に追加 (#517)、`LizyMLAdapter` 実装 (#518)、追加エンドポイント `GET /config/tuning-snapshot` / `PUT /config/tuning-overrides` (#519)、`WorkspaceState.tuning_overrides` 一級フィールド化 + INV-T6 snapshot 凍結 (#520)、frontend 3 useEffect 物理削除 + render-time fallbacks (#521)。当初計画から外したもの: (a) `STUDIO_FORMAT_VERSION` 2 → 3 bump は **未実施**（on-disk `WorkspaceConfig.tuning` block は v2 シェイプのまま、`absorb_legacy_tuning` / `get_legacy_config_view` 双方向 shim で吸収）、(b) `_prepare_tune_config` の hardcoded `maximize_metrics` set 削除 + INV-T3 assertion 追加は **PR-6b へ再スコープ**（INV-ADAPTER-1 制約）、(c) Tune タブを `GET /config/tuning-snapshot` 読みに切替 + accurate "modified" badge は **PR-6c へ再スコープ**
 
 ### 3.0 P-0094 (済)：pytest-benchmark performance baseline（Issue #27 (a)）
 
@@ -300,7 +300,10 @@ Wave 6 完了後の Open Issue は **4 件**（#451 / #453 は 2026-05-13 close 
 
 ### Tier 1：直近の着手候補（ROI 順）
 
-1. **P-0109 implementation chain** — Tune 派生デフォルトの backend SSOT 化 + intent/effective 分離（Change Gate, `format_version` bump）。Proposal (PR-1) Decision 確定後に PR-2〜PR-6 を順次着手。Tune タブ初回マウントで catalog defaults が反映されないバグ ([2026-05-14 確認](HISTORY.md)) の根本治療。intent/effective 分離により catalog 進化の自動伝播 + job 再現性強化も同時達成
+1. **P-0109 PR-6 残作業（3 サブ PR）** — PR-1〜PR-5 で **Tune タブ初回マウントのバグは構造的に解消済** (#516〜#521、2026-05-15 着地)。残るのは reconciliation のみ:
+   - PR-6a: docs reconcile (HISTORY / ROADMAP / BLUEPRINT / architecture-as-implemented) + `TASK_DEFAULT_METRICS` frontend 定数削除
+   - PR-6b: `services/training.py::_prepare_tune_config` の hardcoded `maximize_metrics` set 削除 + INV-T3 assertion 追加 (Protocol semantic refinement)
+   - PR-6c: Tune タブを `GET /config/tuning-snapshot` 読みに切替 + accurate "modified" badge (`tuning_effective.user_set_paths` 参照)
 2. **#513** — `studio_error_handler` に WARNING log を 1 行追加（5 行・観測性インパクト大、R-3.1 precursor）。v0.6.0 検証中に発見した 4xx StudioError が server log に痕跡を残さない問題のクイック対応
 3. **#495** — #456 L5: weekly stale-doc audit cron（`scripts/audit_stale_docs.py` + `.github/workflows/audit-stale-docs.yml` cron weekly、tracking issue 自動更新。tier-3/low、deferred）
 4. **#452-b `lifecycle_mixin.tune` 分割** — 🔒 2nd-adapter 議論（§3.3）後に解禁。それまで着手しない
@@ -339,7 +342,7 @@ Wave 6 完了後の Open Issue は **4 件**（#451 / #453 は 2026-05-13 close 
 
 ## 8. 運用メモ
 
-- 新規 Proposal を起票するときは **P-0110 から採番**（P-0107 = `PICKLE_INCOMPATIBLE` structured envelope / v3-26、P-0108 = search-space run-gate / #474、いずれも 2026-05-13 着地。P-0109 = 2026-05-14 起票 Proposed 中、Tune 派生 SSOT 化）。`H-XXXX` 採番は終了。
+- 新規 Proposal を起票するときは **P-0110 から採番**（P-0107 = `PICKLE_INCOMPATIBLE` structured envelope / v3-26、P-0108 = search-space run-gate / #474、いずれも 2026-05-13 着地。P-0109 = 2026-05-14 起票 → 2026-05-15 Approved & shipped (Option B, PR-6 残作業あり)、Tune 派生 SSOT 化）。`H-XXXX` 採番は終了。
 - 新規 PLAN フェーズは **v3-27 以降**を採番（v3-26 = R-4.2 Pickle compat、2026-05-13 着地で v0.5 phase 完全消化）。
 - E2E 単独追加（仕様変更なし）は HISTORY 起票不要、本 ROADMAP の §3 を更新するだけで OK。
 - 本 ROADMAP はステータス変更時に都度更新。タスク完了時は §1 へ移動、新規着手時は §2/§3/§4 へ追加する。

--- a/docs/architecture-as-implemented.md
+++ b/docs/architecture-as-implemented.md
@@ -152,7 +152,7 @@ flowchart TB
 
 | Prefix | Router | 代表エンドポイント |
 |---|---|---|
-| `/api/workspace` | `api/workspace.py` | GET `/status`, POST `/reset`, POST `/data/path`, POST `/data/upload`, GET `/data/preview\|columns\|describe\|split-preview\|column-stats/{c}`, GET/PUT/PATCH `/config`, POST `/config/validate\|upload`, GET `/config/download`, POST `/fit`, POST `/tune` |
+| `/api/workspace` | `api/workspace.py` | GET `/status`, POST `/reset`, POST `/data/path`, POST `/data/upload`, GET `/data/preview\|columns\|describe\|split-preview\|column-stats/{c}`, GET/PUT/PATCH `/config`, POST `/config/validate\|upload`, GET `/config/download`, GET `/config/tuning-snapshot`, PUT `/config/tuning-overrides`, POST `/fit`, POST `/tune` |
 | `/api/jobs` | `api/jobs.py` + `api/retune.py` | GET `/`, GET `/{id}` / `{id}/log` / `{id}/config`, DELETE `/{id}?cascade=`, POST `/{id}/cancel`, POST `/{id}/pause`, POST `/{id}/unpause` (P-0099 v3-20d), GET `/{id}/{metrics\|split-summary\|importance\|importance-kinds\|learning-curve/metrics\|plot/{type}\|plots}`, POST `/{id}/export`, GET `/{id}/export-code`, POST `/{id}/retune`, POST `/{id}/resume`, GET `/{id}/lineage` |
 | `/api/inference` | `api/inference.py` | POST `/run`, POST `/upload`, GET `/history`, GET `/{inf_id}`, GET `/{inf_id}/{predictions\|metrics\|download\|plot/{type}}`, GET `/{inf_id}/comparison/{other_inf_id}` |
 | `/api/backends` | `api/backends.py` | GET `""`, GET `/ui-schema` |
@@ -174,6 +174,8 @@ classDiagram
     +get_ui_schema()
     +get_default_config()
     +validate_config(cfg)
+    +get_tuning_defaults(task)
+    +compute_effective_tuning(task, overrides)
     +load_config_from_file(p)
     +create_model(cfg)
     +fit(model, on_progress)

--- a/frontend/src/components/workspace/TuneEvaluationSection.tsx
+++ b/frontend/src/components/workspace/TuneEvaluationSection.tsx
@@ -32,9 +32,12 @@ function buildEntry(name: string, k?: number): MetricEntry {
 // follow-up issue per #459's scope statement. P-0109 PR-3 moved the
 // SSOT for these to the lizyml adapter
 // (``backends.lizyml.config_mixin._TASK_DEFAULT_METRICS``) — this
-// frontend constant remains the pre-PR-5 render fallback and is
-// scheduled for removal in PR-6 once the snapshot endpoint becomes
-// the read path.
+// frontend constant remains the post-PR-5 render fallback and is
+// scheduled for removal in PR-6c once the Tune tab reads its
+// effective state from ``GET /api/workspace/config/tuning-snapshot``
+// (PR-4a #519) instead of the legacy ``GET /api/workspace/config``
+// shim. Until then, dropping this constant would regress the
+// initial Additional-Metrics chip state for binary tasks.
 const TASK_DEFAULT_METRICS: Record<string, string[]> = {
   binary: ["auc", "auc_pr", "brier", "logloss"],
 };


### PR DESCRIPTION
## Summary

PR-6a of the P-0109 chain — reconcile spec documents to the intent/effective split implementation that landed in PR-1 through PR-5 (#516 through #521, all merged 2026-05-15).

The user-visible bug — "Tune tab first mount renders the catalog rows in Fixed mode" — is **already fixed structurally on develop** via PR-5 (#521). This PR is the documentation half of the closing loop.

- HISTORY.md: append "Approved & shipped (Option B, partially)" Decision row to P-0109. Records scope deltas (no `STUDIO_FORMAT_VERSION` bump, PR-6 split into 3 sub-PRs) and per-PR status with the PR-6a/6b/6c responsibility split.
- docs/ROADMAP.md: flip P-0109 in section 3 to shipped, replace the section 7 Tier 1 item #1 with the PR-6 sub-PR breakdown, update section 8 numbering note.
- BLUEPRINT.md: add `get_tuning_defaults` / `compute_effective_tuning` to section 3.3.2 (BackendAdapter Protocol) with their INV-T3 / INV-T5 / INV-T6 callouts; add `tuning_overrides` row to the section 3.4.1 Workspace state table; add an intent/effective split intro paragraph + new API surface listing to section 4.2.2 (Tune tab); add `GET /config/tuning-snapshot` and `PUT /config/tuning-overrides` rows to section 5.2 (Config API).
- docs/architecture-as-implemented.md: append the new endpoints to the API surface row in section 3 and the new Protocol methods to the mermaid classDiagram in section 4.
- frontend/src/components/workspace/TuneEvaluationSection.tsx: precise the `TASK_DEFAULT_METRICS` comment from "scheduled for removal in PR-6" to "scheduled for removal in PR-6c" — matches the doc claim and documents the regression rationale (dropping it before the snapshot read path lands would regress the initial Additional-Metrics chip state on binary tasks).

## Scope deltas recorded in HISTORY

- `STUDIO_FORMAT_VERSION` stays at **2**. On-disk `WorkspaceConfig.tuning` is unchanged; `absorb_legacy_tuning` / `get_legacy_config_view` round-trip the legacy shape on PUT/GET. INV-T7 holds trivially.
- `docs/format-version-matrix.md` is **not** updated (no on-disk shape change).
- Physical removal of `TASK_DEFAULT_METRICS` is deferred to **PR-6c** (gated on the snapshot endpoint becoming the read path).
- Hardcoded `maximize_metrics` set removal + INV-T3 assertion is deferred to **PR-6b** (Protocol semantic refinement under the INV-ADAPTER-1 constraint that `services/` must not import `backends.lizyml_*`).

## Test plan

- [x] `uv run pytest tests/ -k "history or blueprint or workspace_api or tuning"` — 140 passed
- [x] `pnpm exec vitest run src/components/workspace/TuneTab.test.tsx` — 33/33 passed
- [x] `uv run ruff check src/lizystudio/backends/base.py src/lizystudio/services/training.py src/lizystudio/services/workspace.py` — clean
- [x] `pnpm check` (Biome on frontend/src) — clean
- [ ] CI (developer-gated) — backend tests, frontend tests, e2e functional gate
- [ ] Reviewer cross-check: HISTORY Decision row vs the actual landed PRs (#516 through #521)

## Refs

P-0109 (HISTORY.md), #516 PR-1, #517 PR-2, #518 PR-3, #519 PR-4a, #520 PR-4b, #521 PR-5
