### PR TITLE
chore(release): prepare v0.6.3 -- maintenance + test-quality patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-05-23
+
+A **maintenance and test-quality** patch release. No behaviour change,
+no API change, no format-version change — `STUDIO_FORMAT_VERSION`
+stays at 2.
+
+Bundles:
+
+1. **#545 — frontend dependency consolidation + security overrides**.
+   Four Dependabot PRs (#541 / #542 / #543 / #544) each touched
+   `frontend/package.json` + `pnpm-lock.yaml` and all failed CI with
+   the same `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` — the security-audit
+   `overrides` block was written to the lockfile but never synced into
+   `package.json` `pnpm.overrides`. They are consolidated into one
+   change: ten dependency bumps (react-query, tailwind-merge, biome,
+   playwright, tailwindcss, @tailwindcss/vite, @types/node,
+   coverage-istanbul, msw, vitest) plus an explicit `pnpm.overrides`
+   block pinning the CVE-patched transitive versions of axios,
+   brace-expansion, follow-redirects, lodash, and ws.
+
+2. **#537 — call-count assertion audit**. The v0.6.2 Target-select bug
+   cluster (#529 / #530 / #531) slipped past the unit suite because
+   assertions checked *that* a mock was called, not *how many times*.
+   All 80 bare `.toHaveBeenCalled()` sites across 27 test files are
+   converted to `.toHaveBeenCalledTimes(N)`. A new `tohavebeencalled-guard`
+   CI job blocks any regression. Test-only — no production code change.
+
 ## [0.6.2] - 2026-05-17
 
 The **Target-select write-traffic reduction** patch release. Closes

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 - このファイルは **横串インデックス** であり、詳細はリンク先で確認すること。
 - 着手する際は HISTORY に Proposal を起票（変更ゲート対象の場合）→ PLAN にフェーズ追加 → 実装、の順で進める。
 
-最終更新: 2026-05-17（**v0.6.1 release 済 (2026-05-16, PyPI lizystudio==0.6.1)** + **v0.6.2 release prep 中** — Target-select 3-issue cluster (#529 / #530 / #531) を develop に着地、PUT count 9 → 2、`saved=False` 0 件、split-preview 400 解消。直近の Tier 1 next は **#527 / #528 (P-0109 follow-up)** / **#495** / 🔒 **#452-b**。次の節目候補は **v0.7+**: 第 2 backend (#403 残・#452-b 解禁トリガ)、Tailwind v4、P-0087 Phase 3、typed error 体系 (R-3.1〜R-3.3) など）
+最終更新: 2026-05-23（**v0.6.2 release 済 (2026-05-17, PyPI lizystudio==0.6.2)** + **v0.6.3 release prep 中** — メンテナンス + テスト品質 patch。#545 (Dependabot 4 PR 統合 + CVE overrides) + #537 (call-count assertion 監査 80 サイト + `tohavebeencalled-guard` CI) を develop に着地、挙動・API・format_version 変更なし。#528 は `TuningOverrides` スキーマと Issue 文面の齟齬で descope、P-0109 follow-up として再 spec 待ち。直近の Tier 1 next は **#527 (P-0109 follow-up)** / **#528 (要再spec)** / **#495** / 🔒 **#452-b**。次の節目候補は **v0.7+**: 第 2 backend (#403 残・#452-b 解禁トリガ)、Tailwind v4、P-0087 Phase 3、typed error 体系 (R-3.1〜R-3.3) など）
 
 ---
 


### PR DESCRIPTION
## Summary

Release-prep for **v0.6.3** — a maintenance + test-quality patch. Adds the CHANGELOG entry and refreshes the ROADMAP last-updated line. No code change.

v0.6.3 bundles two already-merged PRs on `develop`:

- **#545** — frontend dependency consolidation + CVE security overrides (consolidates Dependabot #541/#542/#543/#544)
- **#537** — call-count assertion audit (80 sites → `toHaveBeenCalledTimes`) + `tohavebeencalled-guard` CI job

No behaviour change, no API change, no format-version change (`STUDIO_FORMAT_VERSION` stays at 2).

## Next steps

After this merges to `develop`: release PR `develop → main` (merge commit), then tag `v0.6.3` to trigger `publish.yml`.
