### PR TITLE
test(frontend): assert call counts, not just call fact (#537)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,18 @@ jobs:
         working-directory: frontend
         run: bash scripts/check-no-apifetch.sh
 
+  # Issue #537: the v0.6.2 Target-select bug cluster passed the unit suite
+  # because assertions checked that a mock was called, not how many times.
+  # This grep guard stops a new bare ``.toHaveBeenCalled()`` from landing —
+  # callback assertions must use the count-precise ``.toHaveBeenCalledTimes(N)``.
+  tohavebeencalled-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Scan frontend/src test files for bare .toHaveBeenCalled()
+        working-directory: frontend
+        run: bash scripts/check-tohavebeencalled.sh
+
   # C-1 / INV-CI-1: committed schema.d.ts must match freshly-generated
   # output. Prevents drift between backend response_model declarations
   # and the TypeScript types that the frontend compiles against.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,10 @@ uv run pytest --cov=src/lizystudio --cov-fail-under=80 -q  # test
 - **Formatter/Linter:** [Biome](https://biomejs.dev/) (ESLint/Prettier are **not** used)
 - **Tests:** [Vitest](https://vitest.dev/) (unit) + [Playwright](https://playwright.dev/) (e2e)
 - **API types:** auto-generated via `openapi-typescript` — never hand-write API types
+- **Mock assertions:** assert the call *count*, not just the fact — use
+  `expect(spy).toHaveBeenCalledTimes(N)`, never bare `expect(spy).toHaveBeenCalled()`.
+  When `N` is not 1, add a one-line comment naming the reason. The
+  `tohavebeencalled-guard` CI job enforces this (Issue #537).
 
 ```bash
 cd frontend

--- a/frontend/scripts/check-tohavebeencalled.sh
+++ b/frontend/scripts/check-tohavebeencalled.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# CI guard: forbid bare ``.toHaveBeenCalled()`` in frontend test files.
+#
+# Issue #537: the v0.6.2 Target-select bug cluster (#529 / #530 / #531)
+# slipped past the unit suite because assertions checked *that* a mock was
+# called, not *how many times*. A callback firing 4-9 times when it should
+# fire once satisfies ``.toHaveBeenCalled()`` silently. The audit converted
+# every existing site to ``.toHaveBeenCalledTimes(N)``; this guard stops a
+# regression from landing a new bare assertion.
+#
+# Allowed (NOT flagged):
+#   - ``.toHaveBeenCalledTimes(N)``  — the count-precise form
+#   - ``.not.toHaveBeenCalled()``    — already encodes a count of 0
+#   - ``.toHaveBeenCalledWith(...)`` — asserts args, a different question
+#
+# Exit 1 if any bare ``.toHaveBeenCalled()`` is found.
+# Usage: bash scripts/check-tohavebeencalled.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FRONTEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$FRONTEND_DIR"
+
+if ! command -v grep >/dev/null 2>&1; then
+  echo "ERROR: grep is required but not found in PATH." >&2
+  exit 2
+fi
+
+echo "Scanning src/ test files for bare .toHaveBeenCalled() (Issue #537 guard)..."
+
+# ``.toHaveBeenCalled()`` matches the bare assertion. It also appears inside
+# ``.not.toHaveBeenCalled()`` — those lines are filtered out below. The
+# ``Times`` / ``With`` variants do not contain the literal ``Called()`` so
+# they never match in the first place.
+MATCHES="$(grep -rHn \
+  --include='*.test.ts' --include='*.test.tsx' \
+  '\.toHaveBeenCalled()' src/ || true)"
+
+VIOLATIONS=""
+if [[ -n "$MATCHES" ]]; then
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    # ``.not.toHaveBeenCalled()`` already encodes count 0 — allowed.
+    if [[ "$line" == *".not.toHaveBeenCalled()"* ]]; then
+      continue
+    fi
+    VIOLATIONS+="${line}"$'\n'
+  done <<< "$MATCHES"
+fi
+
+if [[ -n "$VIOLATIONS" ]]; then
+  echo ""
+  echo "ERROR: bare .toHaveBeenCalled() found in test files:"
+  echo ""
+  printf '%s' "$VIOLATIONS"
+  echo ""
+  echo "Fix: assert the intended call count, not just the fact of a call."
+  echo "  expect(spy).toHaveBeenCalled()  ->  expect(spy).toHaveBeenCalledTimes(N)"
+  echo "  When N is not 1, add a one-line comment naming the reason."
+  echo "  See CLAUDE.md section 7 (Flaky / test-quality conventions)."
+  exit 1
+fi
+
+echo "OK: no bare .toHaveBeenCalled() in test files."

--- a/frontend/src/api/queries/queries.phase2.test.ts
+++ b/frontend/src/api/queries/queries.phase2.test.ts
@@ -247,7 +247,7 @@ describe("useFiles", () => {
     expect(fetchDirectory).not.toHaveBeenCalled();
 
     rerender({ on: true });
-    await waitFor(() => expect(fetchDirectory).toHaveBeenCalled());
+    await waitFor(() => expect(fetchDirectory).toHaveBeenCalledTimes(1));
   });
 
   it("passes undefined to fetchDirectory for the ~ root sentinel", async () => {

--- a/frontend/src/api/queries/queries.test.ts
+++ b/frontend/src/api/queries/queries.test.ts
@@ -209,7 +209,7 @@ describe("useRunInference", () => {
       });
     });
 
-    expect(runInference).toHaveBeenCalled();
+    expect(runInference).toHaveBeenCalledTimes(1);
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: queryKeys.infHistoryAll(),
     });

--- a/frontend/src/api/websocket.test.ts
+++ b/frontend/src/api/websocket.test.ts
@@ -166,7 +166,7 @@ describe("connectJobProgress", () => {
 
     ws.readyState = MockWebSocket.OPEN;
     cleanup();
-    expect(ws.close).toHaveBeenCalled();
+    expect(ws.close).toHaveBeenCalledTimes(1);
   });
 
   it("cleanup does not close already-closed WebSocket", () => {

--- a/frontend/src/components/inference/SetupPanel.test.tsx
+++ b/frontend/src/components/inference/SetupPanel.test.tsx
@@ -31,6 +31,11 @@ vi.mock("@/components/workspace/FileBrowser", () => ({
 describe("SetupPanel", () => {
   afterEach(() => {
     cleanup();
+    // File-scoped hoisted mocks accumulate calls across tests; clear them
+    // so per-test `.toHaveBeenCalledTimes(N)` assertions are count-precise.
+    mockUpload.mockClear();
+    mockToast.success.mockClear();
+    mockToast.error.mockClear();
   });
 
   const baseProps = {
@@ -416,7 +421,7 @@ describe("SetupPanel", () => {
       'input[type="file"]',
     ) as HTMLInputElement;
     fireEvent.change(input, { target: { files: [file] } });
-    await waitFor(() => expect(mockUpload).toHaveBeenCalled());
+    await waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(1));
 
     await user.click(screen.getByRole("button", { name: /run inference/i }));
 

--- a/frontend/src/components/jobs/DeleteDialog.test.tsx
+++ b/frontend/src/components/jobs/DeleteDialog.test.tsx
@@ -54,7 +54,7 @@ describe("DeleteDialog", () => {
 
     await waitFor(() => {
       expect(deleteJob).toHaveBeenCalledWith("job-abc");
-      expect(defaultProps.onDeleted).toHaveBeenCalled();
+      expect(defaultProps.onDeleted).toHaveBeenCalledTimes(1);
       expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false);
     });
   });

--- a/frontend/src/components/jobs/PauseActionButton.test.tsx
+++ b/frontend/src/components/jobs/PauseActionButton.test.tsx
@@ -77,7 +77,7 @@ describe("PauseActionButton", () => {
     );
 
     await waitFor(() => {
-      expect(mockPauseJob).toHaveBeenCalled();
+      expect(mockPauseJob).toHaveBeenCalledTimes(1);
     });
     expect(onPauseRequested).not.toHaveBeenCalled();
   });

--- a/frontend/src/components/jobs/UnpauseActionButton.test.tsx
+++ b/frontend/src/components/jobs/UnpauseActionButton.test.tsx
@@ -92,7 +92,7 @@ describe("UnpauseActionButton", () => {
     );
 
     await waitFor(() => {
-      expect(mockUnpauseJob).toHaveBeenCalled();
+      expect(mockUnpauseJob).toHaveBeenCalledTimes(1);
     });
     expect(onUnpauseStarted).not.toHaveBeenCalled();
   });

--- a/frontend/src/components/layout/CommandPalette.test.tsx
+++ b/frontend/src/components/layout/CommandPalette.test.tsx
@@ -69,7 +69,7 @@ describe("CommandPalette", () => {
 
     fireEvent.click(screen.getByText("Run Fit"));
 
-    expect(onFit).toHaveBeenCalled();
+    expect(onFit).toHaveBeenCalledTimes(1);
     // Dialog should be closed (no input visible)
     expect(screen.queryByPlaceholderText("Type a command...")).toBeNull();
   });
@@ -98,7 +98,7 @@ describe("CommandPalette", () => {
 
     fireEvent.click(screen.getByText("Run Tune"));
 
-    expect(onTune).toHaveBeenCalled();
+    expect(onTune).toHaveBeenCalledTimes(1);
     expect(screen.queryByPlaceholderText("Type a command...")).toBeNull();
   });
 

--- a/frontend/src/components/workspace/BlockedGroupKFoldEditor.component.test.tsx
+++ b/frontend/src/components/workspace/BlockedGroupKFoldEditor.component.test.tsx
@@ -507,7 +507,8 @@ describe("BlockedGroupKFoldEditor", () => {
     // First is minTrainRows, second is minValidRows
     await user.type(autoInputs[0], "100");
 
-    expect(mockOnChange).toHaveBeenCalled();
+    // called 3 times: one controlled onChange per keystroke ("1", "0", "0")
+    expect(mockOnChange).toHaveBeenCalledTimes(3);
   });
 
   it("calls onBlockedChange when blockMode is changed to sliding", () => {
@@ -540,7 +541,7 @@ describe("BlockedGroupKFoldEditor", () => {
     );
 
     await waitFor(() => {
-      expect(mockOnBlockedChange).toHaveBeenCalled();
+      expect(mockOnBlockedChange).toHaveBeenCalledTimes(1);
     });
 
     expect(mockOnBlockedChange).toHaveBeenCalledWith(

--- a/frontend/src/components/workspace/ConfigForm.test.tsx
+++ b/frontend/src/components/workspace/ConfigForm.test.tsx
@@ -339,7 +339,7 @@ describe("ConfigForm", () => {
 
     // Allow the effect to flush.
     await waitFor(() => {
-      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledTimes(1);
     });
     // The reset write must zero the calibration field (immutably).
     const calls = onChange.mock.calls.map((c) => c[0]);
@@ -479,8 +479,10 @@ describe("ConfigForm", () => {
       } as unknown as UiSchema,
     });
 
+    // called 3 times: three task-derived effects fire — calibration clear,
+    // objective reset, and metric reset — once config.task catches up.
     await waitFor(() => {
-      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledTimes(3);
     });
 
     // Calibration must clear (regression doesn't support it).
@@ -881,7 +883,7 @@ describe("ConfigForm — handleHintChange (onChange propagation)", () => {
       .find((el) => el.dataset.hintKey === "objective");
     fireEvent.click(dynParam!);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updatedConfig =
       onChange.mock.calls[onChange.mock.calls.length - 1][0];
     expect(updatedConfig.model.params.objective).toBe("__changed__");
@@ -903,7 +905,7 @@ describe("ConfigForm — handleHintChange (onChange propagation)", () => {
       .find((el) => el.dataset.hintKey === "metric");
     fireEvent.click(dynParam!);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updatedConfig =
       onChange.mock.calls[onChange.mock.calls.length - 1][0];
     expect(updatedConfig.model.params.metric).toBe("__changed__");
@@ -927,7 +929,7 @@ describe("ConfigForm — handleHintChange (onChange propagation)", () => {
       .find((el) => el.dataset.hintKey === "learning_rate");
     fireEvent.click(dynParam!);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updatedConfig =
       onChange.mock.calls[onChange.mock.calls.length - 1][0];
     expect(updatedConfig.model.params.learning_rate).toBe("__changed__");
@@ -955,7 +957,7 @@ describe("ConfigForm — auto-select useEffect", () => {
       } as unknown as UiSchema,
     });
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const calls = onChange.mock.calls;
     // Find a call that sets objective
     const objCall = calls.find(
@@ -980,7 +982,7 @@ describe("ConfigForm — auto-select useEffect", () => {
       } as unknown as UiSchema,
     });
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const calls = onChange.mock.calls;
     const metricCall = calls.find(
       ([cfg]) => cfg?.model?.params?.metric !== undefined,
@@ -1328,7 +1330,7 @@ describe("ConfigForm — inner_valid_options (Inner Validation select)", () => {
     const cvOption = screen.getByRole("option", { name: "cv" });
     fireEvent.click(cvOption);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const lastCall = onChange.mock.calls.at(-1);
     const nextConfig = lastCall?.[0] as Record<string, unknown>;
     const written = (
@@ -1509,7 +1511,7 @@ describe("ConfigForm — CalibrationSection onChange propagation", () => {
     const toggle = within(calibrationSection).getByRole("switch");
     fireEvent.click(toggle);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     // After toggling ON (was null), calibration should be set to defaults (non-null object)
     const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
     expect(lastCall.calibration).not.toBeNull();
@@ -1681,7 +1683,7 @@ describe("ConfigForm — advanced DynParam onChange propagation", () => {
     expect(advancedParam).toBeDefined();
     fireEvent.click(advancedParam!);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
     expect(lastCall.model.params.feature_fraction).toBe("__changed__");
   });

--- a/frontend/src/components/workspace/CvSection.component.test.tsx
+++ b/frontend/src/components/workspace/CvSection.component.test.tsx
@@ -260,7 +260,8 @@ describe("CvSection", () => {
     await user.type(foldsInput, "10");
 
     // onChange should be called with the new folds value
-    expect(mockOnChange).toHaveBeenCalled();
+    // called 3 times: clear emits one onChange, then one per keystroke ("1", "0")
+    expect(mockOnChange).toHaveBeenCalledTimes(3);
   });
 
   // -------------------------------------------------------------------------

--- a/frontend/src/components/workspace/DataPanel.test.tsx
+++ b/frontend/src/components/workspace/DataPanel.test.tsx
@@ -333,7 +333,7 @@ describe("DataPanel", () => {
     fireEvent.change(fileInput, { target: { files: [file] } });
 
     await waitFor(() => {
-      expect(onDataChanged).toHaveBeenCalled();
+      expect(onDataChanged).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -644,7 +644,7 @@ describe("DataPanel — handleTargetChange", () => {
       expect(mockFetchConfigDefaults).toHaveBeenCalledWith("binary", "target");
     });
     await waitFor(() => {
-      expect(mockUpdateConfig).toHaveBeenCalled();
+      expect(mockUpdateConfig).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -775,7 +775,7 @@ describe("DataPanel — handleTargetChange", () => {
       expect(mockFetchConfigDefaults).toHaveBeenCalledWith("binary", "target");
     });
     await waitFor(() => {
-      expect(mockUpdateConfig).toHaveBeenCalled();
+      expect(mockUpdateConfig).toHaveBeenCalledTimes(1);
     });
 
     // No partial PUT: every updateConfig call during target selection must
@@ -1033,7 +1033,7 @@ describe("DataPanel — handleColumnExpand (column statistics)", () => {
     await userEvent.click(screen.getByTestId("column-row-age"));
 
     await waitFor(() => {
-      expect(mockFetchColumnStats).toHaveBeenCalled();
+      expect(mockFetchColumnStats).toHaveBeenCalledTimes(1);
     });
 
     await waitFor(() => {
@@ -1128,7 +1128,8 @@ describe("DataPanel — column type and exclude toggles", () => {
 
     // After clicking Cat, syncConfig runs and updateConfig is called
     await waitFor(() => {
-      expect(mockUpdateConfig).toHaveBeenCalled();
+      // called twice: initial mount config-sync + the Cat-toggle-driven sync
+      expect(mockUpdateConfig).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -1144,7 +1145,8 @@ describe("DataPanel — column type and exclude toggles", () => {
     await userEvent.click(numButton!);
 
     await waitFor(() => {
-      expect(mockUpdateConfig).toHaveBeenCalled();
+      // called twice: initial mount config-sync + the Num-toggle-driven sync
+      expect(mockUpdateConfig).toHaveBeenCalledTimes(2);
     });
   });
 });
@@ -1213,7 +1215,8 @@ describe("DataPanel — syncConfig AbortController", () => {
 
     // Wait for syncConfig to start
     await waitFor(() => {
-      expect(mockFetchConfig).toHaveBeenCalled();
+      // called twice: initial mount config-sync fetch + the exclude-toggle sync fetch
+      expect(mockFetchConfig).toHaveBeenCalledTimes(2);
     });
 
     // Abort the in-flight request
@@ -1452,7 +1455,8 @@ describe("DataPanel — handleTaskChange and handleExcludeToggle", () => {
 
     // After toggling, syncConfig should run and updateConfig should be called
     await waitFor(() => {
-      expect(mockUpdateConfig).toHaveBeenCalled();
+      // called twice: initial mount config-sync + the exclude-toggle-driven sync
+      expect(mockUpdateConfig).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/frontend/src/components/workspace/KeyValueEditor.test.tsx
+++ b/frontend/src/components/workspace/KeyValueEditor.test.tsx
@@ -77,7 +77,8 @@ describe("KeyValueEditor", () => {
     fireEvent.change(valueInput, { target: { value: "42" } });
 
     // onChange should have been called with the new param (numeric conversion)
-    expect(onChange).toHaveBeenCalled();
+    // called twice: one controlled onChange per field change (key, then value)
+    expect(onChange).toHaveBeenCalledTimes(2);
   });
 
   it("removes custom row and calls onChange when remove button is clicked", () => {

--- a/frontend/src/components/workspace/ModelPanel.test.tsx
+++ b/frontend/src/components/workspace/ModelPanel.test.tsx
@@ -777,13 +777,13 @@ describe("ModelPanel", () => {
     // Push two configs so undo has history
     captured.onChange!({ model: { name: "lgbm", params: { depth: 5 } } });
     await waitFor(() => {
-      expect(mockUpdate).toHaveBeenCalled();
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
     });
 
     (mockUpdate as ReturnType<typeof vi.fn>).mockClear();
     captured.onChange!({ model: { name: "lgbm", params: { depth: 10 } } });
     await waitFor(() => {
-      expect(mockUpdate).toHaveBeenCalled();
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
     });
 
     // Undo should now be enabled
@@ -795,7 +795,7 @@ describe("ModelPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Undo" }));
 
     await waitFor(() => {
-      expect(mockUpdate).toHaveBeenCalled();
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -885,16 +885,16 @@ describe("ModelPanel", () => {
 
     // Push two configs
     captured.onChange!({ model: { name: "lgbm", params: { d: 1 } } });
-    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
     (mockUpdate as ReturnType<typeof vi.fn>).mockClear();
 
     captured.onChange!({ model: { name: "lgbm", params: { d: 2 } } });
-    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
     (mockUpdate as ReturnType<typeof vi.fn>).mockClear();
 
     // Undo
     fireEvent.click(screen.getByRole("button", { name: "Undo" }));
-    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
     (mockUpdate as ReturnType<typeof vi.fn>).mockClear();
 
     // Redo should be enabled
@@ -903,7 +903,7 @@ describe("ModelPanel", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Redo" }));
-    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
   });
 
   // --- handleLoadPreset ---
@@ -977,7 +977,7 @@ describe("ModelPanel", () => {
     // validateConfig is called after 500ms debounce
     await waitFor(
       () => {
-        expect(mockValidate).toHaveBeenCalled();
+        expect(mockValidate).toHaveBeenCalledTimes(1);
       },
       { timeout: 2000 },
     );

--- a/frontend/src/components/workspace/ResultsPanel.test.tsx
+++ b/frontend/src/components/workspace/ResultsPanel.test.tsx
@@ -346,7 +346,7 @@ describe("ResultsPanel", () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.job("test-job-1") });
     });
 
-    await waitFor(() => expect(onJobDone).toHaveBeenCalled(), {
+    await waitFor(() => expect(onJobDone).toHaveBeenCalledTimes(1), {
       timeout: 3000,
     });
   });
@@ -862,7 +862,7 @@ describe("ResultsPanel", () => {
     const { act } = await import("@testing-library/react");
     act(() => capturedCallbacks.onCompleted?.());
 
-    await waitFor(() => expect(onJobDone).toHaveBeenCalled());
+    await waitFor(() => expect(onJobDone).toHaveBeenCalledTimes(1));
   });
 
   it("shows toast.error on WebSocket onError callback", async () => {
@@ -1004,7 +1004,7 @@ describe("ResultsPanel", () => {
         (toast as unknown as Record<string, ReturnType<typeof vi.fn>>).info,
       ).toHaveBeenCalledWith("Job cancelled"),
     );
-    await waitFor(() => expect(onJobDone).toHaveBeenCalled());
+    await waitFor(() => expect(onJobDone).toHaveBeenCalledTimes(1));
   });
 
   it("shows error toast when cancelJob fails", async () => {

--- a/frontend/src/components/workspace/SearchSpaceRow.test.tsx
+++ b/frontend/src/components/workspace/SearchSpaceRow.test.tsx
@@ -126,7 +126,7 @@ describe("SearchSpaceRow – FixedValueEditor", () => {
     );
     const input = screen.getByRole("textbox");
     fireEvent.change(input, { target: { value: "0.05" } });
-    expect(onModelParamChange).toHaveBeenCalled();
+    expect(onModelParamChange).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/src/components/workspace/SearchSpaceTable.test.tsx
+++ b/frontend/src/components/workspace/SearchSpaceTable.test.tsx
@@ -119,7 +119,7 @@ describe("SearchSpaceTable", () => {
     const rangeButtons = screen.getAllByRole("radio", { name: /range/i });
     fireEvent.click(rangeButtons[0]);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
     // learning_rate should now have a range entry
     expect(lastCall.learning_rate).toBeDefined();
@@ -139,7 +139,7 @@ describe("SearchSpaceTable", () => {
     const fixedButtons = screen.getAllByRole("radio", { name: /fixed/i });
     fireEvent.click(fixedButtons[0]);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
     expect(lastCall.learning_rate).toBeUndefined();
   });
@@ -177,7 +177,7 @@ describe("SearchSpaceTable", () => {
     const rangeBtn = screen.getByRole("radio", { name: /range/i });
     fireEvent.click(rangeBtn);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const spaceArg = onChange.mock.calls[0][0];
     expect(spaceArg.max_depth.type).toBe("int");
   });
@@ -281,7 +281,7 @@ describe("SearchSpaceTable", () => {
     const rangeBtn = screen.getByRole("radio", { name: /range/i });
     fireEvent.click(rangeBtn);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const spaceArg = onChange.mock.calls[0][0];
     expect(spaceArg.learning_rate).toEqual({
       type: "float",
@@ -315,7 +315,7 @@ describe("SearchSpaceTable", () => {
     const rangeBtn = screen.getByRole("radio", { name: /range/i });
     fireEvent.click(rangeBtn);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const spaceArg = onChange.mock.calls[0][0];
     // Falls back to generic {low: 0, high: 1, log: false}
     expect(spaceArg.max_bin.low).toBe(0);
@@ -829,7 +829,7 @@ describe("SearchSpaceTable", () => {
       const choiceBtn = screen.getByRole("radio", { name: /choice/i });
       fireEvent.click(choiceBtn);
 
-      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledTimes(1);
       const spaceArg = onChange.mock.calls[0][0];
       expect(spaceArg.objective.type).toBe("categorical");
       // No current Fixed value -> choices stays empty (the only path
@@ -953,7 +953,7 @@ describe("SearchSpaceTable", () => {
       const choiceBtn = screen.getByRole("radio", { name: /choice/i });
       fireEvent.click(choiceBtn);
 
-      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledTimes(1);
       const spaceArg = onChange.mock.calls[0][0];
       expect(spaceArg.auto_num_leaves.type).toBe("categorical");
       expect(spaceArg.auto_num_leaves.choices).toEqual(["true", "false"]);

--- a/frontend/src/components/workspace/SearchableSelect.test.tsx
+++ b/frontend/src/components/workspace/SearchableSelect.test.tsx
@@ -164,7 +164,7 @@ describe("SearchableSelect (PR-B2 / wide DataFrame)", () => {
     const input = screen.getByPlaceholderText("Search...");
     fireEvent.keyDown(input, { key: "ArrowDown" });
     fireEvent.keyDown(input, { key: "Enter" });
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     // First option (age) is the default highlight; Enter picks it after
     // ArrowDown moves to the second (color). Either is acceptable as
     // long as some option fired.

--- a/frontend/src/components/workspace/TuneTab.test.tsx
+++ b/frontend/src/components/workspace/TuneTab.test.tsx
@@ -210,7 +210,7 @@ describe("TuneTab", () => {
     const f1Button = f1Buttons[f1Buttons.length - 1].closest("button");
     if (f1Button) fireEvent.click(f1Button);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 
   it("reads evaluation from tuning.evaluation (not tuning.optuna.evaluation)", () => {
@@ -271,7 +271,7 @@ describe("TuneTab", () => {
     // Click the optimization metric segment button for "f1"
     fe.click(f1Buttons[0].closest("button") ?? f1Buttons[0]);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updated = onChange.mock.calls[0][0];
     // evaluation must be at tuning.evaluation, NOT tuning.optuna.evaluation
     const tuning = updated.tuning as Record<string, unknown>;
@@ -338,7 +338,7 @@ describe("TuneTab", () => {
     const f1Buttons = screen.getAllByText("f1");
     fe.click(f1Buttons[0].closest("button") ?? f1Buttons[0]);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updated = onChange.mock.calls[0][0];
     const tuning = updated.tuning as Record<string, unknown>;
     const optuna = tuning.optuna as Record<string, unknown>;
@@ -406,7 +406,7 @@ describe("TuneTab", () => {
     const kIncrBtn = plusButtons[plusButtons.length - 1].closest("button");
     if (kIncrBtn) fireEvent.click(kIncrBtn);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updated = onChange.mock.calls[0][0];
     const tuning = updated.tuning as Record<string, unknown>;
     const evaluation = tuning.evaluation as {
@@ -446,7 +446,7 @@ describe("TuneTab", () => {
     const f1AdditionalBtn = f1Badges[f1Badges.length - 1].closest("button");
     if (f1AdditionalBtn) fe.click(f1AdditionalBtn);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updated = onChange.mock.calls[0][0];
     const tuning = updated.tuning as Record<string, unknown>;
     const evaluation = tuning.evaluation as { metrics: string[] };
@@ -621,7 +621,7 @@ describe("TuneTab", () => {
     const pakButtons = screen.getAllByText("precision_at_k");
     fe.click(pakButtons[0].closest("button") ?? pakButtons[0]);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     // Bug 2026-04-14 (4) — Fix 3: TuneEvaluationSection now also runs a
     // defensive useEffect that syncs ``optuna.params.direction`` to the
     // resolved metric direction on mount/metric-change. That effect can
@@ -676,7 +676,7 @@ describe("TuneTab", () => {
     const kIncrBtn = plusButtons[plusButtons.length - 1].closest("button");
     if (kIncrBtn) fireEvent.click(kIncrBtn);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updated = onChange.mock.calls[0][0] as Record<string, unknown>;
     const tuning = updated.tuning as Record<string, unknown>;
     const evaluation = tuning.evaluation as {
@@ -733,7 +733,7 @@ describe("TuneTab", () => {
 
     fireEvent.click(screen.getByTestId("trigger-space-change"));
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updated = onChange.mock.calls[0][0] as Record<string, unknown>;
     const tuning = updated.tuning as Record<string, unknown>;
     const optuna = tuning.optuna as Record<string, unknown>;
@@ -752,7 +752,7 @@ describe("TuneTab", () => {
 
     fireEvent.click(screen.getByTestId("trigger-model-param-change"));
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updated = onChange.mock.calls[0][0] as Record<string, unknown>;
     const model = updated.model as Record<string, unknown>;
     const params = model.params as Record<string, unknown>;
@@ -793,7 +793,7 @@ describe("TuneTab", () => {
     const f1Buttons = screen.getAllByText("f1");
     fireEvent.click(f1Buttons[0].closest("button") ?? f1Buttons[0]);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     // Bug 2026-04-14 (4) — Fix 3: pick the click-induced call, not the
     // direction-sync useEffect that fires on mount. See the matching
     // comment in the precision_at_k test above.

--- a/frontend/src/hooks/useBackgroundNotification.test.ts
+++ b/frontend/src/hooks/useBackgroundNotification.test.ts
@@ -69,7 +69,7 @@ describe("useBackgroundNotification", () => {
     const { result } = renderHook(() => useBackgroundNotification());
     result.current("Job Complete", "Ready");
 
-    expect(Notification.requestPermission).toHaveBeenCalled();
+    expect(Notification.requestPermission).toHaveBeenCalledTimes(1);
     // After permission is granted, notification should be created
     await vi.waitFor(() => {
       expect(mockNotification).toHaveBeenCalledWith("Job Complete", {
@@ -119,7 +119,7 @@ describe("useBackgroundNotification", () => {
 
     // Wait for async requestPermission to complete
     await vi.waitFor(() => {
-      expect(Notification.requestPermission).toHaveBeenCalled();
+      expect(Notification.requestPermission).toHaveBeenCalledTimes(1);
     });
     // Notification should NOT have been created
     expect(mockNotification).not.toHaveBeenCalled();

--- a/frontend/src/hooks/useConfigSync.test.ts
+++ b/frontend/src/hooks/useConfigSync.test.ts
@@ -127,7 +127,7 @@ describe("useConfigSync", () => {
       wrapper: testWrapper.wrapper,
     });
 
-    await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalledTimes(1));
     expect(mocks.fetchConfigDefaults).toHaveBeenCalledWith("binary", "y");
   });
 
@@ -140,7 +140,7 @@ describe("useConfigSync", () => {
 
     // target is set so sync still runs, but fetchConfigDefaults requires
     // both task and target — so it must not be called.
-    await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalledTimes(1));
     expect(mocks.fetchConfigDefaults).not.toHaveBeenCalled();
   });
 
@@ -154,7 +154,7 @@ describe("useConfigSync", () => {
       wrapper: testWrapper.wrapper,
     });
 
-    await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalledTimes(1));
     const [payload] = mocks.updateConfig.mock.calls[0];
     expect(payload.features.categorical).toEqual(["region"]);
     expect(payload.features.exclude).toEqual(["leaky"]);
@@ -213,7 +213,7 @@ describe("useConfigSync", () => {
     );
 
     rerender({ params: defaultParams({ target: "y" }) });
-    await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalledTimes(1));
     // The preseed value differs from the new key → exactly one sync.
     expect(mocks.updateConfig).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/hooks/useDataLoad.test.ts
+++ b/frontend/src/hooks/useDataLoad.test.ts
@@ -97,9 +97,9 @@ describe("useDataLoad", () => {
       COLS_OK.columns,
       ["a"],
     );
-    expect(defaultParams.onReset).toHaveBeenCalled();
-    expect(defaultParams.onDataChanged).toHaveBeenCalled();
-    expect(mocks.toastSuccess).toHaveBeenCalled();
+    expect(defaultParams.onReset).toHaveBeenCalledTimes(1);
+    expect(defaultParams.onDataChanged).toHaveBeenCalledTimes(1);
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(1);
     expect(result.current.loading).toBe(false);
   });
 
@@ -154,8 +154,8 @@ describe("useDataLoad", () => {
 
     expect(result.current.shape).toEqual([100, 5]);
     expect(result.current.dataPath).toBe("/data/x.csv");
-    expect(defaultParams.onColumnsLoaded).toHaveBeenCalled();
-    expect(mocks.toastSuccess).toHaveBeenCalled();
+    expect(defaultParams.onColumnsLoaded).toHaveBeenCalledTimes(1);
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(1);
   });
 
   it("handleUpload shows toast on failure", async () => {
@@ -233,7 +233,7 @@ describe("useDataLoad", () => {
         COLS_OK.columns,
         ["a"],
       );
-      expect(defaultParams.onDataChanged).toHaveBeenCalled();
+      expect(defaultParams.onDataChanged).toHaveBeenCalledTimes(1);
       // ``onReset`` would clear target/task — must NOT fire during
       // hydration since target is exactly what we're trying to keep.
       expect(defaultParams.onReset).not.toHaveBeenCalled();

--- a/frontend/src/hooks/useDataPanel.test.ts
+++ b/frontend/src/hooks/useDataPanel.test.ts
@@ -110,7 +110,7 @@ describe("useDataPanel", () => {
     expect(result.current.columns).toHaveLength(2);
     expect(onDataChanged).toHaveBeenCalledTimes(1);
     expect(onTaskChanged).toHaveBeenCalledWith(null);
-    expect(mocks.toastSuccess).toHaveBeenCalled();
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(1);
     expect(result.current.loading).toBe(false);
   });
 

--- a/frontend/src/hooks/useJobLifecycle.test.ts
+++ b/frontend/src/hooks/useJobLifecycle.test.ts
@@ -50,7 +50,7 @@ describe("useJobLifecycle", () => {
     });
 
     expect(cancelJob).toHaveBeenCalledWith("j1");
-    expect(onTerminal).toHaveBeenCalled();
+    expect(onTerminal).toHaveBeenCalledTimes(1);
   });
 
   it("cancel is a no-op when jobId is null", async () => {
@@ -93,7 +93,7 @@ describe("useJobLifecycle", () => {
     // Even though the server errored, the UI must NOT stay in
     // "Cancelling..." — the parent's running flag is released via
     // onTerminal and the transient progress is cleared.
-    expect(onTerminal).toHaveBeenCalled();
+    expect(onTerminal).toHaveBeenCalledTimes(1);
     expect(result.current.progress).toBeNull();
   });
 

--- a/frontend/src/hooks/useJobProgress.test.ts
+++ b/frontend/src/hooks/useJobProgress.test.ts
@@ -214,7 +214,7 @@ describe("useJobProgress — WebSocket subscription", () => {
     expect(disconnectSpy).not.toHaveBeenCalled();
 
     rerender({ id: "j2" });
-    expect(disconnectSpy).toHaveBeenCalled();
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -228,7 +228,7 @@ describe("useJobProgress — polling fallback", () => {
     );
 
     rerender({ job: runningJob({ status: "completed" }) });
-    expect(onTerminal).toHaveBeenCalled();
+    expect(onTerminal).toHaveBeenCalledTimes(1);
   });
 
   it("fires onTerminal on first observation of an already-terminal job", () => {

--- a/frontend/src/hooks/useKeyboardShortcuts.test.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.test.ts
@@ -125,7 +125,7 @@ describe("useKeyboardShortcuts", () => {
     });
     const preventSpy = vi.spyOn(event, "preventDefault");
     window.dispatchEvent(event);
-    expect(preventSpy).toHaveBeenCalled();
+    expect(preventSpy).toHaveBeenCalledTimes(1);
   });
 
   it("matches first shortcut and stops", () => {

--- a/frontend/src/hooks/useMediaQuery.test.ts
+++ b/frontend/src/hooks/useMediaQuery.test.ts
@@ -92,7 +92,7 @@ describe("useMediaQuery", () => {
 
     const { unmount } = renderHook(() => useMediaQuery("(max-width: 767px)"));
     unmount();
-    expect(mql.removeEventListener).toHaveBeenCalled();
+    expect(mql.removeEventListener).toHaveBeenCalledTimes(1);
   });
 
   it("returns false when matchMedia is unavailable (SSR / jsdom edge case)", () => {


### PR DESCRIPTION
## Summary

Closes #537. Test-only audit — **no production code change**.

The v0.6.2 Target-select bug cluster (#529 / #530 / #531) slipped past the unit suite because assertions checked *that* a mock was called, not *how many times*. A callback firing 4–9 times when it should fire once satisfies a bare `.toHaveBeenCalled()` silently.

## Changes

- **80 bare `.toHaveBeenCalled()` sites** across 27 test files converted to `.toHaveBeenCalledTimes(N)` with the intended count. The canonical query `rg -n 'toHaveBeenCalled\b' frontend/src | rg -v 'Times\b|not\.toHaveBeenCalled'` now returns nothing.
- **6 sites where N ≠ 1** carry a one-line comment naming the reason (multi-keystroke `user.type`, mount-sync + toggle-sync, task-derived effect cascade).
- **`SetupPanel.test.tsx`** — added `mockUpload` / `mockToast` clears to the existing `afterEach`. The file-scoped `vi.hoisted` mocks accumulated calls across tests, so the upload assertion could not otherwise be made count-precise. (Test-isolation fix, not a new test.)
- **`tohavebeencalled-guard` CI job** + `frontend/scripts/check-tohavebeencalled.sh` — grep guard, same pattern as `raw-color-guard` / `no-apifetch-guard`, blocks a new bare `.toHaveBeenCalled()` from regressing in.
- **Convention documented** in `CONTRIBUTING.md`.

## Out of scope (untouched)

- `.not.toHaveBeenCalled()` — already encodes a count of 0
- `.toHaveBeenCalledWith(...)` — asserts args, a different question
- No new tests added; no tests deleted

## Test plan

- [x] `pnpm vitest run` — 1927 tests pass (1 known TuneTab worker-crash harness flake, passes in isolation 33/33)
- [x] `pnpm check` (Biome) — 293 files, no fixes
- [x] `bash scripts/check-tohavebeencalled.sh` — OK, no bare sites
- [ ] CI green
