### PR TITLE
chore(release): prepare v0.6.2 -- Target-select write-traffic reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,102 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-05-17
+
+The **Target-select write-traffic reduction** patch release. Closes
+the three-issue cluster (#529 / #530 / #531) that produced 9 PUTs
+plus a 400 `WORKSPACE_NO_CONFIG` error every time the user picked a
+Target column on a fresh workspace. After this release one Target
+click produces **2 PUTs** — the irreducible minimum — and the
+split-preview 400 disappears.
+
+Bundles:
+
+1. **#529 / PR #532 — partial-body PUTs from `MetricsChips` are
+   eliminated**. The Target-select PUT now seeds `evaluation.metrics`
+   from the UiSchema, and `MetricsChips` gates its task-change
+   `useEffect` on a new `configSeeded` prop so the pre-seed render
+   no longer routes a partial body through `handleFieldChange`. Both
+   silent `saved=false` rejections (with their 5 blocking validation
+   errors) are gone.
+2. **#530 / PR #533 — Target-select PUT oscillation is fixed**.
+   `coalesceByReason` now merges same-reason `kind: "patch"` ops at
+   different paths into a new `kind: "patch-many"` op instead of
+   silently dropping the earlier path. Combined with an
+   `isFlushing` gate on `ConfigForm`'s auto-reset `useEffect`, the
+   GET-refetch-mid-flush race that produced two byte-identical PUTs
+   is closed. PUT count history: 9 -> 4 (#529) -> 3 (Phase 1) -> 2
+   (Phase 2).
+3. **#531 — `GET /split-preview` no longer returns 400 during
+   Target selection**. This was a symptom of #529 (rejected partial
+   PUTs left `ws.config` empty); auto-resolves with the #529 fix and
+   is locked by the e2e regression spec.
+
+### Fixed
+
+- **Partial-body PUTs from `MetricsChips` task-change `useEffect`
+  (#529)** — `MetricsChips` no longer emits `onChange` against an
+  empty `configRef.current` during the pre-seed render window. The
+  emitted body is now always a full config, so the backend's
+  `saved=false, blocking=5` silent rejection cannot occur. Adds
+  `MetricsChips.configSeeded?: boolean` (default `true` for
+  back-compat) and routes `Boolean(config.config_version)` from
+  `ConfigForm`.
+- **Target-select PUT oscillation in `ConfigForm`'s objective /
+  metric auto-reset effect (#530)** — same-reason `kind: "patch"`
+  ops at different paths now coalesce into a new
+  `kind: "patch-many"` variant in `coalesceByReason`. The effect
+  also bails when `funnel.isFlushing()` is true, so the GET-refetch
+  triggered by `handleDataChanged`'s `invalidateQueries` can no
+  longer re-fire the effect against a mid-flush stale snapshot.
+- **`GET /api/workspace/data/split-preview` returning 400
+  `WORKSPACE_NO_CONFIG` (#531)** — auto-resolved as the symptom of
+  #529. The new e2e regression spec
+  (`workspace-target-select-puts.spec.ts`) asserts a zero-count
+  budget for this 400 alongside the PUT-budget assertion.
+
+### Added
+
+- **`MetricsChips.configSeeded?: boolean` prop** — gates the
+  task-change auto-reset `useEffect` on whether the workspace seed
+  config has landed. Default `true` so existing test / Storybook
+  call sites stay backward-compatible.
+- **`buildMergedConfig({ evaluationMetrics })` parameter** — seeds
+  `evaluation.metrics` from the UiSchema's
+  `option_sets.eval_metric[task]` registry. Optional, with a
+  fallback to `defaults.evaluation.metrics ?? []`.
+- **`useConfigWriteFunnel` `kind: "patch-many"` `WriteOp` variant** —
+  funnel-internal op produced by `coalesceByReason` when two
+  same-reason patches at different paths coalesce. `materializeOp`
+  applies each entry in order on top of the cached snapshot. No
+  caller emits this directly.
+- **`frontend/tests/e2e/workspace-target-select-puts.spec.ts`** —
+  Playwright regression spec that intercepts every PUT during
+  Target selection and asserts (a) no partial-body PUT, (b) no 400
+  on `split-preview`, and (c) PUT count within budget (currently 3,
+  measured 2).
+
+### Changed
+
+- **`coalesceByReason` semantics in `useConfigWriteFunnel`** — the
+  legacy "latest wins outright" rule is replaced by a tri-cased
+  reducer: replace always wins, patch-after-replace is dropped, and
+  patch+patch / patch+patch-many merge into a `patch-many` op
+  preserving both paths.
+
+### Compatibility
+
+- **No backend changes.** Same `STUDIO_FORMAT_VERSION` (2). Same
+  API surface. Server-side validation behaviour is unchanged.
+- **No funnel public-API change.** `kind: "patch-many"` is produced
+  only by the funnel itself; every existing writer call site
+  (`useTargetSelection`, `useConfigSync`, `useModelPanelData`,
+  `enqueueAutoReset`) keeps emitting the same `kind: "replace"` /
+  `kind: "patch"` ops as before.
+- **Backward-compatible prop additions.** Both `MetricsChips`'s
+  `configSeeded` and `buildMergedConfig`'s `evaluationMetrics` are
+  optional with safe defaults.
+
 ## [0.6.1] - 2026-05-16
 
 The **Tune backend SSOT consolidation + StudioError observability** patch

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 - このファイルは **横串インデックス** であり、詳細はリンク先で確認すること。
 - 着手する際は HISTORY に Proposal を起票（変更ゲート対象の場合）→ PLAN にフェーズ追加 → 実装、の順で進める。
 
-最終更新: 2026-05-13（**v0.6.0 release 済 (2026-05-13, PyPI lizystudio==0.6.0)** + **`issue-cleanup-plan-2026-05-10.md` Wave 1〜6 完了** — `PLAN.md` v0.5 phase 全消化。直近の Tier 1 next は **#513 (StudioError observability、v0.6.0 検証中に発見した 5 行 PR)** / **#495** / 🔒 **#452-b**。次の節目候補は **v0.7+**: 第 2 backend (#403 残・#452-b 解禁トリガ)、Tailwind v4、P-0087 Phase 3、typed error 体系 (R-3.1〜R-3.3) など）
+最終更新: 2026-05-17（**v0.6.1 release 済 (2026-05-16, PyPI lizystudio==0.6.1)** + **v0.6.2 release prep 中** — Target-select 3-issue cluster (#529 / #530 / #531) を develop に着地、PUT count 9 → 2、`saved=False` 0 件、split-preview 400 解消。直近の Tier 1 next は **#527 / #528 (P-0109 follow-up)** / **#495** / 🔒 **#452-b**。次の節目候補は **v0.7+**: 第 2 backend (#403 残・#452-b 解禁トリガ)、Tailwind v4、P-0087 Phase 3、typed error 体系 (R-3.1〜R-3.3) など）
 
 ---
 
@@ -300,10 +300,13 @@ Wave 6 完了後の Open Issue は **4 件**（#451 / #453 は 2026-05-13 close 
 
 ### Tier 1：直近の着手候補（ROI 順）
 
-1. **A-1 / A-2 — P-0109 follow-up（v0.6.1 後に起票）** — A-1: `_assert_inv_t3` warn-only helper の再有効化（PR #523 で導入 + 一時 disable、`tune-resume.spec.ts:185` の pause-timing race と相互作用、helper 自体は src に残存）。A-2: Tune タブ mutation を legacy `PUT /config` → 新 `PUT /config/tuning-overrides` (sparse REPLACE) へ移行。両者とも tech-debt / low priority、機能影響なし
-2. **#495** — #456 L5: weekly stale-doc audit cron（`scripts/audit_stale_docs.py` + `.github/workflows/audit-stale-docs.yml` cron weekly、tracking issue 自動更新。tier-3/low、deferred）
-3. **#452-b `lifecycle_mixin.tune` 分割** — 🔒 2nd-adapter 議論（§3.3）後に解禁。それまで着手しない
+1. **#527 (`_assert_inv_t3` 再有効化)** — A-1 / P-0109 follow-up。`tune-resume.spec.ts:185` の pause-timing race と相互作用、helper 自体は #523 で残存。再有効化条件: `n_trials` 拡大 or pause 観測の堅牢化。tier-3/low、機能影響なし
+2. **#528 (Tune タブ write path → sparse overrides)** — A-2 / P-0109 follow-up。legacy `PUT /config` → 新 `PUT /config/tuning-overrides` (sparse REPLACE) へ移行。refactor only、`absorb_legacy_tuning` shim 依存解消。tier-3/low
+3. **#495** — #456 L5: weekly stale-doc audit cron（`scripts/audit_stale_docs.py` + `.github/workflows/audit-stale-docs.yml` cron weekly、tracking issue 自動更新。tier-3/low、deferred）
+4. **#452-b `lifecycle_mixin.tune` 分割** — 🔒 2nd-adapter 議論（§3.3）後に解禁。それまで着手しない
 
+> ~~#529 / #530 / #531 (Target-select 3-issue cluster)~~ ✅ 完了 (PR #532 / #533、2026-05-16〜17 着地。v0.6.2 でリリース)。Target click あたり PUT count 9 → 2、`saved=False` 0 件、`GET /split-preview` 400 解消。修正: (1) `MetricsChips` task-change useEffect を `configSeeded` prop で gate + `buildMergedConfig` に evaluation.metrics seed (#529); (2) `coalesceByReason` を patch+patch -> `kind: "patch-many"` merge に拡張 + `ConfigForm` auto-reset を `funnel.isFlushing()` で gate (#530); (3) #531 は #529 の symptom で auto-resolve。e2e regression spec `workspace-target-select-puts.spec.ts` で lock
+>
 > ~~P-0109 PR-6 残作業~~ ✅ 完了 (#522 / #523 / #524、2026-05-16 着地。全 9 PR (#516〜#524) develop に着地、INV-T3 が `LizyMLAdapter.compute_effective_tuning` の SSOT で enforce、`useTuningSnapshot` hook + "Modified" badge 経由で frontend read path 完成、`TASK_DEFAULT_METRICS` frontend 定数削除、HISTORY Decision flip + ROADMAP / BLUEPRINT / architecture-as-implemented reconcile 完了)
 >
 > ~~#513 (StudioError observability / R-3.1 precursor)~~ ✅ 完了 (PR #515、2026-05-14。`api/errors.py::studio_error_handler` で全 StudioError を WARNING level で log、`code` / `status_code` / method / path、PII なし、`details` は意図的に除外)
@@ -336,7 +339,7 @@ Wave 6 完了後の Open Issue は **4 件**（#451 / #453 は 2026-05-13 close 
 | v3-25 | R-4.1 format_version migration matrix CI gate (P-0103) | ✅ 完了 (PR #432 + #434 + #436 + #438) |
 | v3-26 | R-4.2 Pickle compatibility nightly CI | ✅ 完了 (feat/v3-26-pickle-compat-nightly / P-0107) |
 
-直近の next: **v0.6.1 patch release**（P-0109 chain bundle + #513 observability、リリース直前）。その後は上記 Tier 1 の A-1 / A-2 follow-up Issue。v0.6 候補は上記 Tier 2 を参照。
+直近の next: **v0.6.2 patch release**（#529 + #530 + #531 bundle、Target-select write-traffic reduction、リリース直前）。その後は上記 Tier 1 の #527 / #528 (P-0109 follow-up Issue)。v0.6 候補は上記 Tier 2 を参照。
 
 ---
 


### PR DESCRIPTION
## Summary

Release-preparation PR for **v0.6.2** (patch). Docs-only.

- Move `CHANGELOG.md` `[Unreleased]` -> `[0.6.2] - 2026-05-17` with
  the Target-select 3-issue cluster bundled (#529 / #530 / #531).
- Reconcile `docs/ROADMAP.md`:
  - Tier 1 next-actions list demotes the cluster to the completed
    strikethrough block.
  - New top-of-list: `#527` / `#528` (P-0109 follow-ups).
  - Status header updated to reflect v0.6.1 shipped + v0.6.2 prep.

No production code changes. `__version__` is `hatch-vcs` derived;
the `0.6.2` string is materialized when the `v0.6.2` tag is pushed
after the release PR merges to `main`.

## Why bundle now

Per `~/.claude/rules/common/git-workflow.md`, docs-only PRs are
discouraged -- but this PR exists to **gate the actual `develop ->
main` release PR**: CHANGELOG / ROADMAP must reflect the shipped
state before the release PR can credibly describe it. The bundle
keeps churn to a single PR rather than two.

## Test plan

- [x] `git diff --stat` confirms only `CHANGELOG.md` and
      `docs/ROADMAP.md` are touched
- [x] `uv run ruff format --check` clean (no Python files touched)
- [x] Pre-commit hooks (ruff legacy + ruff format + biome + stray
      artefacts) all skipped or passed
- [ ] CI green on this PR (docs-only, format checks should pass; e2e
      and tests should be unaffected)
- [ ] After merge, the release PR (`develop -> main`) is opened with
      the v0.6.2 CHANGELOG section as its body
