### PR TITLE
Release v0.6.3 -- maintenance + test-quality patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,18 @@ jobs:
         working-directory: frontend
         run: bash scripts/check-no-apifetch.sh
 
+  # Issue #537: the v0.6.2 Target-select bug cluster passed the unit suite
+  # because assertions checked that a mock was called, not how many times.
+  # This grep guard stops a new bare ``.toHaveBeenCalled()`` from landing —
+  # callback assertions must use the count-precise ``.toHaveBeenCalledTimes(N)``.
+  tohavebeencalled-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Scan frontend/src test files for bare .toHaveBeenCalled()
+        working-directory: frontend
+        run: bash scripts/check-tohavebeencalled.sh
+
   # C-1 / INV-CI-1: committed schema.d.ts must match freshly-generated
   # output. Prevents drift between backend response_model declarations
   # and the TypeScript types that the frontend compiles against.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,9 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
+      # Allow `gh release create` to publish the GitHub Release in the
+      # post-PyPI step below.
+      contents: write
     env:
       # Prevent local version identifiers (e.g. +dirty, +dN.gHASH)
       # even if the working tree becomes dirty during the build.
@@ -68,3 +71,44 @@ jobs:
           fi
 
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+      # Create the GitHub Release after PyPI upload succeeds. Notes are
+      # extracted verbatim from CHANGELOG.md's section heading
+      # `## [VERSION] - YYYY-MM-DD` so the release page and the file
+      # stay synchronised without a second manual edit step. Skipped (not
+      # failed) when the release already exists, so re-running the
+      # workflow on a re-pushed tag does not clobber a curated release.
+      #
+      # Pre-v0.6.3 releases (v0.6.0 / v0.6.1 / v0.6.2) were created
+      # manually via `gh release create` after PyPI upload. v0.6.1 /
+      # v0.6.2 were briefly forgotten — this step closes that gap.
+      - name: Create GitHub Release from CHANGELOG
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          # Extract the section between `## [VERSION]` and the next
+          # top-level `## [` heading. Outputs nothing when no section
+          # matches — we treat that as an error since shipping a
+          # release with no notes is almost certainly a mistake.
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" { found=1; next }
+            /^## \[/ && found { exit }
+            found { print }
+          ' CHANGELOG.md > /tmp/release_notes.md
+          if [ ! -s /tmp/release_notes.md ]; then
+            echo "::error::CHANGELOG.md has no section for version $VERSION. Add one matching '## [$VERSION] - YYYY-MM-DD' before tagging."
+            exit 1
+          fi
+          # Upsert semantics: skip (do not clobber) if the release
+          # already exists. Operators who want to refresh notes after
+          # the fact can `gh release edit` manually.
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists; skipping create. Use 'gh release edit' to refresh notes."
+            exit 0
+          fi
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file /tmp/release_notes.md \
+            --verify-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-05-23
+
+A **maintenance and test-quality** patch release. No behaviour change,
+no API change, no format-version change — `STUDIO_FORMAT_VERSION`
+stays at 2.
+
+Bundles:
+
+1. **#545 — frontend dependency consolidation + security overrides**.
+   Four Dependabot PRs (#541 / #542 / #543 / #544) each touched
+   `frontend/package.json` + `pnpm-lock.yaml` and all failed CI with
+   the same `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` — the security-audit
+   `overrides` block was written to the lockfile but never synced into
+   `package.json` `pnpm.overrides`. They are consolidated into one
+   change: ten dependency bumps (react-query, tailwind-merge, biome,
+   playwright, tailwindcss, @tailwindcss/vite, @types/node,
+   coverage-istanbul, msw, vitest) plus an explicit `pnpm.overrides`
+   block pinning the CVE-patched transitive versions of axios,
+   brace-expansion, follow-redirects, lodash, and ws.
+
+2. **#537 — call-count assertion audit**. The v0.6.2 Target-select bug
+   cluster (#529 / #530 / #531) slipped past the unit suite because
+   assertions checked *that* a mock was called, not *how many times*.
+   All 80 bare `.toHaveBeenCalled()` sites across 27 test files are
+   converted to `.toHaveBeenCalledTimes(N)`. A new `tohavebeencalled-guard`
+   CI job blocks any regression. Test-only — no production code change.
+
 ## [0.6.2] - 2026-05-17
 
 The **Target-select write-traffic reduction** patch release. Closes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,10 @@ uv run pytest --cov=src/lizystudio --cov-fail-under=80 -q  # test
 - **Formatter/Linter:** [Biome](https://biomejs.dev/) (ESLint/Prettier are **not** used)
 - **Tests:** [Vitest](https://vitest.dev/) (unit) + [Playwright](https://playwright.dev/) (e2e)
 - **API types:** auto-generated via `openapi-typescript` — never hand-write API types
+- **Mock assertions:** assert the call *count*, not just the fact — use
+  `expect(spy).toHaveBeenCalledTimes(N)`, never bare `expect(spy).toHaveBeenCalled()`.
+  When `N` is not 1, add a one-line comment naming the reason. The
+  `tohavebeencalled-guard` CI job enforces this (Issue #537).
 
 ```bash
 cd frontend

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 - このファイルは **横串インデックス** であり、詳細はリンク先で確認すること。
 - 着手する際は HISTORY に Proposal を起票（変更ゲート対象の場合）→ PLAN にフェーズ追加 → 実装、の順で進める。
 
-最終更新: 2026-05-17（**v0.6.1 release 済 (2026-05-16, PyPI lizystudio==0.6.1)** + **v0.6.2 release prep 中** — Target-select 3-issue cluster (#529 / #530 / #531) を develop に着地、PUT count 9 → 2、`saved=False` 0 件、split-preview 400 解消。直近の Tier 1 next は **#527 / #528 (P-0109 follow-up)** / **#495** / 🔒 **#452-b**。次の節目候補は **v0.7+**: 第 2 backend (#403 残・#452-b 解禁トリガ)、Tailwind v4、P-0087 Phase 3、typed error 体系 (R-3.1〜R-3.3) など）
+最終更新: 2026-05-23（**v0.6.2 release 済 (2026-05-17, PyPI lizystudio==0.6.2)** + **v0.6.3 release prep 中** — メンテナンス + テスト品質 patch。#545 (Dependabot 4 PR 統合 + CVE overrides) + #537 (call-count assertion 監査 80 サイト + `tohavebeencalled-guard` CI) を develop に着地、挙動・API・format_version 変更なし。#528 は `TuningOverrides` スキーマと Issue 文面の齟齬で descope、P-0109 follow-up として再 spec 待ち。直近の Tier 1 next は **#527 (P-0109 follow-up)** / **#528 (要再spec)** / **#495** / 🔒 **#452-b**。次の節目候補は **v0.7+**: 第 2 backend (#403 残・#452-b 解禁トリガ)、Tailwind v4、P-0087 Phase 3、typed error 体系 (R-3.1〜R-3.3) など）
 
 ---
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "check:api-types": "bash scripts/check-api-types.sh"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.100.9",
+    "@tanstack/react-query": "^5.100.10",
     "@tanstack/react-virtual": "^3.13.24",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -43,35 +43,48 @@
     "react-resizable-panels": "^4",
     "react-router-dom": "^7.15.0",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",
-    "@biomejs/biome": "^2.4.14",
-    "@playwright/test": "^1.59.1",
+    "@biomejs/biome": "^2.4.15",
+    "@playwright/test": "^1.60.0",
     "@storybook/addon-a11y": "^10.3.6",
     "@storybook/react": "^10.3.6",
     "@storybook/react-vite": "^10.3.6",
     "@storybook/test-runner": "^0.24.3",
-    "@tailwindcss/vite": "^4.2.4",
+    "@tailwindcss/vite": "^4.3.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^25.6.2",
+    "@types/node": "^25.7.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/react-plotly.js": "^2.6.4",
     "@vitejs/plugin-react": "^5.2.0",
-    "@vitest/coverage-istanbul": "^4.1.5",
+    "@vitest/coverage-istanbul": "^4.1.6",
     "happy-dom": "^20.9.0",
-    "msw": "^2.14.5",
+    "msw": "^2.14.6",
     "openapi-typescript": "^7.13.0",
     "storybook": "^10.3.6",
-    "tailwindcss": "^4.2.4",
+    "tailwindcss": "^4.3.0",
     "typescript": "~5.9.3",
     "vite": "^6.4.2",
     "vite-tsconfig-paths": "^6.1.1",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.6"
+  },
+  "pnpm": {
+    "overrides": {
+      "axios@>=1.0.0 <1.15.0": ">=1.15.0",
+      "axios@>=1.0.0 <1.15.1": ">=1.15.1",
+      "axios@>=1.0.0 <1.15.2": ">=1.15.2",
+      "brace-expansion@>=2.0.0 <2.0.3": ">=2.0.3",
+      "brace-expansion@>=5.0.0 <5.0.6": ">=5.0.6",
+      "follow-redirects@<=1.15.11": ">=1.16.0",
+      "lodash@<=4.17.23": ">=4.18.0",
+      "lodash@>=4.0.0 <=4.17.23": ">=4.18.0",
+      "ws@>=8.0.0 <8.20.1": ">=8.20.1"
+    }
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -4,13 +4,24 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  axios@>=1.0.0 <1.15.0: '>=1.15.0'
+  axios@>=1.0.0 <1.15.1: '>=1.15.1'
+  axios@>=1.0.0 <1.15.2: '>=1.15.2'
+  brace-expansion@>=2.0.0 <2.0.3: '>=2.0.3'
+  brace-expansion@>=5.0.0 <5.0.6: '>=5.0.6'
+  follow-redirects@<=1.15.11: '>=1.16.0'
+  lodash@<=4.17.23: '>=4.18.0'
+  lodash@>=4.0.0 <=4.17.23: '>=4.18.0'
+  ws@>=8.0.0 <8.20.1: '>=8.20.1'
+
 importers:
 
   .:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.100.9
-        version: 5.100.9(react@19.2.6)
+        specifier: ^5.100.10
+        version: 5.100.11(react@19.2.6)
       '@tanstack/react-virtual':
         specifier: ^3.13.24
         version: 3.13.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -57,18 +68,18 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tailwind-merge:
-        specifier: ^3.5.0
-        version: 3.5.0
+        specifier: ^3.6.0
+        version: 3.6.0
     devDependencies:
       '@axe-core/playwright':
         specifier: ^4.11.3
-        version: 4.11.3(playwright-core@1.59.1)
+        version: 4.11.3(playwright-core@1.60.0)
       '@biomejs/biome':
-        specifier: ^2.4.14
-        version: 2.4.14
+        specifier: ^2.4.15
+        version: 2.4.15
       '@playwright/test':
-        specifier: ^1.59.1
-        version: 1.59.1
+        specifier: ^1.60.0
+        version: 1.60.0
       '@storybook/addon-a11y':
         specifier: ^10.3.6
         version: 10.3.6(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
@@ -77,13 +88,13 @@ importers:
         version: 10.3.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^10.3.6
-        version: 10.3.6(esbuild@0.27.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 10.3.6(esbuild@0.27.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))
       '@storybook/test-runner':
         specifier: ^0.24.3
-        version: 0.24.3(@types/node@25.6.2)(esbuild-register@3.6.0(esbuild@0.27.7))(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 0.24.3(@types/node@25.9.1)(esbuild-register@3.6.0(esbuild@0.27.7))(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@tailwindcss/vite':
-        specifier: ^4.2.4
-        version: 4.2.4(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))
+        specifier: ^4.3.0
+        version: 4.3.0(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -97,8 +108,8 @@ importers:
         specifier: ^4.0.9
         version: 4.0.9
       '@types/node':
-        specifier: ^25.6.2
-        version: 25.6.2
+        specifier: ^25.7.0
+        version: 25.9.1
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -110,16 +121,16 @@ importers:
         version: 2.6.4
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 5.2.0(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))
       '@vitest/coverage-istanbul':
-        specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        specifier: ^4.1.6
+        version: 4.1.7(vitest@4.1.7)
       happy-dom:
         specifier: ^20.9.0
         version: 20.9.0
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.6.2)(typescript@5.9.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.1)(typescript@5.9.3)
       openapi-typescript:
         specifier: ^7.13.0
         version: 7.13.0(typescript@5.9.3)
@@ -127,20 +138,20 @@ importers:
         specifier: ^10.3.6
         version: 10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tailwindcss:
-        specifier: ^4.2.4
-        version: 4.2.4
+        specifier: ^4.3.0
+        version: 4.3.0
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0)
+        version: 6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@5.9.3)(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 6.1.1(typescript@5.9.3)(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))
       vitest:
-        specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.2)(@vitest/coverage-istanbul@4.1.5)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.14.5(@types/node@25.6.2)(typescript@5.9.3))(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))
+        specifier: ^4.1.6
+        version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.7)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))
 
 packages:
 
@@ -362,59 +373,59 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@biomejs/biome@2.4.14':
-    resolution: {integrity: sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==}
+  '@biomejs/biome@2.4.15':
+    resolution: {integrity: sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.14':
-    resolution: {integrity: sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q==}
+  '@biomejs/cli-darwin-arm64@2.4.15':
+    resolution: {integrity: sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.14':
-    resolution: {integrity: sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q==}
+  '@biomejs/cli-darwin-x64@2.4.15':
+    resolution: {integrity: sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.14':
-    resolution: {integrity: sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A==}
+  '@biomejs/cli-linux-arm64-musl@2.4.15':
+    resolution: {integrity: sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.14':
-    resolution: {integrity: sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==}
+  '@biomejs/cli-linux-arm64@2.4.15':
+    resolution: {integrity: sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.14':
-    resolution: {integrity: sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==}
+  '@biomejs/cli-linux-x64-musl@2.4.15':
+    resolution: {integrity: sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.14':
-    resolution: {integrity: sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==}
+  '@biomejs/cli-linux-x64@2.4.15':
+    resolution: {integrity: sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.14':
-    resolution: {integrity: sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==}
+  '@biomejs/cli-win32-arm64@2.4.15':
+    resolution: {integrity: sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.14':
-    resolution: {integrity: sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA==}
+  '@biomejs/cli-win32-x64@2.4.15':
+    resolution: {integrity: sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -1041,8 +1052,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.59.1':
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2106,69 +2117,69 @@ packages:
   '@swc/types@0.1.26':
     resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
 
-  '@tailwindcss/node@4.2.4':
-    resolution: {integrity: sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==}
+  '@tailwindcss/node@4.3.0':
+    resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
 
-  '@tailwindcss/oxide-android-arm64@4.2.4':
-    resolution: {integrity: sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==}
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    resolution: {integrity: sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
 
-  '@tailwindcss/oxide-darwin-arm64@4.2.4':
-    resolution: {integrity: sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==}
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    resolution: {integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@tailwindcss/oxide-darwin-x64@4.2.4':
-    resolution: {integrity: sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==}
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    resolution: {integrity: sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
-  '@tailwindcss/oxide-freebsd-x64@4.2.4':
-    resolution: {integrity: sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==}
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    resolution: {integrity: sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [freebsd]
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4':
-    resolution: {integrity: sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==}
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    resolution: {integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==}
     engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.2.4':
-    resolution: {integrity: sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==}
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
-    resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
-    resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@tailwindcss/oxide-linux-x64-musl@4.2.4':
-    resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@tailwindcss/oxide-wasm32-wasi@4.2.4':
-    resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     bundledDependencies:
@@ -2179,32 +2190,32 @@ packages:
       - '@emnapi/wasi-threads'
       - tslib
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.2.4':
-    resolution: {integrity: sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==}
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    resolution: {integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.2.4':
-    resolution: {integrity: sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==}
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    resolution: {integrity: sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
 
-  '@tailwindcss/oxide@4.2.4':
-    resolution: {integrity: sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==}
+  '@tailwindcss/oxide@4.3.0':
+    resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
     engines: {node: '>= 20'}
 
-  '@tailwindcss/vite@4.2.4':
-    resolution: {integrity: sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==}
+  '@tailwindcss/vite@4.3.0':
+    resolution: {integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@tanstack/query-core@5.100.9':
-    resolution: {integrity: sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==}
+  '@tanstack/query-core@5.100.11':
+    resolution: {integrity: sha512-lmE0994apShXPj8CUxgx4ch5yUJhE9k/+tVwihBvPOyerACWdBocfFg24t8+0RhtlTd7tEgchDkhlCxNssvDxw==}
 
-  '@tanstack/react-query@5.100.9':
-    resolution: {integrity: sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==}
+  '@tanstack/react-query@5.100.11':
+    resolution: {integrity: sha512-J0f9s5x3LE1450nNNfYx+e/n0DMa0uOBdFJUy5r0RvmsXd4nB/n0rbHtHI1vYXhikNFan+wf51p6Tmp4c8ucrg==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -2318,8 +2329,8 @@ packages:
   '@types/mapbox__vector-tile@1.3.4':
     resolution: {integrity: sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==}
 
-  '@types/node@25.6.2':
-    resolution: {integrity: sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==}
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/pbf@3.0.5':
     resolution: {integrity: sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==}
@@ -2481,19 +2492,19 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@vitest/coverage-istanbul@4.1.5':
-    resolution: {integrity: sha512-X4kQMDEWh9mA0IiLuigtdYv4kXe+W8KLTbucoz15lbyZRPAxT5l+hu0JizI7Am050+G9vQnB7QJNgYi2LnwV4w==}
+  '@vitest/coverage-istanbul@4.1.7':
+    resolution: {integrity: sha512-EbruXy+E9MJk+y7sFzriYfoI4JP2Ow+SyWDkewFOWFjzrbQBHlEgi6dGE7pxge8Z+W+7oJOxAVVb6mQHKCCZlw==}
     peerDependencies:
-      vitest: 4.1.5
+      vitest: 4.1.7
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
-  '@vitest/expect@4.1.5':
-    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
 
-  '@vitest/mocker@4.1.5':
-    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2506,26 +2517,26 @@ packages:
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
-  '@vitest/pretty-format@4.1.5':
-    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
 
-  '@vitest/runner@4.1.5':
-    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
 
-  '@vitest/snapshot@4.1.5':
-    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
-  '@vitest/spy@4.1.5':
-    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  '@vitest/utils@4.1.5':
-    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
@@ -2542,6 +2553,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -2643,8 +2658,8 @@ packages:
     resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
     engines: {node: '>=4'}
 
-  axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+  axios@1.16.1:
+    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   babel-jest@30.3.0:
     resolution: {integrity: sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==}
@@ -2705,14 +2720,15 @@ packages:
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
-
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -3393,8 +3409,8 @@ packages:
   flatten-vertex-data@1.0.2:
     resolution: {integrity: sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -3633,6 +3649,10 @@ packages:
 
   htmlparser2@3.10.1:
     resolution: {integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -4116,8 +4136,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   loglevel@1.9.2:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
@@ -4252,8 +4272,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw@2.14.5:
-    resolution: {integrity: sha512-X6G05oX4x0e+CNI55KMdhMmwHCBKf2iwazGr+iwsdoJ94JA1ED7wSXb6V+lLPdqFkmIlPiGYvayqnaNcOzobDA==}
+  msw@2.14.6:
+    resolution: {integrity: sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -4487,8 +4507,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   playwright@1.59.1:
     resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4544,8 +4574,9 @@ packages:
   protocol-buffers-schema@3.6.1:
     resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -5013,11 +5044,11 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tailwind-merge@3.5.0:
-    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
-  tailwindcss@4.2.4:
-    resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
+  tailwindcss@4.3.0:
+    resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
@@ -5158,8 +5189,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
@@ -5272,20 +5303,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.5:
-    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.5
-      '@vitest/browser-preview': 4.1.5
-      '@vitest/browser-webdriverio': 4.1.5
-      '@vitest/coverage-istanbul': 4.1.5
-      '@vitest/coverage-v8': 4.1.5
-      '@vitest/ui': 4.1.5
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -5405,20 +5436,8 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -5512,10 +5531,10 @@ snapshots:
   '@asamuzakjp/nwsapi@2.3.9':
     optional: true
 
-  '@axe-core/playwright@4.11.3(playwright-core@1.59.1)':
+  '@axe-core/playwright@4.11.3(playwright-core@1.60.0)':
     dependencies:
       axe-core: 4.11.4
-      playwright-core: 1.59.1
+      playwright-core: 1.60.0
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -5728,39 +5747,39 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@biomejs/biome@2.4.14':
+  '@biomejs/biome@2.4.15':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.14
-      '@biomejs/cli-darwin-x64': 2.4.14
-      '@biomejs/cli-linux-arm64': 2.4.14
-      '@biomejs/cli-linux-arm64-musl': 2.4.14
-      '@biomejs/cli-linux-x64': 2.4.14
-      '@biomejs/cli-linux-x64-musl': 2.4.14
-      '@biomejs/cli-win32-arm64': 2.4.14
-      '@biomejs/cli-win32-x64': 2.4.14
+      '@biomejs/cli-darwin-arm64': 2.4.15
+      '@biomejs/cli-darwin-x64': 2.4.15
+      '@biomejs/cli-linux-arm64': 2.4.15
+      '@biomejs/cli-linux-arm64-musl': 2.4.15
+      '@biomejs/cli-linux-x64': 2.4.15
+      '@biomejs/cli-linux-x64-musl': 2.4.15
+      '@biomejs/cli-win32-arm64': 2.4.15
+      '@biomejs/cli-win32-x64': 2.4.15
 
-  '@biomejs/cli-darwin-arm64@2.4.14':
+  '@biomejs/cli-darwin-arm64@2.4.15':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.14':
+  '@biomejs/cli-darwin-x64@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.14':
+  '@biomejs/cli-linux-arm64-musl@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.14':
+  '@biomejs/cli-linux-arm64@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.14':
+  '@biomejs/cli-linux-x64-musl@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.14':
+  '@biomejs/cli-linux-x64@2.4.15':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.14':
+  '@biomejs/cli-win32-arm64@2.4.15':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.14':
+  '@biomejs/cli-win32-x64@2.4.15':
     optional: true
 
   '@bramus/specificity@2.4.2':
@@ -6002,30 +6021,30 @@ snapshots:
 
   '@inquirer/ansi@2.0.5': {}
 
-  '@inquirer/confirm@6.0.13(@types/node@25.6.2)':
+  '@inquirer/confirm@6.0.13(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.6.2)
-      '@inquirer/type': 4.0.5(@types/node@25.6.2)
+      '@inquirer/core': 11.1.10(@types/node@25.9.1)
+      '@inquirer/type': 4.0.5(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
 
-  '@inquirer/core@11.1.10(@types/node@25.6.2)':
+  '@inquirer/core@11.1.10(@types/node@25.9.1)':
     dependencies:
       '@inquirer/ansi': 2.0.5
       '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@25.6.2)
+      '@inquirer/type': 4.0.5(@types/node@25.9.1)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.0
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
 
   '@inquirer/figures@2.0.5': {}
 
-  '@inquirer/type@4.0.5(@types/node@25.6.2)':
+  '@inquirer/type@4.0.5(@types/node@25.9.1)':
     optionalDependencies:
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -6049,7 +6068,7 @@ snapshots:
   '@jest/console@30.3.0':
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       chalk: 4.1.2
       jest-message-util: 30.3.0
       jest-util: 30.3.0
@@ -6063,14 +6082,14 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@25.6.2)(esbuild-register@3.6.0(esbuild@0.27.7))
+      jest-config: 30.3.0(@types/node@25.9.1)(esbuild-register@3.6.0(esbuild@0.27.7))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -6100,7 +6119,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       jest-mock: 30.3.0
 
   '@jest/expect-utils@30.3.0':
@@ -6118,7 +6137,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
       '@sinonjs/fake-timers': 15.3.2
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       jest-message-util: 30.3.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
@@ -6136,7 +6155,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       jest-regex-util: 30.0.1
 
   '@jest/reporters@30.3.0':
@@ -6147,7 +6166,7 @@ snapshots:
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -6223,15 +6242,15 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -6325,9 +6344,9 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@playwright/test@1.59.1':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.59.1
+      playwright: 1.60.0
 
   '@plotly/d3-sankey-circular@0.33.1':
     dependencies:
@@ -7267,25 +7286,25 @@ snapshots:
       axe-core: 4.11.4
       storybook: 10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/builder-vite@10.3.6(esbuild@0.27.7)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@storybook/builder-vite@10.3.6(esbuild@0.27.7)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.7)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.7)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))
       storybook: 10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
-      vite: 6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.6(esbuild@0.27.7)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@storybook/csf-plugin@10.3.6(esbuild@0.27.7)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       storybook: 10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.7
       rollup: 4.60.3
-      vite: 6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)
 
   '@storybook/global@5.0.0': {}
 
@@ -7300,11 +7319,11 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       storybook: 10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/react-vite@10.3.6(esbuild@0.27.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@storybook/react-vite@10.3.6(esbuild@0.27.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
-      '@storybook/builder-vite': 10.3.6(esbuild@0.27.7)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@storybook/builder-vite': 10.3.6(esbuild@0.27.7)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))
       '@storybook/react': 10.3.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -7314,7 +7333,7 @@ snapshots:
       resolve: 1.22.12
       storybook: 10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tsconfig-paths: 4.2.0
-      vite: 6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -7336,7 +7355,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/test-runner@0.24.3(@types/node@25.6.2)(esbuild-register@3.6.0(esbuild@0.27.7))(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/test-runner@0.24.3(@types/node@25.9.1)(esbuild-register@3.6.0(esbuild@0.27.7))(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -7346,14 +7365,14 @@ snapshots:
       '@swc/core': 1.15.21
       '@swc/jest': 0.2.39(@swc/core@1.15.21)
       expect-playwright: 0.8.0
-      jest: 30.3.0(@types/node@25.6.2)(esbuild-register@3.6.0(esbuild@0.27.7))
+      jest: 30.3.0(@types/node@25.9.1)(esbuild-register@3.6.0(esbuild@0.27.7))
       jest-circus: 30.3.0
       jest-environment-node: 30.3.0
       jest-junit: 16.0.0
       jest-process-manager: 0.4.0
       jest-runner: 30.3.0
       jest-serializer-html: 7.1.0
-      jest-watch-typeahead: 3.0.1(jest@30.3.0(@types/node@25.6.2)(esbuild-register@3.6.0(esbuild@0.27.7)))
+      jest-watch-typeahead: 3.0.1(jest@30.3.0(@types/node@25.9.1)(esbuild-register@3.6.0(esbuild@0.27.7)))
       nyc: 15.1.0
       playwright: 1.59.1
       playwright-core: 1.59.1
@@ -7437,7 +7456,7 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@tailwindcss/node@4.2.4':
+  '@tailwindcss/node@4.3.0':
     dependencies:
       '@jridgewell/remapping': 2.3.5
       enhanced-resolve: 5.21.0
@@ -7445,71 +7464,71 @@ snapshots:
       lightningcss: 1.32.0
       magic-string: 0.30.21
       source-map-js: 1.2.1
-      tailwindcss: 4.2.4
+      tailwindcss: 4.3.0
 
-  '@tailwindcss/oxide-android-arm64@4.2.4':
+  '@tailwindcss/oxide-android-arm64@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-darwin-arm64@4.2.4':
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-darwin-x64@4.2.4':
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-freebsd-x64@4.2.4':
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4':
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.2.4':
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-musl@4.2.4':
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-wasm32-wasi@4.2.4':
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.2.4':
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.2.4':
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide@4.2.4':
+  '@tailwindcss/oxide@4.3.0':
     optionalDependencies:
-      '@tailwindcss/oxide-android-arm64': 4.2.4
-      '@tailwindcss/oxide-darwin-arm64': 4.2.4
-      '@tailwindcss/oxide-darwin-x64': 4.2.4
-      '@tailwindcss/oxide-freebsd-x64': 4.2.4
-      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.4
-      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.4
-      '@tailwindcss/oxide-linux-arm64-musl': 4.2.4
-      '@tailwindcss/oxide-linux-x64-gnu': 4.2.4
-      '@tailwindcss/oxide-linux-x64-musl': 4.2.4
-      '@tailwindcss/oxide-wasm32-wasi': 4.2.4
-      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.4
-      '@tailwindcss/oxide-win32-x64-msvc': 4.2.4
+      '@tailwindcss/oxide-android-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-x64': 4.3.0
+      '@tailwindcss/oxide-freebsd-x64': 4.3.0
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.0
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.0
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.0
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/vite@4.2.4(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@tailwindcss/vite@4.3.0(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
-      '@tailwindcss/node': 4.2.4
-      '@tailwindcss/oxide': 4.2.4
-      tailwindcss: 4.2.4
-      vite: 6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0)
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)
 
-  '@tanstack/query-core@5.100.9': {}
+  '@tanstack/query-core@5.100.11': {}
 
-  '@tanstack/react-query@5.100.9(react@19.2.6)':
+  '@tanstack/react-query@5.100.11(react@19.2.6)':
     dependencies:
-      '@tanstack/query-core': 5.100.9
+      '@tanstack/query-core': 5.100.11
       react: 19.2.6
 
   '@tanstack/react-virtual@3.13.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
@@ -7653,9 +7672,9 @@ snapshots:
       '@types/mapbox__point-geometry': 0.1.4
       '@types/pbf': 3.0.5
 
-  '@types/node@25.6.2':
+  '@types/node@25.9.1':
     dependencies:
-      undici-types: 7.19.2
+      undici-types: 7.24.6
 
   '@types/pbf@3.0.5': {}
 
@@ -7678,7 +7697,7 @@ snapshots:
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
 
   '@types/stack-utils@2.0.3': {}
 
@@ -7690,13 +7709,13 @@ snapshots:
 
   '@types/wait-on@5.3.4':
     dependencies:
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
 
   '@types/whatwg-mimetype@3.0.2': {}
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -7765,7 +7784,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@5.2.0(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@vitejs/plugin-react@5.2.0(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -7773,11 +7792,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-istanbul@4.1.5(vitest@4.1.5)':
+  '@vitest/coverage-istanbul@4.1.7(vitest@4.1.7)':
     dependencies:
       '@babel/core': 7.29.0
       '@istanbuljs/schema': 0.1.6
@@ -7789,7 +7808,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.2)(@vitest/coverage-istanbul@4.1.5)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.14.5(@types/node@25.6.2)(typescript@5.9.3))(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.7)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -7801,41 +7820,41 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/expect@4.1.5':
+  '@vitest/expect@4.1.7':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(msw@2.14.5(@types/node@25.6.2)(typescript@5.9.3))(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@vitest/mocker@4.1.7(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
-      '@vitest/spy': 4.1.5
+      '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.14.5(@types/node@25.6.2)(typescript@5.9.3)
-      vite: 6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0)
+      msw: 2.14.6(@types/node@25.9.1)(typescript@5.9.3)
+      vite: 6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/pretty-format@4.1.5':
+  '@vitest/pretty-format@4.1.7':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.5':
+  '@vitest/runner@4.1.7':
     dependencies:
-      '@vitest/utils': 4.1.5
+      '@vitest/utils': 4.1.7
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.5':
+  '@vitest/snapshot@4.1.7':
     dependencies:
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
       magic-string: 0.30.21
       pathe: 2.0.3
 
@@ -7843,7 +7862,7 @@ snapshots:
     dependencies:
       tinyspy: 4.0.4
 
-  '@vitest/spy@4.1.5': {}
+  '@vitest/spy@4.1.7': {}
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -7851,9 +7870,9 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/utils@4.1.5':
+  '@vitest/utils@4.1.7':
     dependencies:
-      '@vitest/pretty-format': 4.1.5
+      '@vitest/pretty-format': 4.1.7
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -7864,6 +7883,12 @@ snapshots:
   acorn@7.4.1: {}
 
   acorn@8.16.0: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -7945,13 +7970,15 @@ snapshots:
 
   axe-core@4.11.4: {}
 
-  axios@1.13.6:
+  axios@1.16.1:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   babel-jest@30.3.0(@babel/core@7.29.0):
     dependencies:
@@ -8034,15 +8061,15 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.2:
-    dependencies:
-      balanced-match: 1.0.2
-
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
 
   brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
+
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8748,7 +8775,7 @@ snapshots:
     dependencies:
       dtype: 2.0.0
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   font-atlas@2.1.0:
     dependencies:
@@ -8999,12 +9026,12 @@ snapshots:
 
   happy-dom@20.9.0:
     dependencies:
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.19.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -9062,6 +9089,13 @@ snapshots:
       entities: 1.1.2
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
@@ -9238,7 +9272,7 @@ snapshots:
       '@jest/expect': 30.3.0
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -9258,7 +9292,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@25.6.2)(esbuild-register@3.6.0(esbuild@0.27.7)):
+  jest-cli@30.3.0(@types/node@25.9.1)(esbuild-register@3.6.0(esbuild@0.27.7)):
     dependencies:
       '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.7))
       '@jest/test-result': 30.3.0
@@ -9266,7 +9300,7 @@ snapshots:
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.6.2)(esbuild-register@3.6.0(esbuild@0.27.7))
+      jest-config: 30.3.0(@types/node@25.9.1)(esbuild-register@3.6.0(esbuild@0.27.7))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -9277,7 +9311,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@25.6.2)(esbuild-register@3.6.0(esbuild@0.27.7)):
+  jest-config@30.3.0(@types/node@25.9.1)(esbuild-register@3.6.0(esbuild@0.27.7)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -9303,7 +9337,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       esbuild-register: 3.6.0(esbuild@0.27.7)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -9333,7 +9367,7 @@ snapshots:
       '@jest/environment': 30.3.0
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       jest-mock: 30.3.0
       jest-util: 30.3.0
       jest-validate: 30.3.0
@@ -9341,7 +9375,7 @@ snapshots:
   jest-haste-map@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -9387,7 +9421,7 @@ snapshots:
   jest-mock@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       jest-util: 30.3.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.3.0):
@@ -9437,7 +9471,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -9466,7 +9500,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -9517,7 +9551,7 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -9532,11 +9566,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 30.3.0
 
-  jest-watch-typeahead@3.0.1(jest@30.3.0(@types/node@25.6.2)(esbuild-register@3.6.0(esbuild@0.27.7))):
+  jest-watch-typeahead@3.0.1(jest@30.3.0(@types/node@25.9.1)(esbuild-register@3.6.0(esbuild@0.27.7))):
     dependencies:
       ansi-escapes: 7.3.0
       chalk: 5.6.2
-      jest: 30.3.0(@types/node@25.6.2)(esbuild-register@3.6.0(esbuild@0.27.7))
+      jest: 30.3.0(@types/node@25.9.1)(esbuild-register@3.6.0(esbuild@0.27.7))
       jest-regex-util: 30.0.1
       jest-watcher: 30.3.0
       slash: 5.1.0
@@ -9547,7 +9581,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -9556,18 +9590,18 @@ snapshots:
 
   jest-worker@30.3.0:
     dependencies:
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.3.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@25.6.2)(esbuild-register@3.6.0(esbuild@0.27.7)):
+  jest@30.3.0(@types/node@25.9.1)(esbuild-register@3.6.0(esbuild@0.27.7)):
     dependencies:
       '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.7))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.6.2)(esbuild-register@3.6.0(esbuild@0.27.7))
+      jest-cli: 30.3.0(@types/node@25.9.1)(esbuild-register@3.6.0(esbuild@0.27.7))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9706,7 +9740,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   loglevel@1.9.2: {}
 
@@ -9736,7 +9770,7 @@ snapshots:
 
   magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
@@ -9831,7 +9865,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
@@ -9839,7 +9873,7 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.5
 
   minimatch@9.0.9:
     dependencies:
@@ -9869,9 +9903,9 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.14.5(@types/node@25.6.2)(typescript@5.9.3):
+  msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3):
     dependencies:
-      '@inquirer/confirm': 6.0.13(@types/node@25.6.2)
+      '@inquirer/confirm': 6.0.13(@types/node@25.9.1)
       '@mswjs/interceptors': 0.41.9
       '@open-draft/deferred-promise': 3.0.0
       '@types/statuses': 2.0.6
@@ -10119,9 +10153,17 @@ snapshots:
 
   playwright-core@1.59.1: {}
 
+  playwright-core@1.60.0: {}
+
   playwright@1.59.1:
     dependencies:
       playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -10236,7 +10278,7 @@ snapshots:
 
   protocol-buffers-schema@3.6.1: {}
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1:
     optional: true
@@ -10678,7 +10720,7 @@ snapshots:
       recast: 0.23.11
       semver: 7.7.4
       use-sync-external-store: 1.6.0(react@19.2.6)
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - '@testing-library/dom'
       - bufferutil
@@ -10803,9 +10845,9 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tailwind-merge@3.5.0: {}
+  tailwind-merge@3.6.0: {}
 
-  tailwindcss@4.2.4: {}
+  tailwindcss@4.3.0: {}
 
   tapable@2.3.3: {}
 
@@ -10918,7 +10960,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@7.19.2: {}
+  undici-types@7.24.6: {}
 
   undici@7.25.0:
     optional: true
@@ -10997,17 +11039,17 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0)):
+  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0):
+  vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -11016,20 +11058,20 @@ snapshots:
       rollup: 4.60.3
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.6.2
+      '@types/node': 25.9.1
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
 
-  vitest@4.1.5(@types/node@25.6.2)(@vitest/coverage-istanbul@4.1.5)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.14.5(@types/node@25.6.2)(typescript@5.9.3))(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0)):
+  vitest@4.1.7(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.7)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)):
     dependencies:
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(msw@2.14.5(@types/node@25.6.2)(typescript@5.9.3))(vite@6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0))
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -11041,11 +11083,11 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 6.4.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.6.2
-      '@vitest/coverage-istanbul': 4.1.5(vitest@4.1.5)
+      '@types/node': 25.9.1
+      '@vitest/coverage-istanbul': 4.1.7(vitest@4.1.7)
       happy-dom: 20.9.0
       jsdom: 29.0.2
     transitivePeerDependencies:
@@ -11064,13 +11106,14 @@ snapshots:
 
   wait-on@7.2.0:
     dependencies:
-      axios: 1.13.6
+      axios: 1.16.1
       joi: 17.13.3
-      lodash: 4.17.23
+      lodash: 4.18.1
       minimist: 1.2.8
       rxjs: 7.8.2
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   wait-port@0.2.14:
     dependencies:
@@ -11164,9 +11207,7 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
-  ws@8.19.0: {}
-
-  ws@8.20.0: {}
+  ws@8.20.1: {}
 
   wsl-utils@0.1.0:
     dependencies:

--- a/frontend/scripts/check-tohavebeencalled.sh
+++ b/frontend/scripts/check-tohavebeencalled.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# CI guard: forbid bare ``.toHaveBeenCalled()`` in frontend test files.
+#
+# Issue #537: the v0.6.2 Target-select bug cluster (#529 / #530 / #531)
+# slipped past the unit suite because assertions checked *that* a mock was
+# called, not *how many times*. A callback firing 4-9 times when it should
+# fire once satisfies ``.toHaveBeenCalled()`` silently. The audit converted
+# every existing site to ``.toHaveBeenCalledTimes(N)``; this guard stops a
+# regression from landing a new bare assertion.
+#
+# Allowed (NOT flagged):
+#   - ``.toHaveBeenCalledTimes(N)``  — the count-precise form
+#   - ``.not.toHaveBeenCalled()``    — already encodes a count of 0
+#   - ``.toHaveBeenCalledWith(...)`` — asserts args, a different question
+#
+# Exit 1 if any bare ``.toHaveBeenCalled()`` is found.
+# Usage: bash scripts/check-tohavebeencalled.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FRONTEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$FRONTEND_DIR"
+
+if ! command -v grep >/dev/null 2>&1; then
+  echo "ERROR: grep is required but not found in PATH." >&2
+  exit 2
+fi
+
+echo "Scanning src/ test files for bare .toHaveBeenCalled() (Issue #537 guard)..."
+
+# ``.toHaveBeenCalled()`` matches the bare assertion. It also appears inside
+# ``.not.toHaveBeenCalled()`` — those lines are filtered out below. The
+# ``Times`` / ``With`` variants do not contain the literal ``Called()`` so
+# they never match in the first place.
+MATCHES="$(grep -rHn \
+  --include='*.test.ts' --include='*.test.tsx' \
+  '\.toHaveBeenCalled()' src/ || true)"
+
+VIOLATIONS=""
+if [[ -n "$MATCHES" ]]; then
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    # ``.not.toHaveBeenCalled()`` already encodes count 0 — allowed.
+    if [[ "$line" == *".not.toHaveBeenCalled()"* ]]; then
+      continue
+    fi
+    VIOLATIONS+="${line}"$'\n'
+  done <<< "$MATCHES"
+fi
+
+if [[ -n "$VIOLATIONS" ]]; then
+  echo ""
+  echo "ERROR: bare .toHaveBeenCalled() found in test files:"
+  echo ""
+  printf '%s' "$VIOLATIONS"
+  echo ""
+  echo "Fix: assert the intended call count, not just the fact of a call."
+  echo "  expect(spy).toHaveBeenCalled()  ->  expect(spy).toHaveBeenCalledTimes(N)"
+  echo "  When N is not 1, add a one-line comment naming the reason."
+  echo "  See CLAUDE.md section 7 (Flaky / test-quality conventions)."
+  exit 1
+fi
+
+echo "OK: no bare .toHaveBeenCalled() in test files."

--- a/frontend/src/api/queries/queries.phase2.test.ts
+++ b/frontend/src/api/queries/queries.phase2.test.ts
@@ -247,7 +247,7 @@ describe("useFiles", () => {
     expect(fetchDirectory).not.toHaveBeenCalled();
 
     rerender({ on: true });
-    await waitFor(() => expect(fetchDirectory).toHaveBeenCalled());
+    await waitFor(() => expect(fetchDirectory).toHaveBeenCalledTimes(1));
   });
 
   it("passes undefined to fetchDirectory for the ~ root sentinel", async () => {

--- a/frontend/src/api/queries/queries.test.ts
+++ b/frontend/src/api/queries/queries.test.ts
@@ -209,7 +209,7 @@ describe("useRunInference", () => {
       });
     });
 
-    expect(runInference).toHaveBeenCalled();
+    expect(runInference).toHaveBeenCalledTimes(1);
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: queryKeys.infHistoryAll(),
     });

--- a/frontend/src/api/websocket.test.ts
+++ b/frontend/src/api/websocket.test.ts
@@ -166,7 +166,7 @@ describe("connectJobProgress", () => {
 
     ws.readyState = MockWebSocket.OPEN;
     cleanup();
-    expect(ws.close).toHaveBeenCalled();
+    expect(ws.close).toHaveBeenCalledTimes(1);
   });
 
   it("cleanup does not close already-closed WebSocket", () => {

--- a/frontend/src/components/inference/SetupPanel.test.tsx
+++ b/frontend/src/components/inference/SetupPanel.test.tsx
@@ -31,6 +31,11 @@ vi.mock("@/components/workspace/FileBrowser", () => ({
 describe("SetupPanel", () => {
   afterEach(() => {
     cleanup();
+    // File-scoped hoisted mocks accumulate calls across tests; clear them
+    // so per-test `.toHaveBeenCalledTimes(N)` assertions are count-precise.
+    mockUpload.mockClear();
+    mockToast.success.mockClear();
+    mockToast.error.mockClear();
   });
 
   const baseProps = {
@@ -416,7 +421,7 @@ describe("SetupPanel", () => {
       'input[type="file"]',
     ) as HTMLInputElement;
     fireEvent.change(input, { target: { files: [file] } });
-    await waitFor(() => expect(mockUpload).toHaveBeenCalled());
+    await waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(1));
 
     await user.click(screen.getByRole("button", { name: /run inference/i }));
 

--- a/frontend/src/components/jobs/DeleteDialog.test.tsx
+++ b/frontend/src/components/jobs/DeleteDialog.test.tsx
@@ -54,7 +54,7 @@ describe("DeleteDialog", () => {
 
     await waitFor(() => {
       expect(deleteJob).toHaveBeenCalledWith("job-abc");
-      expect(defaultProps.onDeleted).toHaveBeenCalled();
+      expect(defaultProps.onDeleted).toHaveBeenCalledTimes(1);
       expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false);
     });
   });

--- a/frontend/src/components/jobs/PauseActionButton.test.tsx
+++ b/frontend/src/components/jobs/PauseActionButton.test.tsx
@@ -77,7 +77,7 @@ describe("PauseActionButton", () => {
     );
 
     await waitFor(() => {
-      expect(mockPauseJob).toHaveBeenCalled();
+      expect(mockPauseJob).toHaveBeenCalledTimes(1);
     });
     expect(onPauseRequested).not.toHaveBeenCalled();
   });

--- a/frontend/src/components/jobs/UnpauseActionButton.test.tsx
+++ b/frontend/src/components/jobs/UnpauseActionButton.test.tsx
@@ -92,7 +92,7 @@ describe("UnpauseActionButton", () => {
     );
 
     await waitFor(() => {
-      expect(mockUnpauseJob).toHaveBeenCalled();
+      expect(mockUnpauseJob).toHaveBeenCalledTimes(1);
     });
     expect(onUnpauseStarted).not.toHaveBeenCalled();
   });

--- a/frontend/src/components/layout/CommandPalette.test.tsx
+++ b/frontend/src/components/layout/CommandPalette.test.tsx
@@ -69,7 +69,7 @@ describe("CommandPalette", () => {
 
     fireEvent.click(screen.getByText("Run Fit"));
 
-    expect(onFit).toHaveBeenCalled();
+    expect(onFit).toHaveBeenCalledTimes(1);
     // Dialog should be closed (no input visible)
     expect(screen.queryByPlaceholderText("Type a command...")).toBeNull();
   });
@@ -98,7 +98,7 @@ describe("CommandPalette", () => {
 
     fireEvent.click(screen.getByText("Run Tune"));
 
-    expect(onTune).toHaveBeenCalled();
+    expect(onTune).toHaveBeenCalledTimes(1);
     expect(screen.queryByPlaceholderText("Type a command...")).toBeNull();
   });
 

--- a/frontend/src/components/workspace/BlockedGroupKFoldEditor.component.test.tsx
+++ b/frontend/src/components/workspace/BlockedGroupKFoldEditor.component.test.tsx
@@ -507,7 +507,8 @@ describe("BlockedGroupKFoldEditor", () => {
     // First is minTrainRows, second is minValidRows
     await user.type(autoInputs[0], "100");
 
-    expect(mockOnChange).toHaveBeenCalled();
+    // called 3 times: one controlled onChange per keystroke ("1", "0", "0")
+    expect(mockOnChange).toHaveBeenCalledTimes(3);
   });
 
   it("calls onBlockedChange when blockMode is changed to sliding", () => {
@@ -540,7 +541,7 @@ describe("BlockedGroupKFoldEditor", () => {
     );
 
     await waitFor(() => {
-      expect(mockOnBlockedChange).toHaveBeenCalled();
+      expect(mockOnBlockedChange).toHaveBeenCalledTimes(1);
     });
 
     expect(mockOnBlockedChange).toHaveBeenCalledWith(

--- a/frontend/src/components/workspace/ConfigForm.test.tsx
+++ b/frontend/src/components/workspace/ConfigForm.test.tsx
@@ -339,7 +339,7 @@ describe("ConfigForm", () => {
 
     // Allow the effect to flush.
     await waitFor(() => {
-      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledTimes(1);
     });
     // The reset write must zero the calibration field (immutably).
     const calls = onChange.mock.calls.map((c) => c[0]);
@@ -479,8 +479,10 @@ describe("ConfigForm", () => {
       } as unknown as UiSchema,
     });
 
+    // called 3 times: three task-derived effects fire — calibration clear,
+    // objective reset, and metric reset — once config.task catches up.
     await waitFor(() => {
-      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledTimes(3);
     });
 
     // Calibration must clear (regression doesn't support it).
@@ -881,7 +883,7 @@ describe("ConfigForm — handleHintChange (onChange propagation)", () => {
       .find((el) => el.dataset.hintKey === "objective");
     fireEvent.click(dynParam!);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updatedConfig =
       onChange.mock.calls[onChange.mock.calls.length - 1][0];
     expect(updatedConfig.model.params.objective).toBe("__changed__");
@@ -903,7 +905,7 @@ describe("ConfigForm — handleHintChange (onChange propagation)", () => {
       .find((el) => el.dataset.hintKey === "metric");
     fireEvent.click(dynParam!);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updatedConfig =
       onChange.mock.calls[onChange.mock.calls.length - 1][0];
     expect(updatedConfig.model.params.metric).toBe("__changed__");
@@ -927,7 +929,7 @@ describe("ConfigForm — handleHintChange (onChange propagation)", () => {
       .find((el) => el.dataset.hintKey === "learning_rate");
     fireEvent.click(dynParam!);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updatedConfig =
       onChange.mock.calls[onChange.mock.calls.length - 1][0];
     expect(updatedConfig.model.params.learning_rate).toBe("__changed__");
@@ -955,7 +957,7 @@ describe("ConfigForm — auto-select useEffect", () => {
       } as unknown as UiSchema,
     });
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const calls = onChange.mock.calls;
     // Find a call that sets objective
     const objCall = calls.find(
@@ -980,7 +982,7 @@ describe("ConfigForm — auto-select useEffect", () => {
       } as unknown as UiSchema,
     });
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const calls = onChange.mock.calls;
     const metricCall = calls.find(
       ([cfg]) => cfg?.model?.params?.metric !== undefined,
@@ -1328,7 +1330,7 @@ describe("ConfigForm — inner_valid_options (Inner Validation select)", () => {
     const cvOption = screen.getByRole("option", { name: "cv" });
     fireEvent.click(cvOption);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const lastCall = onChange.mock.calls.at(-1);
     const nextConfig = lastCall?.[0] as Record<string, unknown>;
     const written = (
@@ -1509,7 +1511,7 @@ describe("ConfigForm — CalibrationSection onChange propagation", () => {
     const toggle = within(calibrationSection).getByRole("switch");
     fireEvent.click(toggle);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     // After toggling ON (was null), calibration should be set to defaults (non-null object)
     const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
     expect(lastCall.calibration).not.toBeNull();
@@ -1681,7 +1683,7 @@ describe("ConfigForm — advanced DynParam onChange propagation", () => {
     expect(advancedParam).toBeDefined();
     fireEvent.click(advancedParam!);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
     expect(lastCall.model.params.feature_fraction).toBe("__changed__");
   });

--- a/frontend/src/components/workspace/CvSection.component.test.tsx
+++ b/frontend/src/components/workspace/CvSection.component.test.tsx
@@ -260,7 +260,8 @@ describe("CvSection", () => {
     await user.type(foldsInput, "10");
 
     // onChange should be called with the new folds value
-    expect(mockOnChange).toHaveBeenCalled();
+    // called 3 times: clear emits one onChange, then one per keystroke ("1", "0")
+    expect(mockOnChange).toHaveBeenCalledTimes(3);
   });
 
   // -------------------------------------------------------------------------

--- a/frontend/src/components/workspace/DataPanel.test.tsx
+++ b/frontend/src/components/workspace/DataPanel.test.tsx
@@ -333,7 +333,7 @@ describe("DataPanel", () => {
     fireEvent.change(fileInput, { target: { files: [file] } });
 
     await waitFor(() => {
-      expect(onDataChanged).toHaveBeenCalled();
+      expect(onDataChanged).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -644,7 +644,7 @@ describe("DataPanel — handleTargetChange", () => {
       expect(mockFetchConfigDefaults).toHaveBeenCalledWith("binary", "target");
     });
     await waitFor(() => {
-      expect(mockUpdateConfig).toHaveBeenCalled();
+      expect(mockUpdateConfig).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -775,7 +775,7 @@ describe("DataPanel — handleTargetChange", () => {
       expect(mockFetchConfigDefaults).toHaveBeenCalledWith("binary", "target");
     });
     await waitFor(() => {
-      expect(mockUpdateConfig).toHaveBeenCalled();
+      expect(mockUpdateConfig).toHaveBeenCalledTimes(1);
     });
 
     // No partial PUT: every updateConfig call during target selection must
@@ -1033,7 +1033,7 @@ describe("DataPanel — handleColumnExpand (column statistics)", () => {
     await userEvent.click(screen.getByTestId("column-row-age"));
 
     await waitFor(() => {
-      expect(mockFetchColumnStats).toHaveBeenCalled();
+      expect(mockFetchColumnStats).toHaveBeenCalledTimes(1);
     });
 
     await waitFor(() => {
@@ -1128,7 +1128,8 @@ describe("DataPanel — column type and exclude toggles", () => {
 
     // After clicking Cat, syncConfig runs and updateConfig is called
     await waitFor(() => {
-      expect(mockUpdateConfig).toHaveBeenCalled();
+      // called twice: initial mount config-sync + the Cat-toggle-driven sync
+      expect(mockUpdateConfig).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -1144,7 +1145,8 @@ describe("DataPanel — column type and exclude toggles", () => {
     await userEvent.click(numButton!);
 
     await waitFor(() => {
-      expect(mockUpdateConfig).toHaveBeenCalled();
+      // called twice: initial mount config-sync + the Num-toggle-driven sync
+      expect(mockUpdateConfig).toHaveBeenCalledTimes(2);
     });
   });
 });
@@ -1213,7 +1215,8 @@ describe("DataPanel — syncConfig AbortController", () => {
 
     // Wait for syncConfig to start
     await waitFor(() => {
-      expect(mockFetchConfig).toHaveBeenCalled();
+      // called twice: initial mount config-sync fetch + the exclude-toggle sync fetch
+      expect(mockFetchConfig).toHaveBeenCalledTimes(2);
     });
 
     // Abort the in-flight request
@@ -1452,7 +1455,8 @@ describe("DataPanel — handleTaskChange and handleExcludeToggle", () => {
 
     // After toggling, syncConfig should run and updateConfig should be called
     await waitFor(() => {
-      expect(mockUpdateConfig).toHaveBeenCalled();
+      // called twice: initial mount config-sync + the exclude-toggle-driven sync
+      expect(mockUpdateConfig).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/frontend/src/components/workspace/KeyValueEditor.test.tsx
+++ b/frontend/src/components/workspace/KeyValueEditor.test.tsx
@@ -77,7 +77,8 @@ describe("KeyValueEditor", () => {
     fireEvent.change(valueInput, { target: { value: "42" } });
 
     // onChange should have been called with the new param (numeric conversion)
-    expect(onChange).toHaveBeenCalled();
+    // called twice: one controlled onChange per field change (key, then value)
+    expect(onChange).toHaveBeenCalledTimes(2);
   });
 
   it("removes custom row and calls onChange when remove button is clicked", () => {

--- a/frontend/src/components/workspace/ModelPanel.test.tsx
+++ b/frontend/src/components/workspace/ModelPanel.test.tsx
@@ -777,13 +777,13 @@ describe("ModelPanel", () => {
     // Push two configs so undo has history
     captured.onChange!({ model: { name: "lgbm", params: { depth: 5 } } });
     await waitFor(() => {
-      expect(mockUpdate).toHaveBeenCalled();
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
     });
 
     (mockUpdate as ReturnType<typeof vi.fn>).mockClear();
     captured.onChange!({ model: { name: "lgbm", params: { depth: 10 } } });
     await waitFor(() => {
-      expect(mockUpdate).toHaveBeenCalled();
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
     });
 
     // Undo should now be enabled
@@ -795,7 +795,7 @@ describe("ModelPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Undo" }));
 
     await waitFor(() => {
-      expect(mockUpdate).toHaveBeenCalled();
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -885,16 +885,16 @@ describe("ModelPanel", () => {
 
     // Push two configs
     captured.onChange!({ model: { name: "lgbm", params: { d: 1 } } });
-    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
     (mockUpdate as ReturnType<typeof vi.fn>).mockClear();
 
     captured.onChange!({ model: { name: "lgbm", params: { d: 2 } } });
-    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
     (mockUpdate as ReturnType<typeof vi.fn>).mockClear();
 
     // Undo
     fireEvent.click(screen.getByRole("button", { name: "Undo" }));
-    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
     (mockUpdate as ReturnType<typeof vi.fn>).mockClear();
 
     // Redo should be enabled
@@ -903,7 +903,7 @@ describe("ModelPanel", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Redo" }));
-    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
   });
 
   // --- handleLoadPreset ---
@@ -977,7 +977,7 @@ describe("ModelPanel", () => {
     // validateConfig is called after 500ms debounce
     await waitFor(
       () => {
-        expect(mockValidate).toHaveBeenCalled();
+        expect(mockValidate).toHaveBeenCalledTimes(1);
       },
       { timeout: 2000 },
     );

--- a/frontend/src/components/workspace/ResultsPanel.test.tsx
+++ b/frontend/src/components/workspace/ResultsPanel.test.tsx
@@ -346,7 +346,7 @@ describe("ResultsPanel", () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.job("test-job-1") });
     });
 
-    await waitFor(() => expect(onJobDone).toHaveBeenCalled(), {
+    await waitFor(() => expect(onJobDone).toHaveBeenCalledTimes(1), {
       timeout: 3000,
     });
   });
@@ -862,7 +862,7 @@ describe("ResultsPanel", () => {
     const { act } = await import("@testing-library/react");
     act(() => capturedCallbacks.onCompleted?.());
 
-    await waitFor(() => expect(onJobDone).toHaveBeenCalled());
+    await waitFor(() => expect(onJobDone).toHaveBeenCalledTimes(1));
   });
 
   it("shows toast.error on WebSocket onError callback", async () => {
@@ -1004,7 +1004,7 @@ describe("ResultsPanel", () => {
         (toast as unknown as Record<string, ReturnType<typeof vi.fn>>).info,
       ).toHaveBeenCalledWith("Job cancelled"),
     );
-    await waitFor(() => expect(onJobDone).toHaveBeenCalled());
+    await waitFor(() => expect(onJobDone).toHaveBeenCalledTimes(1));
   });
 
   it("shows error toast when cancelJob fails", async () => {

--- a/frontend/src/components/workspace/SearchSpaceRow.test.tsx
+++ b/frontend/src/components/workspace/SearchSpaceRow.test.tsx
@@ -126,7 +126,7 @@ describe("SearchSpaceRow – FixedValueEditor", () => {
     );
     const input = screen.getByRole("textbox");
     fireEvent.change(input, { target: { value: "0.05" } });
-    expect(onModelParamChange).toHaveBeenCalled();
+    expect(onModelParamChange).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/src/components/workspace/SearchSpaceTable.test.tsx
+++ b/frontend/src/components/workspace/SearchSpaceTable.test.tsx
@@ -119,7 +119,7 @@ describe("SearchSpaceTable", () => {
     const rangeButtons = screen.getAllByRole("radio", { name: /range/i });
     fireEvent.click(rangeButtons[0]);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
     // learning_rate should now have a range entry
     expect(lastCall.learning_rate).toBeDefined();
@@ -139,7 +139,7 @@ describe("SearchSpaceTable", () => {
     const fixedButtons = screen.getAllByRole("radio", { name: /fixed/i });
     fireEvent.click(fixedButtons[0]);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
     expect(lastCall.learning_rate).toBeUndefined();
   });
@@ -177,7 +177,7 @@ describe("SearchSpaceTable", () => {
     const rangeBtn = screen.getByRole("radio", { name: /range/i });
     fireEvent.click(rangeBtn);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const spaceArg = onChange.mock.calls[0][0];
     expect(spaceArg.max_depth.type).toBe("int");
   });
@@ -281,7 +281,7 @@ describe("SearchSpaceTable", () => {
     const rangeBtn = screen.getByRole("radio", { name: /range/i });
     fireEvent.click(rangeBtn);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const spaceArg = onChange.mock.calls[0][0];
     expect(spaceArg.learning_rate).toEqual({
       type: "float",
@@ -315,7 +315,7 @@ describe("SearchSpaceTable", () => {
     const rangeBtn = screen.getByRole("radio", { name: /range/i });
     fireEvent.click(rangeBtn);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const spaceArg = onChange.mock.calls[0][0];
     // Falls back to generic {low: 0, high: 1, log: false}
     expect(spaceArg.max_bin.low).toBe(0);
@@ -829,7 +829,7 @@ describe("SearchSpaceTable", () => {
       const choiceBtn = screen.getByRole("radio", { name: /choice/i });
       fireEvent.click(choiceBtn);
 
-      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledTimes(1);
       const spaceArg = onChange.mock.calls[0][0];
       expect(spaceArg.objective.type).toBe("categorical");
       // No current Fixed value -> choices stays empty (the only path
@@ -953,7 +953,7 @@ describe("SearchSpaceTable", () => {
       const choiceBtn = screen.getByRole("radio", { name: /choice/i });
       fireEvent.click(choiceBtn);
 
-      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledTimes(1);
       const spaceArg = onChange.mock.calls[0][0];
       expect(spaceArg.auto_num_leaves.type).toBe("categorical");
       expect(spaceArg.auto_num_leaves.choices).toEqual(["true", "false"]);

--- a/frontend/src/components/workspace/SearchableSelect.test.tsx
+++ b/frontend/src/components/workspace/SearchableSelect.test.tsx
@@ -164,7 +164,7 @@ describe("SearchableSelect (PR-B2 / wide DataFrame)", () => {
     const input = screen.getByPlaceholderText("Search...");
     fireEvent.keyDown(input, { key: "ArrowDown" });
     fireEvent.keyDown(input, { key: "Enter" });
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     // First option (age) is the default highlight; Enter picks it after
     // ArrowDown moves to the second (color). Either is acceptable as
     // long as some option fired.

--- a/frontend/src/components/workspace/TuneTab.test.tsx
+++ b/frontend/src/components/workspace/TuneTab.test.tsx
@@ -210,7 +210,7 @@ describe("TuneTab", () => {
     const f1Button = f1Buttons[f1Buttons.length - 1].closest("button");
     if (f1Button) fireEvent.click(f1Button);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 
   it("reads evaluation from tuning.evaluation (not tuning.optuna.evaluation)", () => {
@@ -271,7 +271,7 @@ describe("TuneTab", () => {
     // Click the optimization metric segment button for "f1"
     fe.click(f1Buttons[0].closest("button") ?? f1Buttons[0]);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updated = onChange.mock.calls[0][0];
     // evaluation must be at tuning.evaluation, NOT tuning.optuna.evaluation
     const tuning = updated.tuning as Record<string, unknown>;
@@ -338,7 +338,7 @@ describe("TuneTab", () => {
     const f1Buttons = screen.getAllByText("f1");
     fe.click(f1Buttons[0].closest("button") ?? f1Buttons[0]);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updated = onChange.mock.calls[0][0];
     const tuning = updated.tuning as Record<string, unknown>;
     const optuna = tuning.optuna as Record<string, unknown>;
@@ -406,7 +406,7 @@ describe("TuneTab", () => {
     const kIncrBtn = plusButtons[plusButtons.length - 1].closest("button");
     if (kIncrBtn) fireEvent.click(kIncrBtn);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updated = onChange.mock.calls[0][0];
     const tuning = updated.tuning as Record<string, unknown>;
     const evaluation = tuning.evaluation as {
@@ -446,7 +446,7 @@ describe("TuneTab", () => {
     const f1AdditionalBtn = f1Badges[f1Badges.length - 1].closest("button");
     if (f1AdditionalBtn) fe.click(f1AdditionalBtn);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updated = onChange.mock.calls[0][0];
     const tuning = updated.tuning as Record<string, unknown>;
     const evaluation = tuning.evaluation as { metrics: string[] };
@@ -621,7 +621,7 @@ describe("TuneTab", () => {
     const pakButtons = screen.getAllByText("precision_at_k");
     fe.click(pakButtons[0].closest("button") ?? pakButtons[0]);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     // Bug 2026-04-14 (4) — Fix 3: TuneEvaluationSection now also runs a
     // defensive useEffect that syncs ``optuna.params.direction`` to the
     // resolved metric direction on mount/metric-change. That effect can
@@ -676,7 +676,7 @@ describe("TuneTab", () => {
     const kIncrBtn = plusButtons[plusButtons.length - 1].closest("button");
     if (kIncrBtn) fireEvent.click(kIncrBtn);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updated = onChange.mock.calls[0][0] as Record<string, unknown>;
     const tuning = updated.tuning as Record<string, unknown>;
     const evaluation = tuning.evaluation as {
@@ -733,7 +733,7 @@ describe("TuneTab", () => {
 
     fireEvent.click(screen.getByTestId("trigger-space-change"));
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updated = onChange.mock.calls[0][0] as Record<string, unknown>;
     const tuning = updated.tuning as Record<string, unknown>;
     const optuna = tuning.optuna as Record<string, unknown>;
@@ -752,7 +752,7 @@ describe("TuneTab", () => {
 
     fireEvent.click(screen.getByTestId("trigger-model-param-change"));
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     const updated = onChange.mock.calls[0][0] as Record<string, unknown>;
     const model = updated.model as Record<string, unknown>;
     const params = model.params as Record<string, unknown>;
@@ -793,7 +793,7 @@ describe("TuneTab", () => {
     const f1Buttons = screen.getAllByText("f1");
     fireEvent.click(f1Buttons[0].closest("button") ?? f1Buttons[0]);
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
     // Bug 2026-04-14 (4) — Fix 3: pick the click-induced call, not the
     // direction-sync useEffect that fires on mount. See the matching
     // comment in the precision_at_k test above.

--- a/frontend/src/hooks/useBackgroundNotification.test.ts
+++ b/frontend/src/hooks/useBackgroundNotification.test.ts
@@ -69,7 +69,7 @@ describe("useBackgroundNotification", () => {
     const { result } = renderHook(() => useBackgroundNotification());
     result.current("Job Complete", "Ready");
 
-    expect(Notification.requestPermission).toHaveBeenCalled();
+    expect(Notification.requestPermission).toHaveBeenCalledTimes(1);
     // After permission is granted, notification should be created
     await vi.waitFor(() => {
       expect(mockNotification).toHaveBeenCalledWith("Job Complete", {
@@ -119,7 +119,7 @@ describe("useBackgroundNotification", () => {
 
     // Wait for async requestPermission to complete
     await vi.waitFor(() => {
-      expect(Notification.requestPermission).toHaveBeenCalled();
+      expect(Notification.requestPermission).toHaveBeenCalledTimes(1);
     });
     // Notification should NOT have been created
     expect(mockNotification).not.toHaveBeenCalled();

--- a/frontend/src/hooks/useConfigSync.test.ts
+++ b/frontend/src/hooks/useConfigSync.test.ts
@@ -127,7 +127,7 @@ describe("useConfigSync", () => {
       wrapper: testWrapper.wrapper,
     });
 
-    await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalledTimes(1));
     expect(mocks.fetchConfigDefaults).toHaveBeenCalledWith("binary", "y");
   });
 
@@ -140,7 +140,7 @@ describe("useConfigSync", () => {
 
     // target is set so sync still runs, but fetchConfigDefaults requires
     // both task and target — so it must not be called.
-    await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalledTimes(1));
     expect(mocks.fetchConfigDefaults).not.toHaveBeenCalled();
   });
 
@@ -154,7 +154,7 @@ describe("useConfigSync", () => {
       wrapper: testWrapper.wrapper,
     });
 
-    await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalledTimes(1));
     const [payload] = mocks.updateConfig.mock.calls[0];
     expect(payload.features.categorical).toEqual(["region"]);
     expect(payload.features.exclude).toEqual(["leaky"]);
@@ -213,7 +213,7 @@ describe("useConfigSync", () => {
     );
 
     rerender({ params: defaultParams({ target: "y" }) });
-    await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.updateConfig).toHaveBeenCalledTimes(1));
     // The preseed value differs from the new key → exactly one sync.
     expect(mocks.updateConfig).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/hooks/useDataLoad.test.ts
+++ b/frontend/src/hooks/useDataLoad.test.ts
@@ -97,9 +97,9 @@ describe("useDataLoad", () => {
       COLS_OK.columns,
       ["a"],
     );
-    expect(defaultParams.onReset).toHaveBeenCalled();
-    expect(defaultParams.onDataChanged).toHaveBeenCalled();
-    expect(mocks.toastSuccess).toHaveBeenCalled();
+    expect(defaultParams.onReset).toHaveBeenCalledTimes(1);
+    expect(defaultParams.onDataChanged).toHaveBeenCalledTimes(1);
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(1);
     expect(result.current.loading).toBe(false);
   });
 
@@ -154,8 +154,8 @@ describe("useDataLoad", () => {
 
     expect(result.current.shape).toEqual([100, 5]);
     expect(result.current.dataPath).toBe("/data/x.csv");
-    expect(defaultParams.onColumnsLoaded).toHaveBeenCalled();
-    expect(mocks.toastSuccess).toHaveBeenCalled();
+    expect(defaultParams.onColumnsLoaded).toHaveBeenCalledTimes(1);
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(1);
   });
 
   it("handleUpload shows toast on failure", async () => {
@@ -233,7 +233,7 @@ describe("useDataLoad", () => {
         COLS_OK.columns,
         ["a"],
       );
-      expect(defaultParams.onDataChanged).toHaveBeenCalled();
+      expect(defaultParams.onDataChanged).toHaveBeenCalledTimes(1);
       // ``onReset`` would clear target/task — must NOT fire during
       // hydration since target is exactly what we're trying to keep.
       expect(defaultParams.onReset).not.toHaveBeenCalled();

--- a/frontend/src/hooks/useDataPanel.test.ts
+++ b/frontend/src/hooks/useDataPanel.test.ts
@@ -110,7 +110,7 @@ describe("useDataPanel", () => {
     expect(result.current.columns).toHaveLength(2);
     expect(onDataChanged).toHaveBeenCalledTimes(1);
     expect(onTaskChanged).toHaveBeenCalledWith(null);
-    expect(mocks.toastSuccess).toHaveBeenCalled();
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(1);
     expect(result.current.loading).toBe(false);
   });
 

--- a/frontend/src/hooks/useJobLifecycle.test.ts
+++ b/frontend/src/hooks/useJobLifecycle.test.ts
@@ -50,7 +50,7 @@ describe("useJobLifecycle", () => {
     });
 
     expect(cancelJob).toHaveBeenCalledWith("j1");
-    expect(onTerminal).toHaveBeenCalled();
+    expect(onTerminal).toHaveBeenCalledTimes(1);
   });
 
   it("cancel is a no-op when jobId is null", async () => {
@@ -93,7 +93,7 @@ describe("useJobLifecycle", () => {
     // Even though the server errored, the UI must NOT stay in
     // "Cancelling..." — the parent's running flag is released via
     // onTerminal and the transient progress is cleared.
-    expect(onTerminal).toHaveBeenCalled();
+    expect(onTerminal).toHaveBeenCalledTimes(1);
     expect(result.current.progress).toBeNull();
   });
 

--- a/frontend/src/hooks/useJobProgress.test.ts
+++ b/frontend/src/hooks/useJobProgress.test.ts
@@ -214,7 +214,7 @@ describe("useJobProgress — WebSocket subscription", () => {
     expect(disconnectSpy).not.toHaveBeenCalled();
 
     rerender({ id: "j2" });
-    expect(disconnectSpy).toHaveBeenCalled();
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -228,7 +228,7 @@ describe("useJobProgress — polling fallback", () => {
     );
 
     rerender({ job: runningJob({ status: "completed" }) });
-    expect(onTerminal).toHaveBeenCalled();
+    expect(onTerminal).toHaveBeenCalledTimes(1);
   });
 
   it("fires onTerminal on first observation of an already-terminal job", () => {

--- a/frontend/src/hooks/useKeyboardShortcuts.test.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.test.ts
@@ -125,7 +125,7 @@ describe("useKeyboardShortcuts", () => {
     });
     const preventSpy = vi.spyOn(event, "preventDefault");
     window.dispatchEvent(event);
-    expect(preventSpy).toHaveBeenCalled();
+    expect(preventSpy).toHaveBeenCalledTimes(1);
   });
 
   it("matches first shortcut and stops", () => {

--- a/frontend/src/hooks/useMediaQuery.test.ts
+++ b/frontend/src/hooks/useMediaQuery.test.ts
@@ -92,7 +92,7 @@ describe("useMediaQuery", () => {
 
     const { unmount } = renderHook(() => useMediaQuery("(max-width: 767px)"));
     unmount();
-    expect(mql.removeEventListener).toHaveBeenCalled();
+    expect(mql.removeEventListener).toHaveBeenCalledTimes(1);
   });
 
   it("returns false when matchMedia is unavailable (SSR / jsdom edge case)", () => {


### PR DESCRIPTION
## v0.6.3 — maintenance + test-quality patch

Release PR: `develop → main`.

Bundles two already-merged, CI-green PRs:

- **#545** — frontend dependency consolidation + CVE security overrides (consolidates Dependabot #541/#542/#543/#544; resolves the shared `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`)
- **#537** — call-count assertion audit (80 bare `.toHaveBeenCalled()` → `.toHaveBeenCalledTimes(N)` across 27 files) + `tohavebeencalled-guard` CI job
- **#547** — CHANGELOG + ROADMAP release-prep

No behaviour change, no API change, no format-version change (`STUDIO_FORMAT_VERSION` stays at 2).

After merge: tag `v0.6.3` on `main` to trigger `publish.yml` (PyPI upload + auto GitHub Release from CHANGELOG).
