### PR TITLE
chore(ops): weekly stale-doc audit cron (#495 / #456 L5)

### DIFF
--- a/.github/workflows/audit-stale-docs.yml
+++ b/.github/workflows/audit-stale-docs.yml
@@ -1,0 +1,69 @@
+name: Stale-doc audit (#456 L5)
+
+# Runs ``scripts/audit_stale_docs.py`` weekly and either opens or updates
+# a single tracking Issue (titled "[audit] stale handoff/readiness docs
+# (auto-updated)") with the current list. Failure mode covered: M3 from
+# #456 -- rot of plan-class artefacts that no spec doc references.
+#
+# This workflow never fails the build on stale docs alone. The audit
+# output is informational; the maintainer reviews the tracking Issue
+# weekly and either deletes the doc or adds a reference from one of
+# the index files (BLUEPRINT / HISTORY / PLAN / ROADMAP / etc).
+
+on:
+  schedule:
+    - cron: "0 18 * * 0" # Sunday 03:00 JST (after Nightly @ 02:00 JST)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: develop
+          # ``git log -1 --format=%cI`` needs full history per file so the
+          # last-touched timestamp is accurate even for older docs.
+          fetch-depth: 0
+      - name: Run audit
+        id: audit
+        run: |
+          # Write the Markdown report to a file so we can both echo it
+          # to the action log and feed it to the issue body step. The
+          # script always exits 0; we never fail the build.
+          python3 scripts/audit_stale_docs.py --stale-days 30 > audit-report.md
+          cat audit-report.md
+      - name: Open or update tracking Issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_TITLE: "[audit] stale handoff/readiness docs (auto-updated)"
+        run: |
+          set -euo pipefail
+          # Find an existing open tracking issue by exact title match.
+          existing="$(
+            gh issue list \
+              --state open \
+              --search "in:title \"$ISSUE_TITLE\"" \
+              --json number,title \
+              --jq '.[] | select(.title == env.ISSUE_TITLE) | .number' \
+              | head -1
+          )"
+          # Append a footer with the run link so each refresh is traceable.
+          {
+            cat audit-report.md
+            echo ""
+            echo "---"
+            echo "_Last refreshed: $(date -u '+%Y-%m-%d %H:%M UTC') by [run ${GITHUB_RUN_ID}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})._"
+          } > issue-body.md
+          if [ -z "$existing" ]; then
+            gh issue create \
+              --title "$ISSUE_TITLE" \
+              --body-file issue-body.md \
+              --label "tier-3,priority-low,area-ops"
+          else
+            gh issue edit "$existing" --body-file issue-body.md
+          fi

--- a/scripts/audit_stale_docs.py
+++ b/scripts/audit_stale_docs.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Stale-doc audit — #456 L5 / Issue #495.
+
+Lists plan-class / handoff / readiness / audit documents that are both:
+
+  (a) older than the staleness threshold (last commit > 30 days ago), and
+  (b) not referenced from any of the spec / index files
+      (BLUEPRINT.md, HISTORY.md, PLAN.md, CHANGELOG.md, README.md,
+       docs/ROADMAP.md, .claude/AGENTS.md).
+
+The script is layered for testability:
+
+  ``audit(repo)`` returns a list of ``StaleDoc`` records.
+  ``main()`` formats those records as Markdown to stdout for the
+  ``audit-stale-docs.yml`` workflow to fold into a tracking Issue.
+
+Failure mode covered: M3 from #456 -- rot of plan-class artefacts that
+no spec doc references. L1 (``tmp/`` convention), L2 (``block-stray-artifacts``
+hook), L3 (orphan-golden gate), L4 (CI checks) do not catch this class.
+
+Exit code is always 0 -- the workflow uses the stdout payload to update
+the tracking Issue; it never fails the build on stale docs alone.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Globs whose ``docs/<file>.md`` matches will be considered candidates.
+# Patterns are relative to the repo root.
+#
+# Both ``docs/handoff-*.md`` (no prefix) and ``docs/*-handoff-*.md`` (versioned
+# prefix) shapes appear in the tree — see ``docs/handoff-2026-05-10-...md``
+# vs hypothetical ``docs/v05-handoff-*.md`` — so both are listed.
+CANDIDATE_GLOBS: tuple[str, ...] = (
+    "docs/handoff-*.md",
+    "docs/*-handoff-*.md",
+    "docs/readiness-*.md",
+    "docs/*-readiness-*.md",
+    "docs/audit-*.md",
+    "docs/*-audit-*.md",
+    "docs/v*-prep-*.md",
+    "docs/v*-handoff-*.md",
+)
+
+# Files that, if they reference a candidate doc, mark it as still
+# load-bearing and exempt it from the audit.
+INDEX_FILES: tuple[str, ...] = (
+    "BLUEPRINT.md",
+    "HISTORY.md",
+    "PLAN.md",
+    "CHANGELOG.md",
+    "README.md",
+    "docs/ROADMAP.md",
+    ".claude/AGENTS.md",
+)
+
+DEFAULT_STALE_DAYS = 30
+
+
+@dataclass(frozen=True)
+class StaleDoc:
+    """One audit hit -- a doc that meets both staleness criteria."""
+
+    path: str  # relative to repo root
+    last_touched: datetime  # UTC, from ``git log -1 --format=%cI``
+    line_count: int
+
+
+def _git_last_touched(repo: Path, rel_path: str) -> datetime | None:
+    """Return the UTC datetime of the most recent commit touching ``rel_path``.
+
+    Returns ``None`` when the file is untracked.
+    """
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%cI", "--", rel_path],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    stamp = result.stdout.strip()
+    if not stamp:
+        return None
+    # ``%cI`` is strict ISO-8601 (e.g. ``2026-05-23T12:34:56+00:00``).
+    dt = datetime.fromisoformat(stamp)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _line_count(repo: Path, rel_path: str) -> int:
+    p = repo / rel_path
+    if not p.exists():
+        return 0
+    return sum(1 for _ in p.open("rb"))
+
+
+def _iter_candidates(repo: Path) -> Iterable[str]:
+    """Yield candidate doc paths matching the audit globs."""
+    seen: set[str] = set()
+    for pattern in CANDIDATE_GLOBS:
+        for path in repo.glob(pattern):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(repo).as_posix()
+            if rel in seen:
+                continue
+            seen.add(rel)
+            yield rel
+
+
+def _is_referenced(repo: Path, rel_path: str) -> bool:
+    """Return True when any INDEX_FILES mentions ``rel_path`` verbatim.
+
+    Matching is a substring search on the basename and on the full path.
+    The basename match catches link-style references like
+    ``[handoff](handoff-2026-05-10-post-h0079.md)`` from inside ``docs/``;
+    the full-path match catches references from ``BLUEPRINT.md`` etc.
+    """
+    basename = Path(rel_path).name
+    for index_rel in INDEX_FILES:
+        p = repo / index_rel
+        if not p.exists():
+            continue
+        try:
+            text = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if rel_path in text or basename in text:
+            return True
+    return False
+
+
+def audit(repo: Path, *, stale_days: int = DEFAULT_STALE_DAYS) -> list[StaleDoc]:
+    """Return the list of candidate docs that are stale AND unreferenced."""
+    now = datetime.now(tz=timezone.utc)
+    threshold = now - timedelta(days=stale_days)
+    hits: list[StaleDoc] = []
+    for rel in sorted(_iter_candidates(repo)):
+        last = _git_last_touched(repo, rel)
+        if last is None or last > threshold:
+            continue
+        if _is_referenced(repo, rel):
+            continue
+        hits.append(
+            StaleDoc(path=rel, last_touched=last, line_count=_line_count(repo, rel))
+        )
+    return hits
+
+
+def render_markdown(
+    hits: list[StaleDoc], *, stale_days: int = DEFAULT_STALE_DAYS
+) -> str:
+    """Render the audit result as a Markdown report for the tracking Issue."""
+    title = (
+        f"# Stale handoff / readiness / audit docs ({stale_days}+ days unreferenced)"
+    )
+    header = (
+        f"{title}\n\n"
+        "Generated by `scripts/audit_stale_docs.py` (cron via "
+        "`.github/workflows/audit-stale-docs.yml`).\n\n"
+        "Each entry below is older than the staleness threshold **and** is not "
+        "referenced from any of: `BLUEPRINT.md`, `HISTORY.md`, `PLAN.md`, "
+        "`CHANGELOG.md`, `README.md`, `docs/ROADMAP.md`, `.claude/AGENTS.md`.\n\n"
+        "**Action**: delete the doc unless it is still load-bearing; if it is, "
+        "add a reference from one of the index files above.\n\n"
+    )
+    if not hits:
+        return header + "_No stale docs detected._\n"
+    lines = ["| Path | Last touched | Lines |", "|---|---|---|"]
+    for hit in hits:
+        date = hit.last_touched.date().isoformat()
+        lines.append(f"| `{hit.path}` | {date} | {hit.line_count} |")
+    return header + "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        default=".",
+        help="Repository root (default: cwd).",
+    )
+    parser.add_argument(
+        "--stale-days",
+        type=int,
+        default=DEFAULT_STALE_DAYS,
+        help=f"Staleness threshold in days (default: {DEFAULT_STALE_DAYS}).",
+    )
+    args = parser.parse_args(argv)
+    repo = Path(args.repo).resolve()
+    hits = audit(repo, stale_days=args.stale_days)
+    sys.stdout.write(render_markdown(hits, stale_days=args.stale_days))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_stale_docs.py
+++ b/tests/test_audit_stale_docs.py
@@ -1,0 +1,170 @@
+"""Tests for scripts/audit_stale_docs.py (#456 L5 / Issue #495).
+
+The script lists plan-class / handoff / readiness / audit docs that are
+both stale (last commit > 30 days ago) AND unreferenced from any of the
+spec / index files. These tests build throwaway git repos with controlled
+file ages (via ``GIT_AUTHOR_DATE`` / ``GIT_COMMITTER_DATE``) and assert
+the audit output.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "audit_stale_docs.py"
+
+
+def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, env=env)
+
+
+def _commit_at(repo: Path, *, days_ago: int, message: str) -> None:
+    """Stage everything and commit with author/committer date ``days_ago``."""
+    stamp = (datetime.now(tz=timezone.utc) - timedelta(days=days_ago)).strftime(
+        "%Y-%m-%dT%H:%M:%S+0000"
+    )
+    import os
+
+    env = os.environ.copy()
+    env["GIT_AUTHOR_DATE"] = stamp
+    env["GIT_COMMITTER_DATE"] = stamp
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", message, env=env)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A minimal git repo seeded with empty index files."""
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-q", "-b", "main")
+    _git(r, "config", "user.email", "test@example.com")
+    _git(r, "config", "user.name", "test")
+    # Seed the index files the audit consults.
+    for rel in (
+        "BLUEPRINT.md",
+        "HISTORY.md",
+        "PLAN.md",
+        "CHANGELOG.md",
+        "README.md",
+        "docs/ROADMAP.md",
+        ".claude/AGENTS.md",
+    ):
+        p = r / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# index\n")
+    _commit_at(r, days_ago=60, message="seed index files")
+    return r
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo", str(repo), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _add_doc(repo: Path, rel: str, *, days_ago: int, body: str = "stub\n") -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body)
+    _commit_at(repo, days_ago=days_ago, message=f"add {rel}")
+
+
+def test_empty_repo_reports_no_hits(repo: Path) -> None:
+    """No candidate docs => clean report, exit 0."""
+    result = _run(repo)
+    assert result.returncode == 0
+    assert "No stale docs detected." in result.stdout
+
+
+def test_fresh_doc_is_excluded(repo: Path) -> None:
+    """A doc touched within the threshold (< 30 days) is not stale."""
+    _add_doc(repo, "docs/handoff-recent.md", days_ago=5)
+    result = _run(repo)
+    assert result.returncode == 0
+    assert "handoff-recent" not in result.stdout
+    assert "No stale docs detected." in result.stdout
+
+
+def test_stale_unreferenced_doc_is_flagged(repo: Path) -> None:
+    """A > 30-day-old, unreferenced handoff doc appears in the report."""
+    _add_doc(repo, "docs/handoff-2026-01-01.md", days_ago=60)
+    result = _run(repo)
+    assert result.returncode == 0
+    assert "docs/handoff-2026-01-01.md" in result.stdout
+
+
+def test_stale_doc_referenced_from_roadmap_is_excluded(repo: Path) -> None:
+    """A stale doc referenced from ``docs/ROADMAP.md`` is still load-bearing."""
+    _add_doc(repo, "docs/handoff-2026-01-02.md", days_ago=60)
+    (repo / "docs" / "ROADMAP.md").write_text(
+        "see `docs/handoff-2026-01-02.md` for context\n"
+    )
+    _commit_at(repo, days_ago=60, message="ref handoff from roadmap")
+    result = _run(repo)
+    assert result.returncode == 0
+    assert "handoff-2026-01-02" not in result.stdout
+
+
+def test_basename_reference_counts(repo: Path) -> None:
+    """A basename-only mention (e.g. from a sibling doc) marks load-bearing."""
+    _add_doc(repo, "docs/handoff-2026-01-03.md", days_ago=60)
+    # BLUEPRINT.md references the basename only.
+    (repo / "BLUEPRINT.md").write_text("links to handoff-2026-01-03.md\n")
+    _commit_at(repo, days_ago=60, message="basename ref")
+    result = _run(repo)
+    assert result.returncode == 0
+    assert "handoff-2026-01-03" not in result.stdout
+
+
+def test_audit_pattern_glob_handoff_readiness_audit_prep(repo: Path) -> None:
+    """All four declared glob patterns are honoured."""
+    _add_doc(repo, "docs/handoff-x.md", days_ago=60)
+    _add_doc(repo, "docs/v05-readiness-x.md", days_ago=60)
+    _add_doc(repo, "docs/some-audit-x.md", days_ago=60)
+    _add_doc(repo, "docs/v05-prep-x.md", days_ago=60)
+    # A non-matching doc must NOT appear.
+    _add_doc(repo, "docs/architecture-notes.md", days_ago=60)
+    result = _run(repo)
+    assert result.returncode == 0
+    for path in (
+        "docs/handoff-x.md",
+        "docs/v05-readiness-x.md",
+        "docs/some-audit-x.md",
+        "docs/v05-prep-x.md",
+    ):
+        assert path in result.stdout
+    assert "architecture-notes" not in result.stdout
+
+
+def test_line_count_is_emitted(repo: Path) -> None:
+    """Output table includes line count for prioritisation."""
+    _add_doc(
+        repo,
+        "docs/handoff-multi.md",
+        days_ago=60,
+        body="line1\nline2\nline3\n",
+    )
+    result = _run(repo)
+    assert result.returncode == 0
+    # The table renders ``| 3 |`` for a 3-line file.
+    assert "| 3 |" in result.stdout
+
+
+def test_custom_stale_days_threshold(repo: Path) -> None:
+    """``--stale-days=7`` flags a 14-day-old doc that 30-day default would skip."""
+    _add_doc(repo, "docs/handoff-mid.md", days_ago=14)
+    # 30-day default: not stale
+    result_default = _run(repo)
+    assert "handoff-mid" not in result_default.stdout
+    # 7-day threshold: stale
+    result_strict = _run(repo, "--stale-days", "7")
+    assert "handoff-mid" in result_strict.stdout


### PR DESCRIPTION
Closes #495.

## Summary

Adds the deferred **L5** layer from the #456 layered-prevention plan — a weekly cron that flags plan-class / handoff / readiness / audit docs that are both stale **and** unreferenced from the spec / index files.

Failure mode addressed: **M3** from #456 (rot of plan-class artefacts that no spec doc references). L1 (`tmp/` convention), L2 (`block-stray-artifacts` hook), L3 (orphan-golden gate), L4 (CI checks) do not catch this class.

## Components

| File | Role |
|---|---|
| `scripts/audit_stale_docs.py` | Testable Python module — `audit(repo, stale_days)` returns `list[StaleDoc]`; CLI entry point renders Markdown report |
| `tests/test_audit_stale_docs.py` | 8 pytest cases covering fresh / stale-referenced / stale-unreferenced / basename-ref / custom-threshold branches |
| `.github/workflows/audit-stale-docs.yml` | Weekly cron (Sunday 03:00 JST). Opens or updates a single tracking Issue titled `[audit] stale handoff/readiness docs (auto-updated)` |

## Glob deviation from #495 spec

The Issue listed `docs/*-handoff-*.md` (versioned prefix) but the actual files in the tree are `docs/handoff-*.md` (no prefix). Both forms are listed so existing handoff docs are covered.

## Acceptance criteria

- [x] `scripts/audit_stale_docs.py` exists and is testable
- [x] pytest test mirrors `tests/test_check_stray.py` / `tests/test_check_orphan_goldens.py` style
- [x] `.github/workflows/audit-stale-docs.yml` runs weekly via cron + `workflow_dispatch`
- [x] Workflow opens (if absent) or updates (if present) the tracking Issue via `gh issue create` / `gh issue edit`
- [x] Build never fails on stale docs alone (informational only)

## Test plan

- [x] `uv run pytest tests/test_audit_stale_docs.py -v` — 8/8 pass
- [x] `uv run ruff check scripts/audit_stale_docs.py tests/test_audit_stale_docs.py` — clean
- [x] `uv run ruff format --check ...` — clean
- [x] `uv run mypy scripts/audit_stale_docs.py` — clean
- [x] Smoke run on real repo: no current docs are stale (all handoffs < 30 days old; `ui-config-sync-audit-2026-04.md` is referenced from `docs/ROADMAP.md` + `.claude/AGENTS.md`)
- [ ] Workflow dry-run on PR via `workflow_dispatch` (reviewer can trigger after merge)