### PR TITLE
ci(publish): auto-create GitHub Release from CHANGELOG after PyPI upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,9 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
+      # Allow `gh release create` to publish the GitHub Release in the
+      # post-PyPI step below.
+      contents: write
     env:
       # Prevent local version identifiers (e.g. +dirty, +dN.gHASH)
       # even if the working tree becomes dirty during the build.
@@ -68,3 +71,44 @@ jobs:
           fi
 
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+      # Create the GitHub Release after PyPI upload succeeds. Notes are
+      # extracted verbatim from CHANGELOG.md's section heading
+      # `## [VERSION] - YYYY-MM-DD` so the release page and the file
+      # stay synchronised without a second manual edit step. Skipped (not
+      # failed) when the release already exists, so re-running the
+      # workflow on a re-pushed tag does not clobber a curated release.
+      #
+      # Pre-v0.6.3 releases (v0.6.0 / v0.6.1 / v0.6.2) were created
+      # manually via `gh release create` after PyPI upload. v0.6.1 /
+      # v0.6.2 were briefly forgotten — this step closes that gap.
+      - name: Create GitHub Release from CHANGELOG
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          # Extract the section between `## [VERSION]` and the next
+          # top-level `## [` heading. Outputs nothing when no section
+          # matches — we treat that as an error since shipping a
+          # release with no notes is almost certainly a mistake.
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" { found=1; next }
+            /^## \[/ && found { exit }
+            found { print }
+          ' CHANGELOG.md > /tmp/release_notes.md
+          if [ ! -s /tmp/release_notes.md ]; then
+            echo "::error::CHANGELOG.md has no section for version $VERSION. Add one matching '## [$VERSION] - YYYY-MM-DD' before tagging."
+            exit 1
+          fi
+          # Upsert semantics: skip (do not clobber) if the release
+          # already exists. Operators who want to refresh notes after
+          # the fact can `gh release edit` manually.
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists; skipping create. Use 'gh release edit' to refresh notes."
+            exit 0
+          fi
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file /tmp/release_notes.md \
+            --verify-tag


### PR DESCRIPTION
## Summary

Closes the gap that left v0.6.1 / v0.6.2 without GitHub Releases despite their tags and PyPI artefacts shipping correctly. After this PR, every `v*` tag push will:

1. Run the existing PyPI publish pipeline (lint -> test -> mypy -> build -> verify version -> upload).
2. **NEW** — Extract the matching section from `CHANGELOG.md` and create a GitHub Release for the tag.

## Why

The Releases page is the public face of a release. PyPI is the package itself, but humans land on `https://github.com/<repo>/releases` to see what changed. Until today, the v0.6.1 / v0.6.2 entries were missing, so the page still showed v0.6.0 as the "Latest" release.

Pre-v0.6.3 releases (v0.6.0 / v0.6.1 / v0.6.2) relied on a manual `gh release create` step after PyPI upload. That step was forgotten twice in a row, even though the rest of the release flow was followed perfectly. This PR removes the manual step from the workflow.

## Design choices

- **Notes source: `CHANGELOG.md` section verbatim.** The release page and the CHANGELOG file stay synchronised without a second edit step. The `awk` extractor scans `## [VERSION]` through to the next `## [` heading.
- **Fail loud on missing CHANGELOG entry.** Empty release notes are almost always a mistake (forgot to add the section before tagging). The workflow exits non-zero with a clear error message pointing at the expected heading.
- **Upsert is "create-if-missing" only.** If a Release for the tag already exists (e.g. someone hand-curated one earlier, or the workflow ran twice on a re-pushed tag), the step skips with a log message. Operators who want to refresh the notes after the fact can run `gh release edit` manually.
- **Title is the bare tag name (`vX.Y.Z`).** A curated tagline is nice but extracting it reliably from the CHANGELOG body is fragile. The auto-created release is a safe baseline; maintainers can `gh release edit --title "vX.Y.Z — TAGLINE"` afterwards if they want.
- **Permission: `contents: write`.** Required for `gh release create`. The existing `id-token: write` for PyPI OIDC is preserved.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('publish.yml'))"` parses clean
- [x] Extractor sanity check on real CHANGELOG.md:
  - `VERSION=0.6.2` → 95 lines (matches the v0.6.2 section)
  - `VERSION=0.6.1` → 131 lines (matches the v0.6.1 section; correctly stops at `## [0.6.0]`)
  - `VERSION=9.9.9` → 0 lines (would fail-loud in the workflow)
- [x] `## [Unreleased]` section at the top is NOT matched by `## [0.6.2]` lookup (different bracket content)
- [x] No Python files touched; ruff check + format clean
- [ ] First real exercise: next release (v0.6.3+) — the manual `gh release create` step disappears from the runbook

## Compatibility

- **No effect on past releases.** The step only runs for tags pushed AFTER this PR merges. v0.6.0 / v0.6.1 / v0.6.2 are unaffected.
- **No effect on PyPI upload.** The release step runs AFTER the PyPI publish step. If PyPI fails, no release is created. If PyPI succeeds and the release step fails, the package is on PyPI and the release can be created manually (next `gh release create vX.Y.Z` would succeed because the tag exists).
- **Re-runs are safe.** Running the workflow twice on the same tag (e.g. after a transient failure) leaves the existing release intact instead of clobbering or duplicating.

## Follow-ups (not in this PR)

- Backfill of v0.6.1 / v0.6.2 GitHub Releases was already done today (manual `gh release create` with notes copied from CHANGELOG sections).
- A future improvement could parse a maintainer-supplied tagline from the CHANGELOG (e.g. a `<!-- release-title: ... -->` HTML comment under the section heading), but that's out of scope here.
