### PR TITLE
fix(inference): synchronous in-flight ref absorbs double-click POSTs (#559)

### DIFF
--- a/frontend/src/pages/InferencePage.test.tsx
+++ b/frontend/src/pages/InferencePage.test.tsx
@@ -410,4 +410,62 @@ describe("InferencePage", () => {
       expect(capturedSetupProps.isRunning).toBe(true);
     });
   });
+
+  // Issue #559: ``mutation.isPending`` is React state and only flips
+  // to true on the next render, so a double-click within the same
+  // event-loop tick used to race past the DOM ``disabled`` update and
+  // fire 2 POSTs. ``runInferenceAction`` now tracks an in-flight ref
+  // synchronously; back-to-back invocations within the same tick must
+  // produce exactly ONE network call. Count-based assertion per
+  // ``feedback_count_budget_assertions``.
+  it("absorbs a back-to-back second invocation while a request is in flight (Issue #559)", async () => {
+    const job = makeJob({ job_id: "job-1" });
+    mockFetchJobs.mockResolvedValue([job]);
+
+    // Never resolve so the first call stays in-flight while the
+    // second invocation is dispatched in the same tick.
+    mockRunInference.mockReturnValue(new Promise(() => {}));
+
+    renderWithProviders(<InferencePage />);
+
+    await waitFor(() => {
+      const jobs = capturedSetupProps.completedJobs as unknown[];
+      expect(jobs).toHaveLength(1);
+    });
+
+    const onSelectJob = capturedSetupProps.onSelectJob as (id: string) => void;
+    act(() => onSelectJob("job-1"));
+
+    const onRunInference = capturedSetupProps.onRunInference as (params: {
+      dataPath: string;
+      sourceType: "path" | "upload";
+      evaluate: boolean;
+      returnShap: boolean;
+    }) => void;
+
+    // Both invocations happen inside the SAME ``act`` so they share
+    // one React batch — ``mutation.isPending`` cannot have flipped to
+    // true between them. The ref guard is the only thing standing
+    // between this scenario and a duplicate POST.
+    act(() => {
+      onRunInference({
+        dataPath: "/data/test.csv",
+        sourceType: "path",
+        evaluate: false,
+        returnShap: false,
+      });
+      onRunInference({
+        dataPath: "/data/test.csv",
+        sourceType: "path",
+        evaluate: false,
+        returnShap: false,
+      });
+    });
+
+    // Settle pending promises so the wrapper doesn't see an unflushed
+    // tick before the count assertion.
+    await waitFor(() => {
+      expect(mockRunInference).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/frontend/src/pages/InferencePage.tsx
+++ b/frontend/src/pages/InferencePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { getErrorMessage } from "@/api/errors";
 import {
@@ -56,6 +56,16 @@ export function InferencePage() {
 
   // Run inference mutation
   const mutation = useRunInference();
+  // Issue #559: ``mutation.isPending`` is React state and only flips to
+  // true after the next render. A double-click within the same
+  // event-loop tick races past the DOM ``disabled`` update and fires
+  // two POSTs — discovered by ``inference-run-puts.spec.ts`` during
+  // #538. Track the in-flight state synchronously in a ref so the
+  // guard works inside one microtask, independent of React's render
+  // schedule. ``mutation.isPending`` is kept for the
+  // ``isRunning`` prop because the button still needs a visible
+  // disabled style.
+  const inFlightRef = useRef(false);
   const runInferenceAction = useCallback(
     (params: {
       dataPath: string;
@@ -64,6 +74,8 @@ export function InferencePage() {
       returnShap: boolean;
     }) => {
       if (!selectedJobId) return;
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
       mutation.mutate(
         {
           job_id: selectedJobId,
@@ -78,6 +90,9 @@ export function InferencePage() {
           },
           onError: (err) => {
             toast.error(`Inference failed: ${getErrorMessage(err)}`);
+          },
+          onSettled: () => {
+            inFlightRef.current = false;
           },
         },
       );

--- a/frontend/tests/e2e/inference-run-puts.spec.ts
+++ b/frontend/tests/e2e/inference-run-puts.spec.ts
@@ -10,29 +10,29 @@ import { dismissOnboarding } from "./helpers/onboarding";
 import { expectBudget, installFetchRecorder } from "./helpers/request-budget";
 
 /**
- * Issue #538 — Inference run POST budget regression spec.
+ * Issue #538 / #559 — Inference run POST budget regression spec.
  *
  * Surface: clicking the **Run Inference** button on the
  * ``/inference`` page after picking a completed model + data path.
- * The risk class is **silent extra POST** — a regression that adds a
- * defensive useEffect re-fire (the same family as the v0.6.2
- * Target-select cluster, #530) on the inference page would silently
- * spawn duplicate inference records, with the second one usually
- * losing the race for the file lock and 500-ing while the user only
- * sees the first 200.
  *
- * Budget: ``POST /api/inference/run`` = **1 exactly** for a single
- * user click. The button's in-flight disabled state is verified by
- * the upstream ``inference-flow.spec.ts``; this spec narrowly locks
- * the "single click → single POST" contract so a regression that
- * inflates the count is caught at CI time.
+ * Risk classes (both locked here):
  *
- * Note: the original #538 surface table called for a "double-click
- * guard" test, but the inference page's Run button does not currently
- * implement an in-flight guard — a double-click DOES fire 2 POSTs in
- * production (tracked as a follow-up against #538). Locking the
- * single-click contract here lets this spec ship without depending on
- * that future fix.
+ *   1. **Silent extra POST** from a useEffect re-fire (same family
+ *      as the v0.6.2 Target-select cluster, #530). A regression that
+ *      adds a defensive effect re-firing the mutation would inflate
+ *      the per-click POST count.
+ *   2. **Double-click guard** (#559). ``mutation.isPending`` is React
+ *      state and only flips to true after the next render; a
+ *      synthetic double-click within one event-loop tick used to
+ *      race past the DOM ``disabled`` update and fire 2 POSTs. PR
+ *      that closes #559 adds a synchronous ``inFlightRef`` so the
+ *      second ``mutate()`` call is absorbed before it leaves the
+ *      handler.
+ *
+ * Budget: ``POST /api/inference/run`` = **1 exactly** for **two
+ * back-to-back clicks**. The spec deliberately drives the
+ * race condition that surfaced #559; the in-flight ref keeps the
+ * count at 1.
  *
  * Per ``feedback_count_budget_assertions`` (memory): storm/spam bugs
  * MUST be caught by counting occurrences, not just asserting eventual
@@ -43,7 +43,7 @@ import { expectBudget, installFetchRecorder } from "./helpers/request-budget";
 const CSV_PATH = "/tmp/e2e_inference_run_puts.csv";
 const INFER_POST_BUDGET = 1;
 
-test.describe("Inference run — POST budget (Issue #538)", () => {
+test.describe("Inference run — POST budget (Issue #538 / #559)", () => {
   test.beforeAll(() => {
     createTestCsv(100, CSV_PATH);
   });
@@ -52,7 +52,7 @@ test.describe("Inference run — POST budget (Issue #538)", () => {
     if (fs.existsSync(CSV_PATH)) fs.unlinkSync(CSV_PATH);
   });
 
-  test("single click on Run Inference fires exactly one POST", async ({
+  test("double-click on Run Inference fires exactly one POST", async ({
     page,
     request,
   }) => {
@@ -102,7 +102,27 @@ test.describe("Inference run — POST budget (Issue #538)", () => {
       urlPattern: "/api/inference/run",
     });
 
+    // Issue #559 — drive the race condition. The first click sets
+    // ``inFlightRef.current = true`` synchronously inside the
+    // ``runInferenceAction`` callback BEFORE ``mutation.mutate()``
+    // returns; the second click hits the same handler in the same
+    // event-loop tick and is absorbed by the ref check.
+    //
+    // ``{ force: true, noWaitAfter: true }`` skips Playwright's
+    // actionability checks so the second click is attempted even if
+    // the button transitions to disabled in the DOM between the two
+    // events (which is the correct end state, but is async). If the
+    // ref guard is removed, this DOES fire a second POST and the
+    // budget assertion below fails.
     await runButton.click();
+    await runButton
+      .click({ force: true, noWaitAfter: true })
+      .catch(() => {
+        // Force-click can throw if the button is genuinely disabled.
+        // That's the correct end state and complementary to the ref
+        // guard; swallow so the assertion below is what fails the
+        // test, not the click attempt.
+      });
 
     // 6s capture window — long enough that any delayed extra POST
     // from a useEffect re-fire regression has landed.
@@ -111,10 +131,11 @@ test.describe("Inference run — POST budget (Issue #538)", () => {
     const inferPosts = sincePost();
     expect(
       inferPosts.length,
-      `Single click on Run Inference fired ${inferPosts.length} POST(s) ` +
-        `(budget ${INFER_POST_BUDGET}, expected exactly 1). Risk class: ` +
-        `silent extra POST from a useEffect re-fire (same family as the ` +
-        `v0.6.2 Target-select cluster, #530). Captured:\n` +
+      `Double-click on Run Inference fired ${inferPosts.length} POST(s) ` +
+        `(budget ${INFER_POST_BUDGET}, expected exactly 1). Risk classes: ` +
+        `(1) silent extra POST from useEffect re-fire (#530 family); ` +
+        `(2) double-click guard regression (#559 — synchronous ` +
+        `inFlightRef in InferencePage.runInferenceAction). Captured:\n` +
         inferPosts
           .map(
             (p) =>
@@ -132,7 +153,7 @@ test.describe("Inference run — POST budget (Issue #538)", () => {
       method: "POST",
       urlPattern: "/api/inference/run",
       max: 1,
-      label: "Full session (single Run Inference click)",
+      label: "Full session (double-click Run Inference)",
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #559. Fixes the missing in-flight guard on the Inference page's **Run Inference** button that was surfaced by PR #558's E2E spec.

## Root cause

`InferencePage` passes `mutation.isPending` to `SetupPanel` as `isRunning`, and the button uses `disabled={!canRun}` where `canRun = ... && !isRunning`. So the guard *was* wired up — but `mutation.isPending` is React state and only flips to `true` on the next render. A double-click within one event-loop tick raced past the DOM `disabled` update and called `mutation.mutate()` twice, firing 2 POSTs to `/api/inference/run`. The second one usually loses the race for the file lock and 500s while the user only sees the first 200.

CI run [`26334106627`](https://github.com/nbx-liz/LizyStudio/actions/runs/26334106627) captured this on PR #558's first attempt (2 full-body POSTs with `keys=["data","evaluate","job_id","return_shap"]`).

## Fix

`runInferenceAction` tracks an in-flight state synchronously via `useRef`:

```diff
+const inFlightRef = useRef(false);
 const runInferenceAction = useCallback(
   (params) => {
     if (!selectedJobId) return;
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
     mutation.mutate(
       { ... },
       {
         onSuccess: ...,
         onError: ...,
+        onSettled: () => {
+          inFlightRef.current = false;
+        },
       },
     );
   },
   [mutation, selectedJobId],
 );
```

`mutation.isPending` is kept for the `SetupPanel` `isRunning` prop because the button still needs a visible disabled style. The ref is the *correctness* guard; `isPending` is the *visual* guard. Both layers matter.

## Regression coverage

Two complementary tests:

| Layer | File | What it pins |
|---|---|---|
| Unit (vitest) | `InferencePage.test.tsx` — "absorbs a back-to-back second invocation while a request is in flight (Issue #559)" | Two `onRunInference` calls inside one `act()` batch (no render between them) → asserts `mockRunInference.toHaveBeenCalledTimes(1)`. Captures the React-state staleness directly. |
| Integration (Playwright) | `inference-run-puts.spec.ts` upgraded from single-click to `force: true, noWaitAfter: true` double-click | Drives the actual DOM race condition. Asserts `POST = 1` exactly. Captures the same regression at the network layer. |

Both follow `feedback_count_budget_assertions` (memory): "for storm/spam bugs the regression test MUST count occurrences, not just assert eventual correctness."

## Test plan

- [x] `pnpm exec vitest run src/pages/InferencePage.test.tsx` — 12 / 12 pass (11 existing + 1 new)
- [x] `pnpm check` — biome clean
- [x] `pnpm exec tsc -b` — type-check clean
- [x] `pnpm exec playwright test --list tests/e2e/inference-run-puts.spec.ts` — parses, 3 (file × project) combinations
- [ ] CI: full E2E `inference-run-puts.spec.ts` passes 3 consecutive runs (this PR turns the previously-flaky single-click test into a deterministic double-click test, so flake should drop to zero)

## Compatibility

- Pure frontend change. No backend, no API, no `format_version` change.
- `mutation.isPending` semantics unchanged (still used by `SetupPanel`).
- `onSettled` callback is added; pre-existing `onSuccess` / `onError` paths are unchanged in behaviour.

## Related

- Issue #559 (closes)
- PR #558 (the work that discovered the bug — `inference-run-puts.spec.ts` shipped as single-click pending this fix)
- v0.6.2 Target-select cluster (#529 / #530 / #531) — same general failure family (silent extra request via React-async race)
- memory: `feedback_count_budget_assertions`