### PR TITLE
ci(nightly): swap pnpm/action-setup@v4 for corepack in mutation-test (#561)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -241,10 +241,13 @@ jobs:
           python-version: "3.11"
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
+          node-version: "20"
+      - name: Enable corepack and activate pnpm from packageManager field
+        working-directory: frontend
+        run: |
+          corepack enable
+          corepack prepare --activate
+          pnpm --version
       - name: Install Python deps
         run: uv sync
       - name: Run mutmut on JobStore state-machine modules


### PR DESCRIPTION
## Summary
- The `mutation-test` job introduced by #561 has failed on every Nightly run since 2026-05-24 with `Error: No pnpm version is specified`. The action was configured without a `version:` input and the repo root has no `package.json` containing a `packageManager` field.
- Switch to the corepack activation pattern already used by the `frontend` and `e2e-visual-a11y` jobs in the same workflow. corepack reads `frontend/package.json` line 6 (`"packageManager": "pnpm@10.31.0"`) via the `working-directory: frontend` hint.
- This aligns the job with the project's canonical pnpm activation approach (`memory/reference_pnpm_action_setup_trap.md`) and removes the last `pnpm/action-setup` usage from the repo.

## Why option B (corepack) over option A (add `version:`)
Adding `version: "10.31.0"` to `pnpm/action-setup@v4` would also fix the immediate error, but:
1. It duplicates the pnpm version pin (one in `frontend/package.json:6`, one in the workflow).
2. It re-introduces an action that prior incidents in this repo flagged as a footgun (action versions silently bundling unstable pnpm builds).
3. The two sibling jobs already use corepack — keeping a single pattern reduces drift.

## Verification
Job has `continue-on-error: true` so it doesn't change blocking behaviour. Confirm the next Nightly run (or manual `workflow_dispatch`) sees `mutation-test: success` (or at least passes the pnpm setup step).

## Test plan
- [x] Local diff verified (workflow YAML only, 1 file, +7/-4)
- [ ] Next Nightly's `mutation-test` job advances past `pnpm --version`
- [ ] mutmut + stryker artefacts upload on success