### PR TITLE
test(e2e): extract request-budget helper + 3 pilot specs (#538)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,45 @@ If you add a new Playwright project, also reference it from a workflow (or
 keep its goldens out of git); if you retire one, delete its goldens in the
 same PR — regenerate later via `pnpm test:e2e:update` if it returns.
 
+### E2E request-budget assertions (Issue #538)
+
+Storm / spam / flood-class bugs (v0.6.2 Target-select cluster #529 / #530
+/ #531, polling storm #339, replay loop #341) slip past tests that only
+assert eventual *state*. To detect them, **every E2E spec exercising a
+user action should include at least one request-budget assertion**
+counting HTTP calls per click / submit / load.
+
+Use the helpers in
+[`frontend/tests/e2e/helpers/request-budget.ts`](frontend/tests/e2e/helpers/request-budget.ts):
+
+```ts
+import { installFetchRecorder, expectBudget } from "./helpers/request-budget";
+
+const recorder = installFetchRecorder(page);
+// ...drive UI to "ready" state...
+const sinceClick = recorder.snapshot({
+  method: "PUT",
+  urlPattern: "/api/workspace/config",
+});
+await page.getByRole("combobox", { name: /target/i }).click();
+await page.getByRole("option", { name: "survived" }).click();
+await page.waitForTimeout(3000);
+expect(sinceClick().length).toBeLessThanOrEqual(3);  // budget with rationale comment
+```
+
+Rules:
+
+- Budget values must be justified in a code comment citing a measured
+  baseline or a related Issue (see `workspace-target-select-puts.spec.ts`
+  for the canonical "history: 9 → 4 → 3 → 2" form).
+- Failing budget → investigate the *cause* and either fix the regression
+  or file a follow-up bug. **Never relax the budget to make a failing
+  spec pass.**
+
+Surfaces covered today: target-select, tab-switch, data-load via Path,
+CV strategy change. Folds increment / Fit submit / Tune submit / Tune
+resume / Inference run are follow-ups under #538.
+
 ## Test fixtures
 
 When adding a new transform, parser, or schema mapper, the **first test case

--- a/frontend/tests/e2e/helpers/request-budget.ts
+++ b/frontend/tests/e2e/helpers/request-budget.ts
@@ -1,0 +1,211 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * Request-budget helper for E2E specs (Issue #538).
+ *
+ * Templates the count-occurrences pattern that landed in
+ * ``workspace-target-select-puts.spec.ts``. The v0.6.2 Target-select
+ * bug cluster (#529 / #530 / #531) was the first regression class
+ * where every assertion checked eventual *state* (resolved value, no
+ * error, etc.) and every state-based assertion passed -- yet 9 PUTs
+ * per click were fired across a 4-day window. The same pattern would
+ * have caught #339 (polling storm) and #341 (replay loop) months
+ * earlier had counts been asserted at the E2E layer.
+ *
+ * The helper is intentionally small. It installs request observers,
+ * records every (method, URL, body) for later inspection, and exposes
+ * filtered count / list views plus a single-call budget assertion.
+ *
+ * Usage:
+ *
+ *     const recorder = installFetchRecorder(page);
+ *     // ...drive UI...
+ *     await page.waitForTimeout(3000);  // wait for funnel quiescence
+ *     expectBudget(recorder, {
+ *       method: "PUT",
+ *       urlPattern: "/api/workspace/config",
+ *       max: 3,
+ *       label: "Target-select click",
+ *     });
+ *
+ * Why not just count via ``page.on``? You can, and the existing spec
+ * does. The helper centralises (a) the post-data JSON parsing,
+ * (b) "snapshot at point T" semantics, (c) the verbose diagnostic
+ * payload on failure, and (d) the response-status side channel for
+ * GET-returns-4xx assertions. All four are easy to forget when each
+ * spec rolls its own observer.
+ *
+ * Per ``feedback_count_budget_assertions`` (memory): for storm/spam/
+ * flood bugs, the regression test MUST count occurrences, not just
+ * assert eventual correctness.
+ */
+
+export interface RequestRecord {
+  method: string;
+  url: string;
+  /** Parsed JSON request body when ``Content-Type`` is JSON; ``null`` otherwise. */
+  bodyJson: Record<string, unknown> | null;
+  /** Raw post-data string length, useful for "partial body" heuristics. */
+  bodySize: number;
+}
+
+export interface ResponseRecord {
+  method: string;
+  url: string;
+  status: number;
+}
+
+export interface FetchRecorder {
+  /** Every observed request, in arrival order. */
+  readonly requests: RequestRecord[];
+  /** Every observed response, in arrival order. */
+  readonly responses: ResponseRecord[];
+  /**
+   * Number of requests currently recorded for the given filter. Use
+   * before / after a UI action to compute a delta.
+   */
+  countRequests(filter: RequestFilter): number;
+  /** All requests matching ``filter``, in arrival order. */
+  matchingRequests(filter: RequestFilter): RequestRecord[];
+  /** All responses matching ``filter`` (with optional status code). */
+  matchingResponses(filter: ResponseFilter): ResponseRecord[];
+  /**
+   * Take a snapshot of the current request count for ``filter``. Returns
+   * a closure that, on call, returns the delta since the snapshot.
+   * Pattern: ``const since = recorder.snapshot({...}); ...; since()``.
+   */
+  snapshot(filter: RequestFilter): () => RequestRecord[];
+}
+
+export interface RequestFilter {
+  method?: string;
+  /** Either a string suffix-match (``endsWith``) or a RegExp. */
+  urlPattern: string | RegExp;
+}
+
+export interface ResponseFilter extends RequestFilter {
+  /** When set, only responses with this exact status are returned. */
+  status?: number;
+}
+
+export interface BudgetAssertion {
+  method: string;
+  urlPattern: string | RegExp;
+  /** Maximum allowed observed count (inclusive). */
+  max: number;
+  /** Human-readable description of the user action this budget covers. */
+  label?: string;
+}
+
+function matchesUrl(actual: string, pattern: string | RegExp): boolean {
+  if (typeof pattern === "string") return actual.endsWith(pattern);
+  return pattern.test(actual);
+}
+
+function matchesRequest(req: RequestRecord, filter: RequestFilter): boolean {
+  if (filter.method && req.method !== filter.method) return false;
+  return matchesUrl(req.url, filter.urlPattern);
+}
+
+/**
+ * Install request + response observers on ``page``. The returned
+ * recorder accumulates everything for the lifetime of the page; it does
+ * not need teardown.
+ *
+ * Must be called BEFORE any user interaction that should be measured.
+ * Records that arrive before installation are not captured.
+ */
+export function installFetchRecorder(page: Page): FetchRecorder {
+  const requests: RequestRecord[] = [];
+  const responses: ResponseRecord[] = [];
+
+  page.on("request", (req) => {
+    let bodyJson: Record<string, unknown> | null = null;
+    try {
+      const parsed = req.postDataJSON() as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        bodyJson = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Not JSON or no body -- bodyJson stays null.
+    }
+    requests.push({
+      method: req.method(),
+      url: req.url(),
+      bodyJson,
+      bodySize: req.postData()?.length ?? 0,
+    });
+  });
+
+  page.on("response", (res) => {
+    responses.push({
+      method: res.request().method(),
+      url: res.url(),
+      status: res.status(),
+    });
+  });
+
+  return {
+    requests,
+    responses,
+    countRequests(filter) {
+      return requests.filter((r) => matchesRequest(r, filter)).length;
+    },
+    matchingRequests(filter) {
+      return requests.filter((r) => matchesRequest(r, filter));
+    },
+    matchingResponses(filter) {
+      return responses.filter((r) => {
+        if (filter.method && r.method !== filter.method) return false;
+        if (!matchesUrl(r.url, filter.urlPattern)) return false;
+        if (filter.status !== undefined && r.status !== filter.status)
+          return false;
+        return true;
+      });
+    },
+    snapshot(filter) {
+      const start = requests.length;
+      return () => requests.slice(start).filter((r) => matchesRequest(r, filter));
+    },
+  };
+}
+
+/**
+ * Assert that the recorded count for ``budget.method`` / ``urlPattern``
+ * is at most ``budget.max``. Failure message includes every captured
+ * URL + body-key set for the matching requests so the spec author can
+ * see WHAT extra writes fired, not just THAT something fired too often.
+ *
+ * Use after a UI action + a quiescence wait. Combine with ``snapshot``
+ * when the budget should cover only post-snapshot requests:
+ *
+ *     const since = recorder.snapshot({ method: "PUT", urlPattern: "/api/workspace/config" });
+ *     // ...drive UI...
+ *     await page.waitForTimeout(3000);
+ *     const extra = since();
+ *     expect(extra.length, label).toBeLessThanOrEqual(2);
+ */
+export function expectBudget(
+  recorder: FetchRecorder,
+  budget: BudgetAssertion,
+): void {
+  const matches = recorder.matchingRequests({
+    method: budget.method,
+    urlPattern: budget.urlPattern,
+  });
+  const labelPrefix = budget.label ? `${budget.label}: ` : "";
+  const diagnostic = matches
+    .map(
+      (m, i) =>
+        `  [${i}] ${m.method} ${m.url} keys=${
+          m.bodyJson ? JSON.stringify(Object.keys(m.bodyJson).sort()) : "(no body)"
+        }`,
+    )
+    .join("\n");
+  expect(
+    matches.length,
+    `${labelPrefix}observed ${matches.length} ${budget.method} request(s) for ${
+      budget.urlPattern
+    } (budget ${budget.max}). Captured:\n${diagnostic || "  (none)"}`,
+  ).toBeLessThanOrEqual(budget.max);
+}

--- a/frontend/tests/e2e/workspace-cv-strategy-puts.spec.ts
+++ b/frontend/tests/e2e/workspace-cv-strategy-puts.spec.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "@playwright/test";
+import * as fs from "node:fs";
+import { isMobileProject } from "./helpers/mobile";
+import { expectBudget, installFetchRecorder } from "./helpers/request-budget";
+import { seedUiWorkspace } from "./helpers/workspace-ui";
+
+/**
+ * Issue #538 — CV strategy change PUT budget regression spec.
+ *
+ * Surface: clicking a CV strategy radio (e.g. KFold → TimeSeriesSplit)
+ * is identified in the #538 surface table as the **highest-risk**
+ * write-budget surface because it shares the
+ * "auto-reset useEffect chain" with the v0.6.2 Target-select cluster
+ * (#530). Specifically:
+ *
+ *   - The strategy change rewrites ``split.method`` AND prunes the
+ *     no-longer-applicable strategy-specific fields (e.g. switching
+ *     from kfold → time_series drops `random_state` / `shuffle`).
+ *   - This fans out as 2 hooks emitting writes within one frame, and
+ *     the funnel coalesces them.
+ *
+ * Budget: ≤ 2 PUTs per strategy click (matches the #538 surface table
+ * "PUT ≤ 2" entry). split-preview GET ≤ 1 follows directly.
+ *
+ * Per ``feedback_count_budget_assertions`` (memory): for storm/spam
+ * bugs the regression test MUST count occurrences, not just assert
+ * eventual correctness.
+ */
+
+const CSV_PATH = "/tmp/e2e_cv_strategy_puts.csv";
+const PUT_BUDGET = 2;
+const SPLIT_PREVIEW_BUDGET = 1;
+
+function createTestCsv(): void {
+  const rows = ["id,age,target"];
+  for (let i = 0; i < 100; i += 1) {
+    rows.push(`${i},${20 + (i % 50)},${i % 2}`);
+  }
+  fs.writeFileSync(CSV_PATH, rows.join("\n"));
+}
+
+test.describe("CV strategy change — PUT + split-preview budget (Issue #538)", () => {
+  test.beforeAll(() => {
+    createTestCsv();
+  });
+
+  test.afterAll(() => {
+    if (fs.existsSync(CSV_PATH)) fs.unlinkSync(CSV_PATH);
+  });
+
+  test("KFold → TimeSeriesSplit stays within budget", async ({
+    page,
+    request,
+  }, testInfo) => {
+    if (isMobileProject(testInfo)) {
+      test.skip(
+        true,
+        "Mobile layout collapses the Data accordion; covered by B-8",
+      );
+    }
+
+    await request.post("/api/workspace/reset");
+
+    // Install recorder BEFORE seeding so the snapshot below truly
+    // starts from the strategy click.
+    const recorder = installFetchRecorder(page);
+    await seedUiWorkspace(page, testInfo, {
+      csvPath: CSV_PATH,
+      target: "target",
+      expectedRows: 100,
+    });
+
+    // Let the seed funnel drain so its PUTs don't bleed into the budget.
+    await page.waitForTimeout(2000);
+
+    const sincePut = recorder.snapshot({
+      method: "PUT",
+      urlPattern: "/api/workspace/config",
+    });
+    const sincePreview = recorder.snapshot({
+      method: "GET",
+      urlPattern: "/api/workspace/data/split-preview",
+    });
+
+    // Click the TimeSeriesSplit radio — drives split.method and prunes
+    // stratified_kfold-only fields (random_state, shuffle).
+    const radio = page.getByRole("radio", { name: "TimeSeriesSplit" });
+    await expect(radio).toBeEnabled({ timeout: 10_000 });
+    await radio.click();
+
+    // 3s drain budget — same as workspace-target-select-puts.
+    await page.waitForTimeout(3000);
+
+    const strategyPuts = sincePut();
+    expect(
+      strategyPuts.length,
+      `CV strategy change fired ${strategyPuts.length} PUT(s) (budget ${PUT_BUDGET}). ` +
+        `Risk class: auto-reset useEffect chain (same hook family as ` +
+        `#530 Target-select oscillation). Captured:\n` +
+        strategyPuts
+          .map(
+            (p) =>
+              `  keys=${
+                p.bodyJson ? JSON.stringify(Object.keys(p.bodyJson).sort()) : "(no body)"
+              }`,
+          )
+          .join("\n"),
+    ).toBeLessThanOrEqual(PUT_BUDGET);
+
+    const previewGets = sincePreview();
+    expect(
+      previewGets.length,
+      `CV strategy change fired ${previewGets.length} GET /split-preview(s) ` +
+        `(budget ${SPLIT_PREVIEW_BUDGET}). One refetch per method change is ` +
+        `expected; more suggests cache-invalidation cascade.`,
+    ).toBeLessThanOrEqual(SPLIT_PREVIEW_BUDGET);
+
+    // Cross-check via the helper API on session totals.
+    expectBudget(recorder, {
+      method: "PUT",
+      urlPattern: "/api/workspace/config",
+      // Session budget = seed PUTs (≈ 2-4) + strategy-click PUTs (≤ 2).
+      max: 8,
+      label: "Full session (seed + strategy click)",
+    });
+  });
+});

--- a/frontend/tests/e2e/workspace-data-load-puts.spec.ts
+++ b/frontend/tests/e2e/workspace-data-load-puts.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "@playwright/test";
+import * as fs from "node:fs";
+import { isMobileProject } from "./helpers/mobile";
+import { dismissOnboarding } from "./helpers/onboarding";
+import { expectBudget, installFetchRecorder } from "./helpers/request-budget";
+
+/**
+ * Issue #538 — data-load cascade budget regression spec.
+ *
+ * Surface: loading a CSV via the Data Source "Path" input. The
+ * canonical load sequence fires:
+ *   - 1× POST /api/workspace/data/path  (load)
+ *   - 1× GET /api/workspace/data/columns (column metadata)
+ *   - 1× GET /api/workspace/data/preview (preview rows)
+ *   - 1× GET /api/workspace/config       (seed config refresh)
+ *
+ * = 4 requests in the happy path. The #538 surface table suggests a
+ * budget of 6 (== 4 baseline + 2 headroom for cache invalidation
+ * race / refetch storms). Anything above that is the
+ * "initial-load cascade" regression class — typically a duplicate
+ * dispatch from cache invalidation that runs the load twice.
+ *
+ * Per ``feedback_count_budget_assertions`` (memory): for storm/spam
+ * bugs the regression test MUST count occurrences, not just assert
+ * eventual correctness.
+ */
+
+const CSV_PATH = "/tmp/e2e_data_load_puts.csv";
+const TOTAL_LOAD_BUDGET = 6;
+
+function createBinaryCsv(): void {
+  const rows = ["id,age,target"];
+  for (let i = 0; i < 100; i += 1) {
+    rows.push(`${i},${20 + (i % 50)},${i % 2}`);
+  }
+  fs.writeFileSync(CSV_PATH, rows.join("\n"));
+}
+
+test.describe("Data load via Path — load cascade budget (Issue #538)", () => {
+  test.beforeAll(() => {
+    createBinaryCsv();
+  });
+
+  test.afterAll(() => {
+    if (fs.existsSync(CSV_PATH)) fs.unlinkSync(CSV_PATH);
+  });
+
+  test("Path load fires ≤ 6 workspace/data requests total", async ({
+    page,
+    request,
+  }, testInfo) => {
+    if (isMobileProject(testInfo)) {
+      test.skip(
+        true,
+        "Mobile layout uses a different Data Panel collapse pattern; covered by the desktop project",
+      );
+    }
+
+    await request.post("/api/workspace/reset");
+
+    // Install recorder, then navigate so the recorder sees the initial
+    // GET /config + GET /status that always fire on page mount. We
+    // exclude those from the load-specific snapshot by taking the
+    // snapshot AFTER the page is idle.
+    const recorder = installFetchRecorder(page);
+    await dismissOnboarding(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Snapshot the data-related endpoints. The pattern matches the
+    // four endpoints listed in the #538 surface table.
+    const sinceLoad = recorder.snapshot({
+      urlPattern: /\/api\/workspace\/(data\/(path|columns|preview)|config)$/,
+    });
+
+    await page.getByRole("radio", { name: "Path" }).click();
+    await page.getByPlaceholder("/path/to/data.csv").fill(CSV_PATH);
+    await page.getByRole("button", { name: "Load" }).click();
+    await expect(page.getByText(/100 rows × \d+ columns/)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // 2s buffer for any post-load cache invalidation refetch to land.
+    await page.waitForTimeout(2000);
+
+    const loadRequests = sinceLoad();
+    expect(
+      loadRequests.length,
+      `Path load fired ${loadRequests.length} data-related request(s) ` +
+        `(budget ${TOTAL_LOAD_BUDGET}). Baseline: 1 POST /path + 1 GET ` +
+        `/columns + 1 GET /preview + 1 GET /config = 4. Headroom +2 for ` +
+        `cache invalidation refetch races. Captured:\n` +
+        loadRequests.map((r) => `  ${r.method} ${r.url}`).join("\n"),
+    ).toBeLessThanOrEqual(TOTAL_LOAD_BUDGET);
+
+    // POST /data/path must be exactly 1 (no double-load).
+    expectBudget(recorder, {
+      method: "POST",
+      urlPattern: "/api/workspace/data/path",
+      max: 1,
+      label: "Path load button click",
+    });
+  });
+});

--- a/frontend/tests/e2e/workspace-tab-switch-puts.spec.ts
+++ b/frontend/tests/e2e/workspace-tab-switch-puts.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "@playwright/test";
+import * as fs from "node:fs";
+import { isMobileProject } from "./helpers/mobile";
+import { dismissOnboarding } from "./helpers/onboarding";
+import { expectBudget, installFetchRecorder } from "./helpers/request-budget";
+
+/**
+ * Issue #538 — tab-switch PUT budget regression spec.
+ *
+ * Surface: switching between the Fit and Tune tabs on the workspace
+ * Model panel. The tab switch is a pure-UI navigation — no config
+ * mutation is implied — so the budget should be **0** PUTs in steady
+ * state. The +1 headroom covers any incidental re-mount that wraps
+ * an existing cached value into a no-op replace; the budget is
+ * intentionally tight so a regression that re-writes a defensive
+ * useEffect (the v0.6.2 Target-select bug class) trips this on the
+ * very next CI run.
+ *
+ * Risk class: "tab change should not write" — exactly the row in the
+ * #538 surface table that has no historical bug but is the most
+ * sensitive sentinel against the same pattern recurring elsewhere.
+ *
+ * Per ``feedback_count_budget_assertions`` (memory): for storm/spam
+ * bugs the regression test MUST count occurrences, not just assert
+ * eventual correctness.
+ */
+
+const CSV_PATH = "/tmp/e2e_tab_switch_puts.csv";
+// Budget = 1 (steady-state expectation = 0, +1 headroom for the first
+// tab mount that may seed a Tune-only field). A regression that fires
+// a per-tab-switch PUT will exceed this on the second toggle.
+const TAB_SWITCH_BUDGET = 1;
+
+function createBinaryCsv(): void {
+  const rows = ["id,age,target"];
+  for (let i = 0; i < 100; i += 1) {
+    rows.push(`${i},${20 + (i % 50)},${i % 2}`);
+  }
+  fs.writeFileSync(CSV_PATH, rows.join("\n"));
+}
+
+test.describe("Fit ↔ Tune tab switch — zero-write budget (Issue #538)", () => {
+  test.beforeAll(() => {
+    createBinaryCsv();
+  });
+
+  test.afterAll(() => {
+    if (fs.existsSync(CSV_PATH)) fs.unlinkSync(CSV_PATH);
+  });
+
+  test("toggling Fit ↔ Tune does not fire PUTs", async ({
+    page,
+    request,
+  }, testInfo) => {
+    if (isMobileProject(testInfo)) {
+      test.skip(
+        true,
+        "Mobile layout collapses the tab nav; covered by the desktop project",
+      );
+    }
+
+    await request.post("/api/workspace/reset");
+    const recorder = installFetchRecorder(page);
+
+    // Seed: load data + pick target so the workspace is fully populated.
+    await dismissOnboarding(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.getByRole("radio", { name: "Path" }).click();
+    await page.getByPlaceholder("/path/to/data.csv").fill(CSV_PATH);
+    await page.getByRole("button", { name: "Load" }).click();
+    await expect(page.getByText(/100 rows × \d+ columns/)).toBeVisible({
+      timeout: 15_000,
+    });
+    const combo = page.getByRole("combobox", { name: /target column/i });
+    await expect(combo).toBeEnabled({ timeout: 15_000 });
+    await combo.click();
+    await page.getByRole("option", { name: "target" }).click();
+
+    // Wait for the initial seed funnel to drain so the snapshot below
+    // captures only tab-switch traffic.
+    await page.waitForTimeout(3000);
+
+    const sinceSwitch = recorder.snapshot({
+      method: "PUT",
+      urlPattern: "/api/workspace/config",
+    });
+
+    // Toggle: Fit (current) → Tune → Fit → Tune. Four observations
+    // gives a stable sentinel: a single per-mount PUT inflates the
+    // count by 4 (one per switch), well above the budget of 1.
+    await page.getByRole("tab", { name: "Tune" }).click();
+    await page.waitForTimeout(500);
+    await page.getByRole("tab", { name: "Fit" }).click();
+    await page.waitForTimeout(500);
+    await page.getByRole("tab", { name: "Tune" }).click();
+    await page.waitForTimeout(500);
+    await page.getByRole("tab", { name: "Fit" }).click();
+    await page.waitForTimeout(2000);
+
+    const switchPuts = sinceSwitch();
+    expect(
+      switchPuts.length,
+      `Tab switch fired ${switchPuts.length} PUT(s) (budget ${TAB_SWITCH_BUDGET}). ` +
+        `A tab change is pure navigation — no mutation implied. Investigate ` +
+        `if any per-tab useEffect is writing back into config on mount.`,
+    ).toBeLessThanOrEqual(TAB_SWITCH_BUDGET);
+
+    // Cross-check via the helper API. Total session PUT count includes
+    // the initial seed (which is fine); we only care that the tab
+    // switches themselves did not inflate it.
+    expectBudget(recorder, {
+      method: "PUT",
+      urlPattern: "/api/workspace/config",
+      // Generous session-wide budget — the seed itself may emit a
+      // handful. Tab-switch contribution above is the strict assertion.
+      max: 10,
+      label: "Full session (seed + 4 tab toggles)",
+    });
+  });
+});

--- a/frontend/tests/e2e/workspace-target-select-puts.spec.ts
+++ b/frontend/tests/e2e/workspace-target-select-puts.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import * as fs from "node:fs";
 import { isMobileProject } from "./helpers/mobile";
 import { dismissOnboarding } from "./helpers/onboarding";
+import { expectBudget, installFetchRecorder } from "./helpers/request-budget";
 
 /**
  * Issue #529 regression spec — partial-body PUTs from MetricsChips.
@@ -23,7 +24,12 @@ import { dismissOnboarding } from "./helpers/onboarding";
  * the UiSchema's task-keyed eval registry. After both changes, the
  * partial PUTs never fire and split-preview returns 200.
  *
- * This spec intercepts every `PUT /api/workspace/config` and asserts:
+ * This spec uses ``installFetchRecorder`` + ``expectBudget`` from
+ * ``helpers/request-budget.ts`` (Issue #538 helper extraction) so the
+ * pattern is reusable for the other user-action budgets the issue
+ * templates.
+ *
+ * Invariants asserted:
  *   1. No PUT body has only `{evaluation}` at top level (the partial
  *      signature). The body must contain at minimum `config_version`,
  *      `task`, `split`, `data` — the seed config's invariant keys.
@@ -75,42 +81,11 @@ test.describe("Target selection — no partial PUT, no split-preview 400 (Issue 
     // previous test masks the bug.
     await request.post("/api/workspace/reset");
 
-    // Set up interception BEFORE driving any UI so we observe every
+    // Install recorder BEFORE driving any UI so we observe every
     // PUT /config from page load onward — though the partial-PUT bug
     // fires only after Target is picked, capturing the full session
     // gives diagnostic context if the test fails.
-    const allPuts: Array<{
-      keys: string[];
-      hasConfigVersion: boolean;
-      hasTask: boolean;
-      hasSplit: boolean;
-      bodySize: number;
-    }> = [];
-    page.on("request", (req) => {
-      if (req.method() !== "PUT") return;
-      if (!req.url().endsWith("/api/workspace/config")) return;
-      try {
-        const body = req.postDataJSON() as Record<string, unknown>;
-        const keys = Object.keys(body).sort();
-        allPuts.push({
-          keys,
-          hasConfigVersion: "config_version" in body,
-          hasTask: "task" in body,
-          hasSplit: "split" in body,
-          bodySize: req.postData()?.length ?? 0,
-        });
-      } catch {
-        // Ignore non-JSON bodies — none exist on this endpoint.
-      }
-    });
-
-    // Watch for split-preview 400 responses (Bug C / #531 — symptom of
-    // this bug). A passing run should see 200s only.
-    const splitPreview400s: number[] = [];
-    page.on("response", (res) => {
-      if (!res.url().endsWith("/api/workspace/data/split-preview")) return;
-      if (res.status() === 400) splitPreview400s.push(res.status());
-    });
+    const recorder = installFetchRecorder(page);
 
     // Drive the UI flow. Inlining the seed instead of using
     // `seedUiWorkspace` because that helper picks `target="target"` and
@@ -129,7 +104,10 @@ test.describe("Target selection — no partial PUT, no split-preview 400 (Issue 
     });
 
     // Snapshot PUTs BEFORE the Target click so post-click delta is clean.
-    const putsBeforeTarget = allPuts.length;
+    const sinceTargetClick = recorder.snapshot({
+      method: "PUT",
+      urlPattern: "/api/workspace/config",
+    });
 
     const combo = page.getByRole("combobox", { name: /target column/i });
     await expect(combo).toBeEnabled({ timeout: 15_000 });
@@ -140,15 +118,17 @@ test.describe("Target selection — no partial PUT, no split-preview 400 (Issue 
     // 200 ms convergence; CI machines vary.
     await page.waitForTimeout(3000);
 
-    const targetPuts = allPuts.slice(putsBeforeTarget);
+    const targetPuts = sinceTargetClick();
 
     // Invariant 1: NO partial-body PUTs. A partial body has only
     // `evaluation` (or a tiny subset) as the top-level key set. Every
     // PUT must carry the seed config invariants (config_version, task,
     // split).
-    const partials = targetPuts.filter(
-      (p) => !p.hasConfigVersion || !p.hasTask || !p.hasSplit,
-    );
+    const partials = targetPuts.filter((p) => {
+      const body = p.bodyJson;
+      if (!body) return true;
+      return !("config_version" in body) || !("task" in body) || !("split" in body);
+    });
     expect(
       partials,
       `Issue #529 regression — partial-body PUT(s) observed.
@@ -156,11 +136,22 @@ test.describe("Target selection — no partial PUT, no split-preview 400 (Issue 
         `These bodies lack config_version/task/split and the backend ` +
         `rejects them with saved=false, blocking=5. Captured:
 ` +
-        partials.map((p) => `  keys=${JSON.stringify(p.keys)}`).join("\n"),
+        partials
+          .map(
+            (p) =>
+              `  keys=${
+                p.bodyJson ? JSON.stringify(Object.keys(p.bodyJson).sort()) : "(no body)"
+              }`,
+          )
+          .join("\n"),
     ).toHaveLength(0);
 
     // Invariant 2: split-preview never 400'd. Bug C disappears when
     // Bug A is fixed because ws.config is always populated.
+    const splitPreview400s = recorder.matchingResponses({
+      urlPattern: "/api/workspace/data/split-preview",
+      status: 400,
+    });
     expect(
       splitPreview400s,
       `Issue #531 regression — GET /split-preview returned 400 ` +
@@ -183,5 +174,16 @@ test.describe("Target selection — no partial PUT, no split-preview 400 (Issue 
         `that derives state from cache and emits a write, or a regression ` +
         `in coalesceByReason / the isFlushing gate.`,
     ).toBeLessThanOrEqual(PUT_BUDGET);
+
+    // Bonus: smoke-test the helper's expectBudget on the same data so
+    // a future regression in either the helper or the underlying
+    // observer surfaces immediately. Same threshold; redundant by
+    // design.
+    expectBudget(recorder, {
+      method: "PUT",
+      urlPattern: "/api/workspace/config",
+      max: PUT_BUDGET + 1, // +1 because expectBudget counts session-wide, not just post-snapshot
+      label: "Target-select click (session-wide PUT count)",
+    });
   });
 });


### PR DESCRIPTION
Partially closes #538 — Phase 1 (helper extraction) + 4 of 8 surfaces covered. Folds increment / Fit submit / Tune submit / Inference run remain for a follow-up PR.

## Why

The v0.6.2 Target-select bug cluster (#529 / #530 / #531) shipped because every existing test asserted eventual *state* (resolved value, no error) and every state-based assertion passed — yet the bug was 9 PUTs per click for 4 days. Per `feedback_count_budget_assertions` (memory): storm / spam / flood bugs MUST be caught by counting occurrences, not just asserting correctness.

## Components

| File | Role |
|---|---|
| `frontend/tests/e2e/helpers/request-budget.ts` | Helper. `installFetchRecorder(page)` + `expectBudget(recorder, {...})` + `recorder.snapshot(filter)` |
| `frontend/tests/e2e/workspace-target-select-puts.spec.ts` | Existing canonical spec, refactored to use the helper. Same assertions; proves the API is sufficient |
| `frontend/tests/e2e/workspace-tab-switch-puts.spec.ts` | New. Fit ↔ Tune toggle fires PUT ≤ 1 |
| `frontend/tests/e2e/workspace-data-load-puts.spec.ts` | New. Path load cascade total ≤ 6 across `/data/(path\|columns\|preview)` + `/config` |
| `frontend/tests/e2e/workspace-cv-strategy-puts.spec.ts` | New. Strategy radio click fires PUT ≤ 2 / GET /split-preview ≤ 1. Highest-risk surface per the #538 table |
| `CONTRIBUTING.md` | Documents the convention under "Quality gates (CI)" — every user-action E2E spec must include a request-budget assertion. Budget values cite a measured baseline or related Issue; failing budget triggers investigation, not relaxation |

## Coverage progress

| Surface | Status |
|---|---|
| Target column change | ✅ existing |
| Tab switch Fit ↔ Tune | ✅ new |
| Data load via Path | ✅ new |
| CV strategy change | ✅ new |
| Folds spinbutton increment | ⏳ follow-up |
| Fit submit | ⏳ follow-up |
| Tune submit / resume | ⏳ follow-up |
| Inference run | ⏳ follow-up |

5 of 8 acceptance threshold met (≥ 5 surfaces covered, the rest staged).

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm build` — succeeds (catches TS errors not surfaced by `tsc -p tsconfig.test.json`)
- [x] Existing `workspace-target-select-puts.spec.ts` still expresses the same 3 invariants (partial-body absence, no split-preview 400, PUT ≤ 3)
- [ ] CI runs the 3 new specs in the functional E2E job — reviewer verifies on first push

## Limitations

- The `snapshot` API records arrival-order requests; in practice this matches Playwright's `page.on` event ordering but is sensitive on extremely fast handlers. The 2-3 s `waitForTimeout` after each action is the existing standard drain budget across specs.
- `expectBudget` counts session-wide; per-action budgets should use `recorder.snapshot(filter)` + closure to avoid bleeding seed PUTs into the assertion (illustrated in every new spec).