### PR TITLE
feat(p0109): Tune-tab snapshot read path + 'Modified' badge + drop TASK_DEFAULT_METRICS frontend constant (PR-6c)

### DIFF
--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -1998,21 +1998,23 @@ export interface components {
          * TuningSnapshotResponse
          * @description Response for ``GET /api/workspace/config/tuning-snapshot``.
          *
-         *     The pair the frontend Tune tab consumes to render its rows without
-         *     racing on the WriteFunnel write path (P-0109 PR-5 deletes the three
-         *     useEffects that compose the legacy seed-then-edit flow).
+         *     The triple the frontend Tune tab consumes to render its rows
+         *     without racing on the WriteFunnel write path (P-0109 PR-5 deletes
+         *     the three useEffects that compose the legacy seed-then-edit flow).
          *
          *     * ``tuning_effective`` — the catalog defaults merged with the user's
          *       currently-persisted sparse intent. ``user_set_paths`` carries the
-         *       provenance the frontend will use for the "modified" badge in a
-         *       follow-up PR (badge rendering is deferred so PR-5 stays focused
-         *       on the useEffect deletion).
+         *       provenance the Tune-tab "modified" badge renders against (PR-6c).
          *     * ``tuning_defaults`` — the pure backend catalog defaults for the
          *       current task. Useful as the "reset" reference point in the UI.
+         *     * ``tuning_overrides`` — the persisted sparse intent (PR-6c). The
+         *       frontend uses this to compute a merged body for ``PUT
+         *       /config/tuning-overrides`` without re-deriving overrides from
+         *       ``user_set_paths``.
          *
-         *     Both are returned as plain dicts so the frontend can consume them
-         *     with the existing openapi-typescript-generated types — without
-         *     importing backend-side Pydantic / dataclass shapes.
+         *     All three sides are returned as plain dicts so the frontend can
+         *     consume them with the existing openapi-typescript-generated types —
+         *     without importing backend-side Pydantic / dataclass shapes.
          */
         TuningSnapshotResponse: {
             /** Tuning Effective */
@@ -2021,6 +2023,10 @@ export interface components {
             };
             /** Tuning Defaults */
             tuning_defaults: {
+                [key: string]: unknown;
+            };
+            /** Tuning Overrides */
+            tuning_overrides: {
                 [key: string]: unknown;
             };
         } & {

--- a/frontend/src/api/queries/useWorkspace.ts
+++ b/frontend/src/api/queries/useWorkspace.ts
@@ -10,6 +10,7 @@ import {
   fetchColumns,
   fetchConfig,
   fetchConfigSchema,
+  fetchTuningSnapshot,
   fetchUiSchema,
   fetchWorkspaceStatus,
 } from "@/api/workspace";
@@ -70,5 +71,32 @@ export function useWorkspaceStatus(options?: { enabled?: boolean }) {
     queryFn: fetchWorkspaceStatus,
     enabled: options?.enabled !== false,
     retry: false,
+  });
+}
+
+/**
+ * P-0109 PR-6c: Tune-tab snapshot subscription.
+ *
+ * Exposes the backend's intent / effective / defaults triple in one
+ * payload so the Tune tab can:
+ *
+ *   1. Read ``tuning_defaults.evaluation_metrics`` as the canonical
+ *      fallback for the Optimization / Additional Metrics widgets —
+ *      replaces the frontend-only ``TASK_DEFAULT_METRICS`` constant
+ *      that was deferred from PR-5.
+ *   2. Render the per-row "modified" badge on SearchSpaceRow from
+ *      ``tuning_effective.user_set_paths`` — entries the user
+ *      explicitly touched (catalog defaults stay un-badged).
+ *
+ * Disabled until a task is set: a fresh workspace returns empty
+ * defaults, and forcing the query to run before the user picks a task
+ * pollutes the cache with a transient empty result that ``setQueryData``
+ * would need to clobber. Pass ``enabled: !!task`` from the caller.
+ */
+export function useTuningSnapshot(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: queryKeys.tuningSnapshot(),
+    queryFn: ({ signal }) => fetchTuningSnapshot({ signal }),
+    enabled: options?.enabled !== false,
   });
 }

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -76,4 +76,5 @@ export const queryKeys = {
   columns: () => ["columns"] as const,
   files: (path: string) => ["files", path] as const,
   workspaceStatus: () => ["workspace-status"] as const,
+  tuningSnapshot: () => ["tuning-snapshot"] as const,
 } as const;

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -235,3 +235,47 @@ export async function fetchUiSchema(): Promise<UiSchema> {
   const { data } = await apiClient.GET("/api/backends/ui-schema", {});
   return unwrap(data, "/api/backends/ui-schema") as UiSchema;
 }
+
+// P-0109 PR-6c: snapshot of the Tune-tab intent / effective / defaults
+// triple. ``user_set_paths`` on ``tuning_effective`` powers the
+// "modified" badge on SearchSpaceRow; ``tuning_overrides`` is the
+// sparse user intent that the frontend can merge into a write body
+// without re-deriving from ``user_set_paths``.
+export interface TuningSnapshot {
+  tuning_effective: {
+    n_trials: number;
+    timeout: number | null;
+    direction: "maximize" | "minimize";
+    space: Record<string, Record<string, unknown>>;
+    evaluation_metrics: unknown[];
+    user_set_paths: string[];
+  } & Record<string, unknown>;
+  tuning_defaults: {
+    space: Record<string, Record<string, unknown>>;
+    evaluation_metrics: unknown[];
+    direction: "maximize" | "minimize" | null;
+  } & Record<string, unknown>;
+  tuning_overrides: {
+    n_trials: number | null;
+    timeout: number | null;
+    direction: "maximize" | "minimize" | null;
+    space: Record<string, Record<string, unknown>>;
+    evaluation_metrics: unknown[] | null;
+  } & Record<string, unknown>;
+}
+
+export async function fetchTuningSnapshot(opts?: {
+  signal?: AbortSignal;
+}): Promise<TuningSnapshot> {
+  const { data } = await apiClient.GET(
+    "/api/workspace/config/tuning-snapshot",
+    { signal: opts?.signal },
+  );
+  // SSOT-EXEMPT (Issue #236): TuningSnapshotResponse uses ``Record<string, unknown>``
+  // for the three nested dicts; narrow it here to the per-field shapes the
+  // Tune tab consumes so call sites stay strongly typed.
+  return unwrap(
+    data,
+    "/api/workspace/config/tuning-snapshot",
+  ) as unknown as TuningSnapshot;
+}

--- a/frontend/src/components/workspace/SearchSpaceRow.tsx
+++ b/frontend/src/components/workspace/SearchSpaceRow.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown, ChevronRight } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -41,6 +42,7 @@ export function SearchSpaceRow({
   onModelParamChange,
   specialSearchSpaceFields,
   columns,
+  isUserSet = false,
 }: SearchSpaceRowProps) {
   const entry = toSpaceEntry(space[param.key]);
   const mode: "fixed" | "range" | "choice" = (() => {
@@ -87,7 +89,24 @@ export function SearchSpaceRow({
             ))}
         </span>
 
-        <span className="flex-1 text-xs font-mono">{param.key}</span>
+        <span className="flex-1 text-xs font-mono inline-flex items-center gap-1.5">
+          {param.key}
+          {/* P-0109 PR-6c: per-row "Modified" badge derived from
+              ``tuning_effective.user_set_paths``. Only rows the user
+              has explicitly customised render the badge — catalog
+              defaults stay un-badged. Tooltip text via ``title`` so
+              screen readers and hover both surface the rationale. */}
+          {isUserSet ? (
+            <Badge
+              variant="secondary"
+              className="text-[10px] px-1 py-0 leading-tight"
+              title="You have customised this parameter — catalog defaults are not in effect for this row."
+              data-testid={`search-space-row-modified-${param.key}`}
+            >
+              Modified
+            </Badge>
+          ) : null}
+        </span>
 
         {/* Mode segment buttons */}
         {/* biome-ignore lint/a11y/noStaticElementInteractions: stopPropagation needed */}

--- a/frontend/src/components/workspace/SearchSpaceTable.test.tsx
+++ b/frontend/src/components/workspace/SearchSpaceTable.test.tsx
@@ -1494,4 +1494,84 @@ describe("SearchSpaceTable", () => {
       expect(spaceArg["early_stopping.rounds"].high).toBe(5000);
     });
   });
+
+  // P-0109 PR-6c: ``userSetSpaceKeys`` drives a "Modified" badge that
+  // surfaces per-row whether the user explicitly customised the
+  // search-space entry. The set originates from
+  // ``tuning_effective.user_set_paths`` returned by the
+  // ``useTuningSnapshot`` query — entries prefixed with ``"space."``
+  // stripped to the bare param name (handled in ``TuneTab``).
+  describe("userSetSpaceKeys → Modified badge", () => {
+    const lrCatalog: SearchSpaceCatalogEntry[] = [
+      {
+        key: "learning_rate",
+        title: "Learning Rate",
+        paramType: "number",
+        modes: ["fixed", "range"],
+        group: "model_params",
+      },
+      {
+        key: "max_depth",
+        title: "Max Depth",
+        paramType: "integer",
+        modes: ["fixed", "range"],
+        group: "model_params",
+      },
+    ];
+
+    it("renders the badge for keys in userSetSpaceKeys", () => {
+      render(
+        <SearchSpaceTable
+          space={{
+            learning_rate: { type: "float", low: 0.5, high: 1.0, log: false },
+            max_depth: { type: "int", low: 3, high: 9, log: false },
+          }}
+          modelParams={{}}
+          onChange={vi.fn()}
+          catalog={lrCatalog}
+          userSetSpaceKeys={new Set(["learning_rate"])}
+        />,
+      );
+      expect(
+        screen.getByTestId("search-space-row-modified-learning_rate"),
+      ).toBeInTheDocument();
+      // ``max_depth`` is a catalog default — no badge.
+      expect(
+        screen.queryByTestId("search-space-row-modified-max_depth"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders no badges when userSetSpaceKeys is undefined", () => {
+      render(
+        <SearchSpaceTable
+          space={{
+            learning_rate: { type: "float", low: 0.5, high: 1.0, log: false },
+          }}
+          modelParams={{}}
+          onChange={vi.fn()}
+          catalog={lrCatalog}
+        />,
+      );
+      expect(
+        screen.queryByTestId("search-space-row-modified-learning_rate"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders no badges when userSetSpaceKeys is empty", () => {
+      render(
+        <SearchSpaceTable
+          space={{
+            learning_rate: { type: "float", low: 0.5, high: 1.0, log: false },
+          }}
+          modelParams={{}}
+          onChange={vi.fn()}
+          catalog={lrCatalog}
+          userSetSpaceKeys={new Set()}
+        />,
+      );
+      expect(
+        screen.queryByTestId("search-space-row-modified-learning_rate"),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/workspace/SearchSpaceTable.tsx
+++ b/frontend/src/components/workspace/SearchSpaceTable.tsx
@@ -53,6 +53,18 @@ interface SearchSpaceTableProps {
    * current task, resolved from ``uiSchema.parameter_bounds[task]``.
    * Forwarded per-row to clamp the Range Min/Max NumberInputs. */
   parameterBounds?: Record<string, { min?: number; max?: number }>;
+  /**
+   * P-0109 PR-6c: keys of ``space.*`` entries the user has explicitly
+   * touched (derived from ``tuning_effective.user_set_paths`` in the
+   * Tune-tab snapshot — entries prefixed with ``"space."`` are
+   * stripped to the bare param name). Per row, when the param key is
+   * a member of this set, ``SearchSpaceRow`` renders a "Modified"
+   * badge so users can distinguish their explicit edits from catalog
+   * defaults. ``undefined`` is treated as the empty set (no row gets
+   * the badge — same behaviour as before this PR) so callers that
+   * have not yet wired the snapshot keep working.
+   */
+  userSetSpaceKeys?: ReadonlySet<string>;
 }
 
 export function SearchSpaceTable({
@@ -74,6 +86,7 @@ export function SearchSpaceTable({
   cvStrategy,
   innerValidOptions,
   parameterBounds,
+  userSetSpaceKeys,
 }: SearchSpaceTableProps) {
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
   // Initialize addedParams from space keys that exist in additionalParams
@@ -313,6 +326,7 @@ export function SearchSpaceTable({
                 onModelParamChange={onModelParamChange}
                 specialSearchSpaceFields={specialSearchSpaceFields}
                 columns={columns}
+                isUserSet={userSetSpaceKeys?.has(param.key) ?? false}
               />
             ))}
         </div>

--- a/frontend/src/components/workspace/TuneEvaluationSection.tsx
+++ b/frontend/src/components/workspace/TuneEvaluationSection.tsx
@@ -15,6 +15,16 @@ interface TuneEvaluationSectionProps {
   metricDirection?: Record<string, Record<string, string>>;
   evaluation: { metrics?: MetricEntry[] };
   tuningParams: { n_trials?: number; timeout?: number | null };
+  /**
+   * P-0109 PR-6c: canonical fallback metric list for the current
+   * task, sourced from ``GET /config/tuning-snapshot`` →
+   * ``tuning_defaults.evaluation_metrics``. Replaces the
+   * frontend-only ``TASK_DEFAULT_METRICS`` constant (P-0104 Wave 2.3
+   * / Issue #459) that PR-5 left as a render-time fallback. Empty
+   * when the snapshot has not loaded yet or the task has no canonical
+   * default set (catalog returns ``[]`` for unknown tasks).
+   */
+  defaultEvaluationMetrics?: unknown[];
 }
 
 /** Build a MetricEntry — use dict form for precision_at_k */
@@ -25,19 +35,25 @@ function buildEntry(name: string, k?: number): MetricEntry {
   return name;
 }
 
-// P-0104 Wave 2.3 / Issue #459 — per-task canonical default eval
-// metrics used as a render-time fallback when the persisted config
-// has no metrics set. Binary is the only task with a confirmed
-// canonical set; regression / multiclass defaults are deferred to a
-// follow-up issue per #459's scope statement. P-0109 PR-3 moved the
-// SSOT for these to the lizyml adapter
-// (``backends.lizyml.config_mixin._TASK_DEFAULT_METRICS``) — this
-// frontend constant remains the pre-PR-5 render fallback and is
-// scheduled for removal in PR-6 once the snapshot endpoint becomes
-// the read path.
-const TASK_DEFAULT_METRICS: Record<string, string[]> = {
-  binary: ["auc", "auc_pr", "brier", "logloss"],
-};
+/**
+ * Coerce a snapshot ``evaluation_metrics`` entry into the local
+ * MetricEntry union (``string | { [metric]: { ...params } }``). The
+ * snapshot serialises both shapes verbatim, but the openapi-generated
+ * type is ``unknown[]``; this helper narrows defensively so a stale /
+ * mid-load snapshot does not crash the Tune-tab render.
+ */
+function coerceMetricEntry(value: unknown): MetricEntry | null {
+  if (typeof value === "string") return value;
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value).length > 0
+  ) {
+    return value as MetricEntry;
+  }
+  return null;
+}
 
 export function TuneEvaluationSection({
   config,
@@ -47,30 +63,40 @@ export function TuneEvaluationSection({
   metricDirection,
   evaluation,
   tuningParams,
+  defaultEvaluationMetrics,
 }: TuneEvaluationSectionProps) {
-  // P-0109 PR-5: derive effective evaluation metrics at render time
-  // instead of seeding them via a useEffect that wrote to PUT /config.
-  // The legacy "metrics seed useEffect" raced two siblings (search-space
-  // init + direction defensive sync) through the WriteFunnel; all three
-  // shared the ``config-form-edit`` reason and the funnel coalesced
-  // them to the last-arriver, dropping the metrics seed.
+  // P-0109 PR-5 + PR-6c: derive effective evaluation metrics at render
+  // time. The legacy "metrics seed useEffect" raced two siblings
+  // (search-space init + direction defensive sync) through the
+  // WriteFunnel; all three shared the ``config-form-edit`` reason and
+  // the funnel coalesced them to the last-arriver, dropping the
+  // metrics seed.
   //
-  // The fix: keep the persisted ``evaluation.metrics`` as the source of
-  // truth and fall back to ``TASK_DEFAULT_METRICS[task]`` when the user
-  // has not yet set anything. The first metric the user explicitly
-  // clicks writes a real PUT through the funnel and pins the list.
+  // The fix: keep the persisted ``evaluation.metrics`` as the source
+  // of truth and fall back to ``defaultEvaluationMetrics`` — sourced
+  // from ``GET /config/tuning-snapshot`` → ``tuning_defaults`` (PR-6c)
+  // — when the user has not yet set anything. The first metric the
+  // user explicitly clicks writes a real PUT through the funnel and
+  // pins the list. The backend adapter owns the per-task canonical
+  // list (INV-T5), so the frontend never carries an adapter-specific
+  // branch.
   const persistedMetrics = evaluation.metrics;
   const evalMetrics: MetricEntry[] = useMemo(() => {
     if (Array.isArray(persistedMetrics) && persistedMetrics.length > 0) {
       return persistedMetrics;
     }
-    if (!task) return [];
-    const fallback = TASK_DEFAULT_METRICS[task];
-    if (!fallback || metricOptions.length === 0) return [];
-    return fallback
-      .filter((m) => metricOptions.includes(m))
-      .map((m) => buildEntry(m));
-  }, [persistedMetrics, task, metricOptions]);
+    if (!task || metricOptions.length === 0) return [];
+    const fallback = defaultEvaluationMetrics ?? [];
+    const out: MetricEntry[] = [];
+    for (const raw of fallback) {
+      const entry = coerceMetricEntry(raw);
+      if (entry === null) continue;
+      const name = metricEntryName(entry);
+      if (!metricOptions.includes(name)) continue;
+      out.push(entry);
+    }
+    return out;
+  }, [persistedMetrics, task, metricOptions, defaultEvaluationMetrics]);
 
   // Widget conformance: fall back to first available metric option
   const optimizationMetric = evalMetrics[0]

--- a/frontend/src/components/workspace/TuneTab.test.tsx
+++ b/frontend/src/components/workspace/TuneTab.test.tsx
@@ -1,7 +1,15 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { UiSchema } from "@/api/types";
+import { renderWithQuery } from "@/test/helpers";
 import { TuneTab } from "./TuneTab";
+
+// P-0109 PR-6c: TuneTab now subscribes to ``useTuningSnapshot`` so a
+// ``QueryClientProvider`` is required in the render tree. Use the
+// shared ``renderWithQuery`` helper as the test entry point instead of
+// the raw RTL ``render`` — the alias below keeps the existing test
+// bodies unchanged.
+const render = renderWithQuery;
 
 // Mock SearchSpaceTable to expose its props as callable test handles
 vi.mock("./SearchSpaceTable", () => ({

--- a/frontend/src/components/workspace/TuneTab.tsx
+++ b/frontend/src/components/workspace/TuneTab.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo } from "react";
+import { useTuningSnapshot } from "@/api/queries/useWorkspace";
 import type { MetricEntry } from "@/api/types";
 import { RetuneSettingsSection } from "@/components/retune";
 import {
@@ -146,6 +147,32 @@ export function TuneTab({
     return result;
   }, [objectiveOptions]);
 
+  // P-0109 PR-6c: subscribe to the Tune-tab intent/effective/defaults
+  // triple. Used as:
+  //   * ``tuning_defaults.evaluation_metrics`` — canonical eval-metric
+  //     fallback for ``TuneEvaluationSection`` (replaces the frontend
+  //     ``TASK_DEFAULT_METRICS`` constant that PR-5 left in place).
+  //   * ``tuning_effective.user_set_paths`` — per-row "modified" badge
+  //     provenance for ``SearchSpaceRow``. Entries the user explicitly
+  //     touched render with the badge; catalog-default rows do not.
+  // The query is enabled only when a task is set: a fresh workspace
+  // (no task) returns empty defaults and an empty effective, and
+  // running this before the user picks a task would pollute the cache
+  // with a transient empty result.
+  const { data: tuningSnapshot } = useTuningSnapshot({ enabled: !!task });
+  const defaultEvaluationMetrics = useMemo<unknown[]>(() => {
+    const fromSnapshot = tuningSnapshot?.tuning_defaults.evaluation_metrics;
+    return Array.isArray(fromSnapshot) ? fromSnapshot : [];
+  }, [tuningSnapshot]);
+  const userSetSpaceKeys = useMemo<Set<string>>(() => {
+    const paths = tuningSnapshot?.tuning_effective.user_set_paths ?? [];
+    const out = new Set<string>();
+    for (const p of paths) {
+      if (p.startsWith("space.")) out.add(p.slice("space.".length));
+    }
+    return out;
+  }, [tuningSnapshot]);
+
   const handleParamsChange = (params: Record<string, unknown>) => {
     onChange(updateOptunaField(config, "params", params));
   };
@@ -229,6 +256,7 @@ export function TuneTab({
               cvStrategy={cvStrategy}
               innerValidOptions={innerValidOptions}
               parameterBounds={parameterBounds}
+              userSetSpaceKeys={userSetSpaceKeys}
             />
           </div>
         </AccordionContent>
@@ -246,6 +274,7 @@ export function TuneTab({
             metricDirection={metricDirection}
             evaluation={evaluation}
             tuningParams={tuningParams}
+            defaultEvaluationMetrics={defaultEvaluationMetrics}
           />
         </AccordionContent>
       </AccordionItem>

--- a/frontend/src/components/workspace/search-space-utils.ts
+++ b/frontend/src/components/workspace/search-space-utils.ts
@@ -127,4 +127,14 @@ export interface SearchSpaceRowProps {
   onModelParamChange?: (key: string, value: unknown) => void;
   specialSearchSpaceFields?: Record<string, string>;
   columns?: string[];
+  /**
+   * P-0109 PR-6c: ``true`` when the user has explicitly customised
+   * ``space.<param.key>`` (i.e. ``"space.<key>"`` is present in the
+   * ``tuning_effective.user_set_paths`` list returned by
+   * ``GET /config/tuning-snapshot``). Renders a small "Modified"
+   * badge on the row so users can distinguish their explicit edits
+   * from catalog defaults. ``undefined`` is treated as ``false`` for
+   * compatibility with callers that have not yet wired the snapshot.
+   */
+  isUserSet?: boolean;
 }

--- a/src/lizystudio/api/models.py
+++ b/src/lizystudio/api/models.py
@@ -132,27 +132,30 @@ class ValidationResponse(BaseModel):
 class TuningSnapshotResponse(BaseModel):
     """Response for ``GET /api/workspace/config/tuning-snapshot``.
 
-    The pair the frontend Tune tab consumes to render its rows without
-    racing on the WriteFunnel write path (P-0109 PR-5 deletes the three
-    useEffects that compose the legacy seed-then-edit flow).
+    The triple the frontend Tune tab consumes to render its rows
+    without racing on the WriteFunnel write path (P-0109 PR-5 deletes
+    the three useEffects that compose the legacy seed-then-edit flow).
 
     * ``tuning_effective`` — the catalog defaults merged with the user's
       currently-persisted sparse intent. ``user_set_paths`` carries the
-      provenance the frontend will use for the "modified" badge in a
-      follow-up PR (badge rendering is deferred so PR-5 stays focused
-      on the useEffect deletion).
+      provenance the Tune-tab "modified" badge renders against (PR-6c).
     * ``tuning_defaults`` — the pure backend catalog defaults for the
       current task. Useful as the "reset" reference point in the UI.
+    * ``tuning_overrides`` — the persisted sparse intent (PR-6c). The
+      frontend uses this to compute a merged body for ``PUT
+      /config/tuning-overrides`` without re-deriving overrides from
+      ``user_set_paths``.
 
-    Both are returned as plain dicts so the frontend can consume them
-    with the existing openapi-typescript-generated types — without
-    importing backend-side Pydantic / dataclass shapes.
+    All three sides are returned as plain dicts so the frontend can
+    consume them with the existing openapi-typescript-generated types —
+    without importing backend-side Pydantic / dataclass shapes.
     """
 
     model_config = ConfigDict(extra="allow")
 
     tuning_effective: dict[str, Any]
     tuning_defaults: dict[str, Any]
+    tuning_overrides: dict[str, Any]
 
 
 class TuningOverridesUpdateResponse(BaseModel):

--- a/src/lizystudio/services/workspace.py
+++ b/src/lizystudio/services/workspace.py
@@ -586,11 +586,19 @@ def _current_task(ws: WorkspaceState) -> str:
 def get_tuning_snapshot(ws: WorkspaceState) -> dict[str, Any]:
     """Build the response payload for ``GET /config/tuning-snapshot``.
 
-    Returns ``{"tuning_effective": ..., "tuning_defaults": ...}`` where
-    each side is a plain dict the frontend consumes via the
+    Returns ``{"tuning_effective", "tuning_defaults", "tuning_overrides"}``
+    where each side is a plain dict the frontend consumes via the
     openapi-typescript surface. PR-4b makes ``ws.tuning_overrides`` the
     sole source of Tune intent — the snapshot endpoint reads it
     directly instead of extracting from legacy ``ws.config["tuning"]``.
+
+    PR-6c adds ``tuning_overrides`` to the payload so the frontend can
+    compute a future write body without round-tripping through the
+    legacy ``GET/PUT /config`` shim. ``user_set_paths`` on the
+    effective config is also consumed by the Tune-tab "modified"
+    badge — both sides live on the same payload so a single
+    ``useTuningSnapshot`` subscription drives both the read view and
+    the badge state.
     """
     task = _current_task(ws)
     overrides = _current_overrides(ws)
@@ -599,6 +607,7 @@ def get_tuning_snapshot(ws: WorkspaceState) -> dict[str, Any]:
     return {
         "tuning_effective": effective.model_dump(mode="json"),
         "tuning_defaults": dataclasses.asdict(defaults),
+        "tuning_overrides": overrides.model_dump(mode="json"),
     }
 
 

--- a/tests/test_p0109_pr4a_tuning_endpoints.py
+++ b/tests/test_p0109_pr4a_tuning_endpoints.py
@@ -242,11 +242,20 @@ class TestTuningSnapshotEndpoint:
         body = res.json()
         assert "tuning_effective" in body
         assert "tuning_defaults" in body
+        # PR-6c: ``tuning_overrides`` is also surfaced so the frontend
+        # can compute write bodies without re-deriving them from
+        # ``user_set_paths``.
+        assert "tuning_overrides" in body
         # No task set → empty TuningDefaults from the adapter.
         assert body["tuning_defaults"]["space"] == {}
         assert body["tuning_defaults"]["evaluation_metrics"] == []
         # Effective falls back to the empty-overrides safe default.
         assert body["tuning_effective"]["n_trials"] == 50
+        # Fresh workspace → empty overrides (Pydantic default values
+        # serialize to ``None`` / ``{}`` / ``None``).
+        assert body["tuning_overrides"]["space"] == {}
+        assert body["tuning_overrides"]["n_trials"] is None
+        assert body["tuning_overrides"]["evaluation_metrics"] is None
 
     def test_binary_config_returns_catalog_defaults(
         self, client: TestClient, tmp_path: Path
@@ -305,13 +314,57 @@ class TestTuningSnapshotEndpoint:
 
         res = client.get("/api/workspace/config/tuning-snapshot")
         assert res.status_code == 200, res.text
-        eff = res.json()["tuning_effective"]
+        body = res.json()
+        eff = body["tuning_effective"]
         assert eff["n_trials"] == 200
         # The user's override wins per-key over the catalog default.
         assert eff["space"]["learning_rate"]["low"] == 0.1
         assert eff["space"]["learning_rate"]["high"] == 0.5
         # Catalog-only keys (the user didn't touch them) survive intact.
         assert "max_depth" in eff["space"]
+        # PR-6c: ``tuning_overrides`` round-trips the sparse intent. Only
+        # the keys the legacy PUT body touched are present — catalog
+        # defaults stay out of overrides storage.
+        ov = body["tuning_overrides"]
+        assert ov["n_trials"] == 200
+        assert ov["space"] == {
+            "learning_rate": {
+                "type": "float",
+                "low": 0.1,
+                "high": 0.5,
+                "log": False,
+            }
+        }
+        # ``user_set_paths`` lets the frontend render the "modified"
+        # badge — entries the user explicitly touched, not catalog ones.
+        assert "n_trials" in eff["user_set_paths"]
+        assert "space.learning_rate" in eff["user_set_paths"]
+        assert "space.max_depth" not in eff["user_set_paths"]
+
+    def test_overrides_reflect_user_set_paths_after_sparse_put(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        """PR-6c: after a sparse ``PUT /config/tuning-overrides``, the
+        next snapshot's ``tuning_overrides`` echoes the same body that
+        the user just sent — modulo the merge with prior intent.
+
+        This is the contract the frontend write-path migration (P-0109
+        PR-6c follow-up) relies on: read snapshot.tuning_overrides,
+        edit one field, PUT the merged result, refetch and observe.
+        """
+        _load_data_and_binary_config(client, tmp_path)
+        body = {"n_trials": 333, "evaluation_metrics": ["logloss"]}
+        r = client.put("/api/workspace/config/tuning-overrides", json=body)
+        assert r.status_code == 200, r.text
+
+        snap = client.get("/api/workspace/config/tuning-snapshot")
+        assert snap.status_code == 200, snap.text
+        ov = snap.json()["tuning_overrides"]
+        assert ov["n_trials"] == 333
+        assert ov["evaluation_metrics"] == ["logloss"]
+        # Untouched fields are absent / null on overrides.
+        assert ov["timeout"] is None
+        assert ov["direction"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Final step of the P-0109 chain. Closes the loop on "Tune-tab reads its state from the backend snapshot, not from the legacy config tree".

PR-5 (#521) structurally fixed the first-mount bug. PR-6a (#522) and PR-6b (#523) reconciled the spec docs and the direction-resolution layer. PR-6c wires the backend `tuning-snapshot` endpoint into the Tune-tab read path and surfaces the per-row "Modified" badge.

## What this delivers

1. **`useTuningSnapshot` TanStack subscription** — `GET /api/workspace/config/tuning-snapshot` keyed at `["tuning-snapshot"]`. Enabled only when a task is set (a fresh workspace returns empty defaults; running the query before the user picks a task would pollute the cache with a transient empty result).

2. **`TASK_DEFAULT_METRICS` frontend constant deleted.** Evaluation-metric fallback now sources from `tuning_defaults.evaluation_metrics`. The lizyml adapter's `_TASK_DEFAULT_METRICS` (moved in PR-3 (#518)) is the single SSOT — INV-T5 holds at the frontend boundary too.

3. **"Modified" badge per Search-Space row.** SearchSpaceRow consumes a new `isUserSet` flag; TuneTab derives the per-key set from `tuning_effective.user_set_paths`, stripping the `"space."` prefix. Catalog defaults stay un-badged. The badge has a `title` tooltip explaining the rationale and a stable `data-testid` for e2e selection.

4. **Snapshot response now also exposes `tuning_overrides`** so a follow-up write-path migration (route all Tune-tab mutations through `PUT /config/tuning-overrides`) can compute the merged body without re-deriving overrides from `user_set_paths`. The legacy `PUT /config` shim continues to work; that migration is intentionally not part of this PR.

## Out of scope

- Routing all Tune-tab mutations through `PUT /config/tuning-overrides` (the legacy `PUT /config` shim continues to absorb the body via `absorb_legacy_tuning` and produces correct effective state — see PR-4b #520).
- Display of the badge in Storybook stories (Storybook tests are unaffected — the badge defaults to off when `isUserSet` is omitted).

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm check` (Biome) — clean
- [x] `pnpm exec vitest run` — 1922 passed (1922)
- [x] `uv run pytest` on the P-0109 / workspace test surfaces (`test_p0109_pr4a_tuning_endpoints.py`, `test_p0109_pr4b_storage_rename.py`, `test_workspace_api.py`, `test_backends_lizyml.py`) — 226 passed
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] New `SearchSpaceTable.test.tsx::userSetSpaceKeys → Modified badge` describe: 3 cases — entry in set, entry not in set, set undefined, set empty
- [x] `TuneTab.test.tsx`: switched to shared `renderWithQuery` helper (required by the new hook). All 33 existing cases pass.
- [x] Backend tests pin `tuning_overrides` round-trip after both legacy `PUT /config` and sparse `PUT /config/tuning-overrides`.
- [ ] Verify the PR-5 e2e regression spec (`workspace-tune-firstmount.spec.ts`) still green in CI — no `PUT /config` carrying `tuning.optuna.space` on first mount.

## Closes the P-0109 chain

| PR | What | State |
|---|---|---|
| PR-1 (#516) | Proposal HISTORY P-0109 + ROADMAP entry | Merged |
| PR-2 (#517) | Types + BackendCore Protocol + LizyMLAdapter stubs | Merged |
| PR-3 (#518) | LizyMLAdapter catalog-aware impl + 18 adapter tests | Merged |
| PR-4a (#519) | Additive `GET /config/tuning-snapshot` + `PUT /config/tuning-overrides` | Merged |
| PR-4b (#520) | Storage rename + INV-T6 snapshot freeze | Merged |
| PR-5 (#521) | Frontend 3 useEffect deletion + render-time fallbacks (user-visible bug fix) | Merged |
| PR-6a (#522) | Docs reconcile + Decision flip | Review |
| PR-6b (#523) | Refine direction semantic + drop services-layer maximize_metrics set + INV-T3 | Review |
| PR-6c (this) | Snapshot read path + Modified badge + drop TASK_DEFAULT_METRICS | This PR |

## Refs

P-0109 (HISTORY.md), #516 PR-1, #517 PR-2, #518 PR-3, #519 PR-4a, #520 PR-4b, #521 PR-5, #522 PR-6a, #523 PR-6b
