### PR TITLE
docs(changelog): add v0.6.5 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.5] - 2026-06-09
+
+A **maintenance** release: dependency bumps plus CI / test-infrastructure
+hardening. No behaviour change to documented flows, no API change, no
+`format_version` change — `STUDIO_FORMAT_VERSION` stays at 2.
+
+### CI / Test infrastructure
+
+- **#576 Phase 1 / PR #578 — Nightly streak monitor.** Auto-opens (and
+  auto-closes) a GitHub Issue when a tracked `continue-on-error` Nightly
+  job (`mutation-test`, `E2E visual + a11y`) fails 5 consecutive runs, so
+  non-blocking red can no longer hide indefinitely behind a green overall
+  workflow conclusion.
+- **#561 / PR #573 — mutation-test pnpm setup fix.** Swap
+  `pnpm/action-setup@v4` for corepack (`packageManager` field), fixing the
+  recurring "No pnpm version is specified" failure on the Nightly
+  `mutation-test` job.
+- **#575 / PR #577 — MSW strictness.** Close an MSW handler gap and enforce
+  strict unhandled-request failures in the frontend test suite.
+- **PR #574 — visual goldens.** Regenerate 8 stale visual goldens from the
+  Nightly artefact.
+
+### Dependencies
+
+- Frontend (npm): react-ecosystem (#585), prod-minor-patch (#583 / #592),
+  dev-minor-patch (#572 / #582 / #590), storybook (#581), @types/react
+  (#567).
+- Backend: lizyml requirement updated (#584).
+- GitHub Actions: dorny/paths-filter 3→4 (#571).
+
+### Docs
+
+- **PR #564 — ROADMAP** reconciled to post-v0.6.4 state.
+
 ## [0.6.4] - 2026-05-24
 
 A **bug-fix + test-infrastructure** patch release. Two real bug

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ dev = [
 requires-dist = [
     { name = "cloudpickle", specifier = ">=3.0" },
     { name = "fastapi", specifier = ">=0.115" },
-    { name = "lizyml", extras = ["calibration", "explain", "plots", "tuning"], specifier = ">=0.15.0,<0.16.0" },
+    { name = "lizyml", extras = ["calibration", "explain", "plots", "tuning"], specifier = ">=0.15.0,<0.17.0" },
     { name = "prometheus-client", specifier = ">=0.20" },
     { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },


### PR DESCRIPTION
Prepare for the v0.6.5 maintenance release.

- Add CHANGELOG v0.6.5 section (dependency bumps + CI / test-infrastructure hardening).
- Sync uv.lock lizyml requires-dist to <0.17.0 (#584 updated pyproject but left uv.lock drifted).

No behaviour / API / format_version change. Release PR (develop -> main) + tag follow once this lands.