### PR TITLE
fix(test): close MSW handler gap + strict unhandled requests (#575)

### DIFF
--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -3,7 +3,12 @@ import { cleanup } from "@testing-library/react";
 import { afterAll, afterEach, beforeAll } from "vitest";
 import { server } from "./test/mocks/server";
 
-beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
+// Issue #575: ``"error"`` (was ``"warn"``) makes every unmocked request fail
+// the test immediately, instead of letting it leak to happy-dom's default
+// ``http://localhost:3000`` where it caused stochastic libuv worker crashes
+// during teardown. Individual tests can still override globally-registered
+// handlers via ``server.use(...)``.
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterEach(() => {
   server.resetHandlers();
   cleanup();

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -9,6 +9,7 @@ import type { components } from "@/api/generated/schema";
 type BackendInfo = components["schemas"]["BackendInfoResponse"];
 type UiSchema = components["schemas"]["UiSchemaResponse"];
 type WorkspaceStatus = components["schemas"]["WorkspaceStatusResponse"];
+type TuningSnapshot = components["schemas"]["TuningSnapshotResponse"];
 
 export const handlers = [
   http.get("/api/backends", () =>
@@ -45,6 +46,36 @@ export const handlers = [
       data_ref: null,
       current_job_id: null,
       files_root: "/tmp",
+    }),
+  ),
+  // Issue #575: TuneTab subscribes to ``useTuningSnapshot`` whenever a task
+  // is selected. Without a default handler the request leaks to happy-dom's
+  // default ``http://localhost:3000``, causing socket-hang-up noise and an
+  // intermittent libuv ``uv__stream_destroy`` worker crash. Empty defaults
+  // keep the snapshot semantically inert so individual tests can override
+  // with ``server.use(...)`` when they need richer data.
+  http.get("/api/workspace/config/tuning-snapshot", () =>
+    HttpResponse.json<TuningSnapshot>({
+      tuning_effective: {
+        n_trials: 0,
+        timeout: null,
+        direction: "maximize",
+        space: {},
+        evaluation_metrics: [],
+        user_set_paths: [],
+      },
+      tuning_defaults: {
+        space: {},
+        evaluation_metrics: [],
+        direction: null,
+      },
+      tuning_overrides: {
+        n_trials: null,
+        timeout: null,
+        direction: null,
+        space: {},
+        evaluation_metrics: null,
+      },
     }),
   ),
 ];


### PR DESCRIPTION
## Summary

Closes #575.

The 2026-05-26 Nightly's `frontend` job crashed with a libuv `uv__stream_destroy` assertion inside the Vitest forks worker running `TuneTab.test.tsx`. Investigation traced this to an MSW handler gap:

- `TuneTab.tsx:162` calls `useTuningSnapshot({ enabled: !!task })`
- `/api/workspace/config/tuning-snapshot` was not in `frontend/src/test/mocks/handlers.ts`
- `onUnhandledRequest: "warn"` let the request leak past MSW
- The request resolved against happy-dom's default `http://localhost:3000` → ECONNREFUSED
- At worker exit, undici's open FD tripped libuv's `uv__io_active` assertion → SIGABRT

This PR closes the recurrence vector with two minimal changes:

1. **Add MSW handler** for `GET /api/workspace/config/tuning-snapshot` returning empty defaults typed against `components["schemas"]["TuningSnapshotResponse"]`. Individual tests can still override via `server.use(...)`.
2. **Flip `onUnhandledRequest`** from `"warn"` to `"error"` so future unmocked endpoints fail tests loudly instead of leaking sockets.

## Verification

| Check | Result |
|---|---|
| `pnpm vitest run` (forks pool, default) | 1949/1949 tests pass across 129 files |
| `grep uv__io_active / Worker exited` in stderr | 0 occurrences |
| `pnpm check` (biome) | clean |
| `pnpm tsc --noEmit` | clean |

The full suite passes under strict mode on the first run, confirming no other endpoint was relying on the silent fallthrough.

## Out of scope

The remaining "socket hang up" lines in stderr come from tests that intentionally simulate network errors via `HttpResponse.error()` patterns. They are unrelated to the FD leak and predate this PR.

## Test plan

- [x] Local `pnpm vitest run` clean
- [ ] CI `frontend` job stays green over the next 5+ Nightlies
- [ ] Future TuneTab unit tests don't need to register the handler — covered by the default
