### PR TITLE
ci: shard E2E suite + deduplicate lint + cancel superseded runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches: [main, develop]
 
+# Cancel superseded runs when a PR receives a new push. Only the latest
+# revision's result matters; killing in-flight runs frees runner slots
+# and avoids burning compute on stale commits.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   backend:
     runs-on: ubuntu-latest
@@ -16,9 +23,16 @@ jobs:
         with:
           enable-cache: true
       - run: uv sync
+      # Lint / format / type-check are Python-version-independent. Run them
+      # only on the 3.11 matrix leg so the 3.10 leg does not duplicate
+      # ~18s of work. `backend (3.11)` stays the required check that
+      # gates them in the branch-protection ruleset.
       - run: uv run ruff check .
+        if: matrix.python-version == '3.11'
       - run: uv run ruff format --check .
+        if: matrix.python-version == '3.11'
       - run: uv run mypy src/lizystudio/
+        if: matrix.python-version == '3.11'
       # Flaky-test strategy (Issue #29): CI reruns failures twice.
       # Local runs do NOT retry so flakiness stays visible. Quarantined
       # tests are excluded from this blocking job (default addopts in
@@ -132,8 +146,20 @@ jobs:
   # regression (@visual) and accessibility scans (@a11y) are EXCLUDED
   # here — they are state-sensitive and live on Nightly so they do not
   # block feature PRs on environment noise.
-  e2e-chromium:
+  #
+  # The suite is split into 4 shards (`--shard=N/4`). Each shard is a
+  # separate runner with its own backend process, so the single-worker
+  # state-isolation guarantee (one backend owns one /tmp workspace) is
+  # preserved — sharding does NOT weaken isolation, unlike raising
+  # `workers`. Per-shard names are `e2e-shard (N)`; the `e2e-chromium`
+  # aggregation job below keeps the stable required-check name.
+  e2e-shard:
+    name: e2e-shard
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     defaults:
       run:
         working-directory: frontend
@@ -187,20 +213,42 @@ jobs:
           # inference-flow).  Those assertions are covered by the
           # dedicated Nightly visual job; running them here would red-up
           # PRs whenever the committed golden is missing or stale.
+          # --shard splits the suite across 4 runners; Playwright
+          # distributes tests round-robin so each shard runs ~1/4.
           pnpm exec playwright test \
             --project=chromium \
             --grep-invert="@visual|@a11y|@ci-flaky" \
-            --ignore-snapshots
+            --ignore-snapshots \
+            --shard=${{ matrix.shard }}/4
       - name: Upload Playwright traces/screenshots on failure
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-report-chromium
+          # Per-shard artifact name — a bare name would collide across
+          # the matrix legs and fail the upload.
+          name: playwright-report-chromium-shard-${{ matrix.shard }}
           path: |
             frontend/playwright-report/
             frontend/test-results/
           retention-days: 7
           if-no-files-found: ignore
+
+  # Aggregation gate. Branch-protection ruleset "Protect main" lists
+  # `e2e-chromium` as a required status check; after the shard split the
+  # matrix job reports per-shard names instead. This job keeps the stable
+  # `e2e-chromium` check green only when every shard passed.
+  e2e-chromium:
+    runs-on: ubuntu-latest
+    needs: [e2e-shard]
+    if: always()
+    steps:
+      - name: Verify all E2E shards passed
+        run: |
+          if [ "${{ needs.e2e-shard.result }}" != "success" ]; then
+            echo "::error::One or more E2E shards failed (result: ${{ needs.e2e-shard.result }})"
+            exit 1
+          fi
+          echo "All E2E shards passed."
 
   # B-9 Part 2 (H-0078 follow-up): guard against raw Tailwind color
   # utilities in frontend source. After the semantic-token migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI: shard the E2E suite across 4 runners + deduplicate lint.** The
+  `e2e-chromium` Playwright job was the sole critical-path bottleneck
+  (~914s of a ~15min run). It is now split into a 4-way `--shard` matrix
+  (`e2e-shard`) with an `e2e-chromium` aggregation gate that preserves
+  the required-status-check name. Each shard runs on its own runner with
+  its own backend process, so the single-worker state-isolation guarantee
+  is unchanged. `ruff`/`mypy` now run only on the 3.11 backend matrix leg
+  (they are Python-version-independent), and a `concurrency` group cancels
+  superseded runs. No test, app, or API change — CI wall-clock drops from
+  ~15min to ~5min.
+
 ## [0.6.3] - 2026-05-23
 
 A **maintenance and test-quality** patch release. No behaviour change,


### PR DESCRIPTION
## Summary

CI wall-clock was **~15min**, gated entirely by the `e2e-chromium` job (**914s**). The other 10 jobs all finish within 6min, so shortening E2E shortens the whole pipeline. Three quality-preserving changes bring it to **~5min**.

### Measured bottleneck (latest green run)

| Job | Time | Notes |
|---|---|---|
| **e2e-chromium** | **914s** | E2E run **789s** / build 54s / Playwright install 36s |
| backend (3.10) | 305s | pytest 278s / mypy 17s |
| backend (3.11) | 283s | duplicate of 3.10 |
| frontend | 169s | |
| 8 other jobs | 3–27s | |

## Changes

### 1. E2E sharding (the main win)
`e2e-chromium` is replaced by a 4-way `--shard=N/4` matrix job `e2e-shard`, plus a small `e2e-chromium` aggregation gate that fails unless every shard passed.

- The gate **preserves the `e2e-chromium` required-status-check name** referenced by the `Protect main` ruleset — no ruleset edit needed.
- Each shard runs on its own runner with its own backend process, so the single-worker (`workers: 1`) **state-isolation guarantee is fully preserved**. Sharding does not weaken it the way raising `workers` against a shared `/tmp` workspace would.
- Effect: e2e 914s → ~300s (789/4 + ~95s setup per shard).

### 2. Lint deduplication
`ruff check` / `ruff format` / `mypy` are Python-version-independent but ran on **both** the 3.10 and 3.11 backend matrix legs. They now run only on 3.11 (`if: matrix.python-version == '3.11'`), so `backend (3.11)` still gates them and no new job/required-check is introduced.

### 3. Concurrency group
New `concurrency` block with `cancel-in-progress: true` kills superseded runs when a PR receives a new push, freeing runner slots.

## Quality impact

None. Same tests, same isolation, same required checks. The repo is public so the ~30% increase in total runner-minutes (4×300s vs 1×914s) is free, and change 3 offsets it by cancelling stale runs.

## Test plan

- [ ] CI on this PR is green — confirms the shard matrix, `--shard` distribution, and the `e2e-chromium` gate all work.
- [ ] `e2e-chromium` check still reports (required by `Protect main`).
- [ ] Per-shard artifacts (`playwright-report-chromium-shard-N`) upload without name collision on failure.
- [ ] `backend (3.10)` skips ruff/mypy; `backend (3.11)` runs them.

Out of scope (discussed, deferred): `pytest-xdist` backend parallelism (needs a HISTORY.md Proposal — external dependency) and dropping the E2E `pnpm dev` server (changes the e2e environment).
