### PR TITLE
fix(workspace): MetricsChips no longer emits partial-body PUTs during Target selection (#529)

### DIFF
--- a/frontend/src/components/workspace/ConfigForm.tsx
+++ b/frontend/src/components/workspace/ConfigForm.tsx
@@ -655,6 +655,12 @@ export function ConfigForm({
                   onChange={(metrics) => {
                     handleFieldChange(["evaluation", "metrics"], metrics);
                   }}
+                  // Issue #529: suppress the task-change auto-reset
+                  // until the seed config has landed. Without this gate,
+                  // the auto-reset onChange routes through
+                  // `handleFieldChange` with an empty `configRef.current`
+                  // and PUTs a partial body that the backend rejects.
+                  configSeeded={Boolean(config.config_version)}
                   conditionalParams={{
                     precision_at_k: {
                       label: "k",

--- a/frontend/src/components/workspace/MetricsChips.test.tsx
+++ b/frontend/src/components/workspace/MetricsChips.test.tsx
@@ -147,6 +147,73 @@ describe("MetricsChips", () => {
     expect(onChange).toHaveBeenCalledWith(["rmse", "mae", "r2", "mse"]);
   });
 
+  // Issue #529: the task-change auto-reset must be suppressed while the
+  // seed config has not landed (i.e. `configSeeded=false`). Without the
+  // gate, the parent's `handleFieldChange` reads an empty `configRef.current`
+  // and emits a partial-body PUT (`{evaluation:{metrics:[...]}}`) that
+  // the backend rejects with `saved=false`.
+  it("does NOT call onChange when configSeeded=false and task changes (Issue #529)", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <MetricsChips
+        task="binary"
+        selectedMetrics={["auc"]}
+        onChange={onChange}
+        metricsByTask={ALL_METRICS}
+        configSeeded={false}
+      />,
+    );
+    rerender(
+      <MetricsChips
+        task="regression"
+        selectedMetrics={["auc"]}
+        onChange={onChange}
+        metricsByTask={ALL_METRICS}
+        configSeeded={false}
+      />,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call onChange when configSeeded=false and selectedMetrics is empty (Issue #529)", () => {
+    const onChange = vi.fn();
+    render(
+      <MetricsChips
+        task="binary"
+        selectedMetrics={[]}
+        onChange={onChange}
+        metricsByTask={BINARY_METRICS}
+        configSeeded={false}
+      />,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("auto-resets on transition configSeeded=false -> true with empty selectedMetrics (Issue #529)", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <MetricsChips
+        task="binary"
+        selectedMetrics={[]}
+        onChange={onChange}
+        metricsByTask={BINARY_METRICS}
+        configSeeded={false}
+      />,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+    rerender(
+      <MetricsChips
+        task="binary"
+        selectedMetrics={[]}
+        onChange={onChange}
+        metricsByTask={BINARY_METRICS}
+        configSeeded={true}
+      />,
+    );
+    // Once seeded, the auto-reset is allowed to populate empty metrics.
+    expect(onChange).toHaveBeenCalledWith(BINARY_METRICS.binary);
+  });
+
   it("renders nothing when task has no metrics", () => {
     const { container } = render(
       <MetricsChips

--- a/frontend/src/components/workspace/MetricsChips.tsx
+++ b/frontend/src/components/workspace/MetricsChips.tsx
@@ -19,6 +19,17 @@ interface MetricsChipsProps {
   onChange: (metrics: MetricEntry[]) => void;
   metricsByTask?: Record<string, string[]>;
   conditionalParams?: Record<string, ConditionalParamDef>;
+  /**
+   * Set to `true` once the workspace's seed config has landed (i.e.
+   * `config.config_version` is defined). Issue #529: the task-change
+   * auto-reset useEffect must NOT fire before the seed PUT lands —
+   * otherwise it routes an `onChange([...defaults])` through the
+   * parent's `handleFieldChange`, which reads an empty `configRef` and
+   * emits a partial-body PUT (`{evaluation:{metrics:[...]}}`) that the
+   * backend rejects with `saved=false`. Defaults to `true` so existing
+   * test/story renders (which pre-seed `selectedMetrics`) keep working.
+   */
+  configSeeded?: boolean;
 }
 
 /**
@@ -52,6 +63,7 @@ export function MetricsChips({
   onChange,
   metricsByTask,
   conditionalParams,
+  configSeeded = true,
 }: MetricsChipsProps) {
   // Metric catalog is backend-driven via UiSchema option_sets.metric.
   // Default on task change: ALL metrics enabled for the task.
@@ -62,14 +74,25 @@ export function MetricsChips({
 
   const prevTask = useRef(task);
 
-  // Reset to defaults when task changes or when no metrics are selected
+  // Reset to defaults when task changes or when no metrics are selected.
+  //
+  // Issue #529: gate on `configSeeded` so the auto-reset never fires
+  // during the target-select window when `configRef.current` upstream
+  // is still empty. Firing then would emit a partial-body PUT
+  // (`{evaluation:{metrics:[...]}}`) that the backend silently rejects.
+  // After the seed PUT lands, `configSeeded` flips to true and the
+  // effect runs once to populate metrics if the seed shipped them
+  // empty — but with the buildMergedConfig fix that ships in the same
+  // PR, the seed already carries the task's eval metrics, so this
+  // branch usually no-ops.
   useEffect(() => {
+    if (!configSeeded) return;
     const taskChanged = task !== prevTask.current;
     prevTask.current = task;
     if ((taskChanged || selectedMetrics.length === 0) && available.length > 0) {
       onChange([...available]);
     }
-  }, [task, onChange, available, selectedMetrics.length]);
+  }, [task, onChange, available, selectedMetrics.length, configSeeded]);
 
   if (available.length === 0) return null;
 

--- a/frontend/src/hooks/useDataPanel.types.test.ts
+++ b/frontend/src/hooks/useDataPanel.types.test.ts
@@ -93,6 +93,58 @@ describe("buildMergedConfig", () => {
     });
     expect(result.data).toMatchObject({ path: undefined, target: "y" });
   });
+
+  // Issue #529: the merged config must carry the task's eval metrics
+  // so the target-select PUT lands with a non-empty `evaluation.metrics`.
+  // Otherwise MetricsChips' task-change useEffect sees an empty
+  // selection, fires `onChange([...defaults])`, and the parent's
+  // `handleFieldChange` routes a partial body that backend rejects.
+  it("seeds evaluation.metrics from evaluationMetrics param (Issue #529)", () => {
+    const result = buildMergedConfig({
+      defaults: { data: {}, features: {} },
+      task: "binary",
+      strategy: "kfold",
+      folds: 5,
+      dataPath: "/data/x.csv",
+      target: "y",
+      overrides: {},
+      evaluationMetrics: ["auc", "logloss", "f1"],
+    });
+    expect(result.evaluation).toEqual({
+      metrics: ["auc", "logloss", "f1"],
+    });
+  });
+
+  it("falls back to defaults.evaluation when evaluationMetrics is empty", () => {
+    const result = buildMergedConfig({
+      defaults: {
+        data: {},
+        features: {},
+        evaluation: { metrics: ["legacy_metric"] },
+      },
+      task: "binary",
+      strategy: "kfold",
+      folds: 5,
+      dataPath: "/data/x.csv",
+      target: "y",
+      overrides: {},
+      evaluationMetrics: [],
+    });
+    expect(result.evaluation).toEqual({ metrics: ["legacy_metric"] });
+  });
+
+  it("emits evaluation.metrics=[] when neither param nor defaults supply metrics", () => {
+    const result = buildMergedConfig({
+      defaults: { data: {}, features: {} },
+      task: "binary",
+      strategy: "kfold",
+      folds: 5,
+      dataPath: "/data/x.csv",
+      target: "y",
+      overrides: {},
+    });
+    expect(result.evaluation).toEqual({ metrics: [] });
+  });
 });
 
 describe("extractOverrideArrays", () => {

--- a/frontend/src/hooks/useDataPanel.types.ts
+++ b/frontend/src/hooks/useDataPanel.types.ts
@@ -46,6 +46,7 @@ export function buildMergedConfig({
   dataPath,
   target,
   overrides,
+  evaluationMetrics,
 }: {
   defaults: Record<string, unknown>;
   task: string;
@@ -54,8 +55,19 @@ export function buildMergedConfig({
   dataPath: string;
   target: string;
   overrides: Record<string, ColumnOverride>;
+  /**
+   * UiSchema-derived eval metrics for the chosen task (#529). Seeded into
+   * `evaluation.metrics` so the target-select PUT lands with a complete
+   * Evaluation slice. Without this, `GET /config/defaults` returns
+   * `evaluation.metrics: []`, which lets `MetricsChips`'s task-change
+   * useEffect race the target-select PUT and emit a partial-body PUT
+   * (`{evaluation:{metrics:[...]}}`) that the backend rejects with
+   * `saved=false, blocking=5`. Pass `[]` to preserve legacy behaviour.
+   */
+  evaluationMetrics?: readonly string[];
 }): Record<string, unknown> {
   const { categorical, excluded } = extractOverrideArrays(overrides);
+  const defaultsEval = (defaults.evaluation as Record<string, unknown>) ?? {};
   return {
     ...defaults,
     task,
@@ -72,6 +84,13 @@ export function buildMergedConfig({
     split: {
       method: strategy,
       n_splits: folds,
+    },
+    evaluation: {
+      ...defaultsEval,
+      metrics:
+        evaluationMetrics !== undefined && evaluationMetrics.length > 0
+          ? [...evaluationMetrics]
+          : ((defaultsEval.metrics as unknown[] | undefined) ?? []),
     },
   };
 }

--- a/frontend/src/hooks/useTargetSelection.ts
+++ b/frontend/src/hooks/useTargetSelection.ts
@@ -9,6 +9,7 @@ import {
   getEffectiveCvStrategy,
   resetCvState,
 } from "@/components/workspace/cv-state";
+import { evalMetricMap } from "@/components/workspace/metric-options";
 import type { ConfigWriteFunnel } from "./useConfigWriteFunnel";
 import {
   buildMergedConfig,
@@ -107,6 +108,12 @@ export function useTargetSelection({
 
         if (detectedTask) {
           const defaults = await fetchConfigDefaults(detectedTask, value);
+          // Issue #529: seed `evaluation.metrics` from the UiSchema's
+          // task-keyed eval registry. Without this the merged-config PUT
+          // ships `evaluation.metrics: []`, which lets MetricsChips'
+          // task-change useEffect race the target-select PUT and emit a
+          // partial-body PUT that the backend rejects (saved=false).
+          const evaluationMetrics = evalMetricMap(uiSchema)[detectedTask] ?? [];
           const merged = buildMergedConfig({
             defaults,
             task: detectedTask,
@@ -119,6 +126,7 @@ export function useTargetSelection({
             dataPath,
             target: value,
             overrides: newOverrides,
+            evaluationMetrics,
           });
           // P-0092 Phase 3: route the merged-config PUT through the
           // write funnel when one is wired. The funnel's

--- a/frontend/tests/e2e/workspace-target-select-puts.spec.ts
+++ b/frontend/tests/e2e/workspace-target-select-puts.spec.ts
@@ -1,0 +1,178 @@
+import { expect, test } from "@playwright/test";
+import * as fs from "node:fs";
+import { isMobileProject } from "./helpers/mobile";
+import { dismissOnboarding } from "./helpers/onboarding";
+
+/**
+ * Issue #529 regression spec — partial-body PUTs from MetricsChips.
+ *
+ * Before the fix:
+ *   - Clicking Target = `survived` from a clean workspace produced
+ *     **2 partial-body PUTs** `{evaluation:{metrics:[...]}}` that
+ *     `MetricsChips`'s task-change `useEffect` emitted while
+ *     `ConfigForm`'s `configRef.current` was still empty.
+ *   - The backend silently rejected these with
+ *     `saved=false, blocking=5` (validation errors: `config_version`,
+ *     `task`, `split`, etc. missing).
+ *   - During the empty-`ws.config` window, `GET /data/split-preview`
+ *     could fire and correctly return **400 WORKSPACE_NO_CONFIG**.
+ *
+ * The fix gates the MetricsChips task-change auto-reset on a
+ * `configSeeded` prop (true once `config.config_version` is defined)
+ * and pre-populates `evaluation.metrics` in `buildMergedConfig` from
+ * the UiSchema's task-keyed eval registry. After both changes, the
+ * partial PUTs never fire and split-preview returns 200.
+ *
+ * This spec intercepts every `PUT /api/workspace/config` and asserts:
+ *   1. No PUT body has only `{evaluation}` at top level (the partial
+ *      signature). The body must contain at minimum `config_version`,
+ *      `task`, `split`, `data` — the seed config's invariant keys.
+ *   2. No GET /data/split-preview returns 400 during the Target flow.
+ *   3. Total PUT count is within budget (locks in the network-noise
+ *      regression and gives Bug B / #530 a numeric target to drive
+ *      down further).
+ */
+
+const CSV_PATH = "/tmp/e2e_target_select_puts.csv";
+const PUT_BUDGET = 6;
+
+function createBinaryCsv(): void {
+  const rows = ["id,age,survived"];
+  for (let i = 0; i < 100; i += 1) {
+    rows.push(`${i},${20 + (i % 50)},${i % 2}`);
+  }
+  fs.writeFileSync(CSV_PATH, rows.join("\n"));
+}
+
+test.describe("Target selection — no partial PUT, no split-preview 400 (Issue #529)", () => {
+  test.beforeAll(() => {
+    createBinaryCsv();
+  });
+
+  test.afterAll(() => {
+    if (fs.existsSync(CSV_PATH)) fs.unlinkSync(CSV_PATH);
+  });
+
+  test("partial-body PUT regression locks", async ({
+    page,
+    request,
+  }, testInfo) => {
+    if (isMobileProject(testInfo)) {
+      test.skip(
+        true,
+        "Mobile layout uses a different Data Panel collapse pattern; covered by the desktop project",
+      );
+    }
+
+    // Reset workspace so the seed config is genuinely empty when the
+    // Target selection fires. Without this, a leftover config from a
+    // previous test masks the bug.
+    await request.post("/api/workspace/reset");
+
+    // Set up interception BEFORE driving any UI so we observe every
+    // PUT /config from page load onward — though the partial-PUT bug
+    // fires only after Target is picked, capturing the full session
+    // gives diagnostic context if the test fails.
+    const allPuts: Array<{
+      keys: string[];
+      hasConfigVersion: boolean;
+      hasTask: boolean;
+      hasSplit: boolean;
+      bodySize: number;
+    }> = [];
+    page.on("request", (req) => {
+      if (req.method() !== "PUT") return;
+      if (!req.url().endsWith("/api/workspace/config")) return;
+      try {
+        const body = req.postDataJSON() as Record<string, unknown>;
+        const keys = Object.keys(body).sort();
+        allPuts.push({
+          keys,
+          hasConfigVersion: "config_version" in body,
+          hasTask: "task" in body,
+          hasSplit: "split" in body,
+          bodySize: req.postData()?.length ?? 0,
+        });
+      } catch {
+        // Ignore non-JSON bodies — none exist on this endpoint.
+      }
+    });
+
+    // Watch for split-preview 400 responses (Bug C / #531 — symptom of
+    // this bug). A passing run should see 200s only.
+    const splitPreview400s: number[] = [];
+    page.on("response", (res) => {
+      if (!res.url().endsWith("/api/workspace/data/split-preview")) return;
+      if (res.status() === 400) splitPreview400s.push(res.status());
+    });
+
+    // Drive the UI flow. Inlining the seed instead of using
+    // `seedUiWorkspace` because that helper picks `target="target"` and
+    // does its own quiescence wait that subsumes the events we want to
+    // count. Here we want to count PUTs *across* the Target-select
+    // window.
+    await dismissOnboarding(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("radio", { name: "Path" }).click();
+    await page.getByPlaceholder("/path/to/data.csv").fill(CSV_PATH);
+    await page.getByRole("button", { name: "Load" }).click();
+    await expect(page.getByText(/100 rows × \d+ columns/)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Snapshot PUTs BEFORE the Target click so post-click delta is clean.
+    const putsBeforeTarget = allPuts.length;
+
+    const combo = page.getByRole("combobox", { name: /target column/i });
+    await expect(combo).toBeEnabled({ timeout: 15_000 });
+    await combo.click();
+    await page.getByRole("option", { name: "survived" }).click();
+
+    // Wait for the funnel to drain. 3s is generous against typical
+    // 200 ms convergence; CI machines vary.
+    await page.waitForTimeout(3000);
+
+    const targetPuts = allPuts.slice(putsBeforeTarget);
+
+    // Invariant 1: NO partial-body PUTs. A partial body has only
+    // `evaluation` (or a tiny subset) as the top-level key set. Every
+    // PUT must carry the seed config invariants (config_version, task,
+    // split).
+    const partials = targetPuts.filter(
+      (p) => !p.hasConfigVersion || !p.hasTask || !p.hasSplit,
+    );
+    expect(
+      partials,
+      `Issue #529 regression — partial-body PUT(s) observed.
+` +
+        `These bodies lack config_version/task/split and the backend ` +
+        `rejects them with saved=false, blocking=5. Captured:
+` +
+        partials.map((p) => `  keys=${JSON.stringify(p.keys)}`).join("\n"),
+    ).toHaveLength(0);
+
+    // Invariant 2: split-preview never 400'd. Bug C disappears when
+    // Bug A is fixed because ws.config is always populated.
+    expect(
+      splitPreview400s,
+      `Issue #531 regression — GET /split-preview returned 400 ` +
+        `WORKSPACE_NO_CONFIG. Likely cause: partial PUT from MetricsChips ` +
+        `left ws.config empty (Issue #529 root cause).`,
+    ).toHaveLength(0);
+
+    // Invariant 3: PUT count within budget. We measured 4 PUTs after
+    // the fix (1 target-select + 3 auto-reset oscillation from #530).
+    // Budget of 6 gives headroom for #530 not yet being fixed; tighten
+    // when #530 lands.
+    expect(
+      targetPuts.length,
+      `Target-select fired ${targetPuts.length} PUTs (budget ${PUT_BUDGET}). ` +
+        `Pre-#529 fix this was 9. Investigate if it exceeds the budget — ` +
+        `likely a new useEffect was added that derives state from cache ` +
+        `and emits a write. See also Issue #530 (oscillation between ` +
+        `model.params.objective and model.params.metric).`,
+    ).toBeLessThanOrEqual(PUT_BUDGET);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #529 (and its dependent symptom #531) with a two-pronged
frontend-only fix:

1. **`buildMergedConfig` seeds `evaluation.metrics`** from the
   UiSchema's `option_sets.eval_metric[task]` registry. The
   target-select PUT now lands with a complete `evaluation` slice.
2. **`MetricsChips` gates the task-change `useEffect` on a new
   `configSeeded` prop**. `ConfigForm` passes
   `configSeeded={Boolean(config.config_version)}`. While the seed
   PUT is in flight, the auto-reset bails before reaching `onChange`,
   so no partial body reaches the backend.

Either change alone closes the bug for the target-select flow;
together they also cover edge cases (e.g. legacy YAML imports with an
empty `evaluation` block).

## Why

When the user picks Target = `Survived`, `useTargetSelection.setTask()`
flips the `task` prop synchronously. `MetricsChips`'s task-change
`useEffect` reacts on the NEXT render and calls
`onChange([...defaults])` BEFORE the target-select merged-config PUT
has landed. The chain routes through `ConfigForm.handleFieldChange`,
which writes onto `configRef.current` -- still `{}` at this moment --
producing a partial body `{evaluation:{metrics:[...]}}` that the
backend silently rejects with `saved=false, blocking=5`.

If both partial PUTs are still in-flight when `FoldPreview`'s
`useEffect` fires `GET /split-preview`, `ws.config` is empty and the
endpoint correctly returns 400 `WORKSPACE_NO_CONFIG` (#531 symptom).

This is the **same anti-pattern** that P-0109 PR-5 (#521) eliminated
for the Tune-tab. PR-5 was scoped to Tune-tab; this PR closes the
analogous hole on the legacy Fit-side `ConfigForm` / `MetricsChips`.

## Verification (local repro)

Backend instrumented to log `saved` flag + body key set per PUT.
Workspace reset, load `titanic_418.csv`, click Target = `Survived`.

**Before:**
```
PUT saved=False keys=['evaluation'] blocking=5  <-- rejected partial
PUT saved=True  keys=[full]
PUT saved=False keys=['evaluation'] blocking=5  <-- rejected partial
PUT saved=True  keys=[full]
... 5 more full PUTs from Issue #530 oscillation ...
GET /split-preview -> 400 WORKSPACE_NO_CONFIG
```
**Total: 9 PUTs, 2 rejected, 1 split-preview 400.**

**After:**
```
PUT saved=True keys=[full]
PUT saved=True keys=[full]
PUT saved=True keys=[full]
PUT saved=True keys=[full]
GET /split-preview -> 200 OK
```
**Total: 4 PUTs (all accepted), 0 partial, 0 split-preview 400.**

The remaining 3 redundant full-body PUTs come from Issue #530
(objective/metric oscillation) which is **out of scope** for this PR
and addressed separately.

## Diff scope

- `frontend/src/hooks/useDataPanel.types.ts` — add optional
  `evaluationMetrics` param to `buildMergedConfig`; emit
  `evaluation.metrics` from it (falling back to
  `defaults.evaluation.metrics`).
- `frontend/src/hooks/useTargetSelection.ts` — pass
  `evalMetricMap(uiSchema)[detectedTask]` into `buildMergedConfig`.
- `frontend/src/components/workspace/MetricsChips.tsx` — add
  `configSeeded` prop (default `true` for back-compat with existing
  tests/stories); short-circuit the task-change `useEffect` when
  `!configSeeded`.
- `frontend/src/components/workspace/ConfigForm.tsx` — pass
  `configSeeded={Boolean(config.config_version)}` to MetricsChips.

## Tests

- **6 new unit tests** (3 in `MetricsChips.test.tsx`, 3 in
  `useDataPanel.types.test.ts`):
  - `configSeeded=false` suppresses task-change auto-reset
  - `configSeeded=false` suppresses initial empty-list auto-reset
  - `configSeeded` transition `false -> true` fires the existing
    fallback
  - `buildMergedConfig` seeds `evaluation.metrics` from param
  - `buildMergedConfig` falls back to `defaults.evaluation.metrics`
  - `buildMergedConfig` emits empty when neither source supplies
- **1 new e2e regression spec**
  (`workspace-target-select-puts.spec.ts`):
  - Subscribes to every PUT during Target selection
  - Asserts NO partial body (no PUT without `config_version`, `task`,
    `split`)
  - Asserts NO split-preview 400 (locks #531 symptom)
  - Asserts PUT count <= 6 budget (current observation: 4)

Full local CI:
- `pnpm test` — 1931/1931 unit tests pass
- `pnpm check` — Biome clean (293 files)
- `pnpm build` — frontend builds successfully
- `uv run ruff check` / `ruff format --check` — clean
- `uv run mypy --no-incremental src/lizystudio/` — no issues
- `uv run pytest` — 1665 passed, 10 skipped
- `pnpm playwright test workspace-target-select-puts.spec.ts` — passes

## Compatibility

- No backend changes. No API surface change. No format-version bump.
- `MetricsChips` `configSeeded` prop defaults to `true`, so existing
  test/story renders keep working without modification.
- `buildMergedConfig`'s `evaluationMetrics` param is optional with
  the same `defaults.evaluation.metrics ?? []` fallback the old code
  effectively produced.

## Related

- Issue #529 (root cause — this PR's primary close)
- Issue #531 (symptom — auto-resolves with #529; PR also locks it
  via e2e assertion)
- Issue #530 (cousin bug, oscillation — NOT addressed here; tracked
  as PR-B in the original analysis)
- P-0109 / PR #521 (same anti-pattern eliminated for Tune-tab)
- `feedback_count_budget_assertions` memory — pattern applied via
  the PUT-budget assertion in the e2e spec
