### PR TITLE
[docs-only] P-0110 / P-0111 Decisions approved (#536, #528)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4325,13 +4325,12 @@ Decision 時に M-1 または M-2 のいずれかを確定する。frontend は�
 #### Decision
 
 - 2026-05-23 **Proposal-only kickoff** — Approval / Migration plan (M-1 vs M-2) 確定後に実装 PR を起票する。実装は 1 PR で backend + frontend + docs + openapi 同時に揃える方針（M-1）を推奨案として提示。reviewer が M-2 を選好する場合は段階移行に再分割。Change Gate 通過まで実装着手不可。
-
-#### Open Questions
-
-- **Q1**: Migration plan は M-1（single-PR cutover）/ M-2（opt-in header）のどちらか？
-- **Q2**: `application/problem+json` の `type` URI は何にするか？（社内固定 URI、`https://lizystudio.dev/problems/validation-failed` 形式、または `about:blank` で済ませる）
-- **Q3**: 既存 `errors: []` shape の severity contract（P-0100 で確立）は **そのまま `errors[]` 配列に温存** で良いか？それとも RFC 9457 の `errors` 拡張メンバ規約に合わせて項目名を rename するか？
-- **Q4**: 同 PR で 422 化する対象は 2 endpoint (`PUT /config`, `POST /config/upload`) のみか、それとも残り 6 件の `if not blocking: ...` call-site も同時に揃えるか？ **A**: 同時推奨（リグレッション防止）— ただし reviewer 判断で分割可。
+- 2026-05-23 (later, same day) **APPROVED** with the following resolutions to Open Questions Q1–Q4:
+  - **Q1 → M-1 (Single-PR cutover)**: backend + frontend + docs + `openapi-typescript` regenerate を **1 PR** で揃え、**v0.7.0 major bump** でリリース。外部 CLI クライアントへの breaking はリリースノートで明示（frontend は内製のみが known caller のため実質的に limited）。
+  - **Q2 → `type: "about:blank"` (RFC 9457 default)**: 独自ドメイン採番 (`https://lizystudio.dev/problems/<code>`) や URN (`urn:lizystudio:problem:<code>`) は採用しない。Problem の識別子は `StudioError.code` 拡張メンバで提供し、`type` は最シンプルな default で済ませる。curl `--fail-with-body` / Datadog / Sentry の HTTP error tracking と自然に統合できる。
+  - **Q3 → `errors` を `validation_errors` に rename (RFC 9457 規約 align)**: P-0100 で確立した severity contract（`severity == "warning"` → 200 + body 同居、`severity == "error"` → 4xx）はそのまま温存するが、field name は RFC 9457 慣行に揃えるため `errors` → `validation_errors` に rename する。frontend / docs / `openapi-typescript` 由来の生成型を同 PR で同期させる。
+  - **Q4 → 8 全 call-site を同時に揃える**: 同 PR で 2 endpoint (`PUT /config`, `POST /config/upload`) + 残り 6 件の `if not blocking: ...` 同型 call-site (`L498/L610/L662/L675/L740/L760`) を一括で 422 化する。`silent 200 + saved=false` パターンを repo 内から完全に消す（リグレッション防止）。
+- 実装 PR は `feat(api): adopt RFC 9457 Problem Details for workspace endpoints (P-0110)` で起票し、`feat(*) / refactor(*) / docs(history)` 系列で commit 分割。実装着手は v0.7.0 release window のオープン後（v0.6.x の patch サイクル終了後）。
 
 ### P-0111: Tune-tab write path の sparse-overrides 経路 — `TuningOverrides` schema 拡張 vs 2-path 許容（P-0109 follow-up）
 
@@ -4426,9 +4425,8 @@ Option B は v0.7+ で `STUDIO_FORMAT_VERSION` 2 → 3 bump タイミングで�
 #### Decision
 
 - 2026-05-23 **Proposal-only kickoff** — Option A / B 確定後に実装 PR を起票。Option A は本 Proposal 内で acceptance criterion を完結できる（追加 Proposal 不要）。Option B は data-contract 変更を伴うため別途 P-0112 を起票する必要あり。**reviewer の Option 選好を待つ**。Change Gate 通過まで実装着手不可。
-
-#### Open Questions
-
-- **Q1**: Option A / B のどちらを採用するか？ **推奨**: A
-- **Q2 (Option A 採用時)**: row-mode toggle 由来の 2 PUT は `useConfigWriteFunnel` の coalesce 後に同 frame で発行されるが、両 PUT が同期しないと "Modified" badge が flicker する可能性。badge の cache invalidation を 1 つの effect で gate するか、両 mutation の `onSettled` で個別に invalidate するか？
-- **Q3 (Option A 採用時)**: 既存の `useConfigWriteFunnel` の `coalesceByReason` は同種の reason (`patch` / `replace`) しか merge できない。2 経路（legacy `PUT /config` と `PUT /config/tuning-overrides`）への分離 mutation を funnel 内でどう表現するか — 別 reason として並列に enqueue するか、別 funnel instance を持つか？
+- 2026-05-23 (later, same day) **APPROVED — Option A (2 経路許容 + criterion reword)** with the following resolutions to Open Questions Q1–Q3:
+  - **Q1 → Option A 採用**: `n_trials` / `timeout` / `direction` / `evaluation_metrics` / `space` の 5 フィールドは `PUT /config/tuning-overrides` (sparse REPLACE) へ route。`model.params` (Fixed-mode hyper-params) / `inner_valid` (#459) / `re_tune` の 3 フィールドは引き続き legacy `PUT /api/workspace/config` へ route。`#528` acceptance criterion #1 は本 Proposal 内の reword 済み文面で完結。Option B (schema 拡張) は v0.7+ `STUDIO_FORMAT_VERSION` 2 → 3 bump タイミングで再評価（その時点で `tuning_overrides` を on-disk 一級にする計画があるため、自然に shim 拡張のコストが正当化される）。
+  - **Q2 → 1 つの effect で gate**: row-mode toggle 末端で「両 mutation が `onSettled` 完了」を一括カウントし、その後に 1 回だけ `useTuningSnapshot.invalidate()` を trigger。badge は flicker しない。`useConfigWriteFunnel` 側に `onAllSettled` (両 reason の queue が drain した時点で 1 度発火) フックを追加する。両 mutation の `onSettled` 個別 invalidate は採用しない（同 frame で 2 度走ると stale state が一瞬見える）。
+  - **Q3 → 別 reason として並列に enqueue**: `useConfigWriteFunnel.coalesceByReason` の key 集合に `legacy_config` / `tuning_overrides` を追加し、同 funnel 内で 2 本の queue を並走させる。flush タイミングは両者共通 (同 frame バッチ)。既存 funnel の `isFlushing` gate ロジック + v0.6.2 で導入した `kind: "patch-many"` merge を reuse 可能。別 funnel instance は採用しない（flush タイミング同期 + cache invalidation 順序保証の追加コストが大きい）。
+- 実装 PR は `refactor(frontend): route Tune-tab tuning-field writes through PUT /config/tuning-overrides (P-0111)` で起票し、acceptance criteria に従って TDD 実装。実装着手の優先度は v0.6.x patch サイクル後の v0.7 準備期間、または v0.7.0 (P-0110 RFC 9457) と同一 release window で同時着地候補。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 - このファイルは **横串インデックス** であり、詳細はリンク先で確認すること。
 - 着手する際は HISTORY に Proposal を起票（変更ゲート対象の場合）→ PLAN にフェーズ追加 → 実装、の順で進める。
 
-最終更新: 2026-05-23（**v0.6.2 release 済 (2026-05-17, PyPI lizystudio==0.6.2)** + **v0.6.3 release prep 中** — メンテナンス + テスト品質 patch。#545 (Dependabot 4 PR 統合 + CVE overrides) + #537 (call-count assertion 監査 80 サイト + `tohavebeencalled-guard` CI) を develop に着地、挙動・API・format_version 変更なし。#528 は `TuningOverrides` スキーマと Issue 文面の齟齬で descope、P-0109 follow-up として再 spec 待ち。直近の Tier 1 next は **#527 (P-0109 follow-up)** / **#528 (要再spec)** / **#495** / 🔒 **#452-b**。次の節目候補は **v0.7+**: 第 2 backend (#403 残・#452-b 解禁トリガ)、Tailwind v4、P-0087 Phase 3、typed error 体系 (R-3.1〜R-3.3) など）
+最終更新: 2026-05-23（**v0.6.3 develop 着地、v0.6.x patch サイクル継続** — Wave 1 (#554 + #527 + #495) を 2026-05-23 中に完了: PR #555 で #554 (R-1.4 INV-4 violation, unpause 2× n_trials) を構造的に修正 + #527 `_assert_inv_t3` 再有効化を同 PR で同梱、#495 weekly stale-doc cron は PR #550 で shipped (manual close)。Wave 2 として **P-0110 (RFC 9457 Problem Details) / P-0111 (Tune-tab write path Option A)** の Decision を 2026-05-23 確定（実装は v0.7 release window で同時着地候補）。直近の Tier 1 next は **#538 (PUT_BUDGET 横展開)** / **#539 (mutation+PBT)** / 🔒 **#452-b** / 🔒 **#488 (Vite 8)**。次の節目候補は **v0.7.0**: P-0110 + P-0111 implementation + 第 2 backend (#403 残・#452-b 解禁トリガ) + Tailwind v4 + P-0087 Phase 3 + typed error 体系 (R-3.1〜R-3.3) など）
 
 ---
 
@@ -161,8 +161,8 @@
 - **P-0105**: Residuals plot に kind selector（#457）— 着地済
 - **P-0106**: metric 不適合判定を `BackendCore` capability の裏へ（Change Gate、#403）— 着地済（`BackendCore.get_incompatible_metrics`）。完全な 2nd-backend 移行は §3.3 後
 - **P-0109**: Tune 派生デフォルトの backend SSOT 化 + intent/effective 分離（Change Gate）— ✅ Approved & shipped (Option B, 2026-05-15〜2026-05-16, 全 9 PR 着地)。Tune タブ初回マウントで catalog defaults が Fixed 表示になるバグ（[2026-05-14 確認](HISTORY.md)）の根本治療が **PR-5 (#521) で構造的に解消**。`BackendCore.get_tuning_defaults` + `compute_effective_tuning` を Protocol に追加 (#517)、`LizyMLAdapter` 実装 (#518)、追加エンドポイント `GET /config/tuning-snapshot` / `PUT /config/tuning-overrides` (#519)、`WorkspaceState.tuning_overrides` 一級フィールド化 + INV-T6 snapshot 凍結 (#520)、frontend 3 useEffect 物理削除 + render-time fallbacks (#521)、docs reconcile + HISTORY Decision flip (#522)、`compute_effective_tuning` direction 派生 refine + `_prepare_tune_config` hardcoded `maximize_metrics` set 削除 (#523)、`useTuningSnapshot` hook + `SearchSpaceRow` "Modified" badge + `TASK_DEFAULT_METRICS` frontend 定数削除 + snapshot レスポンスへ `tuning_overrides` 追加 (#524)。Option B として実施しなかったもの: (a) `STUDIO_FORMAT_VERSION` 2 → 3 bump（on-disk `WorkspaceConfig.tuning` block は v2 シェイプのまま、`absorb_legacy_tuning` / `get_legacy_config_view` 双方向 shim で吸収）。残存フォローアップ: A-1 `_assert_inv_t3` 再有効化 = PR #551 着手中（Issue #527）、A-2 Tune タブ write path → **P-0111 follow-up Proposal として起票**（Issue #528 再 spec）。
-- **P-0110** (Proposal-only kickoff, 2026-05-23): silent 200 OK + `{saved: false}` envelope を RFC 9457 Problem Details (`application/problem+json` + 4xx) に置換する Change Gate kickoff（Issue #536）。frontend / backend / docs を v0.7.0 major bump で同 PR cutover (M-1) 推奨。実装着手は Decision 確定後。
-- **P-0111** (Proposal-only kickoff, 2026-05-23): Tune タブ write path → `PUT /config/tuning-overrides` (sparse) refactor の re-spec（Issue #528 follow-up）。`TuningOverrides` schema が `model.params` / `inner_valid` / `re_tune` を表現できないため original acceptance criterion #1 が実装不可。Option A (2 経路許容 + criterion reword) 推奨。Option B (schema 拡張) は v0.7+ `STUDIO_FORMAT_VERSION` bump タイミングで再評価。
+- **P-0110** (Approved 2026-05-23, awaiting v0.7 implementation window): silent 200 OK + `{saved: false}` envelope を RFC 9457 Problem Details (`application/problem+json` + 4xx) に置換する Change Gate（Issue #536）。**Decision 確定**: M-1 (single-PR cutover, v0.7.0 major bump) / `type: "about:blank"` / `errors` → `validation_errors` rename / 8 全 call-site 同時化。実装 PR は v0.6.x patch サイクル終了後に起票（`feat(api): adopt RFC 9457 Problem Details for workspace endpoints (P-0110)`）。
+- **P-0111** (Approved 2026-05-23, awaiting v0.7 implementation window): Tune タブ write path → `PUT /config/tuning-overrides` (sparse) refactor の re-spec（Issue #528 follow-up）。**Decision 確定**: Option A 採用 (2 経路許容 + criterion reword) / "Modified" badge は 1 effect で gate / `useConfigWriteFunnel.coalesceByReason` に `legacy_config` / `tuning_overrides` の 2 reason 並列 enqueue。Option B (schema 拡張) は v0.7+ `STUDIO_FORMAT_VERSION` bump タイミングで再評価。実装 PR は v0.7 release window で P-0110 と同時着地候補 (`refactor(frontend): route Tune-tab tuning-field writes through PUT /config/tuning-overrides (P-0111)`)。
 
 ### 3.0 P-0094 (済)：pytest-benchmark performance baseline（Issue #27 (a)）
 
@@ -302,10 +302,10 @@ Wave 6 完了後の Open Issue は **4 件**（#451 / #453 は 2026-05-13 close 
 
 ### Tier 1：直近の着手候補（ROI 順）
 
-1. **#527 (`_assert_inv_t3` 再有効化)** — A-1 / P-0109 follow-up。`tune-resume.spec.ts:185` の pause-timing race と相互作用、helper 自体は #523 で残存。再有効化条件: `n_trials` 拡大 or pause 観測の堅牢化。tier-3/low、機能影響なし
-2. **#528 (Tune タブ write path → sparse overrides)** — A-2 / P-0109 follow-up。legacy `PUT /config` → 新 `PUT /config/tuning-overrides` (sparse REPLACE) へ移行。refactor only、`absorb_legacy_tuning` shim 依存解消。tier-3/low
-3. **#495** — #456 L5: weekly stale-doc audit cron（`scripts/audit_stale_docs.py` + `.github/workflows/audit-stale-docs.yml` cron weekly、tracking issue 自動更新。tier-3/low、deferred）
-4. **#452-b `lifecycle_mixin.tune` 分割** — 🔒 2nd-adapter 議論（§3.3）後に解禁。それまで着手しない
+1. **#538 PUT_BUDGET 横展開** — pilot 4 spec (#553) で landed 済 helper (`request-budget.ts`) を残り surface に templatize（CV strategy / Folds spinbutton / Tab switch / Data-load 等）。tier-4/medium、機械的展開フェーズ。次に着手しやすい
+2. **#539 mutation + property-based testing** — `mutmut` + `hypothesis` + `stryker-js` + `fast-check` を `useConfigWriteFunnel` / `JobStore` 限定で CI 導入。tier-4/low、探索的
+3. **#452-b `lifecycle_mixin.tune` 分割** — 🔒 2nd-adapter 議論（§3.3）後に解禁。それまで着手しない
+4. **#488 Vite 8 移行** — 🔒 Rolldown 移行 / `/api/ws` proxy regression 解消後に着手
 
 > ~~#529 / #530 / #531 (Target-select 3-issue cluster)~~ ✅ 完了 (PR #532 / #533、2026-05-16〜17 着地。v0.6.2 でリリース)。Target click あたり PUT count 9 → 2、`saved=False` 0 件、`GET /split-preview` 400 解消。修正: (1) `MetricsChips` task-change useEffect を `configSeeded` prop で gate + `buildMergedConfig` に evaluation.metrics seed (#529); (2) `coalesceByReason` を patch+patch -> `kind: "patch-many"` merge に拡張 + `ConfigForm` auto-reset を `funnel.isFlushing()` で gate (#530); (3) #531 は #529 の symptom で auto-resolve。e2e regression spec `workspace-target-select-puts.spec.ts` で lock
 >


### PR DESCRIPTION
## Summary

`[docs-only]` — Records the resolved Open Questions for **P-0110** (RFC 9457 Problem Details, Issue #536) and **P-0111** (Tune-tab write path, Issue #528). Both Change Gate Proposals flip from "Proposal-only kickoff" to "Approved, awaiting v0.7 implementation window".

No behaviour / API / `format_version` change. ROADMAP Tier 1 next-action list refreshed to post-Wave 1 state.

## P-0110 Decisions (RFC 9457 Problem Details, Issue #536)

| Question | Resolution |
|---|---|
| **Q1**: Migration plan? | **M-1** — single-PR cutover (backend + frontend + docs + openapi-typescript regenerate) in **v0.7.0 major bump**. External CLI clients see breaking; release notes will list it (frontend is the only known caller, so practical blast radius is limited). |
| **Q2**: `type` URI? | **`about:blank`** (RFC 9457 default). No custom domain numbering; `StudioError.code` extension member supplies the identifier. Natural integration with `curl --fail-with-body`, Datadog HTTP error tracking, Sentry 4xx classification. |
| **Q3**: `errors[]` shape? | **Rename `errors` → `validation_errors`** to align with RFC 9457 convention. P-0100 severity contract (warning = 200 + body, error = 4xx) is preserved verbatim — only the field name changes. Frontend / docs / openapi-typescript types synchronised in the same PR. |
| **Q4**: Scope? | **All 8 call-sites simultaneously** — `PUT /config`, `POST /config/upload`, plus the 6 same-shape `if not blocking: ...` sites at `L498/L610/L662/L675/L740/L760`. Eliminates the silent-200-trap completely from the repo (regression prevention). |

Implementation PR will be titled `feat(api): adopt RFC 9457 Problem Details for workspace endpoints (P-0110)`. Commit split: `feat(api) / refactor(*) / docs(history)`. Triggers `v0.7.0` major bump.

## P-0111 Decisions (Tune-tab write path, Issue #528)

| Question | Resolution |
|---|---|
| **Q1**: Option A vs B? | **Option A** — 2-path tolerant + criterion reword. `n_trials` / `timeout` / `direction` / `evaluation_metrics` / `space` route through `PUT /config/tuning-overrides` (sparse REPLACE). `model.params` (Fixed-mode hyper-params) / `inner_valid` (#459) / `re_tune` continue routing through legacy `PUT /api/workspace/config`. Option B (schema expansion → P-0112) deferred to v0.7+ `STUDIO_FORMAT_VERSION` 2→3 bump timing. |
| **Q2**: Badge cache invalidation? | **Single `onAllSettled` effect** — both mutations' completion is counted at the row-mode toggle terminus, then `useTuningSnapshot.invalidate()` fires exactly once. Avoids the brief stale-state flicker that per-mutation `onSettled` would cause. Requires adding an `onAllSettled` hook to `useConfigWriteFunnel`. |
| **Q3**: Funnel coalesce? | **Parallel enqueue with two reason keys** — extend `coalesceByReason` to accept `legacy_config` / `tuning_overrides` and run two queues in the same funnel (shared flush timing, same-frame batch). Reuses existing `isFlushing` gate logic + the `kind: "patch-many"` merge from v0.6.2. A separate funnel instance would require additional flush-sync + invalidation-order guarantees. |

Implementation PR will be titled `refactor(frontend): route Tune-tab tuning-field writes through PUT /config/tuning-overrides (P-0111)`. Candidate for the same v0.7 release window as P-0110.

## ROADMAP Tier 1 next-action refresh

Post-Wave 1 (#554 + #527 landed in PR #555, #495 manually closed), the immediate ROI candidates are now:

1. **#538** PUT_BUDGET fan-out (templatize the `request-budget.ts` helper from #553 across remaining workspace user actions)
2. **#539** mutation + property-based testing (`mutmut` + `hypothesis` + `stryker-js` + `fast-check` for `useConfigWriteFunnel` / `JobStore`)
3. 🔒 **#452-b** `lifecycle_mixin.tune` split — gated on 2nd-adapter discussion
4. 🔒 **#488** Vite 8 (Rolldown) — gated on `/api/ws` proxy regression fix

## Test plan

- [x] Pure docs change; no code touched
- [x] `git diff --stat`: 2 files, +18 / -20 (HISTORY.md + docs/ROADMAP.md)
- [x] block-stray-artefacts hook green; ruff / biome skipped (no source files)

Closes neither #536 nor #528 — both stay open until the implementation PRs ship in v0.7. This PR records the gate decisions only.

## Related

- Issue #536 (P-0110 RFC 9457 — Decision recorded in HISTORY.md)
- Issue #528 (P-0111 Tune-tab write path — Decision recorded in HISTORY.md)
- Wave 1 completion: PR #555 (#554 + #527 closed), PR #550 (#495 closed)